### PR TITLE
fix(input): close question-mark help overlay after submit

### DIFF
--- a/src/app/input_submit.rs
+++ b/src/app/input_submit.rs
@@ -26,6 +26,7 @@ pub(super) fn submit_input(app: &mut App) {
     if slash::is_cancel_command(&text) {
         app.pending_auto_submit_after_cancel = false;
         app.input.clear();
+        app.sync_help_open_with_input();
         dispatch_submission(app, text);
         return;
     }
@@ -59,6 +60,7 @@ pub(super) fn submit_input(app: &mut App) {
 
     app.pending_auto_submit_after_cancel = false;
     app.input.clear();
+    app.sync_help_open_with_input();
     dispatch_submission(app, text);
 }
 

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -305,7 +305,7 @@ pub(super) fn handle_normal_key(app: &mut App, key: KeyEvent) -> bool {
     let changed = handle_normal_key_actions(app, key);
 
     if app.input.version != input_version_before {
-        sync_help_open_after_input_change(app);
+        app.sync_help_open_with_input();
     }
 
     if app.input.version != input_version_before && should_sync_autocomplete_after_key(app, key) {
@@ -748,12 +748,6 @@ fn handle_printable_key(app: &mut App, key: KeyEvent) -> bool {
         subagent::activate(app);
     }
     true
-}
-
-fn sync_help_open_after_input_change(app: &mut App) {
-    if app.is_help_active() && app.input.text().trim() != "?" {
-        app.help_open = false;
-    }
 }
 
 fn try_move_input_cursor_up(app: &mut App) -> bool {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -729,6 +729,40 @@ mod tests {
     }
 
     #[test]
+    fn sending_lone_question_mark_closes_help_overlay() {
+        let (mut app, mut rx) = app_with_connection();
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE)),
+        );
+
+        assert_eq!(app.input.text(), "?");
+        assert!(app.is_help_active());
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+        assert!(app.pending_submit.is_some());
+
+        finalize_deferred_submit(&mut app);
+
+        assert!(app.pending_submit.is_none());
+        assert!(app.input.text().is_empty());
+        assert!(!app.is_help_active());
+        assert!(matches!(
+            app.messages[0].blocks.as_slice(),
+            [MessageBlock::Text(block)] if block.text == "?"
+        ));
+        let envelope = rx.try_recv().expect("prompt command should be sent");
+        assert!(matches!(
+            envelope.command,
+            BridgeCommand::Prompt { session_id, .. } if session_id == "session-1"
+        ));
+    }
+
+    #[test]
     fn paste_event_cancels_deferred_submit_snapshot() {
         let mut app = App::test_default();
         app.input.set_text("draft");

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -1141,6 +1141,13 @@ impl App {
         self.help_open
     }
 
+    pub fn sync_help_open_with_input(&mut self) {
+        if self.help_open && self.input.text().trim() != "?" {
+            self.help_open = false;
+            self.release_focus_target(FocusTarget::Help);
+        }
+    }
+
     #[must_use]
     pub fn autocomplete_focus_available(&self) -> bool {
         self.mention.as_ref().is_some_and(mention::MentionState::has_selectable_candidates)


### PR DESCRIPTION
## Summary

- close the `?` help overlay when the input is submitted and cleared
- centralize the help visibility rule so key edits and submit-driven input changes use the same logic
- add a regression test for sending a lone `?` with Enter

## Why

Typing `?` correctly opened the help panel, but sending that same `?` left the help panel visible even after the input had been cleared. This keeps the help overlay aligned with the real input contents and avoids stale help focus after submit.

Closes #

## Validation

- Automated: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test`; `cargo check --offline`
- Manual: yes, works
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
