### PR TITLE
feat(slash): add /docs command with in-chat help topics

### DIFF
--- a/src/app/input_submit.rs
+++ b/src/app/input_submit.rs
@@ -300,6 +300,22 @@ mod tests {
     }
 
     #[test]
+    fn local_slash_submit_marks_redraw() {
+        let (mut app, _rx) = app_with_connection();
+        app.input.set_text("/docs commands");
+        app.needs_redraw = false;
+
+        submit_input(&mut app);
+
+        assert!(app.needs_redraw);
+        assert!(app.input.text().is_empty());
+        let Some(last) = app.messages.last() else {
+            panic!("expected docs system message");
+        };
+        assert!(matches!(last.role, MessageRole::System(Some(super::super::SystemSeverity::Info))));
+    }
+
+    #[test]
     fn auto_submit_dispatches_draft_once_ready() {
         let (mut app, mut rx) = app_with_connection();
         app.status = AppStatus::Running;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -763,6 +763,189 @@ mod tests {
     }
 
     #[test]
+    fn docs_topic_selected_with_enter_then_second_enter_submits() {
+        let mut app = App::test_default();
+        app.input.set_text("/docs co");
+        let _ = app.input.set_cursor(0, "/docs co".chars().count());
+        crate::app::slash::sync_with_cursor(&mut app);
+
+        assert!(app.slash.is_some(), "topic autocomplete should be active before selection");
+        assert_eq!(app.focus_owner(), FocusOwner::Mention);
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert_eq!(app.input.text(), "/docs commands ");
+        assert!(app.slash.is_none(), "topic selection should leave slash mode");
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert!(app.pending_submit.is_some(), "second Enter should arm submit");
+
+        finalize_deferred_submit(&mut app);
+
+        assert!(app.pending_submit.is_none());
+        let last = app.messages.last().expect("expected docs system message");
+        assert!(matches!(last.role, MessageRole::System(_)));
+        assert!(matches!(
+            last.blocks.as_slice(),
+            [MessageBlock::Text(block)] if block.text.contains("| Command | Description |")
+        ));
+    }
+
+    #[test]
+    fn docs_command_selection_then_topic_selection_then_submit_works_with_enter_only() {
+        let mut app = App::test_default();
+        app.input.set_text("/do");
+        let _ = app.input.set_cursor(0, "/do".chars().count());
+        crate::app::slash::sync_with_cursor(&mut app);
+
+        assert!(app.slash.is_some(), "command autocomplete should be active before selection");
+        assert_eq!(app.focus_owner(), FocusOwner::Mention);
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert_eq!(app.input.text(), "/docs ");
+        let slash = app.slash.as_ref().expect("topic autocomplete should activate");
+        assert!(matches!(slash.context, crate::app::slash::SlashContext::Argument { .. }));
+        assert_eq!(app.focus_owner(), FocusOwner::Mention);
+
+        for _ in 0..3 {
+            events::handle_terminal_event(
+                &mut app,
+                Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
+            );
+        }
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert_eq!(app.input.text(), "/docs commands ");
+        assert!(app.slash.is_none(), "topic selection should leave slash mode");
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert!(app.pending_submit.is_some(), "submit should arm after topic selection");
+
+        finalize_deferred_submit(&mut app);
+
+        let last = app.messages.last().expect("expected docs system message");
+        assert!(matches!(
+            last.blocks.as_slice(),
+            [MessageBlock::Text(block)] if block.text.contains("| Command | Description |")
+        ));
+    }
+
+    #[test]
+    fn mode_selection_then_second_enter_arms_submit() {
+        let mut app = App::test_default();
+        app.mode = Some(ModeState {
+            current_mode_id: "code".to_owned(),
+            current_mode_name: "Code".to_owned(),
+            available_modes: vec![
+                ModeInfo { id: "plan".to_owned(), name: "Plan".to_owned() },
+                ModeInfo { id: "code".to_owned(), name: "Code".to_owned() },
+            ],
+        });
+        app.input.set_text("/mode pl");
+        let _ = app.input.set_cursor(0, "/mode pl".chars().count());
+        crate::app::slash::sync_with_cursor(&mut app);
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert_eq!(app.input.text(), "/mode plan ");
+        assert!(app.slash.is_none());
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert!(app.pending_submit.is_some());
+    }
+
+    #[test]
+    fn model_selection_then_second_enter_arms_submit() {
+        let mut app = App::test_default();
+        app.available_models = vec![
+            model::AvailableModel::new("sonnet", "Claude Sonnet"),
+            model::AvailableModel::new("haiku", "Claude Haiku"),
+        ];
+        app.input.set_text("/model so");
+        let _ = app.input.set_cursor(0, "/model so".chars().count());
+        crate::app::slash::sync_with_cursor(&mut app);
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert_eq!(app.input.text(), "/model sonnet ");
+        assert!(app.slash.is_none());
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert!(app.pending_submit.is_some());
+    }
+
+    #[test]
+    fn resume_selection_then_second_enter_arms_submit() {
+        let mut app = App::test_default();
+        app.recent_sessions = vec![RecentSessionInfo {
+            session_id: "session-1".to_owned(),
+            summary: "Session one".to_owned(),
+            last_modified_ms: 1,
+            file_size_bytes: 1,
+            cwd: None,
+            git_branch: None,
+            custom_title: None,
+            first_prompt: None,
+        }];
+        app.input.set_text("/resume se");
+        let _ = app.input.set_cursor(0, "/resume se".chars().count());
+        crate::app::slash::sync_with_cursor(&mut app);
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert_eq!(app.input.text(), "/resume session-1 ");
+        assert!(app.slash.is_none());
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
+
+        events::handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert!(app.pending_submit.is_some());
+    }
+
+    #[test]
     fn paste_event_cancels_deferred_submit_snapshot() {
         let mut app = App::test_default();
         app.input.set_text("draft");

--- a/src/app/slash/candidates.rs
+++ b/src/app/slash/candidates.rs
@@ -109,7 +109,11 @@ pub(super) fn find_advertised_command<'a>(
 }
 
 fn is_builtin_variable_input_command(command_name: &str) -> bool {
-    matches!(command_name, "/mode" | "/model" | "/resume")
+    matches!(command_name, "/docs" | "/mode" | "/model" | "/resume")
+}
+
+pub(super) fn builtin_argument_confirmation_closes(command_name: &str, arg_index: usize) -> bool {
+    arg_index == 0 && matches!(command_name, "/docs" | "/mode" | "/model" | "/resume")
 }
 
 pub(super) fn is_variable_input_command(app: &App, command_name: &str) -> bool {
@@ -129,6 +133,7 @@ pub(super) fn supported_command_candidates(app: &App) -> Vec<SlashCandidate> {
     by_name.insert("/cancel".into(), "Cancel active turn".into());
     by_name.insert("/compact".into(), "Compact session context".into());
     by_name.insert("/config".into(), "Open settings".into());
+    by_name.insert("/docs".into(), "Show in-chat help topics".into());
     by_name.insert("/login".into(), "Authenticate with Claude".into());
     by_name.insert("/logout".into(), "Sign out of Claude".into());
     by_name.insert("/mcp".into(), "Open MCP".into());
@@ -253,6 +258,14 @@ pub(super) fn argument_candidates(
     }
 
     match command_name {
+        "/docs" => super::DOCS_TOPICS
+            .iter()
+            .map(|(topic, description)| SlashCandidate {
+                insert_value: (*topic).to_owned(),
+                primary: (*topic).to_owned(),
+                secondary: Some((*description).to_owned()),
+            })
+            .collect(),
         "/resume" => app
             .recent_sessions
             .iter()

--- a/src/app/slash/executors.rs
+++ b/src/app/slash/executors.rs
@@ -11,6 +11,7 @@ use crate::agent::events::ClientEvent;
 use crate::app::connect::{SessionStartReason, begin_resume_session, start_new_session};
 use crate::app::events::push_system_message_with_severity;
 use crate::app::{App, AppStatus, CancelOrigin, SystemSeverity};
+use std::fmt::Write as _;
 
 /// Handle slash command submission.
 ///
@@ -25,6 +26,7 @@ pub fn try_handle_submit(app: &mut App, text: &str) -> bool {
         "/cancel" => handle_cancel_submit(app),
         "/compact" => handle_compact_submit(app, &parsed.args),
         "/config" => handle_config_submit(app, &parsed.args),
+        "/docs" => handle_docs_submit(app, &parsed.args),
         "/mcp" => handle_mcp_submit(app, &parsed.args),
         "/plugins" => handle_plugins_submit(app, &parsed.args),
         "/status" => handle_status_submit(app, &parsed.args),
@@ -77,6 +79,31 @@ fn handle_config_submit(app: &mut App, args: &[&str]) -> bool {
     if let Err(err) = crate::app::config::open(app) {
         push_system_message(app, format!("Failed to open settings: {err}"));
     }
+    true
+}
+
+fn handle_docs_submit(app: &mut App, args: &[&str]) -> bool {
+    let topic = match args {
+        [topic] if !topic.trim().is_empty() => topic.trim(),
+        _ => {
+            push_system_message(app, docs_usage());
+            return true;
+        }
+    };
+
+    let body = match topic {
+        "mode" => build_docs_mode_markdown(app),
+        "models" => build_docs_models_markdown(app),
+        "shortcuts" => build_docs_shortcuts_markdown(app),
+        "commands" => build_docs_commands_markdown(app),
+        "agents" => build_docs_agents_markdown(app),
+        other => {
+            push_system_message(app, format!("Unknown docs topic: {other}\n{}", docs_usage()));
+            return true;
+        }
+    };
+
+    push_system_message_with_severity(app, Some(SystemSeverity::Info), &body);
     true
 }
 
@@ -388,9 +415,13 @@ fn handle_mode_submit(app: &mut App, args: &[&str]) -> bool {
 }
 
 fn handle_model_submit(app: &mut App, args: &[&str]) -> bool {
-    let model_name = args.join(" ");
-    if model_name.trim().is_empty() {
-        push_system_message(app, "Usage: /model <name>");
+    let [model_name_arg] = args else {
+        push_system_message(app, "Usage: /model <id>");
+        return true;
+    };
+    let model_name = model_name_arg.trim();
+    if model_name.is_empty() {
+        push_system_message(app, "Usage: /model <id>");
         return true;
     }
 
@@ -416,6 +447,7 @@ fn handle_model_submit(app: &mut App, args: &[&str]) -> bool {
     );
 
     let tx = app.event_tx.clone();
+    let model_name = model_name.to_owned();
     tokio::task::spawn_local(async move {
         match conn.set_model(sid.to_string(), model_name) {
             Ok(()) => {}
@@ -483,4 +515,144 @@ fn handle_unknown_submit(app: &mut App, command_name: &str) -> bool {
     }
     push_system_message(app, format!("{command_name} is not yet supported"));
     true
+}
+
+fn docs_usage() -> &'static str {
+    "Usage: /docs <mode|models|shortcuts|commands|agents>"
+}
+
+fn build_docs_mode_markdown(app: &App) -> String {
+    let rows = app.mode.as_ref().map_or_else(
+        || vec![("Unavailable".to_owned(), "Connect to load the current session mode.".to_owned())],
+        |mode| {
+            let mut rows: Vec<(String, String)> = mode
+                .available_modes
+                .iter()
+                .map(|entry| {
+                    let mut details = format!("ID `{}`", entry.id);
+                    if entry.id == mode.current_mode_id {
+                        details.push_str("; current");
+                    }
+                    (entry.name.clone(), details)
+                })
+                .collect();
+            if rows.is_empty() {
+                rows.push((
+                    mode.current_mode_name.clone(),
+                    format!("ID `{}`; current", mode.current_mode_id),
+                ));
+            }
+            rows
+        },
+    );
+
+    render_docs_table(
+        "Docs: Mode",
+        "Current and available session modes.",
+        ("Mode", "Details"),
+        rows,
+    )
+}
+
+fn build_docs_models_markdown(app: &App) -> String {
+    let rows = if app.available_models.is_empty() {
+        vec![("Unavailable".to_owned(), "Connect to load advertised models.".to_owned())]
+    } else {
+        app.available_models
+            .iter()
+            .map(|model| {
+                let name = if model.display_name.trim().is_empty() {
+                    model.id.clone()
+                } else {
+                    model.display_name.clone()
+                };
+                (name, model_details(model))
+            })
+            .collect()
+    };
+
+    render_docs_table(
+        "Docs: Models",
+        "Advertised models and capabilities for the current session.",
+        ("Model", "Details"),
+        rows,
+    )
+}
+
+fn build_docs_shortcuts_markdown(app: &App) -> String {
+    render_docs_table(
+        "Docs: Shortcuts",
+        "Live keyboard shortcuts for the current app state.",
+        ("Shortcut", "Action"),
+        crate::ui::help::key_help_items(app),
+    )
+}
+
+fn build_docs_commands_markdown(app: &App) -> String {
+    render_docs_table(
+        "Docs: Commands",
+        "App-owned and advertised slash commands.",
+        ("Command", "Description"),
+        crate::ui::help::docs_command_items(app),
+    )
+}
+
+fn build_docs_agents_markdown(app: &App) -> String {
+    render_docs_table(
+        "Docs: Agents",
+        "Advertised subagents for the current session.",
+        ("Agent", "Description"),
+        crate::ui::help::subagent_help_items(app),
+    )
+}
+
+fn model_details(model: &crate::agent::model::AvailableModel) -> String {
+    let mut parts = Vec::new();
+    parts.push(format!("ID `{}`", model.id));
+    if let Some(description) = model.description.as_deref()
+        && !description.trim().is_empty()
+    {
+        parts.push(description.trim().to_owned());
+    }
+    if model.supports_effort {
+        parts.push("Effort".to_owned());
+    }
+    if model.supports_adaptive_thinking == Some(true) {
+        parts.push("Adaptive thinking".to_owned());
+    }
+    if model.supports_fast_mode == Some(true) {
+        parts.push("Fast mode".to_owned());
+    }
+    if model.supports_auto_mode == Some(true) {
+        parts.push("Auto mode".to_owned());
+    }
+    parts.join("; ")
+}
+
+fn render_docs_table(
+    title: &str,
+    intro: &str,
+    headers: (&str, &str),
+    rows: Vec<(String, String)>,
+) -> String {
+    let mut markdown = String::new();
+    let _ = writeln!(&mut markdown, "# {title}");
+    let _ = writeln!(&mut markdown);
+    let _ = writeln!(&mut markdown, "{intro}");
+    let _ = writeln!(&mut markdown);
+    let _ = writeln!(&mut markdown, "| {} | {} |", headers.0, headers.1);
+    let _ = writeln!(&mut markdown, "| --- | --- |");
+    for (left, right) in rows {
+        let _ = writeln!(
+            &mut markdown,
+            "| {} | {} |",
+            markdown_table_cell(&left),
+            markdown_table_cell(&right),
+        );
+    }
+    markdown
+}
+
+fn markdown_table_cell(value: &str) -> String {
+    value.trim().replace('|', "\\|").replace('\r', "").replace('\n', " - ")
 }

--- a/src/app/slash/mod.rs
+++ b/src/app/slash/mod.rs
@@ -20,6 +20,13 @@ use std::rc::Rc;
 
 pub const MAX_VISIBLE: usize = 8;
 const MAX_CANDIDATES: usize = 50;
+const DOCS_TOPICS: [(&str, &str); 5] = [
+    ("mode", "Show current and available session modes"),
+    ("models", "Show advertised models and capabilities"),
+    ("shortcuts", "Show live keyboard shortcuts for the current app state"),
+    ("commands", "Show app and SDK slash commands"),
+    ("agents", "Show advertised subagents"),
+];
 
 // Re-export public API
 pub use executors::try_handle_submit;
@@ -187,6 +194,7 @@ mod tests {
         let names: Vec<String> =
             supported_command_candidates(&app).into_iter().map(|c| c.primary).collect();
         assert!(names.iter().any(|n| n == "/config"), "missing /config");
+        assert!(names.iter().any(|n| n == "/docs"), "missing /docs");
         assert!(names.iter().any(|n| n == "/login"), "missing /login");
         assert!(names.iter().any(|n| n == "/logout"), "missing /logout");
         assert!(names.iter().any(|n| n == "/mcp"), "missing /mcp");
@@ -371,6 +379,100 @@ mod tests {
     }
 
     #[test]
+    fn docs_argument_candidates_are_static_topics() {
+        let app = App::test_default();
+        let candidates = argument_candidates(&app, "/docs", 0);
+        assert!(candidates.iter().any(|c| c.insert_value == "mode"));
+        assert!(candidates.iter().any(|c| c.insert_value == "models"));
+        assert!(candidates.iter().any(|c| c.insert_value == "shortcuts"));
+        assert!(candidates.iter().any(|c| c.insert_value == "commands"));
+        assert!(candidates.iter().any(|c| c.insert_value == "agents"));
+    }
+
+    #[test]
+    fn docs_without_args_returns_usage() {
+        let mut app = App::test_default();
+
+        let consumed = try_handle_submit(&mut app, "/docs");
+
+        assert!(consumed);
+        let last = app.messages.last().expect("expected system message");
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "Usage: /docs <mode|models|shortcuts|commands|agents>");
+    }
+
+    #[test]
+    fn docs_commands_reuse_help_rows() {
+        let mut app = App::test_default();
+        app.available_commands =
+            vec![crate::agent::model::AvailableCommand::new("/help", "Open help")];
+
+        let consumed = try_handle_submit(&mut app, "/docs commands");
+
+        assert!(consumed);
+        let last = app.messages.last().expect("expected system message");
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert!(block.text.contains("| Command | Description |"));
+        assert!(block.text.contains("/config"));
+        assert!(block.text.contains("/docs"));
+        assert!(block.text.contains("/help"));
+    }
+
+    #[test]
+    fn docs_shortcuts_use_live_help_state() {
+        let mut app = App::test_default();
+        app.show_todo_panel = true;
+        app.todos.push(crate::app::TodoItem {
+            content: "Task".into(),
+            status: crate::app::TodoStatus::Pending,
+            active_form: String::new(),
+        });
+
+        let consumed = try_handle_submit(&mut app, "/docs shortcuts");
+
+        assert!(consumed);
+        let last = app.messages.last().expect("expected system message");
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert!(block.text.contains("| Shortcut | Action |"));
+        assert!(block.text.contains("Toggle todo focus"));
+    }
+
+    #[test]
+    fn docs_with_unknown_topic_returns_usage() {
+        let mut app = App::test_default();
+
+        let consumed = try_handle_submit(&mut app, "/docs nope");
+
+        assert!(consumed);
+        let last = app.messages.last().expect("expected system message");
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert!(block.text.contains("Unknown docs topic: nope"));
+        assert!(block.text.contains("Usage: /docs <mode|models|shortcuts|commands|agents>"));
+    }
+
+    #[test]
+    fn docs_with_extra_args_returns_usage() {
+        let mut app = App::test_default();
+
+        let consumed = try_handle_submit(&mut app, "/docs commands extra");
+
+        assert!(consumed);
+        let last = app.messages.last().expect("expected system message");
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "Usage: /docs <mode|models|shortcuts|commands|agents>");
+    }
+
+    #[test]
     fn non_variable_command_argument_mode_is_disabled() {
         let mut app = App::test_default();
         app.input.set_text("/cancel now");
@@ -458,6 +560,20 @@ mod tests {
     fn resume_with_missing_id_returns_usage() {
         let mut app = App::test_default();
         let consumed = try_handle_submit(&mut app, "/resume");
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected usage message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "Usage: /resume <session_id>");
+    }
+
+    #[test]
+    fn resume_with_extra_args_returns_usage() {
+        let mut app = App::test_default();
+        let consumed = try_handle_submit(&mut app, "/resume abc-123 extra");
         assert!(consumed);
         let Some(last) = app.messages.last() else {
             panic!("expected usage message");
@@ -681,6 +797,36 @@ mod tests {
     }
 
     #[test]
+    fn model_with_missing_id_returns_usage_message() {
+        let mut app = App::test_default();
+
+        let consumed = try_handle_submit(&mut app, "/model");
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected system usage message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "Usage: /model <id>");
+    }
+
+    #[test]
+    fn model_with_extra_args_returns_usage_message() {
+        let mut app = App::test_default();
+
+        let consumed = try_handle_submit(&mut app, "/model sonnet extra");
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected system usage message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "Usage: /model <id>");
+    }
+
+    #[test]
     fn confirm_selection_with_invalid_trigger_row_is_noop() {
         let mut app = App::test_default();
         app.input.set_text("/mode");
@@ -700,6 +846,74 @@ mod tests {
         confirm_selection(&mut app);
 
         assert_eq!(app.input.text(), "/mode");
+    }
+
+    #[test]
+    fn docs_command_confirm_enters_argument_mode() {
+        let mut app = App::test_default();
+        app.input.set_text("/do");
+        let _ = app.input.set_cursor(0, "/do".chars().count());
+        app.slash = Some(SlashState {
+            trigger_row: 0,
+            trigger_col: 0,
+            query: "do".into(),
+            context: SlashContext::CommandName,
+            candidates: vec![SlashCandidate {
+                insert_value: "/docs".into(),
+                primary: "/docs".into(),
+                secondary: Some("Show in-chat help topics".into()),
+            }],
+            dialog: DialogState::default(),
+        });
+
+        confirm_selection(&mut app);
+
+        assert_eq!(app.input.text(), "/docs ");
+        let slash = app.slash.as_ref().expect("topic autocomplete should activate");
+        match &slash.context {
+            SlashContext::Argument { command, arg_index, .. } => {
+                assert_eq!(command, "/docs");
+                assert_eq!(*arg_index, 0);
+            }
+            SlashContext::CommandName => panic!("expected argument autocomplete"),
+        }
+        assert!(slash.candidates.iter().any(|candidate| candidate.insert_value == "mode"));
+    }
+
+    #[test]
+    fn single_argument_builtin_selection_closes_autocomplete() {
+        for (command, value) in [
+            ("/docs", "commands"),
+            ("/mode", "plan"),
+            ("/model", "sonnet"),
+            ("/resume", "session-1"),
+        ] {
+            let mut app = App::test_default();
+            let input = format!("{command} ");
+            app.input.set_text(&input);
+            let _ = app.input.set_cursor(0, input.chars().count());
+            app.slash = Some(SlashState {
+                trigger_row: 0,
+                trigger_col: input.chars().count(),
+                query: String::new(),
+                context: SlashContext::Argument {
+                    command: command.to_owned(),
+                    arg_index: 0,
+                    token_range: (input.chars().count(), input.chars().count()),
+                },
+                candidates: vec![SlashCandidate {
+                    insert_value: value.to_owned(),
+                    primary: value.to_owned(),
+                    secondary: None,
+                }],
+                dialog: DialogState::default(),
+            });
+
+            confirm_selection(&mut app);
+
+            assert_eq!(app.input.text(), format!("{command} {value} "));
+            assert!(app.slash.is_none(), "{command} should close after first argument");
+        }
     }
 
     #[test]

--- a/src/app/slash/navigation.rs
+++ b/src/app/slash/navigation.rs
@@ -4,9 +4,56 @@
 //! Slash command autocomplete navigation: activate, deactivate, sync,
 //! move selection, and confirm.
 
-use super::candidates::build_slash_state;
-use super::{MAX_VISIBLE, SlashContext};
+use super::candidates::{build_slash_state, builtin_argument_confirmation_closes};
+use super::{MAX_VISIBLE, SlashContext, SlashState};
 use crate::app::{App, FocusTarget};
+
+fn release_autocomplete_focus_if_idle(app: &mut App) {
+    if app.slash.is_none() && app.mention.is_none() && app.subagent.is_none() {
+        app.release_focus_target(FocusTarget::Mention);
+    }
+}
+
+fn replacement_range(slash: &SlashState, chars: &[char]) -> Option<(usize, usize)> {
+    match &slash.context {
+        SlashContext::CommandName => {
+            if slash.trigger_col >= chars.len() {
+                tracing::debug!(
+                    trigger_col = slash.trigger_col,
+                    line_len = chars.len(),
+                    "Slash confirm aborted: trigger column out of bounds"
+                );
+                return None;
+            }
+            if chars[slash.trigger_col] != '/' {
+                tracing::debug!(
+                    trigger_col = slash.trigger_col,
+                    found = ?chars[slash.trigger_col],
+                    "Slash confirm aborted: trigger column is not slash"
+                );
+                return None;
+            }
+
+            let token_end = (slash.trigger_col + 1..chars.len())
+                .find(|&i| chars[i].is_whitespace())
+                .unwrap_or(chars.len());
+            Some((slash.trigger_col, token_end))
+        }
+        SlashContext::Argument { token_range, .. } => {
+            let (start, end) = *token_range;
+            if start > end || end > chars.len() {
+                tracing::debug!(
+                    start,
+                    end,
+                    line_len = chars.len(),
+                    "Slash confirm aborted: invalid argument token range"
+                );
+                return None;
+            }
+            Some((start, end))
+        }
+    }
+}
 
 pub fn activate(app: &mut App) {
     let Some(state) = build_slash_state(app) else {
@@ -52,9 +99,7 @@ pub fn sync_with_cursor(app: &mut App) {
 
 pub fn deactivate(app: &mut App) {
     app.slash = None;
-    if app.mention.is_none() && app.subagent.is_none() {
-        app.release_focus_target(FocusTarget::Mention);
-    }
+    release_autocomplete_focus_if_idle(app);
 }
 
 pub fn move_up(app: &mut App) {
@@ -76,9 +121,7 @@ pub fn confirm_selection(app: &mut App) {
     };
 
     let Some(candidate) = slash.candidates.get(slash.dialog.selected) else {
-        if app.mention.is_none() && app.subagent.is_none() {
-            app.release_focus_target(FocusTarget::Mention);
-        }
+        release_autocomplete_focus_if_idle(app);
         return;
     };
 
@@ -89,59 +132,20 @@ pub fn confirm_selection(app: &mut App) {
             line_count = app.input.lines().len(),
             "Slash confirm aborted: trigger row out of bounds"
         );
-        if app.mention.is_none() && app.subagent.is_none() {
-            app.release_focus_target(FocusTarget::Mention);
-        }
+        release_autocomplete_focus_if_idle(app);
         return;
     };
 
     let chars: Vec<char> = line.chars().collect();
-    let (replace_start, replace_end) = match slash.context {
-        SlashContext::CommandName => {
-            if slash.trigger_col >= chars.len() {
-                tracing::debug!(
-                    trigger_col = slash.trigger_col,
-                    line_len = chars.len(),
-                    "Slash confirm aborted: trigger column out of bounds"
-                );
-                if app.mention.is_none() && app.subagent.is_none() {
-                    app.release_focus_target(FocusTarget::Mention);
-                }
-                return;
-            }
-            if chars[slash.trigger_col] != '/' {
-                tracing::debug!(
-                    trigger_col = slash.trigger_col,
-                    found = ?chars[slash.trigger_col],
-                    "Slash confirm aborted: trigger column is not slash"
-                );
-                if app.mention.is_none() && app.subagent.is_none() {
-                    app.release_focus_target(FocusTarget::Mention);
-                }
-                return;
-            }
-
-            let token_end = (slash.trigger_col + 1..chars.len())
-                .find(|&i| chars[i].is_whitespace())
-                .unwrap_or(chars.len());
-            (slash.trigger_col, token_end)
+    let closes_after_confirmation = match &slash.context {
+        SlashContext::Argument { command, arg_index, .. } => {
+            builtin_argument_confirmation_closes(command, *arg_index)
         }
-        SlashContext::Argument { token_range, .. } => {
-            let (start, end) = token_range;
-            if start > end || end > chars.len() {
-                tracing::debug!(
-                    start,
-                    end,
-                    line_len = chars.len(),
-                    "Slash confirm aborted: invalid argument token range"
-                );
-                if app.mention.is_none() && app.subagent.is_none() {
-                    app.release_focus_target(FocusTarget::Mention);
-                }
-                return;
-            }
-            (start, end)
-        }
+        SlashContext::CommandName => false,
+    };
+    let Some((replace_start, replace_end)) = replacement_range(&slash, &chars) else {
+        release_autocomplete_focus_if_idle(app);
+        return;
     };
 
     let before: String = chars[..replace_start].iter().collect();
@@ -164,8 +168,10 @@ pub fn confirm_selection(app: &mut App) {
     lines[slash.trigger_row] = new_line;
     app.input.replace_lines_and_cursor(lines, slash.trigger_row, new_cursor_col.min(new_line_len));
 
-    sync_with_cursor(app);
-    if app.slash.is_none() && app.mention.is_none() && app.subagent.is_none() {
-        app.release_focus_target(FocusTarget::Mention);
+    if closes_after_confirmation {
+        deactivate(app);
+    } else {
+        sync_with_cursor(app);
     }
+    release_autocomplete_focus_if_idle(app);
 }

--- a/src/app/state/history_retention.rs
+++ b/src/app/state/history_retention.rs
@@ -288,6 +288,7 @@ impl super::App {
         self.retained_history_bytes = self.retained_history_bytes.saturating_add(bytes);
         self.rebuild_render_cache_accounting();
         self.invalidate_tail_transition(previous_tail, self.messages.len().checked_sub(1));
+        self.needs_redraw = true;
     }
 
     pub(crate) fn insert_message_tracked(&mut self, idx: usize, msg: ChatMessage) {
@@ -312,6 +313,7 @@ impl super::App {
         } else {
             self.sync_after_message_topology_change(insert_idx);
         }
+        self.needs_redraw = true;
     }
 
     pub(crate) fn remove_message_tracked(&mut self, idx: usize) -> Option<ChatMessage> {
@@ -335,6 +337,7 @@ impl super::App {
         } else {
             self.viewport.sync_message_count(0);
         }
+        self.needs_redraw = true;
         Some(removed)
     }
 
@@ -347,6 +350,7 @@ impl super::App {
         self.rebuild_render_cache_accounting();
         self.rebuild_tool_indices_and_terminal_refs();
         self.viewport.sync_message_count(0);
+        self.needs_redraw = true;
     }
 
     pub(crate) fn recompute_message_retained_bytes(&mut self, idx: usize) {

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -20,6 +20,16 @@ const SUBAGENT_NAME_MAX_WIDTH: usize = 28;
 const SUBAGENT_NAME_MAX_SHARE_NUM: usize = 2;
 const SUBAGENT_NAME_MAX_SHARE_DEN: usize = 5;
 const HELP_PANEL_HEIGHT: u16 = 14;
+const HELP_BUILTIN_SLASH_COMMANDS: [(&str, &str); 8] = [
+    ("/config", "Open settings"),
+    ("/docs", "Show in-chat help topics"),
+    ("/login", "Authenticate with Claude"),
+    ("/logout", "Sign out of Claude"),
+    ("/mcp", "Open MCP"),
+    ("/plugins", "Open plugins"),
+    ("/status", "Show session status"),
+    ("/usage", "Open usage"),
+];
 
 pub fn is_active(app: &App) -> bool {
     app.is_help_active()
@@ -323,19 +333,30 @@ fn pending_command_help_label(app: &App) -> String {
     app.pending_command_label.clone().unwrap_or_else(|| "Processing command...".to_owned())
 }
 
-fn builtin_slash_help_commands() -> [(&'static str, &'static str); 7] {
-    [
-        ("/config", "Open settings"),
-        ("/login", "Authenticate with Claude"),
-        ("/logout", "Sign out of Claude"),
-        ("/mcp", "Open MCP"),
-        ("/plugins", "Open plugins"),
-        ("/status", "Show session status"),
-        ("/usage", "Open usage"),
-    ]
+pub(crate) fn key_help_items(app: &App) -> Vec<(String, String)> {
+    build_key_help_items(app)
+}
+
+pub(crate) fn slash_help_items(app: &App) -> Vec<(String, String)> {
+    build_slash_command_items(app, &HELP_BUILTIN_SLASH_COMMANDS)
+}
+
+pub(crate) fn docs_command_items(app: &App) -> Vec<(String, String)> {
+    slash_help_items(app)
+}
+
+pub(crate) fn subagent_help_items(app: &App) -> Vec<(String, String)> {
+    build_subagent_help_items(app)
 }
 
 fn build_slash_help_items(app: &App) -> Vec<(String, String)> {
+    slash_help_items(app)
+}
+
+fn build_slash_command_items(
+    app: &App,
+    builtin_commands: &[(&str, &str)],
+) -> Vec<(String, String)> {
     use std::collections::BTreeMap;
 
     let mut rows = Vec::new();
@@ -348,9 +369,9 @@ fn build_slash_help_items(app: &App) -> Vec<(String, String)> {
         return rows;
     }
 
-    let mut commands: BTreeMap<String, String> = builtin_slash_help_commands()
-        .into_iter()
-        .map(|(name, description)| (name.to_owned(), description.to_owned()))
+    let mut commands: BTreeMap<String, String> = builtin_commands
+        .iter()
+        .map(|(name, description)| ((*name).to_owned(), (*description).to_owned()))
         .collect();
 
     for cmd in &app.available_commands {
@@ -650,6 +671,7 @@ mod tests {
 
         let items = build_help_items(&app);
         assert!(has_item(&items, "/config", "Open settings"));
+        assert!(has_item(&items, "/docs", "Show in-chat help topics"));
         assert!(has_item(&items, "/login", "Authenticate with Claude"));
         assert!(has_item(&items, "/logout", "Sign out of Claude"));
         assert!(has_item(&items, "/mcp", "Open MCP"));


### PR DESCRIPTION
## Summary

- Add `/docs` slash command that renders help topics (mode, models, shortcuts, commands, agents) as markdown tables directly in chat
- Refactor slash navigation so single-argument builtins (`/docs`, `/mode`, `/model`, `/resume`) close autocomplete after argument selection
- Ensure `needs_redraw = true` is set on all message-list mutations (`push_message_tracked`, `insert_message_tracked`, `remove_message_tracked`, `clear_messages_tracked`)
- Extract reusable helpers in `navigation.rs` (`replacement_range`, `release_autocomplete_focus_if_idle`) and `help.rs` (`key_help_items`, `docs_command_items`, `subagent_help_items`)

## Why

Users currently have no way to look up available modes, models, shortcuts, commands, or agents without leaving the chat. `/docs` surfaces this information inline. The autocomplete and redraw fixes address UX issues where the autocomplete popup lingered after single-argument selection and system messages didn't always trigger a repaint.

## Validation

- Automated: 20+ new unit/integration tests covering `/docs` execution, argument candidates, topic rendering, unknown-topic handling, extra-args handling, autocomplete closing for all single-argument builtins, and end-to-end Enter flows
- Manual: Verified `/docs commands`, `/docs shortcuts`, `/docs models`, `/docs mode`, `/docs agents` render correctly in-chat
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A