### PR TITLE
chore(github): simplify collaboration templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,2 @@
 # Default owner for everything
-*                           @srothgan
-
-# ACP protocol layer
-/src/acp/                   @srothgan
-
-# TUI / interface
-/src/ui/                    @srothgan
-
-# Terminal management
-/src/terminal/              @srothgan
-
-# CI/CD configuration
-/.github/                   @srothgan
-
-# Documentation
-/*.md                       @srothgan
-/docs/                      @srothgan
+* @srothgan

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -83,16 +83,6 @@ body:
       description: Paste any relevant log output (run with `RUST_LOG=debug`)
       render: shell
 
-  - type: textarea
-    id: implementation-notes
-    attributes:
-      label: Implementation Notes (optional)
-      description: Maintainer notes, suspected root cause, or technical pointers
-      placeholder: |
-        - Suspected module/path:
-        - Possible root cause:
-        - Constraints:
-
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -31,22 +31,6 @@ body:
       label: Alternatives Considered
       description: Any alternative solutions or features you've considered
 
-  - type: textarea
-    id: implementation-notes
-    attributes:
-      label: Implementation Notes (optional)
-      description: Maintainer notes, technical direction, constraints, or rollout plan
-
-  - type: textarea
-    id: dependencies
-    attributes:
-      label: Dependencies / Blockers (optional)
-      description: Related issues, upstream blockers, or required sequencing
-      placeholder: |
-        - Blocked by #...
-        - Depends on #...
-        - Must ship after #...
-
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,20 @@
 ## Summary
 
-<!-- What changed and why -->
+<!-- What changed -->
+
+## Why
+
+<!-- Why this change is needed -->
 
 Closes #
 
-## Changes
+## Validation
 
-- 
+- Automated:
+- Manual:
+- Screenshot/video (if UI changed): N/A
 
-## Checklist
+## Notes
 
-- [ ] `cargo fmt --all -- --check` passes
-- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
-- [ ] `cargo test --all-features` passes
-- [ ] `cargo check --all-features` passes (MSRV 1.88.0)
-- [ ] `cargo fetch --locked` passes (lockfile up to date)
-- [ ] Tests added/updated for behavior changes (or N/A)
-- [ ] Docs updated for user-facing/config/CLI changes (or N/A)
-- [ ] Breaking changes are clearly documented (or N/A)
-- [ ] UI/TUI changes include screenshot/recording (or N/A)
-- [ ] Manual validation performed for changed flows (brief notes below)
-
-## Validation Notes
-
-<!-- Briefly list manual checks run and their outcomes -->
+- Breaking changes: N/A
+- Docs updated: N/A

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ By participating, you agree to uphold this code.
    fix: prevent panic on empty terminal output
    ```
 7. Push to your fork and open a Pull Request against `main`
-8. Fill out the PR template completely
+8. Fill out the PR summary, validation, and any relevant notes
 
 ## Development Setup
 


### PR DESCRIPTION
## Summary

Simplify the contributor-facing GitHub metadata so it matches the repo's current collaboration shape and removes duplicate process.

## Changes

- shorten the pull request template to summary, why, validation, and notes
- remove maintainer-only fields from the bug and feature issue forms
- collapse `CODEOWNERS` to the single effective owner
- align `CONTRIBUTING.md` with the lighter PR template

## Validation

- metadata-only change
- CI will still validate the repository on the PR

## Notes

- no behavior, API, or release artifact changes