### PR TITLE
fix: scrollbar-geometry-anchor-sync

### DIFF
--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -4074,6 +4074,36 @@ mod tests {
     }
 
     #[test]
+    fn dragging_uses_displayed_thumb_track_when_scrollbar_is_smoothed() {
+        let mut app = make_test_app();
+        app.rendered_chat_area = Rect::new(0, 0, 20, 10);
+        app.viewport.height_prefix_sums = vec![30];
+        app.viewport.scrollbar_thumb_top = 2.0;
+        app.viewport.scrollbar_thumb_size = 6.0;
+
+        handle_terminal_event(
+            &mut app,
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(crossterm::event::MouseButton::Left),
+                column: 19,
+                row: 7,
+                modifiers: KeyModifiers::NONE,
+            }),
+        );
+        handle_terminal_event(
+            &mut app,
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Drag(crossterm::event::MouseButton::Left),
+                column: 19,
+                row: 9,
+                modifiers: KeyModifiers::NONE,
+            }),
+        );
+
+        assert_eq!(app.viewport.scroll_target, 20);
+    }
+
+    #[test]
     fn mention_owner_overrides_todo_focus_then_releases_back() {
         let mut app = make_test_app();
         app.todos.push(TodoItem {

--- a/src/app/events/mouse.rs
+++ b/src/app/events/mouse.rs
@@ -3,11 +3,10 @@
 
 use super::super::selection::clear_selection;
 use super::super::state::ScrollbarDragState;
-use super::super::{App, SelectionKind, SelectionPoint};
+use super::super::{App, ScrollbarGeometry, SelectionKind, SelectionPoint};
 use crossterm::event::{MouseEvent, MouseEventKind};
 
 pub(super) const MOUSE_SCROLL_LINES: usize = 3;
-const SCROLLBAR_MIN_THUMB_HEIGHT: usize = 1;
 
 struct MouseSelectionPoint {
     kind: SelectionKind,
@@ -69,9 +68,7 @@ pub(super) fn handle_mouse_event(app: &mut App, mouse: MouseEvent) {
 #[derive(Clone, Copy)]
 pub(super) struct ScrollbarMetrics {
     pub viewport_height: usize,
-    pub max_scroll: usize,
-    pub thumb_size: usize,
-    pub track_space: usize,
+    pub target: ScrollbarGeometry,
 }
 
 fn start_scrollbar_drag(app: &mut App, mouse: MouseEvent) -> bool {
@@ -85,7 +82,9 @@ fn start_scrollbar_drag(app: &mut App, mouse: MouseEvent) -> bool {
         return false;
     };
 
-    let (thumb_top, thumb_size) = current_thumb_geometry(app, metrics);
+    let geometry = current_thumb_geometry(app, metrics);
+    let thumb_top = geometry.thumb_top;
+    let thumb_size = geometry.thumb_size;
     let thumb_end = thumb_top.saturating_add(thumb_size);
     let grab_offset = if (thumb_top..thumb_end).contains(&local_row) {
         local_row.saturating_sub(thumb_top)
@@ -93,8 +92,17 @@ fn start_scrollbar_drag(app: &mut App, mouse: MouseEvent) -> bool {
         thumb_size / 2
     };
 
-    set_scroll_from_thumb_top(app, local_row.saturating_sub(grab_offset), metrics);
-    app.scrollbar_drag = Some(ScrollbarDragState { thumb_grab_offset: grab_offset });
+    set_scroll_from_thumb_top(
+        app,
+        local_row.saturating_sub(grab_offset),
+        geometry.track_space,
+        geometry.max_scroll,
+    );
+    app.scrollbar_drag = Some(ScrollbarDragState {
+        thumb_grab_offset: grab_offset,
+        track_space: geometry.track_space,
+        max_scroll: geometry.max_scroll,
+    });
     clear_selection(app);
     true
 }
@@ -103,15 +111,20 @@ fn update_scrollbar_drag(app: &mut App, mouse: MouseEvent) -> bool {
     let Some(drag) = app.scrollbar_drag else {
         return false;
     };
-    let Some(metrics) = scrollbar_metrics(app) else {
+    if scrollbar_metrics(app).is_none() {
         app.scrollbar_drag = None;
         return false;
-    };
+    }
     let Some(local_row) = mouse_row_on_chat_track(app, mouse) else {
         return false;
     };
 
-    set_scroll_from_thumb_top(app, local_row.saturating_sub(drag.thumb_grab_offset), metrics);
+    set_scroll_from_thumb_top(
+        app,
+        local_row.saturating_sub(drag.thumb_grab_offset),
+        drag.track_space,
+        drag.max_scroll,
+    );
     true
 }
 
@@ -123,44 +136,45 @@ fn scrollbar_metrics(app: &App) -> Option<ScrollbarMetrics> {
 
     let viewport_height = area.height as usize;
     let content_height = app.viewport.total_message_height();
-    if content_height <= viewport_height {
-        return None;
-    }
-
-    let max_scroll = content_height.saturating_sub(viewport_height);
-    let thumb_size = viewport_height
-        .saturating_mul(viewport_height)
-        .checked_div(content_height)
-        .unwrap_or(0)
-        .max(SCROLLBAR_MIN_THUMB_HEIGHT)
-        .min(viewport_height);
-    let track_space = viewport_height.saturating_sub(thumb_size);
-
-    Some(ScrollbarMetrics { viewport_height, max_scroll, thumb_size, track_space })
+    let target = crate::app::compute_scrollbar_geometry(
+        content_height,
+        viewport_height,
+        app.viewport.scroll_pos,
+    )?;
+    Some(ScrollbarMetrics { viewport_height, target })
 }
 
 #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss, clippy::cast_sign_loss)]
-fn current_thumb_geometry(app: &App, metrics: ScrollbarMetrics) -> (usize, usize) {
+fn current_thumb_geometry(app: &App, metrics: ScrollbarMetrics) -> ScrollbarGeometry {
     let mut thumb_size = app.viewport.scrollbar_thumb_size.round() as usize;
     if thumb_size == 0 {
-        thumb_size = metrics.thumb_size;
+        thumb_size = metrics.target.thumb_size;
     }
-    thumb_size = thumb_size.max(SCROLLBAR_MIN_THUMB_HEIGHT).min(metrics.viewport_height);
+    thumb_size = thumb_size.max(1).min(metrics.viewport_height);
     let max_top = metrics.viewport_height.saturating_sub(thumb_size);
     let thumb_top = app.viewport.scrollbar_thumb_top.round().clamp(0.0, max_top as f32) as usize;
-    (thumb_top, thumb_size)
+    ScrollbarGeometry {
+        thumb_top,
+        thumb_size,
+        track_space: metrics.viewport_height.saturating_sub(thumb_size),
+        max_scroll: metrics.target.max_scroll,
+    }
 }
 
 #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss, clippy::cast_sign_loss)]
-fn set_scroll_from_thumb_top(app: &mut App, thumb_top: usize, metrics: ScrollbarMetrics) {
-    let thumb_top = thumb_top.min(metrics.track_space);
-    let target = if metrics.track_space == 0 {
+fn set_scroll_from_thumb_top(
+    app: &mut App,
+    thumb_top: usize,
+    track_space: usize,
+    max_scroll: usize,
+) {
+    let thumb_top = thumb_top.min(track_space);
+    let target = if track_space == 0 {
         0
     } else {
-        ((thumb_top as f32 / metrics.track_space as f32) * metrics.max_scroll as f32).round()
-            as usize
+        ((thumb_top as f32 / track_space as f32) * max_scroll as f32).round() as usize
     }
-    .min(metrics.max_scroll);
+    .min(max_scroll);
 
     app.viewport.auto_scroll = false;
     app.viewport.scroll_target = target;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -57,11 +57,12 @@ pub use state::{
     MessageBlock, MessageBlockRenderSignature, MessageRenderCache, MessageRenderCacheKey,
     MessageRenderSignature, MessageRole, MessageUsage, ModeInfo, ModeState, NoticeBlock,
     NoticeDedupKey, NoticeStage, PasteSessionState, PendingCommandAck, RateLimitIncidentKey,
-    RecentSessionInfo, SelectionKind, SelectionPoint, SelectionState, SessionPickerState,
-    SessionUsageState, SystemSeverity, TerminalSnapshotMode, TextBlock, TextBlockSpacing, TodoItem,
-    TodoStatus, ToolCallInfo, ToolCallScope, TurnNoticeLocation, TurnNoticeRef, UsageSnapshot,
-    UsageSourceKind, UsageSourceMode, UsageState, UsageWindow, WelcomeBlock,
-    hash_text_block_content, hash_welcome_block_content, is_execute_tool_name,
+    RecentSessionInfo, ScrollbarGeometry, SelectionKind, SelectionPoint, SelectionState,
+    SessionPickerState, SessionUsageState, SystemSeverity, TerminalSnapshotMode, TextBlock,
+    TextBlockSpacing, TodoItem, TodoStatus, ToolCallInfo, ToolCallScope, TurnNoticeLocation,
+    TurnNoticeRef, UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow,
+    WelcomeBlock, compute_scrollbar_geometry, hash_text_block_content, hash_welcome_block_content,
+    is_execute_tool_name,
 };
 pub use trust::TrustSelection;
 pub use update_check::start_update_check;

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -33,7 +33,7 @@ pub use types::{
 };
 pub use viewport::{
     ChatViewport, LayoutInvalidation, LayoutInvalidation as InvalidationLevel,
-    LayoutRemeasureReason,
+    LayoutRemeasureReason, ScrollbarGeometry, compute_scrollbar_geometry,
 };
 
 use crate::agent::events::ClientEvent;
@@ -2748,6 +2748,39 @@ mod tests {
         assert_eq!(vp.remeasure_reason(), Some(LayoutRemeasureReason::MessagesFrom));
         assert_eq!(vp.resize_scroll_anchor(), Some(resize_anchor));
         assert_eq!(vp.scroll_anchor_to_restore(), Some(resize_anchor));
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    #[test]
+    fn viewport_message_change_preserves_manual_anchor() {
+        let mut vp = ChatViewport::new();
+        let _ = vp.on_frame(80, 24);
+        vp.sync_message_count(4);
+        for idx in 0..4 {
+            vp.set_message_height(idx, 5);
+        }
+        vp.mark_heights_valid();
+        vp.rebuild_prefix_sums();
+
+        vp.auto_scroll = false;
+        vp.scroll_offset = 7;
+        vp.scroll_target = 7;
+        vp.scroll_pos = 7.0;
+
+        vp.invalidate_message(0);
+
+        let anchor =
+            vp.scroll_anchor_to_restore().expect("manual scroll should preserve an anchor");
+        assert_eq!(anchor, (1, 2));
+
+        vp.set_message_height(0, 12);
+        vp.mark_message_height_measured(0);
+        vp.rebuild_prefix_sums();
+        assert_eq!(vp.ready_scroll_anchor_to_restore(), Some(anchor));
+
+        vp.restore_scroll_anchor(anchor.0, anchor.1);
+        assert_eq!(vp.scroll_offset, 14);
+        assert_eq!(vp.find_first_visible(vp.scroll_offset), 1);
     }
 
     #[allow(clippy::cast_precision_loss)]

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -259,6 +259,10 @@ pub struct SelectionState {
 pub struct ScrollbarDragState {
     /// Row offset from thumb top where the initial click happened.
     pub thumb_grab_offset: usize,
+    /// Visible track length used when the drag started.
+    pub track_space: usize,
+    /// Maximum scrollable row offset when the drag started.
+    pub max_scroll: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/app/state/viewport.rs
+++ b/src/app/state/viewport.rs
@@ -43,6 +43,48 @@ impl FrameGeometryChange {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScrollbarGeometry {
+    pub thumb_top: usize,
+    pub thumb_size: usize,
+    pub track_space: usize,
+    pub max_scroll: usize,
+}
+
+impl ScrollbarGeometry {
+    #[must_use]
+    pub fn viewport_height(self) -> usize {
+        self.thumb_size.saturating_add(self.track_space)
+    }
+}
+
+#[must_use]
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub fn compute_scrollbar_geometry(
+    content_height: usize,
+    viewport_height: usize,
+    scroll_pos: f32,
+) -> Option<ScrollbarGeometry> {
+    if viewport_height == 0 || content_height <= viewport_height {
+        return None;
+    }
+    let max_scroll = content_height.saturating_sub(viewport_height);
+    let thumb_size = viewport_height
+        .saturating_mul(viewport_height)
+        .checked_div(content_height)
+        .unwrap_or(0)
+        .max(1)
+        .min(viewport_height);
+    let track_space = viewport_height.saturating_sub(thumb_size);
+    let thumb_top = if max_scroll == 0 || track_space == 0 {
+        0
+    } else {
+        ((scroll_pos.clamp(0.0, max_scroll as f32) / max_scroll as f32) * track_space as f32)
+            .round() as usize
+    };
+    Some(ScrollbarGeometry { thumb_top, thumb_size, track_space, max_scroll })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PreservedScrollAnchor {
     reason: LayoutRemeasureReason,
     index: usize,
@@ -450,12 +492,15 @@ impl ChatViewport {
             return;
         }
         let (anchor_index, anchor_offset) = self.current_scroll_anchor();
-        let preserved_scroll_anchor =
-            if matches!(reason, LayoutRemeasureReason::Resize | LayoutRemeasureReason::Global) {
-                Some(PreservedScrollAnchor { reason, index: anchor_index, offset: anchor_offset })
-            } else {
-                self.remeasure_plan.and_then(|plan| plan.preserved_scroll_anchor)
-            };
+        let preserved_scroll_anchor = if self.auto_scroll {
+            self.remeasure_plan.and_then(|plan| plan.preserved_scroll_anchor)
+        } else if let Some(anchor) =
+            self.remeasure_plan.and_then(|plan| plan.preserved_scroll_anchor)
+        {
+            Some(anchor)
+        } else {
+            Some(PreservedScrollAnchor { reason, index: anchor_index, offset: anchor_offset })
+        };
         self.remeasure_plan = Some(LayoutRemeasurePlan::from_scroll_anchor(
             reason,
             anchor_index,
@@ -538,8 +583,10 @@ impl ChatViewport {
     /// Resume outward remeasurement from the current visible anchor.
     pub fn next_remeasure_index(&mut self, message_count: usize) -> Option<usize> {
         let prioritize_above_for_anchor = self.remeasure_plan.is_some_and(|plan| {
-            plan.preserved_scroll_anchor
-                .is_some_and(|anchor| !self.prefix_is_exact_through(anchor.index))
+            matches!(plan.reason, LayoutRemeasureReason::Resize) && plan.next_above.is_some()
+                || plan
+                    .preserved_scroll_anchor
+                    .is_some_and(|anchor| !self.prefix_is_exact_through(anchor.index))
         });
         let plan = self.remeasure_plan.as_mut()?;
         let choose_above = match (plan.next_above, plan.next_below < message_count) {

--- a/src/app/view/tests.rs
+++ b/src/app/view/tests.rs
@@ -18,7 +18,8 @@ fn busy_view_test_app() -> App {
         end: SelectionPoint { row: 0, col: 4 },
         dragging: true,
     });
-    app.scrollbar_drag = Some(ScrollbarDragState { thumb_grab_offset: 1 });
+    app.scrollbar_drag =
+        Some(ScrollbarDragState { thumb_grab_offset: 1, track_space: 4, max_scroll: 12 });
     app.pending_submit = Some(app.input.snapshot());
     app.pending_paste_text = "blocked".to_owned();
     app.pending_paste_session = Some(PasteSessionState {

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::app::cache_metrics;
-use crate::app::{App, AppStatus, MessageBlock, MessageRole, SelectionKind, SelectionState};
+use crate::app::{
+    App, AppStatus, MessageBlock, MessageRole, ScrollbarGeometry, SelectionKind, SelectionState,
+};
 use crate::ui::message::{self, SpinnerState};
 use crate::ui::theme;
 use ratatui::Frame;
@@ -63,12 +65,6 @@ struct CulledRenderStats {
     rendered_msgs: usize,
     last_rendered_idx: Option<usize>,
     rendered_line_count: usize,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct ScrollbarGeometry {
-    thumb_top: usize,
-    thumb_size: usize,
 }
 
 struct ScrolledRenderData {
@@ -526,34 +522,6 @@ fn clamp_scroll_to_content(
     }
 }
 
-/// Compute overlay scrollbar geometry for a single-column track.
-///
-/// Returns None when content fits in the viewport.
-#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-fn compute_scrollbar_geometry(
-    content_height: usize,
-    viewport_height: usize,
-    scroll_pos: f32,
-) -> Option<ScrollbarGeometry> {
-    if viewport_height == 0 || content_height <= viewport_height {
-        return None;
-    }
-    let max_scroll = content_height.saturating_sub(viewport_height) as f32;
-    let thumb_size = viewport_height
-        .saturating_mul(viewport_height)
-        .checked_div(content_height)
-        .unwrap_or(0)
-        .max(SCROLLBAR_MIN_THUMB_HEIGHT)
-        .min(viewport_height);
-    let track_space = viewport_height.saturating_sub(thumb_size) as f32;
-    let thumb_top = if max_scroll <= f32::EPSILON || track_space <= 0.0 {
-        0
-    } else {
-        ((scroll_pos.clamp(0.0, max_scroll) / max_scroll) * track_space).round() as usize
-    };
-    Some(ScrollbarGeometry { thumb_top, thumb_size })
-}
-
 fn ease_value(current: &mut f32, target: f32, factor: f32) {
     let delta = target - *current;
     if delta.abs() < SCROLLBAR_EASE_EPSILON {
@@ -586,7 +554,12 @@ fn smooth_scrollbar_geometry(
     let max_top = viewport_height.saturating_sub(thumb_size);
     let thumb_top = viewport.scrollbar_thumb_top.round().clamp(0.0, max_top as f32) as usize;
 
-    ScrollbarGeometry { thumb_top, thumb_size }
+    ScrollbarGeometry {
+        thumb_top,
+        thumb_size,
+        track_space: viewport_height.saturating_sub(thumb_size),
+        max_scroll: target.max_scroll,
+    }
 }
 #[allow(clippy::cast_possible_truncation)]
 fn render_scrollbar_overlay(
@@ -597,9 +570,11 @@ fn render_scrollbar_overlay(
     content_height: usize,
     viewport_height: usize,
 ) {
-    let Some(target) =
-        compute_scrollbar_geometry(content_height, viewport_height, viewport.scroll_pos)
-    else {
+    let Some(target) = crate::app::compute_scrollbar_geometry(
+        content_height,
+        viewport_height,
+        viewport.scroll_pos,
+    ) else {
         viewport.scrollbar_thumb_top = 0.0;
         viewport.scrollbar_thumb_size = 0.0;
         return;
@@ -952,14 +927,14 @@ fn render_lines_from_paragraph(
 #[cfg(test)]
 mod tests {
     use super::{
-        SCROLLBAR_MIN_THUMB_HEIGHT, ScrollbarGeometry, clamp_scroll_to_content,
-        compute_scrollbar_geometry, paragraph_scroll_offset, render_culled_messages,
-        render_lines_from_paragraph, render_scrolled, smooth_scrollbar_geometry,
-        sync_active_turn_height_state, update_visual_heights,
+        SCROLLBAR_MIN_THUMB_HEIGHT, clamp_scroll_to_content, paragraph_scroll_offset,
+        render_culled_messages, render_lines_from_paragraph, render_scrolled,
+        smooth_scrollbar_geometry, sync_active_turn_height_state, update_visual_heights,
     };
     use crate::app::{
         App, AppStatus, ChatMessage, ChatViewport, InvalidationLevel, MessageBlock, MessageRole,
-        SelectionKind, SelectionPoint, SelectionState, SystemSeverity, TextBlock,
+        ScrollbarGeometry, SelectionKind, SelectionPoint, SelectionState, SystemSeverity,
+        TextBlock, compute_scrollbar_geometry,
     };
     use crate::ui::message::{self, SpinnerState};
     use ratatui::Terminal;
@@ -1076,36 +1051,41 @@ mod tests {
     fn scrollbar_thumb_positions_are_stable() {
         assert_eq!(
             compute_scrollbar_geometry(50, 10, 0.0),
-            Some(ScrollbarGeometry { thumb_top: 0, thumb_size: 2 })
+            Some(ScrollbarGeometry { thumb_top: 0, thumb_size: 2, track_space: 8, max_scroll: 40 })
         );
         assert_eq!(
             compute_scrollbar_geometry(50, 10, 20.0),
-            Some(ScrollbarGeometry { thumb_top: 4, thumb_size: 2 })
+            Some(ScrollbarGeometry { thumb_top: 4, thumb_size: 2, track_space: 8, max_scroll: 40 })
         );
         assert_eq!(
             compute_scrollbar_geometry(50, 10, 40.0),
-            Some(ScrollbarGeometry { thumb_top: 8, thumb_size: 2 })
+            Some(ScrollbarGeometry { thumb_top: 8, thumb_size: 2, track_space: 8, max_scroll: 40 })
         );
     }
     #[test]
     fn scrollbar_scroll_offset_is_clamped() {
         assert_eq!(
             compute_scrollbar_geometry(50, 10, 999.0),
-            Some(ScrollbarGeometry { thumb_top: 8, thumb_size: 2 })
+            Some(ScrollbarGeometry { thumb_top: 8, thumb_size: 2, track_space: 8, max_scroll: 40 })
         );
     }
     #[test]
     fn scrollbar_handles_small_overflow() {
         assert_eq!(
             compute_scrollbar_geometry(11, 10, 1.0),
-            Some(ScrollbarGeometry { thumb_top: 1, thumb_size: 9 })
+            Some(ScrollbarGeometry { thumb_top: 1, thumb_size: 9, track_space: 1, max_scroll: 1 })
         );
     }
     #[test]
     fn scrollbar_respects_min_thumb_height() {
         assert_eq!(
             compute_scrollbar_geometry(10_000, 10, 0.0),
-            Some(ScrollbarGeometry { thumb_top: 0, thumb_size: SCROLLBAR_MIN_THUMB_HEIGHT })
+            Some(ScrollbarGeometry {
+                thumb_top: 0,
+                thumb_size: SCROLLBAR_MIN_THUMB_HEIGHT,
+                track_space: 9,
+                max_scroll: 9_990,
+            })
         );
     }
 
@@ -1620,12 +1600,15 @@ mod tests {
 
         let geometry = smooth_scrollbar_geometry(
             &mut viewport,
-            ScrollbarGeometry { thumb_top: 9, thumb_size: 5 },
+            ScrollbarGeometry { thumb_top: 9, thumb_size: 5, track_space: 15, max_scroll: 40 },
             20,
             true,
         );
 
-        assert_eq!(geometry, ScrollbarGeometry { thumb_top: 9, thumb_size: 5 });
+        assert_eq!(
+            geometry,
+            ScrollbarGeometry { thumb_top: 9, thumb_size: 5, track_space: 15, max_scroll: 40 }
+        );
         assert!((viewport.scrollbar_thumb_top - 9.0).abs() < f32::EPSILON);
         assert!((viewport.scrollbar_thumb_size - 5.0).abs() < f32::EPSILON);
     }

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -114,20 +114,8 @@ fn assistant_role_label_line() -> Line<'static> {
     Line::from(spans)
 }
 
-/// Render a single chat message into a `Vec<Line>`, using per-block caches.
-/// Takes `&mut` so block caches can be updated.
-/// `spinner` is only used for the "Thinking..." animation on empty assistant messages.
-#[allow(dead_code)]
-pub fn render_message(
-    msg: &mut ChatMessage,
-    spinner: &SpinnerState,
-    width: u16,
-    out: &mut Vec<Line<'static>>,
-) {
-    render_message_with_tools_collapsed(msg, spinner, width, false, out);
-}
-
-pub fn render_message_with_tools_collapsed(
+#[cfg(test)]
+pub(crate) fn render_message_with_tools_collapsed(
     msg: &mut ChatMessage,
     spinner: &SpinnerState,
     width: u16,
@@ -137,8 +125,8 @@ pub fn render_message_with_tools_collapsed(
     render_message_internal(msg, spinner, width, 0, tools_collapsed, true, out);
 }
 
-#[allow(dead_code)]
-pub fn render_message_with_tools_collapsed_and_separator(
+#[cfg(test)]
+pub(crate) fn render_message_with_tools_collapsed_and_separator(
     msg: &mut ChatMessage,
     spinner: &SpinnerState,
     width: u16,
@@ -538,8 +526,8 @@ pub fn measure_message_height_cached_with_tools_collapsed_and_separator(
 /// (label/separators/full blocks) without rendering them. If skipping lands inside
 /// a block, that block is rendered in full and the remaining skip is returned so
 /// the caller can apply `Paragraph::scroll()` for exact intra-block offset.
-#[allow(dead_code)]
-pub fn render_message_from_offset(
+#[cfg(test)]
+pub(crate) fn render_message_from_offset(
     msg: &mut ChatMessage,
     spinner: &SpinnerState,
     width: u16,
@@ -558,7 +546,8 @@ pub fn render_message_from_offset(
     )
 }
 
-pub fn render_message_from_offset_with_tools_collapsed(
+#[cfg(test)]
+pub(crate) fn render_message_from_offset_with_tools_collapsed(
     msg: &mut ChatMessage,
     spinner: &SpinnerState,
     width: u16,
@@ -1511,7 +1500,7 @@ mod tests {
 
     fn ground_truth_height(msg: &mut ChatMessage, spinner: &SpinnerState, width: u16) -> usize {
         let mut lines = Vec::new();
-        render_message(msg, spinner, width, &mut lines);
+        render_message_with_tools_collapsed(msg, spinner, width, false, &mut lines);
         Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false }).line_count(width)
     }
 
@@ -1574,7 +1563,7 @@ mod tests {
         let spinner = idle_spinner();
         let mut msg = make_assistant_split_message("First paragraph", "Second paragraph");
         let mut lines = Vec::new();
-        render_message(&mut msg, &spinner, 80, &mut lines);
+        render_message_with_tools_collapsed(&mut msg, &spinner, 80, false, &mut lines);
 
         assert_eq!(
             render_lines_to_strings(&lines),
@@ -1593,7 +1582,7 @@ mod tests {
         let spinner = idle_spinner();
         let mut msg = make_assistant_notice_message();
         let mut lines = Vec::new();
-        render_message(&mut msg, &spinner, 80, &mut lines);
+        render_message_with_tools_collapsed(&mut msg, &spinner, 80, false, &mut lines);
 
         assert_eq!(
             render_lines_to_strings(&lines),
@@ -1612,7 +1601,7 @@ mod tests {
         let spinner = idle_spinner();
         let mut msg = make_assistant_notice_message();
         let mut lines = Vec::new();
-        render_message(&mut msg, &spinner, 80, &mut lines);
+        render_message_with_tools_collapsed(&mut msg, &spinner, 80, false, &mut lines);
 
         let notice_line = lines
             .iter()
@@ -1905,7 +1894,7 @@ mod tests {
             "Rate limit warning",
         );
         let mut lines = Vec::new();
-        render_message(&mut msg, &spinner, 120, &mut lines);
+        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
         let rendered = render_lines_to_strings(&lines);
 
         assert!(rendered.iter().any(|line| line.contains("Warning")));
@@ -1927,7 +1916,7 @@ mod tests {
         );
 
         let mut lines = Vec::new();
-        render_message(&mut msg, &spinner, 120, &mut lines);
+        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
         let rendered = render_lines_to_strings(&lines);
 
         assert!(rendered.iter().any(|line| line.contains("Thinking...")));
@@ -1939,7 +1928,7 @@ mod tests {
         let mut msg = make_text_message(MessageRole::Assistant, "\n# Heading\nBody");
 
         let mut lines = Vec::new();
-        render_message(&mut msg, &spinner, 80, &mut lines);
+        render_message_with_tools_collapsed(&mut msg, &spinner, 80, false, &mut lines);
         let rendered = render_lines_to_strings(&lines);
 
         assert_eq!(rendered[0], "Claude");
@@ -1997,7 +1986,7 @@ mod tests {
         );
 
         let mut lines = Vec::new();
-        render_message(&mut msg, &spinner, 120, &mut lines);
+        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
         let rendered = render_lines_to_strings(&lines);
 
         assert!(!rendered.iter().any(|line| line.contains("Thinking...")));
@@ -2026,7 +2015,7 @@ mod tests {
         );
 
         let mut lines = Vec::new();
-        render_message(&mut msg, &spinner, 120, &mut lines);
+        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
         let rendered = render_lines_to_strings(&lines);
 
         let bash_idx = rendered.iter().position(|line| line.contains("Bash")).expect("bash line");
@@ -2048,7 +2037,7 @@ mod tests {
         let mut msg = make_text_message(MessageRole::Assistant, "done");
 
         let mut lines = Vec::new();
-        render_message(&mut msg, &spinner, 120, &mut lines);
+        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
         let rendered = render_lines_to_strings(&lines);
 
         assert!(!rendered.iter().any(|line| line.contains("Thinking...")));
@@ -2065,7 +2054,7 @@ mod tests {
         let mut msg = make_text_message(MessageRole::Assistant, "done");
 
         let mut lines = Vec::new();
-        render_message(&mut msg, &spinner, 120, &mut lines);
+        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
         let rendered = render_lines_to_strings(&lines);
 
         assert!(rendered.iter().any(|line| line.contains("Compacting context...")));

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -592,6 +592,7 @@ pub(crate) fn render_message_from_offset_internal(
     let mut can_consume_skip = true;
     render_cached_message_from_offset(
         cache.segments(),
+        width,
         out,
         &mut remaining_skip,
         &mut can_consume_skip,
@@ -601,6 +602,7 @@ pub(crate) fn render_message_from_offset_internal(
 
 fn render_cached_message_from_offset(
     segments: &[CachedMessageSegment],
+    width: u16,
     out: &mut Vec<Line<'static>>,
     remaining_skip: &mut usize,
     can_consume_skip: &mut bool,
@@ -618,8 +620,44 @@ fn render_cached_message_from_offset(
                 if should_skip_whole_block(*height, remaining_skip, can_consume_skip) {
                     continue;
                 }
-                out.extend(lines.iter().cloned());
+                render_cached_lines_from_offset(
+                    lines,
+                    width,
+                    out,
+                    remaining_skip,
+                    can_consume_skip,
+                );
             }
+        }
+    }
+}
+
+fn render_cached_lines_from_offset(
+    lines: &[Line<'static>],
+    width: u16,
+    out: &mut Vec<Line<'static>>,
+    remaining_skip: &mut usize,
+    can_consume_skip: &mut bool,
+) {
+    if !*can_consume_skip || *remaining_skip == 0 {
+        out.extend(lines.iter().cloned());
+        return;
+    }
+
+    for line in lines {
+        let logical_lines = split_line_on_newlines(line);
+        for logical_line in logical_lines {
+            if !*can_consume_skip {
+                out.push(logical_line);
+                continue;
+            }
+            let line_height = rendered_line_height(&logical_line, width);
+            if *remaining_skip >= line_height {
+                *remaining_skip -= line_height;
+                continue;
+            }
+            *can_consume_skip = false;
+            out.push(logical_line);
         }
     }
 }
@@ -753,6 +791,36 @@ fn rendered_lines_height(lines: &[Line<'static>], width: u16) -> usize {
         return 0;
     }
     Paragraph::new(Text::from(lines.to_vec())).wrap(Wrap { trim: false }).line_count(width)
+}
+
+fn rendered_line_height(line: &Line<'static>, width: u16) -> usize {
+    Paragraph::new(Text::from(vec![line.clone()]))
+        .wrap(Wrap { trim: false })
+        .line_count(width)
+        .max(1)
+}
+
+fn split_line_on_newlines(line: &Line<'static>) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    let mut current_spans = Vec::new();
+
+    for span in &line.spans {
+        for chunk in span.content.as_ref().split_inclusive('\n') {
+            let ends_with_newline = chunk.ends_with('\n');
+            let content = chunk.strip_suffix('\n').unwrap_or(chunk);
+            if !content.is_empty() {
+                let mut next_span = span.clone();
+                next_span.content = content.to_owned().into();
+                current_spans.push(next_span);
+            }
+            if ends_with_newline {
+                lines.push(Line::from(std::mem::take(&mut current_spans)));
+            }
+        }
+    }
+
+    lines.push(Line::from(current_spans));
+    lines
 }
 
 fn welcome_block_layout(block: &mut WelcomeBlock, width: u16) -> RenderedBlockLayout {
@@ -1787,6 +1855,35 @@ mod tests {
 
         assert!(out.is_empty());
         assert_eq!(rem, 3);
+    }
+
+    #[test]
+    fn render_cached_lines_from_offset_consumes_skip_across_cached_lines() {
+        let skip = usize::from(u16::MAX) + 5;
+        let lines =
+            (0..skip + 3).map(|idx| Line::from(format!("line {idx:05}"))).collect::<Vec<_>>();
+        let mut out = Vec::new();
+        let mut remaining = skip;
+        let mut can_consume_skip = true;
+
+        render_cached_lines_from_offset(
+            &lines,
+            40,
+            &mut out,
+            &mut remaining,
+            &mut can_consume_skip,
+        );
+
+        assert_eq!(remaining, 0);
+        assert!(!can_consume_skip);
+        assert_eq!(
+            render_lines_to_strings(&out),
+            vec![
+                format!("line {skip:05}"),
+                format!("line {:05}", skip + 1),
+                format!("line {:05}", skip + 2),
+            ]
+        );
     }
 
     #[test]

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -65,16 +65,6 @@ pub fn status_icon(status: model::ToolCallStatus, spinner_frame: usize) -> (&'st
 /// For other tool calls, the title is rendered live and the expanded body is cached
 /// independently, so session collapse preference can change without invalidating
 /// every completed tool-call cache.
-#[allow(dead_code)]
-pub fn render_tool_call_cached(
-    tc: &mut ToolCallInfo,
-    width: u16,
-    spinner_frame: usize,
-    out: &mut Vec<Line<'static>>,
-) {
-    render_tool_call_cached_with_tools_collapsed(tc, width, spinner_frame, false, out);
-}
-
 pub fn render_tool_call_cached_with_tools_collapsed(
     tc: &mut ToolCallInfo,
     width: u16,
@@ -133,22 +123,6 @@ pub fn render_tool_call_cached_with_tools_collapsed(
 
 /// Ensure tool call caches are up-to-date and return visual wrapped height at `width`.
 /// Returns `(height, lines_wrapped_for_measurement)`.
-#[allow(dead_code)]
-pub fn measure_tool_call_height_cached(
-    tc: &mut ToolCallInfo,
-    width: u16,
-    spinner_frame: usize,
-    layout_generation: u64,
-) -> (usize, usize) {
-    measure_tool_call_height_cached_with_tools_collapsed(
-        tc,
-        width,
-        spinner_frame,
-        layout_generation,
-        false,
-    )
-}
-
 pub fn measure_tool_call_height_cached_with_tools_collapsed(
     tc: &mut ToolCallInfo,
     width: u16,
@@ -481,11 +455,13 @@ mod tests {
         tc.terminal_command = Some("echo hi".to_owned());
         tc.terminal_output = Some("hello\nworld".to_owned());
 
-        let (h1, lines1) = measure_tool_call_height_cached(&mut tc, 80, 0, 1);
+        let (h1, lines1) =
+            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 1, false);
         assert!(h1 > 0);
         assert!(lines1 > 0);
 
-        let (h2, lines2) = measure_tool_call_height_cached(&mut tc, 80, 4, 1);
+        let (h2, lines2) =
+            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 4, 1, false);
         assert_eq!(h2, h1);
         assert_eq!(lines2, 0);
     }
@@ -496,9 +472,11 @@ mod tests {
         tc.terminal_command = Some("echo hi".to_owned());
         tc.terminal_output = Some("hello".to_owned());
 
-        let (_, first_lines) = measure_tool_call_height_cached(&mut tc, 80, 0, 1);
+        let (_, first_lines) =
+            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 1, false);
         assert!(first_lines > 0);
-        let (_, second_lines) = measure_tool_call_height_cached(&mut tc, 80, 0, 2);
+        let (_, second_lines) =
+            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 2, false);
         assert!(second_lines > 0);
     }
 
@@ -507,13 +485,16 @@ mod tests {
         let mut tc = test_tool_call("tc-dirty", "Read", model::ToolCallStatus::Completed);
         tc.content = vec![model::ToolCallContent::from("one line")];
 
-        let (_, first_lines) = measure_tool_call_height_cached(&mut tc, 80, 0, 1);
+        let (_, first_lines) =
+            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 1, false);
         assert!(first_lines > 0);
-        let (_, fast_lines) = measure_tool_call_height_cached(&mut tc, 80, 0, 1);
+        let (_, fast_lines) =
+            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 1, false);
         assert_eq!(fast_lines, 0);
 
         tc.mark_tool_call_layout_dirty();
-        let (_, recompute_lines) = measure_tool_call_height_cached(&mut tc, 80, 0, 1);
+        let (_, recompute_lines) =
+            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 1, false);
         assert!(recompute_lines > 0);
     }
 


### PR DESCRIPTION
## Summary

- unify scrollbar geometry so render, smoothing, and drag calculations share the same track math
- preserve manual viewport anchors across message reflow and keep resize remeasurement converging from the visible window outward
- consume large cached line offsets correctly during offset rendering and remove dead-code render helper wrappers and allowances
- add regressions for smoothed thumb dragging, manual anchor preservation, and large cached-line skip handling

## Why

- the scrollbar could desync from rendered content when large wrapped messages pushed local paragraph offsets past the `u16` scroll boundary
- drag interactions could jump because the displayed smoothed thumb geometry and the drag target math were computed from different tracks
- manual scrolling was not anchored when content above the viewport changed height, so reflow could shift the visible message unexpectedly
- dead-code allowances in render helpers weakened the no-dead-code policy and were no longer justified once production callers moved to the direct internal paths

Closes #

## Validation

- Automated:
  - `cargo test --all-features`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo fmt --all -- --check`
  - `rustup run 1.88.0-x86_64-pc-windows-msvc cargo check --all-features`
  - `cargo fetch --locked`
- Manual: Not run
- Screenshot/video (if UI changed): N/A (scroll behavior change only)

## Notes

- Breaking changes: N/A
- Docs updated: N/A
