### PR TITLE
fix(ci): update macOS runners and add workflow_dispatch to releases

### DIFF
--- a/.github/workflows/release-cargo.yml
+++ b/.github/workflows/release-cargo.yml
@@ -1,6 +1,7 @@
 name: Release Cargo
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,6 +1,7 @@
 name: Release npm
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -54,10 +55,10 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             exe_suffix: ".exe"
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             exe_suffix: ""
-          - os: macos-14
+          - os: macos-15
             target: aarch64-apple-darwin
             exe_suffix: ""
     steps:


### PR DESCRIPTION
**Description**

Fix macOS runner deprecation in release workflows and add manual trigger support.

**Motivation**

The `release-npm` workflow failed after merging PR #6 because `macos-13` runners have been removed by GitHub. Additionally, release workflows could not be re-triggered
without a version bump.

**Changes**

- Update macOS runners: `macos-13` to `macos-15-intel`, `macos-14` to `macos-15`
- Add `workflow_dispatch` trigger to both `release-cargo.yml` and `release-npm.yml`

**Type of Change**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [x] CI/build changes

**Checklist**

- [x] My code follows the project's coding style (`cargo fmt` passes)
- [x] `cargo clippy` passes with no warnings
- [ ] I have added tests covering my changes
- [x] All existing tests pass (`cargo test`)
- [ ] I have updated documentation where necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have added AGPL-3.0 license headers to any new files