### PR TITLE
refactor(ui): redesign document tables and help list rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "tracing-subscriber",
  "tui-markdown",
  "tui-textarea-2",
+ "unicode-segmentation",
  "unicode-width",
  "uuid",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "json"] }
 tui-markdown = { version = "0.3.7" }
 tui-textarea-2 = "0.10.2"
+unicode-segmentation = "1.12.0"
 unicode-width = "0.2.2"
 uuid = { version = "1.23.0", features = ["v4"] }
 which = "8.0.2"

--- a/src/ui/document_table.rs
+++ b/src/ui/document_table.rs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::markdown;
+use super::wrap::{
+    StyledChunk, blank_line, display_width, line_display_width, pad_line_to_width,
+    wrap_styled_chunks,
+};
 use pulldown_cmark::{Alignment, Event, Options, Parser, Tag, TagEnd};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ColumnAlignment {
@@ -14,34 +17,26 @@ enum ColumnAlignment {
     Right,
 }
 
-#[derive(Clone, Debug, Default)]
-struct TableRowAst {
-    cells: Vec<TableCellAst>,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TableLayoutMode {
+    Grid,
+    DenseGrid,
+    Stacked,
 }
 
-#[derive(Clone, Debug)]
-struct TableCellAst {
-    chunks: Vec<StyledChunk>,
-    preferred_width: usize,
-    soft_min_width: usize,
+#[derive(Clone, Copy, Debug)]
+struct TableRenderPolicy {
+    preferred_spacing: usize,
+    min_spacing: usize,
+    min_column_width: usize,
+    allow_stacked_fallback: bool,
 }
 
-#[derive(Clone, Debug, Default)]
-struct TableAst {
-    header: TableRowAst,
-    rows: Vec<TableRowAst>,
-    alignments: Vec<ColumnAlignment>,
-}
-
-#[derive(Clone, Debug)]
-struct StyledChunk {
-    text: String,
-    style: Style,
-}
-
-enum MarkdownBlock {
-    Text(String),
-    Table(TableAst),
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ResolvedTableLayout {
+    mode: TableLayoutMode,
+    column_widths: Vec<usize>,
+    spacing: usize,
 }
 
 #[derive(Clone, Copy)]
@@ -50,22 +45,61 @@ struct ColumnMetrics {
     soft_min: usize,
 }
 
-impl TableAst {
+#[derive(Clone, Debug, Default)]
+struct TableRowAst {
+    cells: Vec<TableCellAst>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct TableCellAst {
+    chunks: Vec<StyledChunk>,
+    plain_text: String,
+    preferred_width: usize,
+    soft_min_width: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+struct DocumentTable {
+    header: TableRowAst,
+    rows: Vec<TableRowAst>,
+    alignments: Vec<ColumnAlignment>,
+}
+
+enum MarkdownBlock {
+    Text(String),
+    Table(DocumentTable),
+}
+
+impl DocumentTable {
     fn column_count(&self) -> usize {
         let body_cols = self.rows.iter().map(|row| row.cells.len()).max().unwrap_or(0);
         self.header.cells.len().max(self.alignments.len()).max(body_cols)
+    }
+
+    fn render_lines(&self, width: u16, bg: Option<Color>) -> Vec<Line<'static>> {
+        if self.column_count() == 0 || width == 0 {
+            return Vec::new();
+        }
+
+        let policy = TableRenderPolicy {
+            preferred_spacing: 3,
+            min_spacing: 1,
+            min_column_width: 4,
+            allow_stacked_fallback: true,
+        };
+        let layout = resolve_layout(self, usize::from(width), policy);
+        match layout.mode {
+            TableLayoutMode::Grid | TableLayoutMode::DenseGrid => {
+                render_grid_lines(self, &layout, bg)
+            }
+            TableLayoutMode::Stacked => render_stacked_lines(self, usize::from(width), bg),
+        }
     }
 }
 
 impl TableCellAst {
     fn empty() -> Self {
-        Self { chunks: Vec::new(), preferred_width: 1, soft_min_width: 1 }
-    }
-}
-
-impl Default for TableCellAst {
-    fn default() -> Self {
-        Self::empty()
+        Self::default()
     }
 }
 
@@ -88,7 +122,7 @@ pub fn render_markdown_with_tables(
                 if !out.is_empty() {
                     out.push(Line::default());
                 }
-                out.extend(render_table_lines(&table, width, bg));
+                out.extend(table.render_lines(width, bg));
                 out.push(Line::default());
             }
         }
@@ -134,7 +168,7 @@ fn parse_table_ast<'input, I>(
     alignments: Vec<Alignment>,
     parser: &mut std::iter::Peekable<I>,
     table_end: &mut usize,
-) -> TableAst
+) -> DocumentTable
 where
     I: Iterator<Item = (Event<'input>, std::ops::Range<usize>)>,
 {
@@ -230,7 +264,7 @@ where
         }
     }
 
-    TableAst {
+    DocumentTable {
         header: header.unwrap_or_default(),
         rows,
         alignments: alignments.into_iter().map(ColumnAlignment::from).collect(),
@@ -302,60 +336,93 @@ impl CellBuilder {
 
     fn finish(mut self) -> TableCellAst {
         self.flush_current();
-        let plain: String = self.chunks.iter().map(|chunk| chunk.text.as_str()).collect();
-        let (preferred_width, soft_min_width) = measure_cell_widths(&plain);
+        let plain_text: String = self.chunks.iter().map(|chunk| chunk.text.as_str()).collect();
+        let (preferred_width, soft_min_width) = measure_cell_widths(&plain_text);
         TableCellAst {
             chunks: self.chunks,
+            plain_text,
             preferred_width: preferred_width.max(1),
             soft_min_width: soft_min_width.max(1),
         }
     }
 }
 
+fn resolve_layout(
+    table: &DocumentTable,
+    total_width: usize,
+    policy: TableRenderPolicy,
+) -> ResolvedTableLayout {
+    let cols = table.column_count();
+    if cols == 0 {
+        return ResolvedTableLayout {
+            mode: TableLayoutMode::Stacked,
+            column_widths: Vec::new(),
+            spacing: 0,
+        };
+    }
+
+    let metrics = collect_column_metrics(table, cols);
+    if let Some(layout) = resolve_grid_layout(
+        &metrics,
+        total_width,
+        policy.preferred_spacing,
+        TableLayoutMode::Grid,
+        policy.min_column_width,
+    ) {
+        return layout;
+    }
+    if let Some(layout) = resolve_grid_layout(
+        &metrics,
+        total_width,
+        policy.min_spacing,
+        TableLayoutMode::DenseGrid,
+        policy.min_column_width,
+    ) {
+        return layout;
+    }
+
+    let _ = policy.allow_stacked_fallback;
+    ResolvedTableLayout { mode: TableLayoutMode::Stacked, column_widths: Vec::new(), spacing: 0 }
+}
+
+fn resolve_grid_layout(
+    metrics: &[ColumnMetrics],
+    total_width: usize,
+    spacing: usize,
+    mode: TableLayoutMode,
+    min_column_width: usize,
+) -> Option<ResolvedTableLayout> {
+    if metrics.is_empty() {
+        return Some(ResolvedTableLayout { mode, column_widths: Vec::new(), spacing });
+    }
+
+    let spacing_budget = spacing.saturating_mul(metrics.len().saturating_sub(1));
+    let available = total_width.saturating_sub(spacing_budget);
+    let soft_floor_total: usize =
+        metrics.iter().map(|metric| metric.soft_min.max(min_column_width)).sum();
+    if available < soft_floor_total {
+        return None;
+    }
+    if available < min_column_width.saturating_mul(metrics.len()) {
+        return None;
+    }
+
+    let column_widths = solve_column_widths(metrics, available, min_column_width);
+    Some(ResolvedTableLayout { mode, column_widths, spacing })
+}
+
 fn measure_cell_widths(text: &str) -> (usize, usize) {
-    let preferred = text.lines().map(UnicodeWidthStr::width).max().unwrap_or(0);
+    let preferred = text.lines().map(display_width).max().unwrap_or(0);
     let soft_min = text
         .lines()
         .flat_map(|line| line.split_whitespace())
-        .map(UnicodeWidthStr::width)
+        .map(display_width)
         .max()
         .unwrap_or(preferred);
     (preferred, soft_min)
 }
 
-fn render_table_lines(table: &TableAst, width: u16, bg: Option<Color>) -> Vec<Line<'static>> {
-    let cols = table.column_count();
-    if cols == 0 || width == 0 {
-        return Vec::new();
-    }
-
-    let spacing = 3usize;
-    let available = (width as usize).saturating_sub(spacing.saturating_mul(cols.saturating_sub(1)));
-    if available == 0 {
-        return Vec::new();
-    }
-
-    let metrics = collect_column_metrics(table, cols);
-    let widths = solve_column_widths(&metrics, available);
-
-    let header_style = bg.map_or_else(
-        || Style::default().add_modifier(Modifier::BOLD),
-        |bg_color| Style::default().bg(bg_color).add_modifier(Modifier::BOLD),
-    );
-    let row_style = bg.map_or_else(Style::default, |bg_color| Style::default().bg(bg_color));
-
-    let mut lines =
-        render_row_lines(&table.header, &widths, &table.alignments, header_style, spacing);
-    if !lines.is_empty() {
-        lines.push(render_separator_line(&widths, spacing, row_style));
-    }
-    for row in &table.rows {
-        lines.extend(render_row_lines(row, &widths, &table.alignments, row_style, spacing));
-    }
-    lines
-}
-
-fn collect_column_metrics(table: &TableAst, cols: usize) -> Vec<ColumnMetrics> {
+fn collect_column_metrics(table: &DocumentTable, cols: usize) -> Vec<ColumnMetrics> {
     let mut metrics = vec![ColumnMetrics { preferred: 1, soft_min: 1 }; cols];
     for row in std::iter::once(&table.header).chain(table.rows.iter()) {
         for (idx, cell) in row.cells.iter().enumerate() {
@@ -366,21 +433,26 @@ fn collect_column_metrics(table: &TableAst, cols: usize) -> Vec<ColumnMetrics> {
     metrics
 }
 
-fn solve_column_widths(metrics: &[ColumnMetrics], available: usize) -> Vec<usize> {
+fn solve_column_widths(
+    metrics: &[ColumnMetrics],
+    available: usize,
+    min_column_width: usize,
+) -> Vec<usize> {
     if metrics.is_empty() {
         return Vec::new();
     }
 
-    let mut widths: Vec<usize> = metrics.iter().map(|metric| metric.preferred.max(1)).collect();
+    let mut widths: Vec<usize> =
+        metrics.iter().map(|metric| metric.preferred.max(min_column_width)).collect();
     let soft_floor: Vec<usize> = metrics
         .iter()
         .zip(widths.iter())
-        .map(|(metric, width)| metric.soft_min.clamp(1, *width))
+        .map(|(metric, width)| metric.soft_min.clamp(min_column_width, *width))
         .collect();
 
     reduce_widths(&mut widths, available, &soft_floor);
     if widths.iter().sum::<usize>() > available {
-        let hard_floor = vec![1; widths.len()];
+        let hard_floor = vec![min_column_width; widths.len()];
         reduce_widths(&mut widths, available, &hard_floor);
     }
     widths
@@ -400,6 +472,39 @@ fn reduce_widths(widths: &mut [usize], available: usize, floor: &[usize]) {
     }
 }
 
+fn render_grid_lines(
+    table: &DocumentTable,
+    layout: &ResolvedTableLayout,
+    bg: Option<Color>,
+) -> Vec<Line<'static>> {
+    let header_style = bg.map_or_else(
+        || Style::default().add_modifier(Modifier::BOLD),
+        |bg_color| Style::default().bg(bg_color).add_modifier(Modifier::BOLD),
+    );
+    let row_style = bg.map_or_else(Style::default, |bg_color| Style::default().bg(bg_color));
+
+    let mut lines = render_row_lines(
+        &table.header,
+        &layout.column_widths,
+        &table.alignments,
+        header_style,
+        layout.spacing,
+    );
+    if !lines.is_empty() {
+        lines.push(render_separator_line(&layout.column_widths, layout.spacing, row_style));
+    }
+    for row in &table.rows {
+        lines.extend(render_row_lines(
+            row,
+            &layout.column_widths,
+            &table.alignments,
+            row_style,
+            layout.spacing,
+        ));
+    }
+    lines
+}
+
 fn render_row_lines(
     row: &TableRowAst,
     widths: &[usize],
@@ -412,7 +517,7 @@ fn render_row_lines(
 
     for (idx, width) in widths.iter().copied().enumerate() {
         let alignment = alignments.get(idx).copied().unwrap_or(ColumnAlignment::Left);
-        let cell = row.cells.get(idx).cloned().unwrap_or_default();
+        let cell = row.cells.get(idx).cloned().unwrap_or_else(TableCellAst::empty);
         let rendered = render_cell_lines(&cell, width, alignment, base_style);
         row_height = row_height.max(rendered.len());
         cell_lines.push(rendered);
@@ -420,7 +525,7 @@ fn render_row_lines(
 
     for (idx, width) in widths.iter().copied().enumerate() {
         while cell_lines[idx].len() < row_height {
-            cell_lines[idx].push(blank_cell_line(width, base_style));
+            cell_lines[idx].push(blank_line(width, base_style));
         }
     }
 
@@ -457,207 +562,37 @@ fn render_cell_lines(
     base_style: Style,
 ) -> Vec<Line<'static>> {
     if width == 0 {
-        return Vec::new();
+        return vec![Line::default()];
     }
     if cell.chunks.is_empty() {
-        return vec![blank_cell_line(width, base_style)];
+        return vec![blank_line(width, base_style)];
     }
 
-    let tokens = tokenize_chunks(&cell.chunks, base_style);
-    let mut lines = Vec::new();
-    let mut spans = Vec::new();
-    let mut line_width = 0usize;
-    let mut pending_spaces = Vec::<StyledToken>::new();
-
-    for token in tokens {
-        match token {
-            WrapToken::Newline => {
-                finish_wrapped_line(
-                    &mut lines,
-                    &mut spans,
-                    &mut line_width,
-                    width,
-                    alignment,
-                    base_style,
-                );
-                pending_spaces.clear();
-            }
-            WrapToken::Space(space) => {
-                if line_width > 0 {
-                    pending_spaces.push(space);
-                }
-            }
-            WrapToken::Text(text) => {
-                let pending_width: usize = pending_spaces.iter().map(|space| space.width).sum();
-                if line_width > 0 && line_width + pending_width + text.width > width {
-                    finish_wrapped_line(
-                        &mut lines,
-                        &mut spans,
-                        &mut line_width,
-                        width,
-                        alignment,
-                        base_style,
-                    );
-                    pending_spaces.clear();
-                }
-
-                if line_width > 0 {
-                    for space in pending_spaces.drain(..) {
-                        push_styled_text(&mut spans, &space.text, space.style);
-                        line_width += space.width;
-                    }
-                }
-
-                if text.width <= width.saturating_sub(line_width) {
-                    push_styled_text(&mut spans, &text.text, text.style);
-                    line_width += text.width;
-                    continue;
-                }
-
-                wrap_long_token(
-                    &text,
-                    width,
-                    alignment,
-                    base_style,
-                    &mut lines,
-                    &mut spans,
-                    &mut line_width,
-                );
-            }
-        }
-    }
-
-    finish_wrapped_line(&mut lines, &mut spans, &mut line_width, width, alignment, base_style);
-    if lines.is_empty() {
-        lines.push(blank_cell_line(width, base_style));
-    }
-    lines
+    wrap_styled_chunks(
+        &cell
+            .chunks
+            .iter()
+            .map(|chunk| StyledChunk {
+                text: chunk.text.clone(),
+                style: base_style.patch(chunk.style),
+            })
+            .collect::<Vec<_>>(),
+        width,
+    )
+    .into_iter()
+    .map(|line| align_line_to_width(line, width, alignment, base_style))
+    .collect()
 }
 
-#[derive(Clone)]
-struct StyledToken {
-    text: String,
-    style: Style,
-    width: usize,
-}
-
-enum WrapToken {
-    Text(StyledToken),
-    Space(StyledToken),
-    Newline,
-}
-
-fn tokenize_chunks(chunks: &[StyledChunk], base_style: Style) -> Vec<WrapToken> {
-    let mut tokens = Vec::new();
-    for chunk in chunks {
-        let mut current = String::new();
-        let mut is_space = None;
-        let style = base_style.patch(chunk.style);
-
-        let flush_current = |tokens: &mut Vec<WrapToken>,
-                             current: &mut String,
-                             is_space: &mut Option<bool>,
-                             style: Style| {
-            if current.is_empty() {
-                return;
-            }
-            let text = std::mem::take(current);
-            let width = UnicodeWidthStr::width(text.as_str());
-            let token = StyledToken { text, style, width };
-            if is_space.unwrap_or(false) {
-                tokens.push(WrapToken::Space(token));
-            } else {
-                tokens.push(WrapToken::Text(token));
-            }
-        };
-
-        for ch in chunk.text.chars() {
-            if ch == '\n' {
-                flush_current(&mut tokens, &mut current, &mut is_space, style);
-                is_space = None;
-                tokens.push(WrapToken::Newline);
-                continue;
-            }
-
-            let ch_is_space = ch.is_whitespace();
-            if is_space.is_some_and(|value| value != ch_is_space) {
-                flush_current(&mut tokens, &mut current, &mut is_space, style);
-            }
-
-            is_space = Some(ch_is_space);
-            current.push(ch);
-        }
-
-        flush_current(&mut tokens, &mut current, &mut is_space, style);
-    }
-    tokens
-}
-
-fn wrap_long_token(
-    token: &StyledToken,
+fn align_line_to_width(
+    mut line: Line<'static>,
     width: usize,
     alignment: ColumnAlignment,
     base_style: Style,
-    lines: &mut Vec<Line<'static>>,
-    spans: &mut Vec<Span<'static>>,
-    line_width: &mut usize,
-) {
-    let mut segment = String::new();
-    let mut segment_width = 0usize;
-
-    for ch in token.text.chars() {
-        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if *line_width > 0 && *line_width + segment_width + ch_width > width {
-            if !segment.is_empty() {
-                push_styled_text(spans, &segment, token.style);
-                *line_width += segment_width;
-                segment.clear();
-                segment_width = 0;
-            }
-            finish_wrapped_line(lines, spans, line_width, width, alignment, base_style);
-        }
-
-        if segment_width + ch_width > width && !segment.is_empty() {
-            push_styled_text(spans, &segment, token.style);
-            *line_width += segment_width;
-            segment.clear();
-            segment_width = 0;
-            finish_wrapped_line(lines, spans, line_width, width, alignment, base_style);
-        }
-
-        segment.push(ch);
-        segment_width += ch_width;
-    }
-
-    if !segment.is_empty() {
-        push_styled_text(spans, &segment, token.style);
-        *line_width += segment_width;
-    }
-}
-
-fn finish_wrapped_line(
-    lines: &mut Vec<Line<'static>>,
-    spans: &mut Vec<Span<'static>>,
-    line_width: &mut usize,
-    width: usize,
-    alignment: ColumnAlignment,
-    base_style: Style,
-) {
-    let line =
-        align_spans_to_width(std::mem::take(spans), *line_width, width, alignment, base_style);
-    lines.push(Line::from(line));
-    *line_width = 0;
-}
-
-fn align_spans_to_width(
-    mut spans: Vec<Span<'static>>,
-    content_width: usize,
-    width: usize,
-    alignment: ColumnAlignment,
-    base_style: Style,
-) -> Vec<Span<'static>> {
+) -> Line<'static> {
+    let content_width = line_display_width(&line);
     if content_width >= width {
-        return spans;
+        return line;
     }
 
     let padding = width - content_width;
@@ -668,29 +603,111 @@ fn align_spans_to_width(
     };
 
     if left_pad > 0 {
-        spans.insert(0, Span::styled(" ".repeat(left_pad), base_style));
+        line.spans.insert(0, Span::styled(" ".repeat(left_pad), base_style));
     }
     if right_pad > 0 {
-        spans.push(Span::styled(" ".repeat(right_pad), base_style));
+        line.spans.push(Span::styled(" ".repeat(right_pad), base_style));
     }
-    spans
+    line
 }
 
-fn blank_cell_line(width: usize, style: Style) -> Line<'static> {
-    Line::from(Span::styled(" ".repeat(width), style))
+fn render_stacked_lines(
+    table: &DocumentTable,
+    width: usize,
+    bg: Option<Color>,
+) -> Vec<Line<'static>> {
+    let header_style = bg.map_or_else(
+        || Style::default().add_modifier(Modifier::BOLD),
+        |bg_color| Style::default().bg(bg_color).add_modifier(Modifier::BOLD),
+    );
+    let row_style = bg.map_or_else(Style::default, |bg_color| Style::default().bg(bg_color));
+    let indent = 2usize;
+    let mut lines = Vec::new();
+
+    for (row_idx, row) in table.rows.iter().enumerate() {
+        if row_idx > 0 {
+            lines.push(Line::default());
+        }
+        for col_idx in 0..table.column_count() {
+            let label = table
+                .header
+                .cells
+                .get(col_idx)
+                .map(|cell| cell.plain_text.trim())
+                .filter(|text| !text.is_empty())
+                .map_or_else(|| format!("Column {}", col_idx + 1), str::to_owned);
+            let value = row.cells.get(col_idx).cloned().unwrap_or_else(TableCellAst::empty);
+            lines.extend(render_stacked_pair(
+                &label,
+                &value,
+                width,
+                indent,
+                header_style,
+                row_style,
+            ));
+        }
+    }
+
+    lines
 }
 
-fn push_styled_text(spans: &mut Vec<Span<'static>>, text: &str, style: Style) {
-    if text.is_empty() {
-        return;
+fn render_stacked_pair(
+    label: &str,
+    value: &TableCellAst,
+    width: usize,
+    indent: usize,
+    label_style: Style,
+    value_style: Style,
+) -> Vec<Line<'static>> {
+    if width == 0 {
+        return vec![Line::default()];
     }
-    if let Some(last) = spans.last_mut()
-        && last.style == style
-    {
-        last.content.to_mut().push_str(text);
-        return;
+
+    let inline_prefix = format!("{label}: ");
+    let inline_width = display_width(&inline_prefix);
+    let inline_value_width = width.saturating_sub(inline_width).max(1);
+    let multiline_value_width = width.saturating_sub(indent).max(1);
+    let styled_value = value
+        .chunks
+        .iter()
+        .map(|chunk| StyledChunk {
+            text: chunk.text.clone(),
+            style: value_style.patch(chunk.style),
+        })
+        .collect::<Vec<_>>();
+
+    if inline_value_width >= 8 {
+        let value_lines = if styled_value.is_empty() {
+            vec![Line::default()]
+        } else {
+            wrap_styled_chunks(&styled_value, inline_value_width)
+        };
+        let mut lines = Vec::new();
+        for (idx, value_line) in value_lines.into_iter().enumerate() {
+            let mut line = if idx == 0 {
+                Line::from(vec![Span::styled(inline_prefix.clone(), label_style)])
+            } else {
+                Line::from(Span::styled(" ".repeat(inline_width), label_style))
+            };
+            line.spans.extend(value_line.spans);
+            lines.push(pad_line_to_width(line, width, value_style));
+        }
+        return lines;
     }
-    spans.push(Span::styled(text.to_owned(), style));
+
+    let mut lines = vec![Line::from(Span::styled(format!("{label}:"), label_style))];
+    let indent_prefix = " ".repeat(indent);
+    let value_lines = if styled_value.is_empty() {
+        vec![Line::default()]
+    } else {
+        wrap_styled_chunks(&styled_value, multiline_value_width)
+    };
+    for value_line in value_lines {
+        let mut line = Line::from(Span::styled(indent_prefix.clone(), value_style));
+        line.spans.extend(value_line.spans);
+        lines.push(pad_line_to_width(line, width, value_style));
+    }
+    lines
 }
 
 impl From<Alignment> for ColumnAlignment {
@@ -740,7 +757,7 @@ mod tests {
         assert!(rendered.iter().any(|line| line.contains("Intro")));
         assert!(rendered.iter().any(|line| line.contains("Outro")));
         assert!(rendered.iter().any(|line| line.contains('A')));
-        assert!(rendered.iter().any(|line| line.contains("─")));
+        assert!(rendered.iter().any(|line| line.contains('─')));
     }
 
     #[test]
@@ -785,5 +802,15 @@ mod tests {
         let body = &rendered[2];
         assert!(body.spans.iter().any(|span| span.style.add_modifier.contains(Modifier::BOLD)));
         assert!(body.spans.iter().any(|span| span.style.add_modifier.contains(Modifier::REVERSED)));
+    }
+
+    #[test]
+    fn narrow_tables_fall_back_to_stacked_layout() {
+        let input = "| Name | Description |\n| --- | --- |\n| foo | long wrapped value |\n";
+        let rendered = render_strings(input, 12);
+        assert!(rendered.iter().any(|line| line.contains("Name:")));
+        assert!(rendered.iter().any(|line| line.contains("foo")));
+        assert!(rendered.iter().any(|line| line.contains("Description")));
+        assert!(!rendered.iter().any(|line| line.contains('─')));
     }
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -3,13 +3,13 @@
 
 use crate::app::{App, AppStatus, FocusOwner, HelpView};
 use crate::ui::theme;
+use crate::ui::two_column_list::{self, TwoColumnItem};
+use crate::ui::wrap::{display_width, take_prefix_by_width, truncate_to_width};
 use ratatui::Frame;
-use ratatui::layout::Constraint;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, BorderType, Borders, Cell, Row, Table};
-use unicode_width::UnicodeWidthStr;
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
 
 const COLUMN_GAP: usize = 4;
 /// Content lines available in the help panel (excluding padding and borders).
@@ -80,12 +80,10 @@ fn render_keys_help(frame: &mut Frame, area: Rect, app: &App, items: &[(String, 
     let col_width = (inner_width.saturating_sub(COLUMN_GAP)) / 2;
     let left_width = col_width;
     let right_width = col_width;
-
-    let mut table_rows: Vec<Row<'static>> =
-        Vec::with_capacity(rows + HELP_VERTICAL_PADDING_LINES * 2);
+    let mut lines = Vec::with_capacity(rows + HELP_VERTICAL_PADDING_LINES * 2);
 
     for _ in 0..HELP_VERTICAL_PADDING_LINES {
-        table_rows.push(Row::new(vec![Cell::from(Line::default()), Cell::from(Line::default())]));
+        lines.push(Line::default());
     }
 
     for row in 0..rows {
@@ -97,31 +95,23 @@ fn render_keys_help(frame: &mut Frame, area: Rect, app: &App, items: &[(String, 
 
         let left_lines = format_item_cell_lines(&left, left_width);
         let right_lines = format_item_cell_lines(&right, right_width);
-        let row_height = left_lines.len().max(right_lines.len()).max(1);
-
-        table_rows.push(
-            Row::new(vec![Cell::from(Text::from(left_lines)), Cell::from(Text::from(right_lines))])
-                .height(row_height as u16),
-        );
+        lines.extend(two_column_list::join_column_lines(
+            left_lines,
+            right_lines,
+            left_width,
+            COLUMN_GAP,
+        ));
     }
 
     for _ in 0..HELP_VERTICAL_PADDING_LINES {
-        table_rows.push(Row::new(vec![Cell::from(Line::default()), Cell::from(Line::default())]));
+        lines.push(Line::default());
     }
 
     let block = Block::default()
         .title(help_title(app.help_view))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded);
-
-    let table = Table::new(
-        table_rows,
-        [Constraint::Length(left_width as u16), Constraint::Length(right_width as u16)],
-    )
-    .column_spacing(COLUMN_GAP as u16)
-    .block(block);
-
-    frame.render_widget(table, area);
+    frame.render_widget(Paragraph::new(Text::from(lines)).block(block), area);
 }
 
 #[allow(clippy::cast_possible_truncation)]
@@ -137,64 +127,28 @@ fn render_two_column_help(
 
     let start = app.help_dialog.scroll_offset;
     let end = (start + visible_count).min(items.len());
-    let visible_items = &items[start..end];
     let selected = app.help_dialog.selected;
-
-    // Capacity: items + spacers between items + vertical padding.
-    let mut table_rows: Vec<Row<'static>> = Vec::with_capacity(
+    let visible_items = &items[start..end];
+    let list_items = build_two_column_items(visible_items, selected, start);
+    let mut lines = Vec::with_capacity(
         visible_count + visible_count.saturating_sub(1) + HELP_VERTICAL_PADDING_LINES * 2,
     );
 
     for _ in 0..HELP_VERTICAL_PADDING_LINES {
-        table_rows.push(Row::new(vec![Cell::from(Line::default()), Cell::from(Line::default())]));
+        lines.push(Line::default());
     }
 
-    for (view_index, (name, description)) in visible_items.iter().enumerate() {
-        let abs_index = start + view_index;
-        let is_selected = abs_index == selected;
-
-        let name_style = if is_selected {
-            Style::default().fg(theme::RUST_ORANGE).add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().add_modifier(Modifier::BOLD)
-        };
-        let desc_style =
-            if is_selected { Style::default().fg(theme::RUST_ORANGE) } else { Style::default() };
-
-        let name_lines = wrap_text_lines_styled(name, name_width, name_style);
-        let desc_lines = wrap_text_lines_styled(description, desc_width, desc_style);
-        let row_height = name_lines.len().max(desc_lines.len()).max(1);
-
-        table_rows.push(
-            Row::new(vec![Cell::from(Text::from(name_lines)), Cell::from(Text::from(desc_lines))])
-                .height(row_height as u16),
-        );
-
-        // Spacer row between items for readability.
-        if view_index + 1 < visible_count {
-            table_rows.push(
-                Row::new(vec![Cell::from(Line::default()), Cell::from(Line::default())]).height(1),
-            );
-        }
-    }
+    lines.extend(two_column_list::render_lines(&list_items, name_width, desc_width, COLUMN_GAP, 1));
 
     for _ in 0..HELP_VERTICAL_PADDING_LINES {
-        table_rows.push(Row::new(vec![Cell::from(Line::default()), Cell::from(Line::default())]));
+        lines.push(Line::default());
     }
 
     let block = Block::default()
         .title(help_title(app.help_view))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded);
-
-    let table = Table::new(
-        table_rows,
-        [Constraint::Length(name_width as u16), Constraint::Length(desc_width as u16)],
-    )
-    .column_spacing(COLUMN_GAP as u16)
-    .block(block);
-
-    frame.render_widget(table, area);
+    frame.render_widget(Paragraph::new(Text::from(lines)).block(block), area);
 }
 
 fn visible_count_for_view(app: &App, items: &[(String, String)], panel_width: u16) -> usize {
@@ -207,12 +161,22 @@ fn visible_count_for_view(app: &App, items: &[(String, String)], panel_width: u1
         HelpView::SlashCommands | HelpView::Subagents => {
             let inner_width = panel_width.saturating_sub(2) as usize;
             let (name_width, desc_width) = help_item_column_widths(items, inner_width);
-            compute_visible_count(
-                items,
+            let count_items = items
+                .iter()
+                .map(|(left, right)| TwoColumnItem {
+                    left: left.clone(),
+                    right: right.clone(),
+                    left_style: Style::default().add_modifier(Modifier::BOLD),
+                    right_style: Style::default(),
+                })
+                .collect::<Vec<_>>();
+            two_column_list::visible_item_count(
+                &count_items,
                 app.help_dialog.scroll_offset,
                 MAX_ROWS,
                 name_width,
                 desc_width,
+                1,
             )
         }
     }
@@ -465,62 +429,6 @@ fn build_subagent_help_items(app: &App) -> Vec<(String, String)> {
     rows
 }
 
-/// Count how many terminal lines `text` wraps into at the given column `width`.
-/// Uses the same splitting logic as `take_prefix_by_width` / `wrap_text_lines_styled`.
-fn wrapped_line_count(text: &str, width: usize) -> usize {
-    if width == 0 || text.is_empty() {
-        return 1;
-    }
-    let mut count = 0;
-    for segment in text.split('\n') {
-        if segment.is_empty() {
-            count += 1;
-            continue;
-        }
-        let mut rest = segment.to_owned();
-        while !rest.is_empty() {
-            let (chunk, remaining) = take_prefix_by_width(&rest, width);
-            if chunk.is_empty() {
-                break;
-            }
-            count += 1;
-            rest = remaining;
-        }
-    }
-    count.max(1)
-}
-
-/// Compute how many items (starting from `start`) fit within `available_lines`,
-/// accounting for each item's actual wrapped height and 1-line spacers between items.
-fn compute_visible_count(
-    items: &[(String, String)],
-    start: usize,
-    available_lines: usize,
-    name_width: usize,
-    desc_width: usize,
-) -> usize {
-    let mut used = 0;
-    let mut count = 0;
-
-    for (name, desc) in items.iter().skip(start) {
-        let name_h = wrapped_line_count(name, name_width);
-        let desc_h = wrapped_line_count(desc, desc_width);
-        let item_h = name_h.max(desc_h).max(1);
-
-        // 1-line spacer before every item except the first.
-        let spacer = usize::from(count > 0);
-
-        if used + spacer + item_h > available_lines {
-            break;
-        }
-
-        used += spacer + item_h;
-        count += 1;
-    }
-
-    count.max(1)
-}
-
 fn help_item_column_widths(items: &[(String, String)], inner_width: usize) -> (usize, usize) {
     if inner_width == 0 {
         return (0, 0);
@@ -530,7 +438,7 @@ fn help_item_column_widths(items: &[(String, String)], inner_width: usize) -> (u
     }
 
     let max_name_width =
-        items.iter().map(|(name, _)| UnicodeWidthStr::width(name.as_str())).max().unwrap_or(0);
+        items.iter().map(|(name, _)| display_width(name.as_str())).max().unwrap_or(0);
     let share_cap =
         inner_width.saturating_mul(SUBAGENT_NAME_MAX_SHARE_NUM) / SUBAGENT_NAME_MAX_SHARE_DEN;
     let min_name_width = SUBAGENT_NAME_MIN_WIDTH.min(share_cap.max(1));
@@ -541,32 +449,6 @@ fn help_item_column_widths(items: &[(String, String)], inner_width: usize) -> (u
     let desc_width = inner_width.saturating_sub(name_width + COLUMN_GAP).max(1);
 
     (name_width, desc_width)
-}
-
-fn wrap_text_lines_styled(text: &str, width: usize, style: Style) -> Vec<Line<'static>> {
-    if width == 0 || text.is_empty() {
-        return vec![Line::default()];
-    }
-
-    let mut lines = Vec::new();
-    for segment in text.split('\n') {
-        if segment.is_empty() {
-            lines.push(Line::default());
-            continue;
-        }
-
-        let mut rest = segment.to_owned();
-        while !rest.is_empty() {
-            let (chunk, remaining) = take_prefix_by_width(&rest, width);
-            if chunk.is_empty() {
-                break;
-            }
-            lines.push(Line::from(Span::styled(chunk, style)));
-            rest = remaining;
-        }
-    }
-
-    if lines.is_empty() { vec![Line::default()] } else { lines }
 }
 
 fn help_title(view: HelpView) -> Line<'static> {
@@ -618,9 +500,9 @@ fn format_item_cell_lines(item: &(String, String), width: usize) -> Vec<Line<'st
     }
 
     let label = truncate_to_width(label, width);
-    let label_width = UnicodeWidthStr::width(label.as_str());
+    let label_width = display_width(label.as_str());
     let sep = " : ";
-    let sep_width = UnicodeWidthStr::width(sep);
+    let sep_width = display_width(sep);
 
     if desc.is_empty() {
         return vec![Line::from(Span::styled(
@@ -657,47 +539,35 @@ fn format_item_cell_lines(item: &(String, String), width: usize) -> Vec<Line<'st
     if lines.is_empty() { vec![Line::default()] } else { lines }
 }
 
-fn take_prefix_by_width(text: &str, width: usize) -> (String, String) {
-    if width == 0 || text.is_empty() {
-        return (String::new(), text.to_owned());
-    }
-
-    let mut used = 0usize;
-    let mut split_at = 0usize;
-    for (idx, ch) in text.char_indices() {
-        let w = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
-        if used + w > width {
-            break;
-        }
-        used += w;
-        split_at = idx + ch.len_utf8();
-    }
-
-    if split_at == 0 {
-        return (String::new(), text.to_owned());
-    }
-
-    (text[..split_at].to_owned(), text[split_at..].to_owned())
-}
-
-fn truncate_to_width(text: &str, width: usize) -> String {
-    if width == 0 {
-        return String::new();
-    }
-    if UnicodeWidthStr::width(text) <= width {
-        return text.to_owned();
-    }
-    let mut out = String::new();
-    let mut used = 0usize;
-    for ch in text.chars() {
-        let w = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
-        if used + w > width {
-            break;
-        }
-        out.push(ch);
-        used += w;
-    }
-    out
+fn build_two_column_items(
+    items: &[(String, String)],
+    selected: usize,
+    absolute_start: usize,
+) -> Vec<TwoColumnItem> {
+    items
+        .iter()
+        .enumerate()
+        .map(|(view_index, (name, description))| {
+            let abs_index = absolute_start + view_index;
+            let is_selected = abs_index == selected;
+            let left_style = if is_selected {
+                Style::default().fg(theme::RUST_ORANGE).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().add_modifier(Modifier::BOLD)
+            };
+            let right_style = if is_selected {
+                Style::default().fg(theme::RUST_ORANGE)
+            } else {
+                Style::default()
+            };
+            TwoColumnItem {
+                left: name.clone(),
+                right: description.clone(),
+                left_style,
+                right_style,
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -7,7 +7,6 @@ use crate::app::{
     MessageRenderSignature, MessageRole, SystemSeverity, TextBlock, WelcomeBlock,
     hash_text_block_content, hash_welcome_block_content,
 };
-use crate::ui::tables;
 use crate::ui::theme;
 use crate::ui::tool_call;
 use ratatui::style::{Color, Modifier, Style};
@@ -1072,7 +1071,7 @@ pub(super) fn render_text_cached(
         if preserve_newlines {
             preprocessed = force_markdown_line_breaks(&preprocessed);
         }
-        tables::render_markdown_with_tables(&preprocessed, width, bg)
+        super::document_table::render_markdown_with_tables(&preprocessed, width, bg)
     };
     let render_key = MarkdownRenderKey { width, bg, preserve_newlines };
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,6 +6,7 @@ mod chat;
 mod chat_view;
 mod config;
 mod diff;
+mod document_table;
 mod footer;
 pub(crate) mod help;
 mod highlight;
@@ -14,11 +15,12 @@ mod layout;
 mod markdown;
 mod message;
 mod session_picker;
-mod tables;
 pub mod theme;
 mod todo;
 mod tool_call;
 mod trusted;
+mod two_column_list;
+mod wrap;
 
 pub use message::{SpinnerState, measure_message_height_cached};
 

--- a/src/ui/two_column_list.rs
+++ b/src/ui/two_column_list.rs
@@ -1,0 +1,116 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use super::wrap::{
+    StyledChunk, blank_line, pad_line_to_width, wrap_styled_chunks, wrapped_line_count,
+};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+
+#[derive(Clone, Debug)]
+pub(crate) struct TwoColumnItem {
+    pub left: String,
+    pub right: String,
+    pub left_style: Style,
+    pub right_style: Style,
+}
+
+#[must_use]
+pub(crate) fn visible_item_count(
+    items: &[TwoColumnItem],
+    start: usize,
+    available_lines: usize,
+    left_width: usize,
+    right_width: usize,
+    spacer_rows: usize,
+) -> usize {
+    let mut used = 0usize;
+    let mut count = 0usize;
+
+    for item in items.iter().skip(start) {
+        let item_height = wrapped_item_height(item, left_width, right_width).max(1);
+        let spacer = if count == 0 { 0 } else { spacer_rows };
+        if used + spacer + item_height > available_lines {
+            break;
+        }
+
+        used += spacer + item_height;
+        count += 1;
+    }
+
+    count.max(1)
+}
+
+#[must_use]
+pub(crate) fn wrapped_item_height(
+    item: &TwoColumnItem,
+    left_width: usize,
+    right_width: usize,
+) -> usize {
+    wrapped_line_count(&item.left, left_width)
+        .max(wrapped_line_count(&item.right, right_width))
+        .max(1)
+}
+
+#[must_use]
+pub(crate) fn render_lines(
+    items: &[TwoColumnItem],
+    left_width: usize,
+    right_width: usize,
+    gap: usize,
+    spacer_rows: usize,
+) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+
+    for (idx, item) in items.iter().enumerate() {
+        if idx > 0 {
+            for _ in 0..spacer_rows {
+                lines.push(Line::default());
+            }
+        }
+
+        let left_lines = wrap_styled_chunks(
+            &[StyledChunk { text: item.left.clone(), style: item.left_style }],
+            left_width,
+        );
+        let right_lines = wrap_styled_chunks(
+            &[StyledChunk { text: item.right.clone(), style: item.right_style }],
+            right_width,
+        );
+        lines.extend(join_column_lines(left_lines, right_lines, left_width, gap));
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::default());
+    }
+    lines
+}
+
+#[must_use]
+pub(crate) fn join_column_lines(
+    mut left_lines: Vec<Line<'static>>,
+    mut right_lines: Vec<Line<'static>>,
+    left_width: usize,
+    gap: usize,
+) -> Vec<Line<'static>> {
+    let row_height = left_lines.len().max(right_lines.len()).max(1);
+    while left_lines.len() < row_height {
+        left_lines.push(blank_line(left_width, Style::default()));
+    }
+    while right_lines.len() < row_height {
+        right_lines.push(Line::default());
+    }
+
+    let mut lines = Vec::with_capacity(row_height);
+    for idx in 0..row_height {
+        let mut line =
+            pad_line_to_width(std::mem::take(&mut left_lines[idx]), left_width, Style::default());
+        if gap > 0 {
+            line.spans.push(Span::styled(" ".repeat(gap), Style::default()));
+        }
+        line.spans.extend(std::mem::take(&mut right_lines[idx].spans));
+        lines.push(line);
+    }
+
+    lines
+}

--- a/src/ui/wrap.rs
+++ b/src/ui/wrap.rs
@@ -1,0 +1,320 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+#[derive(Clone, Debug)]
+pub(crate) struct StyledChunk {
+    pub text: String,
+    pub style: Style,
+}
+
+#[derive(Clone)]
+struct StyledToken {
+    text: String,
+    style: Style,
+    width: usize,
+}
+
+enum WrapToken {
+    Text(StyledToken),
+    Space(StyledToken),
+    Newline,
+}
+
+#[must_use]
+pub(crate) fn display_width(text: &str) -> usize {
+    UnicodeWidthStr::width(text)
+}
+
+#[must_use]
+pub(crate) fn line_display_width(line: &Line<'_>) -> usize {
+    line.spans.iter().map(|span| display_width(span.content.as_ref())).sum()
+}
+
+#[must_use]
+pub(crate) fn truncate_to_width(text: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    if display_width(text) <= width {
+        return text.to_owned();
+    }
+
+    let mut out = String::new();
+    let mut used = 0usize;
+    for grapheme in UnicodeSegmentation::graphemes(text, true) {
+        let grapheme_width = display_width(grapheme);
+        if used + grapheme_width > width {
+            break;
+        }
+        out.push_str(grapheme);
+        used += grapheme_width;
+    }
+    out
+}
+
+#[must_use]
+pub(crate) fn take_prefix_by_width(text: &str, width: usize) -> (String, String) {
+    if width == 0 || text.is_empty() {
+        return (String::new(), text.to_owned());
+    }
+
+    let mut used = 0usize;
+    let mut split_at = 0usize;
+    for (idx, grapheme) in UnicodeSegmentation::grapheme_indices(text, true) {
+        let grapheme_width = display_width(grapheme);
+        if used + grapheme_width > width {
+            break;
+        }
+        used += grapheme_width;
+        split_at = idx + grapheme.len();
+    }
+
+    if split_at == 0 {
+        return (String::new(), text.to_owned());
+    }
+
+    (text[..split_at].to_owned(), text[split_at..].to_owned())
+}
+
+#[must_use]
+pub(crate) fn wrap_plain(text: &str, width: usize) -> Vec<String> {
+    wrap_styled_chunks(&[StyledChunk { text: text.to_owned(), style: Style::default() }], width)
+        .into_iter()
+        .map(|line| line.spans.into_iter().map(|span| span.content.into_owned()).collect())
+        .collect()
+}
+
+#[must_use]
+pub(crate) fn wrapped_line_count(text: &str, width: usize) -> usize {
+    wrap_plain(text, width).len().max(1)
+}
+
+#[must_use]
+pub(crate) fn wrap_styled_chunks(chunks: &[StyledChunk], width: usize) -> Vec<Line<'static>> {
+    if width == 0 || chunks.is_empty() {
+        return vec![Line::default()];
+    }
+
+    let tokens = tokenize_chunks(chunks);
+    let mut lines = Vec::new();
+    let mut spans = Vec::new();
+    let mut line_width = 0usize;
+    let mut pending_spaces = Vec::<StyledToken>::new();
+
+    for token in tokens {
+        match token {
+            WrapToken::Newline => {
+                finish_wrapped_line(&mut lines, &mut spans, &mut line_width);
+                pending_spaces.clear();
+            }
+            WrapToken::Space(space) => {
+                if line_width > 0 {
+                    pending_spaces.push(space);
+                }
+            }
+            WrapToken::Text(text) => {
+                let pending_width: usize = pending_spaces.iter().map(|space| space.width).sum();
+                if line_width > 0 && line_width + pending_width + text.width > width {
+                    finish_wrapped_line(&mut lines, &mut spans, &mut line_width);
+                    pending_spaces.clear();
+                }
+
+                if line_width > 0 {
+                    for space in pending_spaces.drain(..) {
+                        push_styled_text(&mut spans, &space.text, space.style);
+                        line_width += space.width;
+                    }
+                }
+
+                if text.width <= width.saturating_sub(line_width) {
+                    push_styled_text(&mut spans, &text.text, text.style);
+                    line_width += text.width;
+                    continue;
+                }
+
+                wrap_long_token(&text, width, &mut lines, &mut spans, &mut line_width);
+            }
+        }
+    }
+
+    finish_wrapped_line(&mut lines, &mut spans, &mut line_width);
+    if lines.is_empty() {
+        lines.push(Line::default());
+    }
+    lines
+}
+
+#[must_use]
+pub(crate) fn pad_line_to_width(
+    mut line: Line<'static>,
+    width: usize,
+    padding_style: Style,
+) -> Line<'static> {
+    let padding = width.saturating_sub(line_display_width(&line));
+    if padding > 0 {
+        line.spans.push(Span::styled(" ".repeat(padding), padding_style));
+    }
+    line
+}
+
+#[must_use]
+pub(crate) fn blank_line(width: usize, style: Style) -> Line<'static> {
+    Line::from(Span::styled(" ".repeat(width), style))
+}
+
+fn tokenize_chunks(chunks: &[StyledChunk]) -> Vec<WrapToken> {
+    let mut tokens = Vec::new();
+
+    for chunk in chunks {
+        let mut current = String::new();
+        let mut is_space = None;
+
+        let flush_current = |tokens: &mut Vec<WrapToken>,
+                             current: &mut String,
+                             is_space: &mut Option<bool>,
+                             style: Style| {
+            if current.is_empty() {
+                return;
+            }
+            let text = std::mem::take(current);
+            let width = display_width(text.as_str());
+            let token = StyledToken { text, style, width };
+            if is_space.unwrap_or(false) {
+                tokens.push(WrapToken::Space(token));
+            } else {
+                tokens.push(WrapToken::Text(token));
+            }
+        };
+
+        for grapheme in UnicodeSegmentation::graphemes(chunk.text.as_str(), true) {
+            if grapheme == "\n" {
+                flush_current(&mut tokens, &mut current, &mut is_space, chunk.style);
+                is_space = None;
+                tokens.push(WrapToken::Newline);
+                continue;
+            }
+
+            let grapheme_is_space =
+                grapheme.chars().all(char::is_whitespace) && grapheme.chars().all(|ch| ch != '\n');
+            if is_space.is_some_and(|value| value != grapheme_is_space) {
+                flush_current(&mut tokens, &mut current, &mut is_space, chunk.style);
+            }
+
+            is_space = Some(grapheme_is_space);
+            current.push_str(grapheme);
+        }
+
+        flush_current(&mut tokens, &mut current, &mut is_space, chunk.style);
+    }
+
+    tokens
+}
+
+fn wrap_long_token(
+    token: &StyledToken,
+    width: usize,
+    lines: &mut Vec<Line<'static>>,
+    spans: &mut Vec<Span<'static>>,
+    line_width: &mut usize,
+) {
+    let mut segment = String::new();
+    let mut segment_width = 0usize;
+
+    for grapheme in UnicodeSegmentation::graphemes(token.text.as_str(), true) {
+        let grapheme_width = display_width(grapheme);
+        if *line_width > 0 && *line_width + segment_width + grapheme_width > width {
+            if !segment.is_empty() {
+                push_styled_text(spans, &segment, token.style);
+                *line_width += segment_width;
+                segment.clear();
+                segment_width = 0;
+            }
+            finish_wrapped_line(lines, spans, line_width);
+        }
+
+        if segment_width + grapheme_width > width && !segment.is_empty() {
+            push_styled_text(spans, &segment, token.style);
+            *line_width += segment_width;
+            segment.clear();
+            segment_width = 0;
+            finish_wrapped_line(lines, spans, line_width);
+        }
+
+        segment.push_str(grapheme);
+        segment_width += grapheme_width;
+    }
+
+    if !segment.is_empty() {
+        push_styled_text(spans, &segment, token.style);
+        *line_width += segment_width;
+    }
+}
+
+fn finish_wrapped_line(
+    lines: &mut Vec<Line<'static>>,
+    spans: &mut Vec<Span<'static>>,
+    line_width: &mut usize,
+) {
+    lines.push(Line::from(std::mem::take(spans)));
+    *line_width = 0;
+}
+
+fn push_styled_text(spans: &mut Vec<Span<'static>>, text: &str, style: Style) {
+    if text.is_empty() {
+        return;
+    }
+    if let Some(last) = spans.last_mut()
+        && last.style == style
+    {
+        last.content.to_mut().push_str(text);
+        return;
+    }
+    spans.push(Span::styled(text.to_owned(), style));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use ratatui::style::Modifier;
+
+    #[test]
+    fn take_prefix_by_width_handles_grapheme_clusters() {
+        let text = "a👩‍💻b";
+        let (chunk, rest) = take_prefix_by_width(text, 3);
+        assert_eq!(chunk, "a👩‍💻");
+        assert_eq!(rest, "b");
+    }
+
+    #[test]
+    fn wrap_plain_preserves_explicit_newlines() {
+        assert_eq!(wrap_plain("alpha\nbeta", 16), vec!["alpha".to_owned(), "beta".to_owned()]);
+    }
+
+    #[test]
+    fn wrap_plain_handles_cjk_width() {
+        assert_eq!(wrap_plain("你好 世界", 4), vec!["你好".to_owned(), "世界".to_owned()]);
+    }
+
+    #[test]
+    fn wrap_plain_wraps_long_emoji_graphemes() {
+        assert_eq!(wrap_plain("👩‍💻👩‍💻👩‍💻", 4), vec!["👩‍💻👩‍💻".to_owned(), "👩‍💻".to_owned()]);
+    }
+
+    #[test]
+    fn wrap_styled_chunks_preserves_styles() {
+        let lines = wrap_styled_chunks(
+            &[StyledChunk {
+                text: "bold text".to_owned(),
+                style: Style::default().add_modifier(Modifier::BOLD),
+            }],
+            32,
+        );
+        assert!(lines[0].spans[0].style.add_modifier.contains(Modifier::BOLD));
+    }
+}


### PR DESCRIPTION
## Summary

- redesign UI table rendering by separating shared wrapping, markdown document tables, and two-column help/catalog rendering
- replace the legacy markdown table implementation with `DocumentTable` layout resolution and explicit `Grid`, `DenseGrid`, and `Stacked` fallbacks
- replace help overlay `ratatui::Table` usage with a custom two-column renderer backed by shared wrapping primitives
- route chat markdocn rendering through the new document-table path and remove the old `src/ui/tables.rs`

## Why

- the previous implementation mixed width measurement, wrapping, layout policy, and rendering in one markdown-table path
- help/slash/subagent views were using a generic table widget for document-style wrapped content, which made wrapping and pagination harder to reason about
- this split gives one source of truth for wrapping behavior and ensures narrow markdown tables degrade to a readable stacked layout instead of disappearing

Closes #

## Validation

- Automated:
  - `cargo test --all-features`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo fmt --all -- --check`
  - `cargo check --all-features`
  - `cargo +1.88.0-x86_64-pc-windows-msvc check --all-features`
  - `cargo fetch --locked`
- Manual:
  - verified narrow markdown tables render via stacked fallback instead of vanishing
  - verified help `Slash` and `Subagents` views still render wrapped two-column content after replacing `ratatui::Table`
- Screenshot/video (if UI changed): Not included

## Notes