### PR TITLE
feat(input): adopt tui-textarea-2 v0.10 height API and word wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytemuck"
@@ -1490,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.87"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3395,9 +3395,9 @@ dependencies = [
 
 [[package]]
 name = "tui-textarea-2"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae981fdb654241cb325bf15b78adba3ce21ad85972ebe4820ad7dc7f2884e49"
+checksum = "e3ecbd03ca80cb3a9fdf2ef47a06a14f3e0ff31277ae9aa40161259462c870a6"
 dependencies = [
  "crossterm",
  "portable-atomic",
@@ -3568,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.110"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3581,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.60"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3595,9 +3595,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.110"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3605,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.110"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3618,9 +3618,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.110"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -3661,9 +3661,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.87"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tokio-util = { version = "0.7.18", features = ["compat"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 tui-markdown = { version = "0.3.7" }
-tui-textarea-2 = "0.9.0"
+tui-textarea-2 = "0.10.0"
 unicode-width = "0.2.2"
 uuid = { version = "1.20.0", features = ["v4"] }
 which = "8.0.0"

--- a/src/app/connect.rs
+++ b/src/app/connect.rs
@@ -101,7 +101,6 @@ pub fn create_app(cli: &Cli) -> App {
         paste_burst: crate::app::paste_burst::PasteBurstDetector::new(),
         pending_paste_text: String::new(),
         file_cache: None,
-        input_wrap_cache: None,
         cached_todo_compact: None,
         git_branch: None,
         cached_header_line: None,

--- a/src/app/events.rs
+++ b/src/app/events.rs
@@ -540,7 +540,6 @@ fn reset_for_new_session(
     app.drain_key_count = 0;
     app.paste_burst.reset();
     app.pending_paste_text.clear();
-    app.input_wrap_cache = None;
 
     app.pending_permission_ids.clear();
     app.active_task_ids.clear();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -39,9 +39,8 @@ pub use input::InputState;
 pub(crate) use selection::normalize_selection;
 pub use state::{
     App, AppStatus, BlockCache, ChatMessage, ChatViewport, HelpView, IncrementalMarkdown,
-    InlinePermission, InputWrapCache, LoginHint, MessageBlock, MessageRole, ModeInfo, ModeState,
-    SelectionKind, SelectionPoint, SelectionState, TodoItem, TodoStatus, ToolCallInfo,
-    WelcomeBlock,
+    InlinePermission, LoginHint, MessageBlock, MessageRole, ModeInfo, ModeState, SelectionKind,
+    SelectionPoint, SelectionState, TodoItem, TodoStatus, ToolCallInfo, WelcomeBlock,
 };
 pub use update_check::start_update_check;
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -169,8 +169,6 @@ pub struct App {
     pub pending_paste_text: String,
     /// Cached file list from cwd (scanned on first `@` trigger).
     pub file_cache: Option<Vec<mention::FileCandidate>>,
-    /// Cached input wrap result (keyed by input version + width).
-    pub input_wrap_cache: Option<InputWrapCache>,
     /// Cached todo compact line (invalidated on `set_todos()`).
     pub cached_todo_compact: Option<ratatui::text::Line<'static>>,
     /// Current git branch (refreshed on focus gain + turn complete).
@@ -380,7 +378,6 @@ impl App {
             paste_burst: super::paste_burst::PasteBurstDetector::new(),
             pending_paste_text: String::new(),
             file_cache: None,
-            input_wrap_cache: None,
             cached_todo_compact: None,
             git_branch: None,
             cached_header_line: None,
@@ -703,15 +700,6 @@ impl ChatMessage {
             })],
         }
     }
-}
-
-/// Cached result of `wrap_lines_and_cursor()` for the input field.
-/// Keyed by input version + width so the expensive wrapping runs at most once per frame.
-pub struct InputWrapCache {
-    pub version: u64,
-    pub content_width: u16,
-    pub wrapped_lines: Vec<ratatui::text::Line<'static>>,
-    pub cursor_pos: Option<(u16, u16)>,
 }
 
 /// Cached rendered lines for a block. Stores a version counter so the cache


### PR DESCRIPTION
## Summary
Adopt tui-textarea-2 v0.10.0 input sizing APIs to remove custom wrap/height logic and rely on crate-native measurement and row limits.

## Changes
- bump dependency to tui-textarea-2 = "0.10.0"
- replace custom input wrap-height/cache path with TextArea::measure(width)
- set textarea row bounds via set_min_rows(1) and set_max_rows(12)
- switch input wrapping from glyph-only to WrapMode::WordOrGlyph
- remove InputWrapCache state and related app wiring/reset/re-export code
- add/adjust input UI tests for visual line count behavior

## Checklist
- [x] cargo fmt --all -- --check passes
- [x] cargo clippy --all-targets --all-features -- -D warnings passes
- [x] cargo test passes
- [x] Tests added/updated for behavior changes (or N/A)
- [x] Docs updated for user-facing/config/CLI changes (or N/A)
- [x] Breaking changes are clearly documented (or N/A)
- [x] UI/TUI changes include screenshot/recording (or N/A)
- [x] Manual validation performed for changed flows (brief notes below)

## Validation Notes
- verified input area height is measured via TextArea::measure() and clamps correctly at max rows
- verified word-based wrapping is used in input (WordOrGlyph) with sane fallback for long tokens
- verified login hint + input height composition still renders correctly
- validated dependency resolution against published tui-textarea-2 v0.10.0 and removed local patch path