### PR TITLE
feat(agent-sdk): upgrade to 0.2.104 and realign bridge and TUI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,4 +9,8 @@ ignore = [
     # Upstream fix merged in syntect main (PR #608, Feb 2026), waiting on release
     # Tracked: https://github.com/trishume/syntect/pull/608
     "RUSTSEC-2024-0320",
+
+    # rand unsoundness with custom logger + ThreadRng reseeding
+    # rand is only a transitive dev-dep of upstream crates, not in our build
+    "RUSTSEC-2026-0097",
 ]

--- a/.github/workflows/agent-sdk.yml
+++ b/.github/workflows/agent-sdk.yml
@@ -1,0 +1,42 @@
+name: Agent SDK
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "agent-sdk/**"
+      - ".github/workflows/agent-sdk.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "agent-sdk/**"
+      - ".github/workflows/agent-sdk.yml"
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Check agent-sdk
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agent-sdk
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: agent-sdk/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run audit
+        run: npm run audit
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run Knip
+        run: npm run knip

--- a/.github/workflows/agent-sdk.yml
+++ b/.github/workflows/agent-sdk.yml
@@ -32,7 +32,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run audit
+      - name: Run raw audit report
+        run: npm run audit:raw
+        continue-on-error: true
+
+      - name: Run direct dependency audit gate
         run: npm run audit
 
       - name: Run lint

--- a/README.md
+++ b/README.md
@@ -25,11 +25,9 @@ Claude Code Rust replaces the stock Claude Code terminal interface with a native
 npm install -g claude-code-rust
 ```
 
-The published package installs a `claude-rs` command and fetches the matching
-prebuilt release binary for your platform during install.
+The published package installs a `claude-rs` command and fetches the matching prebuilt release binary for your platform during install.
 
-If `claude-rs` resolves to an older global shim, ensure your npm global bin
-directory comes first on `PATH` or remove the stale shim before retrying.
+If `claude-rs` resolves to an older global shim, ensure your npm global bin directory comes first on `PATH` or remove the stale shim before retrying.
 
 ## Usage
 
@@ -63,10 +61,13 @@ Three-layer design:
 
 This project is pre-1.0 and under active development. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get involved.
 
+## Limitations
+
+Startup is still constrained by the upstream Claude Agent SDK runtime that this TUI wraps. The Rust interface itself is fast, but end-to-end readiness can still take noticeable time before a session is fully available. Improving that remains an active area of work.
+
 ## License
 
-This project is licensed under the [Apache License 2.0](LICENSE).
-Apache-2.0 was chosen to keep usage and redistribution straightforward for individual users, downstream packagers, and commercial adopters.
+This project is licensed under the [Apache License 2.0](LICENSE). Apache-2.0 was chosen to keep usage and redistribution straightforward for individual users, downstream packagers, and commercial adopters.
 
 ## Disclaimer and Legal Notice
 

--- a/agent-sdk/knip.json
+++ b/agent-sdk/knip.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "./node_modules/knip/schema.json",
+  "entry": [
+    "src/**/*.test.ts"
+  ],
+  "project": [
+    "src/**/*.ts"
+  ]
+}

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -7,8 +7,9 @@
     "": {
       "name": "@srothgan/claude-rs-agent-bridge",
       "version": "0.0.1",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.74"
+        "@anthropic-ai/claude-agent-sdk": "0.2.104"
       },
       "devDependencies": {
         "@types/node": "25.3.3",
@@ -16,10 +17,14 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.74",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.74.tgz",
-      "integrity": "sha512-S/SFSSbZHPL1HiQxAqCCxU3iHuE5nM+ir0OK1n0bZ+9hlVUH7OOn88AsV9s54E0c1kvH9YF4/foWH8J9kICsBw==",
+      "version": "0.2.104",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.104.tgz",
+      "integrity": "sha512-lVm+nS79r6WWlDnv5AgRzTtAlbP8O6M6kkWmDZAWE3nt9agmngxls9frJFvH55uzws2+6l0yyup/JYspfijkzw==",
       "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
       "engines": {
         "node": ">=18.0.0"
       },
@@ -36,6 +41,47 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -310,12 +356,1085 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.3.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typescript": {
@@ -335,12 +1454,59 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -12,7 +12,10 @@
         "@anthropic-ai/claude-agent-sdk": "0.2.104"
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "0.81.0",
+        "@biomejs/biome": "2.4.12",
         "@types/node": "25.3.3",
+        "knip": "6.4.1",
         "typescript": "5.9.3"
       }
     },
@@ -70,6 +73,206 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.12.tgz",
+      "integrity": "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.12",
+        "@biomejs/cli-darwin-x64": "2.4.12",
+        "@biomejs/cli-linux-arm64": "2.4.12",
+        "@biomejs/cli-linux-arm64-musl": "2.4.12",
+        "@biomejs/cli-linux-x64": "2.4.12",
+        "@biomejs/cli-linux-x64-musl": "2.4.12",
+        "@biomejs/cli-win32-arm64": "2.4.12",
+        "@biomejs/cli-win32-x64": "2.4.12"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.12.tgz",
+      "integrity": "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.12.tgz",
+      "integrity": "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.12.tgz",
+      "integrity": "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.12.tgz",
+      "integrity": "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.12.tgz",
+      "integrity": "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.12.tgz",
+      "integrity": "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.12.tgz",
+      "integrity": "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.12.tgz",
+      "integrity": "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -396,6 +599,707 @@
         }
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.121.0.tgz",
+      "integrity": "sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.121.0.tgz",
+      "integrity": "sha512-/Dd1xIXboYAicw+twT2utxPD7bL8qh7d3ej0qvaYIMj3/EgIrGR+tSnjCUkiCT6g6uTC0neSS4JY8LxhdSU/sA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.121.0.tgz",
+      "integrity": "sha512-A0jNEvv7QMtCO1yk205t3DWU9sWUjQ2KNF0hSVO5W9R9r/R1BIvzG01UQAfmtC0dQm7sCrs5puixurKSfr2bRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.121.0.tgz",
+      "integrity": "sha512-SsHzipdxTKUs3I9EOAPmnIimEeJOemqRlRDOp9LIj+96wtxZejF51gNibmoGq8KoqbT1ssAI5po/E3J+vEtXGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.121.0.tgz",
+      "integrity": "sha512-v1APOTkCp+RWOIDAHRoaeW/UoaHF15a60E8eUL6kUQXh+i4K7PBwq2Wi7jm8p0ymID5/m/oC1w3W31Z/+r7HQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.121.0.tgz",
+      "integrity": "sha512-PmqPQuqHZyFVWA4ycr0eu4VnTMmq9laOHZd+8R359w6kzuNZPvmmunmNJ8ybkm769A0nCoVp3TJ6dUz7B3FYIQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.121.0.tgz",
+      "integrity": "sha512-vF24htj+MOH+Q7y9A8NuC6pUZu8t/C2Fr/kDOi2OcNf28oogr2xadBPXAbml802E8wRAVfbta6YLDQTearz+jw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.121.0.tgz",
+      "integrity": "sha512-wjH8cIG2Lu/3d64iZpbYr73hREMgKAfu7fqpXjgM2S16y2zhTfDIp8EQjxO8vlDtKP5Rc7waZW72lh8nZtWrpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.121.0.tgz",
+      "integrity": "sha512-qT663J/W8yQFw3dtscbEi9LKJevr20V7uWs2MPGTnvNZ3rm8anhhE16gXGpxDOHeg9raySaSHKhd4IGa3YZvuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.121.0.tgz",
+      "integrity": "sha512-mYNe4NhVvDBbPkAP8JaVS8lC1dsoJZWH5WCjpw5E+sjhk1R08wt3NnXYUzum7tIiWPfgQxbCMcoxgeemFASbRw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.121.0.tgz",
+      "integrity": "sha512-+QiFoGxhAbaI/amqX567784cDyyuZIpinBrJNxUzb+/L2aBRX67mN6Jv40pqduHf15yYByI+K5gUEygCuv0z9w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.121.0.tgz",
+      "integrity": "sha512-9ykEgyTa5JD/Uhv2sttbKnCfl2PieUfOjyxJC/oDL2UO0qtXOtjPLl7H8Kaj5G7p3hIvFgu3YWvAxvE0sqY+hQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.121.0.tgz",
+      "integrity": "sha512-DB1EW5VHZdc1lIRjOI3bW/wV6R6y0xlfvdVrqj6kKi7Ayu2U3UqUBdq9KviVkcUGd5Oq+dROqvUEEFRXGAM7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.121.0.tgz",
+      "integrity": "sha512-s4lfobX9p4kPTclvMiH3gcQUd88VlnkMTF6n2MTMDAyX5FPNRhhRSFZK05Ykhf8Zy5NibV4PbGR6DnK7FGNN6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.121.0.tgz",
+      "integrity": "sha512-P9KlyTpuBuMi3NRGpJO8MicuGZfOoqZVRP1WjOecwx8yk4L/+mrCRNc5egSi0byhuReblBF2oVoDSMgV9Bj4Hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.121.0.tgz",
+      "integrity": "sha512-R+4jrWOfF2OAPPhj3Eb3U5CaKNAH9/btMveMULIrcNW/hjfysFQlF8wE0GaVBr81dWz8JLgQlsxwctoL78JwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.121.0.tgz",
+      "integrity": "sha512-5TFISkPTymKvsmIlKasPVTPuWxzCcrT8pM+p77+mtQbIZDd1UC8zww4CJcRI46kolmgrEX6QpKO8AvWMVZ+ifw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.121.0.tgz",
+      "integrity": "sha512-V0pxh4mql4XTt3aiEtRNUeBAUFOw5jzZNxPABLaOKAWrVzSr9+XUaB095lY7jqMf5t8vkfh8NManGB28zanYKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.121.0.tgz",
+      "integrity": "sha512-4Ob1qvYMPnlF2N9rdmKdkQFdrq16QVcQwBsO8yiPZXof0fHKFF+LmQV501XFbi7lHyrKm8rlJRfQ/M8bZZPVLw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.121.0.tgz",
+      "integrity": "sha512-BOp1KCzdboB1tPqoCPXgntgFs0jjeSyOXHzgxVFR7B/qfr3F8r4YDacHkTOUNXtDgM8YwKnkf3rE5gwALYX7NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.121.0.tgz",
+      "integrity": "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.19.1.tgz",
+      "integrity": "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.19.1.tgz",
+      "integrity": "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.19.1.tgz",
+      "integrity": "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.19.1.tgz",
+      "integrity": "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.19.1.tgz",
+      "integrity": "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.19.1.tgz",
+      "integrity": "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.19.1.tgz",
+      "integrity": "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.19.1.tgz",
+      "integrity": "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.19.1.tgz",
+      "integrity": "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.19.1.tgz",
+      "integrity": "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.19.1.tgz",
+      "integrity": "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.19.1.tgz",
+      "integrity": "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.19.1.tgz",
+      "integrity": "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.19.1.tgz",
+      "integrity": "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.19.1.tgz",
+      "integrity": "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.19.1.tgz",
+      "integrity": "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.19.1.tgz",
+      "integrity": "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.19.1.tgz",
+      "integrity": "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.19.1.tgz",
+      "integrity": "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.19.1.tgz",
+      "integrity": "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.3.3",
       "dev": true,
@@ -472,6 +1376,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/bytes": {
@@ -771,6 +1688,23 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -786,6 +1720,39 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -806,6 +1773,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/formatly": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+      "integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^2.0.0"
+      },
+      "bin": {
+        "formatly": "bin/index.mjs"
+      },
+      "engines": {
+        "node": ">=18.3.0"
       }
     },
     "node_modules/forwarded": {
@@ -870,6 +1853,32 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/gopd": {
@@ -977,6 +1986,39 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -988,6 +2030,16 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -1023,6 +2075,47 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/knip": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.4.1.tgz",
+      "integrity": "sha512-Ry+ywmDFSZvKp/jx7LxMgsZWRTs931alV84e60lh0Stf6kSRYqSIUTkviyyDFRcSO3yY1Kpbi83OirN+4lA2Xw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/knip"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "@nodelib/fs.walk": "^1.2.3",
+        "fast-glob": "^3.3.3",
+        "formatly": "^0.3.0",
+        "get-tsconfig": "4.13.7",
+        "jiti": "^2.6.0",
+        "minimist": "^1.2.8",
+        "oxc-parser": "^0.121.0",
+        "oxc-resolver": "^11.19.1",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.1",
+        "smol-toml": "^1.6.1",
+        "strip-json-comments": "5.0.3",
+        "unbash": "^2.2.0",
+        "yaml": "^2.8.2",
+        "zod": "^4.1.11"
+      },
+      "bin": {
+        "knip": "bin/knip.js",
+        "knip-bun": "bin/knip-bun.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1053,6 +2146,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -1076,6 +2206,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -1135,6 +2275,76 @@
         "wrappy": "1"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.121.0.tgz",
+      "integrity": "sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.121.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.121.0",
+        "@oxc-parser/binding-android-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-x64": "0.121.0",
+        "@oxc-parser/binding-freebsd-x64": "0.121.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.121.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.121.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.121.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.121.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
+      "integrity": "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.19.1",
+        "@oxc-resolver/binding-android-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-x64": "11.19.1",
+        "@oxc-resolver/binding-freebsd-x64": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-musl": "11.19.1",
+        "@oxc-resolver/binding-openharmony-arm64": "11.19.1",
+        "@oxc-resolver/binding-wasm32-wasi": "11.19.1",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1161,6 +2371,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pkce-challenge": {
@@ -1200,6 +2430,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1233,6 +2484,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1247,6 +2519,30 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safer-buffer": {
@@ -1399,6 +2695,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1406,6 +2715,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/toidentifier": {
@@ -1422,6 +2757,14 @@
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -1449,6 +2792,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/unbash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-2.2.0.tgz",
+      "integrity": "sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "dev": true,
@@ -1472,6 +2825,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1492,6 +2855,22 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -13,7 +13,7 @@
     "test": "npm run build && node --test dist/**/*.test.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.74"
+    "@anthropic-ai/claude-agent-sdk": "0.2.104"
   },
   "devDependencies": {
     "@types/node": "25.3.3",

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -10,13 +10,19 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/bridge.js",
     "check": "npm run build",
+    "lint": "biome lint src",
+    "knip": "knip --include files,dependencies,unlisted,unresolved",
+    "audit": "npm audit --audit-level=moderate",
     "test": "npm run build && node --test dist/**/*.test.js"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.104"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "0.81.0",
+    "@biomejs/biome": "2.4.12",
     "@types/node": "25.3.3",
+    "knip": "6.4.1",
     "typescript": "5.9.3"
   }
 }

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -12,7 +12,8 @@
     "check": "npm run build",
     "lint": "biome lint src",
     "knip": "knip --include files,dependencies,unlisted,unresolved",
-    "audit": "npm audit --audit-level=moderate",
+    "audit": "node ./scripts/audit-direct-deps.mjs",
+    "audit:raw": "npm audit --audit-level=moderate",
     "test": "npm run build && node --test dist/**/*.test.js"
   },
   "dependencies": {

--- a/agent-sdk/scripts/audit-direct-deps.mjs
+++ b/agent-sdk/scripts/audit-direct-deps.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const packageDir = resolve(scriptDir, "..");
+const packageJsonPath = resolve(packageDir, "package.json");
+const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+
+const declaredDependencies = new Set(
+  Object.keys({
+    ...(packageJson.dependencies ?? {}),
+    ...(packageJson.devDependencies ?? {}),
+    ...(packageJson.optionalDependencies ?? {}),
+    ...(packageJson.peerDependencies ?? {}),
+  }),
+);
+
+const auditArgs = ["audit", "--json", "--audit-level=moderate"];
+const auditCommand =
+  process.platform === "win32"
+    ? {
+        command: process.env.ComSpec || "cmd.exe",
+        args: ["/d", "/s", "/c", `npm ${auditArgs.join(" ")}`],
+      }
+    : {
+        command: "npm",
+        args: auditArgs,
+      };
+
+const audit = spawnSync(auditCommand.command, auditCommand.args, {
+  cwd: packageDir,
+  encoding: "utf8",
+});
+
+if (audit.error) {
+  console.error(`failed to run npm audit: ${audit.error.message}`);
+  process.exit(1);
+}
+
+const stdout = audit.stdout?.trim();
+if (!stdout) {
+  if (audit.stderr?.trim()) {
+    console.error(audit.stderr.trim());
+  } else {
+    console.error("npm audit did not return JSON output");
+  }
+  process.exit(1);
+}
+
+let report;
+try {
+  report = JSON.parse(stdout);
+} catch (error) {
+  console.error("failed to parse npm audit JSON output");
+  console.error(stdout);
+  process.exit(1);
+}
+
+const vulnerabilities =
+  report.vulnerabilities && typeof report.vulnerabilities === "object"
+    ? report.vulnerabilities
+    : {};
+
+function normalizeViaEntries(via) {
+  if (Array.isArray(via)) {
+    return via;
+  }
+  return via === undefined ? [] : [via];
+}
+
+function advisoryObjectsForPackage(packageName, vulnerability) {
+  return normalizeViaEntries(vulnerability.via).filter(
+    (entry) =>
+      entry &&
+      typeof entry === "object" &&
+      !Array.isArray(entry) &&
+      typeof entry.name === "string" &&
+      entry.name === packageName,
+  );
+}
+
+function viaPackageNames(vulnerability) {
+  return normalizeViaEntries(vulnerability.via)
+    .map((entry) => {
+      if (typeof entry === "string") {
+        return entry;
+      }
+      if (entry && typeof entry === "object" && !Array.isArray(entry) && typeof entry.name === "string") {
+        return entry.name;
+      }
+      return null;
+    })
+    .filter((entry) => typeof entry === "string");
+}
+
+const directFindings = [];
+const ignoredMetaVulnerabilities = [];
+
+for (const [packageName, vulnerability] of Object.entries(vulnerabilities)) {
+  if (!declaredDependencies.has(packageName)) {
+    continue;
+  }
+
+  const advisories = advisoryObjectsForPackage(packageName, vulnerability);
+  if (advisories.length > 0) {
+    directFindings.push({
+      packageName,
+      severity: vulnerability.severity ?? "unknown",
+      advisories,
+      fixAvailable: vulnerability.fixAvailable ?? false,
+    });
+    continue;
+  }
+
+  ignoredMetaVulnerabilities.push({
+    packageName,
+    severity: vulnerability.severity ?? "unknown",
+    via: viaPackageNames(vulnerability),
+  });
+}
+
+if (directFindings.length === 0) {
+  console.log("No direct dependency advisories at moderate or higher severity.");
+  if (ignoredMetaVulnerabilities.length > 0) {
+    console.log("Ignored direct dependency meta-vulnerabilities caused by transitive packages:");
+    for (const finding of ignoredMetaVulnerabilities) {
+      const via = finding.via.length > 0 ? finding.via.join(", ") : "unknown";
+      console.log(`- ${finding.packageName} (${finding.severity}) via ${via}`);
+    }
+  }
+  process.exit(0);
+}
+
+console.error("Direct dependency advisories found:");
+for (const finding of directFindings) {
+  const firstAdvisory = finding.advisories[0];
+  const title =
+    firstAdvisory && typeof firstAdvisory.title === "string"
+      ? firstAdvisory.title
+      : "security advisory";
+  const range =
+    firstAdvisory && typeof firstAdvisory.range === "string" && firstAdvisory.range.length > 0
+      ? firstAdvisory.range
+      : "unknown range";
+  const url =
+    firstAdvisory && typeof firstAdvisory.url === "string" ? firstAdvisory.url : "no URL provided";
+  console.error(`- ${finding.packageName} (${finding.severity})`);
+  console.error(`  ${title}`);
+  console.error(`  affected range: ${range}`);
+  console.error(`  fix available: ${String(finding.fixAvailable)}`);
+  console.error(`  ${url}`);
+}
+process.exit(1);

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   AsyncQueue,
   CACHE_SPLIT_POLICY,
+  buildApiRetryUpdate,
   buildRateLimitUpdate,
   buildQueryOptions,
   canGenerateSessionTitle,
@@ -12,6 +13,7 @@ import {
   buildToolResultFields,
   createToolCall,
   handleTaskSystemMessage,
+  handleSdkMessage,
   mapAvailableAgents,
   mapAvailableModels,
   mapSessionMessagesToUpdates,
@@ -21,7 +23,9 @@ import {
   looksLikeAuthRequired,
   normalizeToolResultText,
   parseFastModeState,
+  parseRuntimeSessionState,
   parseRateLimitStatus,
+  normalizeSettingsParseError,
   normalizeToolKind,
   parseCommandEnvelope,
   permissionOptionsFromSuggestions,
@@ -586,6 +590,7 @@ test("buildQueryOptions maps launch settings into sdk query options", () => {
   assert.equal("thinking" in options, false);
   assert.equal("effort" in options, false);
   assert.equal(options.agentProgressSummaries, true);
+  assert.equal(options.promptSuggestions, true);
   assert.equal(options.sessionId, "session-1");
   assert.deepEqual(options.settingSources, ["user", "project", "local"]);
   assert.deepEqual(options.toolConfig, {
@@ -1283,6 +1288,14 @@ test("parseRateLimitStatus accepts known values and rejects unknown values", () 
   assert.equal(parseRateLimitStatus(undefined), null);
 });
 
+test("parseRuntimeSessionState accepts known values and rejects unknown values", () => {
+  assert.equal(parseRuntimeSessionState("idle"), "idle");
+  assert.equal(parseRuntimeSessionState("running"), "running");
+  assert.equal(parseRuntimeSessionState("requires_action"), "requires_action");
+  assert.equal(parseRuntimeSessionState("blocked"), null);
+  assert.equal(parseRuntimeSessionState(undefined), null);
+});
+
 test("buildRateLimitUpdate maps SDK fields to wire shape", () => {
   const update = buildRateLimitUpdate({
     status: "allowed_warning",
@@ -1321,6 +1334,131 @@ test("buildRateLimitUpdate rejects invalid payloads", () => {
     }),
     { type: "rate_limit_update", status: "rejected" },
   );
+});
+
+test("buildApiRetryUpdate maps SDK api_retry messages to wire shape", () => {
+  assert.deepEqual(
+    buildApiRetryUpdate({
+      attempt: 2,
+      max_retries: 4,
+      retry_delay_ms: 1500,
+      error_status: 529,
+      error: "server_error",
+    }),
+    {
+      type: "api_retry_update",
+      attempt: 2,
+      max_retries: 4,
+      retry_delay_ms: 1500,
+      error_status: 529,
+      error: "server_error",
+    },
+  );
+
+  assert.deepEqual(
+    buildApiRetryUpdate({
+      attempt: 1,
+      maxRetries: 4,
+      retryDelayMs: 1000,
+      errorStatus: null,
+      error: "unexpected",
+    }),
+    {
+      type: "api_retry_update",
+      attempt: 1,
+      max_retries: 4,
+      retry_delay_ms: 1000,
+      error_status: null,
+      error: "unknown",
+    },
+  );
+  assert.equal(buildApiRetryUpdate({ attempt: 1 }), null);
+});
+
+test("normalizeSettingsParseError accepts only SDK-shaped errors", () => {
+  assert.deepEqual(
+    normalizeSettingsParseError({
+      file: "C:/work/.claude/settings.json",
+      path: "permissions.allow",
+      message: "Expected array",
+    }),
+    {
+      file: "C:/work/.claude/settings.json",
+      path: "permissions.allow",
+      message: "Expected array",
+    },
+  );
+  assert.deepEqual(normalizeSettingsParseError({ path: "", message: "Invalid JSON" }), {
+    path: "",
+    message: "Invalid JSON",
+  });
+  assert.equal(normalizeSettingsParseError({ path: "", message: "" }), null);
+  assert.equal(normalizeSettingsParseError("Invalid JSON"), null);
+});
+
+test("handleSdkMessage emits lifecycle compatibility session updates", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "prompt_suggestion",
+      suggestion: "Write tests for this change",
+      uuid: "message-1",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "api_retry",
+      attempt: 1,
+      max_retries: 4,
+      retry_delay_ms: 1000,
+      error_status: null,
+      error: "server_error",
+      uuid: "message-2",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+      uuid: "message-3",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      { type: "prompt_suggestion_update", suggestion: "Write tests for this change" },
+      {
+        type: "api_retry_update",
+        attempt: 1,
+        max_retries: 4,
+        retry_delay_ms: 1000,
+        error_status: null,
+        error: "server_error",
+      },
+      { type: "runtime_session_state_update", state: "idle" },
+    ],
+  );
+});
+
+test("handleSdkMessage emits settings parse errors from defensive payloads", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "settings_parse_error",
+      file: "C:/work/.claude/settings.json",
+      path: "permissions.allow",
+      message: "Expected array",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.at(-1)?.update, {
+    type: "settings_parse_error",
+    file: "C:/work/.claude/settings.json",
+    path: "permissions.allow",
+    message: "Expected array",
+  });
 });
 
 test("mapAvailableAgents normalizes and deduplicates agents", () => {

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -17,6 +17,7 @@ import {
   mapSessionMessagesToUpdates,
   mapSdkSessions,
   agentSdkVersionCompatibilityError,
+  attachRequestUserDialogInterceptor,
   looksLikeAuthRequired,
   normalizeToolResultText,
   parseFastModeState,
@@ -38,6 +39,12 @@ import {
   permissionModeFailureLooksUnsupported,
   refreshSupportedModesForSession,
 } from "./bridge/commands.js";
+import {
+  emitCurrentModelUpdate,
+  refreshCurrentModel,
+  resolveCurrentModel,
+  shouldInvalidateResolvedRuntimeModel,
+} from "./bridge/session_lifecycle.js";
 import { emitToolProgressUpdate } from "./bridge/tool_calls.js";
 import { requestAskUserQuestionAnswers } from "./bridge/user_interaction.js";
 import { handleResultMessage } from "./bridge/message_handlers.js";
@@ -99,6 +106,36 @@ test("buildModeState includes auto and bypassPermissions when supported", () => 
   assert.deepEqual(
     mode.available_modes.map((entry) => entry.id),
     ["default", "auto", "acceptEdits", "plan", "dontAsk", "bypassPermissions"],
+  );
+});
+
+test("refreshSupportedModesForSession uses resolved current model for auto-mode eligibility", () => {
+  const session = makeSessionState();
+  session.model = "sonnet";
+  session.availableModels = [
+    {
+      id: "sonnet",
+      display_name: "Claude Sonnet",
+      supports_effort: true,
+      supported_effort_levels: ["low", "medium", "high"],
+      supports_auto_mode: true,
+    },
+  ];
+  session.currentModel = {
+    resolved_id: "claude-sonnet-4-6[1m]",
+    display_name_short: "Sonnet [1M]",
+    display_name_long: "Sonnet 4.6 [1M]",
+    supports_effort: true,
+    supported_effort_levels: ["low", "medium", "high"],
+    supports_auto_mode: false,
+    is_authoritative: true,
+  };
+
+  refreshSupportedModesForSession(session);
+
+  assert.deepEqual(
+    availableModesForSession(session).map((entry) => entry.id),
+    ["default", "acceptEdits", "plan", "dontAsk"],
   );
 });
 
@@ -378,6 +415,38 @@ test("parseCommandEnvelope validates mcp_set_servers command", () => {
         "X-Test": "1",
       },
     },
+  });
+});
+
+test("parseCommandEnvelope validates reload_plugins command", () => {
+  const parsed = parseCommandEnvelope(
+    JSON.stringify({
+      request_id: "req-reload",
+      command: "reload_plugins",
+      session_id: "session-123",
+    }),
+  );
+
+  assert.equal(parsed.requestId, "req-reload");
+  assert.deepEqual(parsed.command, {
+    command: "reload_plugins",
+    session_id: "session-123",
+  });
+});
+
+test("parseCommandEnvelope validates get_context_usage command", () => {
+  const parsed = parseCommandEnvelope(
+    JSON.stringify({
+      request_id: "req-usage",
+      command: "get_context_usage",
+      session_id: "session-123",
+    }),
+  );
+
+  assert.equal(parsed.requestId, "req-usage");
+  assert.deepEqual(parsed.command, {
+    command: "get_context_usage",
+    session_id: "session-123",
   });
 });
 
@@ -818,6 +887,143 @@ test("handleTaskSystemMessage final summary replaces prior task content and fina
     },
   });
   assert.equal(session.taskToolUseIds.has("task-1"), false);
+});
+
+test("handleTaskSystemMessage applies task_updated description patches to the linked task", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleTaskSystemMessage(session, "task_started", {
+      task_id: "task-1",
+      tool_use_id: "tool-1",
+      description: "Initial task description",
+    });
+    handleTaskSystemMessage(session, "task_updated", {
+      task_id: "task-1",
+      patch: {
+        status: "running",
+        description: "Refining the migration plan",
+        is_backgrounded: true,
+      },
+    });
+  });
+
+  const lastEvent = events.at(-1);
+  assert.ok(lastEvent);
+  assert.equal(lastEvent.event, "session_update");
+  assert.deepEqual(lastEvent.update, {
+    type: "tool_call_update",
+    tool_call_update: {
+      tool_call_id: "tool-1",
+      fields: {
+        status: "in_progress",
+        raw_output: "Refining the migration plan",
+        content: [
+          {
+            type: "content",
+            content: { type: "text", text: "Refining the migration plan" },
+          },
+        ],
+        task_metadata: {
+          is_backgrounded: true,
+        },
+      },
+    },
+  });
+});
+
+test("handleTaskSystemMessage uses task_updated terminal error text when description is absent", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleTaskSystemMessage(session, "task_started", {
+      task_id: "task-1",
+      tool_use_id: "tool-1",
+      description: "Initial task description",
+    });
+    handleTaskSystemMessage(session, "task_updated", {
+      task_id: "task-1",
+      patch: {
+        status: "killed",
+        error: "Task stopped by parent agent",
+        end_time: 1234,
+        total_paused_ms: 250,
+      },
+    });
+  });
+
+  const lastEvent = events.at(-1);
+  assert.ok(lastEvent);
+  assert.equal(lastEvent.event, "session_update");
+  assert.deepEqual(lastEvent.update, {
+    type: "tool_call_update",
+    tool_call_update: {
+      tool_call_id: "tool-1",
+      fields: {
+        status: "killed",
+        raw_output: "Task stopped by parent agent",
+        content: [
+          {
+            type: "content",
+            content: { type: "text", text: "Task stopped by parent agent" },
+          },
+        ],
+        task_metadata: {
+          error: "Task stopped by parent agent",
+          end_time: 1234,
+          total_paused_ms: 250,
+        },
+      },
+    },
+  });
+});
+
+test("handleTaskSystemMessage merges task metadata patches into the linked task state", () => {
+  const session = makeSessionState();
+
+  captureBridgeEvents(() => {
+    handleTaskSystemMessage(session, "task_started", {
+      task_id: "task-1",
+      tool_use_id: "tool-1",
+      description: "Initial task description",
+    });
+    handleTaskSystemMessage(session, "task_updated", {
+      task_id: "task-1",
+      patch: {
+        status: "running",
+        is_backgrounded: true,
+      },
+    });
+    handleTaskSystemMessage(session, "task_updated", {
+      task_id: "task-1",
+      patch: {
+        error: "Task stopped by parent agent",
+        end_time: 1234,
+      },
+    });
+  });
+
+  assert.deepEqual(session.toolCalls.get("tool-1")?.task_metadata, {
+    is_backgrounded: true,
+    error: "Task stopped by parent agent",
+    end_time: 1234,
+  });
+});
+
+test("handleTaskSystemMessage skips unlinked task_updated messages", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleTaskSystemMessage(session, "task_updated", {
+      task_id: "task-missing",
+      patch: {
+        status: "running",
+        description: "This should not be emitted",
+      },
+    });
+  });
+
+  assert.equal(events.length, 0);
 });
 
 test("emitToolProgressUpdate does not reopen completed tools", () => {
@@ -1926,4 +2132,248 @@ test("mapAvailableModels preserves optional fast and auto mode metadata", () => 
       supported_effort_levels: [],
     },
   ]);
+});
+
+test("resolveCurrentModel keeps 1M context suffix in short and long display names", () => {
+  const session = makeSessionState();
+  session.resolvedRuntimeModelId = "claude-opus-4-6[1m]";
+
+  const currentModel = resolveCurrentModel(session);
+
+  assert.equal(currentModel.display_name_short, "Opus [1M]");
+  assert.equal(currentModel.display_name_long, "Opus 4.6 [1M]");
+});
+
+test("resolveCurrentModel does not inherit standard Opus capabilities for 1M when sibling variants exist", () => {
+  const session = makeSessionState();
+  session.requestedModelId = "claude-opus-4-6";
+  session.resolvedRuntimeModelId = "claude-opus-4-6[1m]";
+  session.availableModels = [
+    {
+      id: "claude-opus-4-6",
+      display_name: "Claude Opus",
+      supports_effort: true,
+      supported_effort_levels: ["low", "medium", "high"],
+    },
+    {
+      id: "claude-opus-4-6[1m]",
+      display_name: "Claude Opus 1M",
+      supports_effort: false,
+      supported_effort_levels: [],
+    },
+  ];
+
+  const currentModel = resolveCurrentModel(session);
+
+  assert.equal(currentModel.catalog_id, "claude-opus-4-6[1m]");
+  assert.equal(currentModel.supports_effort, false);
+});
+
+test("resolveCurrentModel avoids suffix-insensitive fallback when sibling variants make it ambiguous", () => {
+  const session = makeSessionState();
+  session.requestedModelId = "claude-opus-4-6";
+  session.resolvedRuntimeModelId = "claude-opus-4-6[1m]";
+  session.availableModels = [
+    {
+      id: "claude-opus-4-6",
+      display_name: "Claude Opus",
+      supports_effort: true,
+      supported_effort_levels: ["low", "medium", "high"],
+    },
+    {
+      id: "claude-opus-4-6-alt[1m]",
+      display_name: "Claude Opus Alt 1M",
+      supports_effort: false,
+      supported_effort_levels: [],
+    },
+  ];
+
+  const currentModel = resolveCurrentModel(session);
+
+  assert.equal(currentModel.catalog_id, undefined);
+  assert.equal(currentModel.supports_effort, false);
+});
+
+test("emitCurrentModelUpdate can acknowledge a successful no-op set_model", () => {
+  const session = makeSessionState();
+  session.model = "default";
+  session.requestedModelId = "default";
+  session.resolvedRuntimeModelId = "claude-opus-4-6[1m]";
+  refreshCurrentModel(session);
+
+  const events = captureBridgeEvents(() => {
+    const changed = refreshCurrentModel(session, true);
+    const forced = !changed && emitCurrentModelUpdate(session);
+    assert.equal(changed, false);
+    assert.equal(forced, true);
+  });
+
+  const lastEvent = events.at(-1);
+  assert.ok(lastEvent);
+  assert.equal(lastEvent.event, "session_update");
+  assert.deepEqual(lastEvent.update, {
+    type: "current_model_update",
+    current_model: {
+      requested_id: "default",
+      resolved_id: "claude-opus-4-6[1m]",
+      display_name_short: "Opus [1M]",
+      display_name_long: "Opus 4.6 [1M]",
+      supports_effort: false,
+      supported_effort_levels: [],
+      is_authoritative: true,
+    },
+  });
+});
+
+test("emitCurrentModelUpdate can publish catalog-enriched current model metadata after connect", () => {
+  const session = makeSessionState();
+  session.model = "sonnet";
+  refreshCurrentModel(session);
+  session.availableModels = [
+    {
+      id: "sonnet",
+      display_name: "Claude Sonnet",
+      supports_effort: true,
+      supported_effort_levels: ["low", "medium", "high"],
+      supports_auto_mode: true,
+    },
+  ];
+
+  const events = captureBridgeEvents(() => {
+    const changed = refreshCurrentModel(session, false);
+    assert.equal(changed, true);
+    assert.equal(emitCurrentModelUpdate(session), true);
+  });
+
+  const lastEvent = events.at(-1);
+  assert.ok(lastEvent);
+  assert.equal(lastEvent.event, "session_update");
+  assert.deepEqual(lastEvent.update, {
+    type: "current_model_update",
+    current_model: {
+      resolved_id: "sonnet",
+      display_name_short: "Sonnet",
+      display_name_long: "Sonnet",
+      catalog_id: "sonnet",
+      supports_effort: true,
+      supported_effort_levels: ["low", "medium", "high"],
+      supports_auto_mode: true,
+      is_authoritative: true,
+    },
+  });
+});
+
+test("shouldInvalidateResolvedRuntimeModel invalidates stale runtime identity only when the request changes", () => {
+  assert.equal(
+    shouldInvalidateResolvedRuntimeModel("default", "default", "sonnet"),
+    true,
+  );
+  assert.equal(
+    shouldInvalidateResolvedRuntimeModel("sonnet", "sonnet", "haiku"),
+    true,
+  );
+  assert.equal(
+    shouldInvalidateResolvedRuntimeModel("default", "default", "default"),
+    false,
+  );
+});
+
+test("resolveCurrentModel falls back to the requested model immediately after stale runtime identity is cleared", () => {
+  const session = makeSessionState();
+  session.requestedModelId = "sonnet";
+  session.model = "sonnet";
+  session.availableModels = [
+    {
+      id: "sonnet",
+      display_name: "Claude Sonnet",
+      supports_effort: true,
+      supported_effort_levels: ["low", "medium", "high"],
+    },
+  ];
+
+  const currentModel = resolveCurrentModel(session);
+
+  assert.equal(currentModel.resolved_id, "sonnet");
+  assert.equal(currentModel.display_name_short, "Sonnet");
+  assert.equal(currentModel.display_name_long, "Sonnet");
+  assert.equal(currentModel.catalog_id, "sonnet");
+  assert.equal(currentModel.supports_effort, true);
+});
+
+test("attachRequestUserDialogInterceptor rejects request_user_dialog with a stable error", async () => {
+  const calls: Array<{ request_id: string; request: Record<string, unknown> }> = [];
+  const fakeQuery = {
+    async processControlRequest(
+      request: { request_id: string; request: Record<string, unknown> },
+      _signal: AbortSignal,
+    ): Promise<Record<string, unknown>> {
+      calls.push(request);
+      return { ok: true };
+    },
+  } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
+
+  assert.equal(
+    attachRequestUserDialogInterceptor(fakeQuery, () => "session-test"),
+    true,
+  );
+
+  await assert.rejects(
+    (fakeQuery as import("@anthropic-ai/claude-agent-sdk").Query & {
+      processControlRequest: (
+        request: { request_id: string; request: Record<string, unknown> },
+        signal: AbortSignal,
+      ) => Promise<Record<string, unknown> | undefined>;
+    }).processControlRequest(
+      {
+        request_id: "dialog-1",
+        request: {
+          subtype: "request_user_dialog",
+          dialog_kind: "computer_use_approval",
+          payload: { title: "Need approval", kind: "computer_use_approval" },
+          tool_use_id: "tool-1",
+        },
+      },
+      new AbortController().signal,
+    ),
+    /request_user_dialog is not supported by claude-rs yet \(dialog_kind: computer_use_approval\)/,
+  );
+  assert.equal(calls.length, 0);
+});
+
+test("attachRequestUserDialogInterceptor preserves non-dialog control requests", async () => {
+  const calls: Array<{ request_id: string; request: Record<string, unknown> }> = [];
+  const fakeQuery = {
+    async processControlRequest(
+      request: { request_id: string; request: Record<string, unknown> },
+      _signal: AbortSignal,
+    ): Promise<Record<string, unknown>> {
+      calls.push(request);
+      return { ok: true };
+    },
+  } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
+
+  attachRequestUserDialogInterceptor(fakeQuery, () => "session-test");
+  const result = await (
+    fakeQuery as import("@anthropic-ai/claude-agent-sdk").Query & {
+      processControlRequest: (
+        request: { request_id: string; request: Record<string, unknown> },
+        signal: AbortSignal,
+      ) => Promise<Record<string, unknown> | undefined>;
+    }
+  ).processControlRequest(
+    {
+      request_id: "permission-1",
+      request: {
+        subtype: "can_use_tool",
+        tool_name: "Bash",
+        input: { command: "dir" },
+        tool_use_id: "tool-1",
+      },
+    },
+    new AbortController().signal,
+  );
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.request.subtype, "can_use_tool");
 });

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -48,6 +48,7 @@ import {
   refreshCurrentModel,
   resolveCurrentModel,
   shouldInvalidateResolvedRuntimeModel,
+  shouldEmitStartupAuthRequiredForAccount,
 } from "./bridge/session_lifecycle.js";
 import { emitToolProgressUpdate } from "./bridge/tool_calls.js";
 import { requestAskUserQuestionAnswers } from "./bridge/user_interaction.js";
@@ -1440,6 +1441,40 @@ test("handleSdkMessage emits lifecycle compatibility session updates", () => {
       { type: "runtime_session_state_update", state: "idle" },
     ],
   );
+});
+
+test("shouldEmitStartupAuthRequiredForAccount keeps legacy first-party behavior", () => {
+  assert.equal(shouldEmitStartupAuthRequiredForAccount({}), true);
+  assert.equal(
+    shouldEmitStartupAuthRequiredForAccount({ apiProvider: "firstParty" }),
+    true,
+  );
+  assert.equal(
+    shouldEmitStartupAuthRequiredForAccount({
+      apiProvider: "firstParty",
+      apiKeySource: "oauth",
+    }),
+    false,
+  );
+  assert.equal(
+    shouldEmitStartupAuthRequiredForAccount({
+      apiProvider: "firstParty",
+      email: "user@example.com",
+    }),
+    false,
+  );
+});
+
+test("shouldEmitStartupAuthRequiredForAccount skips Claude OAuth hint for external providers", () => {
+  for (const apiProvider of [
+    "bedrock",
+    "vertex",
+    "foundry",
+    "anthropicAws",
+    "mantle",
+  ] as const) {
+    assert.equal(shouldEmitStartupAuthRequiredForAccount({ apiProvider }), false);
+  }
 });
 
 test("handleSdkMessage emits settings parse errors from defensive payloads", () => {

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -1725,7 +1725,7 @@ test("buildToolResultFields preserves Edit diff content from input and structure
   ]);
 });
 
-test("buildToolResultFields prefers structured Bash stdout over token-saver output", () => {
+test("buildToolResultFields ignores model-facing Bash stale read hints", () => {
   const base = createToolCall("tc-bash", "Bash", { command: "npm test" });
   const fields = buildToolResultFields(
     false,
@@ -1733,7 +1733,7 @@ test("buildToolResultFields prefers structured Bash stdout over token-saver outp
       stdout: "real stdout",
       stderr: "",
       interrupted: false,
-      tokenSaverOutput: "compressed output for model",
+      staleReadFileStateHint: "src/main.rs changed while command ran",
     },
     base,
     {
@@ -1741,17 +1741,13 @@ test("buildToolResultFields prefers structured Bash stdout over token-saver outp
         stdout: "real stdout",
         stderr: "",
         interrupted: false,
-        tokenSaverOutput: "compressed output for model",
+        staleReadFileStateHint: "src/main.rs changed while command ran",
       },
     },
   );
 
   assert.equal(fields.raw_output, "real stdout");
-  assert.deepEqual(fields.output_metadata, {
-    bash: {
-      token_saver_active: true,
-    },
-  });
+  assert.equal(fields.output_metadata, undefined);
 });
 
 test("buildToolResultFields adds Bash auto-backgrounded metadata and message", () => {
@@ -2286,25 +2282,88 @@ test("buildSessionListOptions scopes repo-local listings to worktrees", () => {
   });
 });
 
-test("buildToolResultFields extracts ExitPlanMode ultraplan metadata from structured results", () => {
-  const base = createToolCall("tc-plan", "ExitPlanMode", {});
+test("buildToolResultFields renders file_unchanged Read results compactly", () => {
+  const base = createToolCall("tc-read", "Read", { file_path: "src/main.rs" });
   const fields = buildToolResultFields(
     false,
-    [{ text: "Plan ready for approval" }],
+    {
+      type: "file_unchanged",
+      file: { filePath: "src/main.rs" },
+    },
     base,
     {
       result: {
-        plan: "Plan contents",
-        isUltraplan: true,
+        type: "file_unchanged",
+        file: { filePath: "src/main.rs" },
       },
     },
   );
 
-  assert.deepEqual(fields.output_metadata, {
-    exit_plan_mode: {
-      is_ultraplan: true,
+  assert.equal(fields.raw_output, "File unchanged: src/main.rs");
+  assert.deepEqual(fields.content, [
+    { type: "content", content: { type: "text", text: "File unchanged: src/main.rs" } },
+  ]);
+});
+
+test("buildToolResultFields renders array-wrapped file_unchanged Read results compactly", () => {
+  const base = createToolCall("tc-read", "Read", { file_path: "src/lib.rs" });
+  const fields = buildToolResultFields(
+    false,
+    [],
+    base,
+    {
+      result: [
+        {
+          type: "file_unchanged",
+          file: { filePath: "src/lib.rs" },
+        },
+      ],
     },
-  });
+  );
+
+  assert.equal(fields.raw_output, "File unchanged: src/lib.rs");
+});
+
+test("buildToolResultFields uses Agent output agentType as task title", () => {
+  const base = createToolCall("tc-agent", "Agent", { prompt: "Review tests" });
+  const fields = buildToolResultFields(
+    false,
+    {
+      agentId: "agent-1",
+      agentType: "reviewer",
+      content: [{ type: "text", text: "Done" }],
+      totalToolUseCount: 0,
+      totalDurationMs: 10,
+      totalTokens: 20,
+      usage: {},
+      status: "completed",
+      prompt: "Review tests",
+    },
+    base,
+  );
+
+  assert.equal(fields.title, "reviewer");
+});
+
+test("buildToolResultFields reads array-wrapped Agent output agentType", () => {
+  const base = createToolCall("tc-agent", "Agent", { prompt: "Review tests" });
+  const fields = buildToolResultFields(
+    false,
+    [],
+    base,
+    {
+      result: [
+        {
+          agentId: "agent-1",
+          agentType: "planner",
+          content: [{ type: "text", text: "Done" }],
+          status: "completed",
+        },
+      ],
+    },
+  );
+
+  assert.equal(fields.title, "planner");
 });
 
 test("buildToolResultFields extracts TodoWrite verification metadata from structured results", () => {

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -1489,7 +1489,7 @@ test("looksLikeAuthRequired detects login hints", () => {
 });
 
 test("agent sdk version compatibility check matches pinned version", () => {
-  assert.equal(resolveInstalledAgentSdkVersion(), "0.2.74");
+  assert.equal(resolveInstalledAgentSdkVersion(), "0.2.104");
   assert.equal(agentSdkVersionCompatibilityError(), undefined);
 });
 

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -31,8 +31,16 @@ import {
   unwrapToolUseResult,
 } from "./bridge.js";
 import type { SessionState } from "./bridge.js";
+import {
+  availableModesForSession,
+  buildModeState,
+  markModeUnavailableForSession,
+  permissionModeFailureLooksUnsupported,
+  refreshSupportedModesForSession,
+} from "./bridge/commands.js";
 import { emitToolProgressUpdate } from "./bridge/tool_calls.js";
 import { requestAskUserQuestionAnswers } from "./bridge/user_interaction.js";
+import { handleResultMessage } from "./bridge/message_handlers.js";
 
 function makeSessionState(): SessionState {
   const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
@@ -42,6 +50,9 @@ function makeSessionState(): SessionState {
     model: "haiku",
     availableModels: [],
     mode: null,
+    supportedModeIds: [],
+    runtimeUnavailableModeIds: [],
+    supportsBypassPermissionsMode: false,
     fastModeState: "off",
     query: {} as import("@anthropic-ai/claude-agent-sdk").Query,
     input,
@@ -56,6 +67,97 @@ function makeSessionState(): SessionState {
     authHintSent: false,
   };
 }
+
+test("availableModesForSession omits conditional modes when unsupported", () => {
+  const session = makeSessionState();
+  refreshSupportedModesForSession(session);
+
+  assert.deepEqual(
+    availableModesForSession(session).map((entry) => entry.id),
+    ["default", "acceptEdits", "plan", "dontAsk"],
+  );
+});
+
+test("buildModeState includes auto and bypassPermissions when supported", () => {
+  const session = makeSessionState();
+  session.mode = "default";
+  session.model = "sonnet";
+  session.supportsBypassPermissionsMode = true;
+  session.availableModels = [
+    {
+      id: "sonnet",
+      display_name: "Sonnet",
+      supports_effort: true,
+      supported_effort_levels: ["low", "medium", "high"],
+      supports_auto_mode: true,
+    },
+  ];
+  refreshSupportedModesForSession(session);
+
+  const mode = buildModeState(session, "default");
+
+  assert.deepEqual(
+    mode.available_modes.map((entry) => entry.id),
+    ["default", "auto", "acceptEdits", "plan", "dontAsk", "bypassPermissions"],
+  );
+});
+
+test("refreshSupportedModesForSession retains current mode before capability data arrives", () => {
+  const session = makeSessionState();
+  session.mode = "auto";
+
+  refreshSupportedModesForSession(session);
+
+  assert.deepEqual(
+    session.supportedModeIds,
+    ["default", "auto", "acceptEdits", "plan", "dontAsk"],
+  );
+});
+
+test("markModeUnavailableForSession prunes rejected runtime mode from session list", () => {
+  const session = makeSessionState();
+  session.model = "sonnet";
+  session.availableModels = [
+    {
+      id: "sonnet",
+      display_name: "Sonnet",
+      supports_effort: true,
+      supported_effort_levels: ["low", "medium", "high"],
+      supports_auto_mode: true,
+    },
+  ];
+  refreshSupportedModesForSession(session);
+
+  assert.equal(markModeUnavailableForSession(session, "auto"), true);
+  assert.deepEqual(
+    availableModesForSession(session).map((entry) => entry.id),
+    ["default", "acceptEdits", "plan", "dontAsk"],
+  );
+});
+
+test("permissionModeFailureLooksUnsupported detects SDK capability rejections", () => {
+  assert.equal(
+    permissionModeFailureLooksUnsupported(
+      "auto",
+      "Cannot set permission mode to auto: not available in my plan",
+    ),
+    true,
+  );
+  assert.equal(
+    permissionModeFailureLooksUnsupported(
+      "bypassPermissions",
+      "Cannot set permission mode to bypassPermissions because the session was not launched with --dangerously-skip-permissions",
+    ),
+    true,
+  );
+  assert.equal(
+    permissionModeFailureLooksUnsupported(
+      "auto",
+      "bridge disconnected before request completed",
+    ),
+    false,
+  );
+});
 
 function captureBridgeEvents(run: () => void): Array<Record<string, unknown>> {
   const writes: string[] = [];
@@ -483,6 +585,27 @@ test("buildQueryOptions trims startup model before passing sdk option", () => {
   assert.equal(options.permissionMode, "plan");
 });
 
+test("buildQueryOptions maps auto startup permission mode", () => {
+  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const options = buildQueryOptions({
+    cwd: "C:/work",
+    launchSettings: {
+      settings: {
+        permissions: { defaultMode: "auto" },
+      },
+    },
+    provisionalSessionId: "session-auto",
+    input,
+    canUseTool: async () => ({ behavior: "deny", message: "not used" }),
+    enableSdkDebug: false,
+    enableSpawnDebug: false,
+    sessionIdForLogs: () => "session-auto",
+  });
+
+  assert.equal(options.permissionMode, "auto");
+  assert.equal("allowDangerouslySkipPermissions" in options, false);
+});
+
 test("buildQueryOptions enables dangerous skip flag for bypass permissions startup mode", () => {
   const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
   const options = buildQueryOptions({
@@ -522,6 +645,61 @@ test("buildQueryOptions omits startup overrides for default logout path", () => 
   assert.equal("allowDangerouslySkipPermissions" in options, false);
   assert.equal("systemPrompt" in options, false);
   assert.equal("agentProgressSummaries" in options, false);
+});
+
+test("buildQueryOptions makes sandbox fallback explicit when enabled", () => {
+  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const options = buildQueryOptions({
+    cwd: "C:/work",
+    launchSettings: {
+      settings: {
+        sandbox: {
+          enabled: true,
+        },
+      },
+    },
+    provisionalSessionId: "session-sandbox",
+    input,
+    canUseTool: async () => ({ behavior: "deny", message: "not used" }),
+    enableSdkDebug: false,
+    enableSpawnDebug: false,
+    sessionIdForLogs: () => "session-sandbox",
+  });
+
+  assert.deepEqual(options.settings, {
+    sandbox: {
+      enabled: true,
+      failIfUnavailable: false,
+    },
+  });
+});
+
+test("buildQueryOptions preserves explicit sandbox failIfUnavailable setting", () => {
+  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const options = buildQueryOptions({
+    cwd: "C:/work",
+    launchSettings: {
+      settings: {
+        sandbox: {
+          enabled: true,
+          failIfUnavailable: true,
+        },
+      },
+    },
+    provisionalSessionId: "session-sandbox-explicit",
+    input,
+    canUseTool: async () => ({ behavior: "deny", message: "not used" }),
+    enableSdkDebug: false,
+    enableSpawnDebug: false,
+    sessionIdForLogs: () => "session-sandbox-explicit",
+  });
+
+  assert.deepEqual(options.settings, {
+    sandbox: {
+      enabled: true,
+      failIfUnavailable: true,
+    },
+  });
 });
 
 test("handleTaskSystemMessage prefers task_progress summary over fallback text", () => {
@@ -1553,6 +1731,48 @@ test("mapSessionMessagesToUpdates maps message content blocks", () => {
   assert.equal(variantCounts.get("agent_message_chunk"), 1);
   assert.equal(variantCounts.get("tool_call"), 1);
   assert.equal(variantCounts.get("tool_call_update"), 1);
+});
+
+test("handleResultMessage emits terminal reason on successful turn completion", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleResultMessage(session, {
+      type: "result",
+      subtype: "success",
+      terminal_reason: "completed",
+    });
+  });
+
+  const lastEvent = events.at(-1);
+  assert.deepEqual(lastEvent, {
+    event: "turn_complete",
+    session_id: "session-1",
+    terminal_reason: "completed",
+  });
+});
+
+test("handleResultMessage emits terminal reason on turn errors", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleResultMessage(session, {
+      type: "result",
+      subtype: "error_max_turns",
+      terminal_reason: "max_turns",
+      errors: ["max turns exceeded"],
+    });
+  });
+
+  const lastEvent = events.at(-1);
+  assert.deepEqual(lastEvent, {
+    event: "turn_error",
+    session_id: "session-1",
+    message: "max turns exceeded",
+    error_kind: "plan_limit",
+    sdk_result_subtype: "error_max_turns",
+    terminal_reason: "max_turns",
+  });
 });
 
 test("mapSessionMessagesToUpdates ignores unsupported records", () => {

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -1040,7 +1040,7 @@ test("emitToolProgressUpdate does not reopen completed tools", () => {
     status: "completed",
     content: [],
     locations: [],
-    meta: { claudeCode: { toolName: "Bash" } },
+    meta: { claudeCode: { toolName: "Bash", parentToolUseId: null } },
   });
 
   const events = captureBridgeEvents(() => {
@@ -1124,7 +1124,7 @@ test("requestAskUserQuestionAnswers preserves previews and annotations in update
     status: "in_progress",
     content: [] as Array<import("./types.js").ToolCallContent>,
     locations: [] as Array<import("./types.js").ToolLocation>,
-    meta: { claudeCode: { toolName: "AskUserQuestion" } },
+    meta: { claudeCode: { toolName: "AskUserQuestion", parentToolUseId: null } },
   };
 
   const events = await captureBridgeEventsAsync(async () => {
@@ -1213,7 +1213,7 @@ test("requestAskUserQuestionAnswers preserves previews and annotations in update
       status: "in_progress",
       content: [],
       locations: [],
-      meta: { claudeCode: { toolName: "AskUserQuestion" } },
+      meta: { claudeCode: { toolName: "AskUserQuestion", parentToolUseId: null } },
       raw_input: {
         prompt: {
           question: "Pick deployment target",
@@ -1496,7 +1496,15 @@ test("createToolCall builds edit diff content", () => {
     old: "old",
     new: "new",
   });
-  assert.deepEqual(toolCall.meta, { claudeCode: { toolName: "Edit" } });
+  assert.deepEqual(toolCall.meta, { claudeCode: { toolName: "Edit", parentToolUseId: null } });
+});
+
+test("createToolCall preserves parent tool linkage metadata", () => {
+  const toolCall = createToolCall("tc-child", "Bash", { command: "echo hi" }, "tc-parent");
+
+  assert.deepEqual(toolCall.meta, {
+    claudeCode: { toolName: "Bash", parentToolUseId: "tc-parent" },
+  });
 });
 
 test("createToolCall builds write preview diff content", () => {

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -2085,6 +2085,63 @@ test("mapSessionMessagesToUpdates maps message content blocks", () => {
   assert.equal(variantCounts.get("tool_call_update"), 1);
 });
 
+test("mapSessionMessagesToUpdates preserves parallel tool results", () => {
+  const updates = mapSessionMessagesToUpdates([
+    {
+      type: "assistant",
+      uuid: "a1",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tool-a", name: "Bash", input: { command: "echo a" } },
+          { type: "tool_use", id: "tool-b", name: "Bash", input: { command: "echo b" } },
+        ],
+      },
+    },
+    {
+      type: "user",
+      uuid: "u1",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool-b",
+            content: "result b",
+            is_error: false,
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "tool-a",
+            content: "result a",
+            is_error: false,
+          },
+        ],
+      },
+    },
+  ]);
+
+  const toolCalls = updates.filter((update) => update.type === "tool_call");
+  const toolUpdates = updates.filter((update) => update.type === "tool_call_update");
+
+  assert.deepEqual(
+    toolCalls.map((update) => update.tool_call.tool_call_id),
+    ["tool-a", "tool-b"],
+  );
+  assert.deepEqual(
+    toolUpdates.map((update) => update.tool_call_update.tool_call_id),
+    ["tool-b", "tool-a"],
+  );
+  assert.deepEqual(
+    toolUpdates.map((update) => update.tool_call_update.fields.raw_output),
+    ["result b", "result a"],
+  );
+});
+
 test("handleResultMessage emits terminal reason on successful turn completion", () => {
   const session = makeSessionState();
 

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -9,7 +9,14 @@ import {
   renameSession,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { BridgeCommand } from "./types.js";
-import { parseCommandEnvelope, toPermissionMode } from "./bridge/commands.js";
+import {
+  buildModeState,
+  markModeUnavailableForSession,
+  parseCommandEnvelope,
+  permissionModeFailureLooksUnsupported,
+  refreshSupportedModesForSession,
+  toPermissionMode,
+} from "./bridge/commands.js";
 import {
   writeEvent,
   failConnection,
@@ -356,13 +363,25 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
         slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
         return;
       }
-      await session.query.setModel(command.model);
-      session.model = command.model;
-      emitSessionUpdate(session.sessionId, {
-        type: "config_option_update",
-        option_id: "model",
-        value: command.model,
-      });
+      try {
+        await session.query.setModel(command.model);
+        session.model = command.model;
+        refreshSupportedModesForSession(session);
+        emitSessionUpdate(session.sessionId, {
+          type: "config_option_update",
+          option_id: "model",
+          value: command.model,
+        });
+        if (session.mode) {
+          emitSessionUpdate(session.sessionId, {
+            type: "mode_state_update",
+            mode: buildModeState(session, session.mode),
+          });
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        slashError(command.session_id, `failed to set model: ${message}`, requestId);
+      }
       return;
     }
 
@@ -377,12 +396,27 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
         slashError(command.session_id, `unsupported mode: ${command.mode}`, requestId);
         return;
       }
-      await session.query.setPermissionMode(mode);
-      session.mode = mode;
-      emitSessionUpdate(session.sessionId, {
-        type: "current_mode_update",
-        current_mode_id: mode,
-      });
+      try {
+        await session.query.setPermissionMode(mode);
+        session.mode = mode;
+        refreshSupportedModesForSession(session);
+        emitSessionUpdate(session.sessionId, {
+          type: "current_mode_update",
+          current_mode_id: mode,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (permissionModeFailureLooksUnsupported(mode, message)) {
+          const changed = markModeUnavailableForSession(session, mode);
+          if (changed && session.mode) {
+            emitSessionUpdate(session.sessionId, {
+              type: "mode_state_update",
+              mode: buildModeState(session, session.mode),
+            });
+          }
+        }
+        slashError(command.session_id, `failed to set mode to ${mode}: ${message}`, requestId);
+      }
       return;
     }
 

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -79,7 +79,7 @@ export {
   mapSessionMessagesToUpdates,
   mapSdkSessions,
 } from "./bridge/history.js";
-export { handleTaskSystemMessage } from "./bridge/message_handlers.js";
+export { handleSdkMessage, handleTaskSystemMessage } from "./bridge/message_handlers.js";
 export { mapAvailableAgents } from "./bridge/agents.js";
 export {
   attachRequestUserDialogInterceptor,
@@ -89,7 +89,12 @@ export {
 export {
   parseFastModeState,
   parseRateLimitStatus,
+  parseRuntimeSessionState,
+  parseApiRetryError,
   buildRateLimitUpdate,
+  buildApiRetryUpdate,
+  normalizeSettingsParseError,
+  normalizeSettingsParseErrors,
 } from "./bridge/state_parsing.js";
 export { MCP_STALE_STATUS_REVALIDATION_COOLDOWN_MS, staleMcpAuthCandidates };
 export type {

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -552,6 +552,7 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
             subscription_type: account.subscriptionType,
             token_source: account.tokenSource,
             api_key_source: account.apiKeySource,
+            api_provider: account.apiProvider,
           },
         });
         writeEvent(
@@ -564,6 +565,7 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
               subscription_type: account.subscriptionType,
               token_source: account.tokenSource,
               api_key_source: account.apiKeySource,
+              api_provider: account.apiProvider,
             },
           },
           requestId,

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -28,12 +28,11 @@ import {
   currentSessionListOptions,
   setSessionListingDir,
 } from "./bridge/events.js";
-import { textFromPrompt, contentFromPrompt } from "./bridge/message_handlers.js";
+import { contentFromPrompt } from "./bridge/message_handlers.js";
 import {
   sessions,
   sessionById,
   createSession,
-  closeSession,
   closeAllSessions,
   handleElicitationResponse,
   handlePermissionResponse,
@@ -786,6 +785,7 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
         ...(requestId ? { requestId } : {}),
       });
       process.exit(0);
+      return;
 
     default:
       bridgeLogger.error({

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -21,6 +21,8 @@ import {
   writeEvent,
   failConnection,
   slashError,
+  emitRuntimeReloadCompleted,
+  emitRuntimeReloadFailed,
   emitSessionUpdate,
   emitSessionsList,
   currentSessionListOptions,
@@ -36,8 +38,12 @@ import {
   handleElicitationResponse,
   handlePermissionResponse,
   handleQuestionResponse,
+  emitCurrentModelUpdate,
+  refreshCurrentModel,
+  shouldInvalidateResolvedRuntimeModel,
 } from "./bridge/session_lifecycle.js";
 import { mapSessionMessagesToUpdates } from "./bridge/history.js";
+import { emitAvailableAgentsIfChanged, mapAvailableAgents } from "./bridge/agents.js";
 import {
   MCP_STALE_STATUS_REVALIDATION_COOLDOWN_MS,
   handleMcpAuthenticateCommand,
@@ -75,7 +81,11 @@ export {
 } from "./bridge/history.js";
 export { handleTaskSystemMessage } from "./bridge/message_handlers.js";
 export { mapAvailableAgents } from "./bridge/agents.js";
-export { buildQueryOptions, mapAvailableModels } from "./bridge/session_lifecycle.js";
+export {
+  attachRequestUserDialogInterceptor,
+  buildQueryOptions,
+  mapAvailableModels,
+} from "./bridge/session_lifecycle.js";
 export {
   parseFastModeState,
   parseRateLimitStatus,
@@ -363,15 +373,57 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
         slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
         return;
       }
+      bridgeLogger.info({
+        target: LOG_TARGETS.APP_SESSION,
+        eventName: "set_model_started",
+        message: "set model started",
+        outcome: "start",
+        sessionId: session.sessionId,
+        requestId,
+        fields: {
+          requested_model: command.model,
+          previous_requested_model: session.requestedModelId,
+          previous_session_model: session.model,
+          previous_resolved_runtime_model: session.resolvedRuntimeModelId,
+          previous_current_model: session.currentModel?.resolved_id,
+        },
+      });
       try {
+        const previousRequestedModel = session.requestedModelId;
+        const previousSessionModel = session.model;
         await session.query.setModel(command.model);
+        session.requestedModelId = command.model;
         session.model = command.model;
-        refreshSupportedModesForSession(session);
-        emitSessionUpdate(session.sessionId, {
-          type: "config_option_update",
-          option_id: "model",
-          value: command.model,
+        const invalidatedResolvedRuntimeModel = shouldInvalidateResolvedRuntimeModel(
+          previousRequestedModel,
+          previousSessionModel,
+          command.model,
+        );
+        if (invalidatedResolvedRuntimeModel) {
+          session.resolvedRuntimeModelId = undefined;
+        }
+        const changed = refreshCurrentModel(session, true);
+        const forcedCurrentModelUpdate = !changed && emitCurrentModelUpdate(session);
+        bridgeLogger.info({
+          target: LOG_TARGETS.APP_SESSION,
+          eventName: "set_model_succeeded",
+          message: "set model completed",
+          outcome: "success",
+          sessionId: session.sessionId,
+          requestId,
+          fields: {
+            requested_model: command.model,
+            session_model_after: session.model,
+            resolved_runtime_model_after: session.resolvedRuntimeModelId,
+            current_model_after: session.currentModel?.resolved_id,
+            current_model_display_short: session.currentModel?.display_name_short,
+            current_model_display_long: session.currentModel?.display_name_long,
+            current_model_update_emitted: changed || forcedCurrentModelUpdate,
+            current_model_update_forced: forcedCurrentModelUpdate,
+            resolved_runtime_model_invalidated: invalidatedResolvedRuntimeModel,
+          },
         });
+        refreshSupportedModesForSession(session);
         if (session.mode) {
           emitSessionUpdate(session.sessionId, {
             type: "mode_state_update",
@@ -380,6 +432,22 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+        bridgeLogger.warn({
+          target: LOG_TARGETS.APP_SESSION,
+          eventName: "set_model_failed",
+          message: "set model failed",
+          outcome: "failure",
+          sessionId: session.sessionId,
+          requestId,
+          fields: {
+            requested_model: command.model,
+            error_message: message,
+            previous_requested_model: session.requestedModelId,
+            previous_session_model: session.model,
+            previous_resolved_runtime_model: session.resolvedRuntimeModelId,
+            previous_current_model: session.currentModel?.resolved_id,
+          },
+        });
         slashError(command.session_id, `failed to set model: ${message}`, requestId);
       }
       return;
@@ -507,6 +575,107 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
           fields: { error_message: message },
         });
         throw error;
+      }
+      return;
+    }
+
+    case "get_context_usage": {
+      const session = sessionById(command.session_id);
+      if (!session) {
+        slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
+        return;
+      }
+      try {
+        const usage = await session.query.getContextUsage();
+        if (typeof usage.model === "string" && usage.model.trim().length > 0) {
+          session.resolvedRuntimeModelId = usage.model.trim();
+          refreshCurrentModel(session, true);
+        }
+        const rawPercentage = typeof usage.percentage === "number" ? usage.percentage : undefined;
+        const normalizedPercentage =
+          rawPercentage === undefined || !Number.isFinite(rawPercentage)
+            ? undefined
+            : Math.max(0, Math.min(100, Math.round(rawPercentage)));
+        bridgeLogger.debug({
+          target: LOG_TARGETS.APP_SESSION,
+          eventName: "context_usage_succeeded",
+          message: "session context usage received from SDK",
+          outcome: "success",
+          ...(requestId ? { requestId } : {}),
+          sessionId: session.sessionId,
+          fields: {
+            raw_percentage: rawPercentage,
+            normalized_percentage: normalizedPercentage,
+            total_tokens: typeof usage.totalTokens === "number" ? usage.totalTokens : undefined,
+            max_tokens: typeof usage.maxTokens === "number" ? usage.maxTokens : undefined,
+            raw_max_tokens: typeof usage.rawMaxTokens === "number" ? usage.rawMaxTokens : undefined,
+            model: typeof usage.model === "string" ? usage.model : undefined,
+          },
+        });
+        writeEvent(
+          {
+            event: "context_usage",
+            session_id: session.sessionId,
+            ...(normalizedPercentage !== undefined ? { percentage: normalizedPercentage } : {}),
+          },
+          requestId,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        bridgeLogger.warn({
+          target: LOG_TARGETS.APP_SESSION,
+          eventName: "context_usage_failed",
+          message: "failed to get session context usage",
+          outcome: "failure",
+          ...(requestId ? { requestId } : {}),
+          sessionId: session.sessionId,
+          fields: { error_message: message },
+        });
+        writeEvent(
+          {
+            event: "context_usage",
+            session_id: session.sessionId,
+          },
+          requestId,
+        );
+      }
+      return;
+    }
+
+    case "reload_plugins": {
+      const session = sessionById(command.session_id);
+      if (!session) {
+        slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
+        return;
+      }
+      try {
+        const result = await session.query.reloadPlugins();
+        const commands = Array.isArray(result.commands)
+          ? result.commands.map((entry) => ({
+              name: entry.name,
+              description: entry.description ?? "",
+              input_hint: entry.argumentHint ?? undefined,
+            }))
+          : [];
+        emitSessionUpdate(session.sessionId, {
+          type: "available_commands_update",
+          commands,
+        });
+        emitAvailableAgentsIfChanged(session, mapAvailableAgents(result.agents));
+        await handleMcpStatusCommand(session, requestId);
+        emitRuntimeReloadCompleted(session.sessionId, requestId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        bridgeLogger.warn({
+          target: LOG_TARGETS.APP_SESSION,
+          eventName: "reload_plugins_failed",
+          message: "failed to reload session plugins",
+          outcome: "failure",
+          ...(requestId ? { requestId } : {}),
+          sessionId: session.sessionId,
+          fields: { error_message: message },
+        });
+        emitRuntimeReloadFailed(session.sessionId, message, requestId);
       }
       return;
     }

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -115,7 +115,7 @@ export async function generatePersistedSessionTitle(
   return title;
 }
 
-const EXPECTED_AGENT_SDK_VERSION = "0.2.74";
+const EXPECTED_AGENT_SDK_VERSION = "0.2.104";
 const require = createRequire(import.meta.url);
 
 export function resolveInstalledAgentSdkVersion(): string | undefined {
@@ -327,7 +327,7 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
       if (content.length === 0) {
         return;
       }
-      session.input.enqueue({
+      const message: import("@anthropic-ai/claude-agent-sdk").SDKUserMessage = {
         type: "user",
         session_id: session.sessionId,
         parent_tool_use_id: null,
@@ -335,7 +335,8 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
           role: "user",
           content,
         },
-      } as import("@anthropic-ai/claude-agent-sdk").SDKUserMessage);
+      };
+      session.input.enqueue(message);
       return;
     }
 

--- a/agent-sdk/src/bridge/commands.ts
+++ b/agent-sdk/src/bridge/commands.ts
@@ -14,6 +14,7 @@ import type {
 
 const MODE_NAMES: Record<PermissionMode, string> = {
   default: "Default",
+  auto: "Auto",
   acceptEdits: "Accept Edits",
   bypassPermissions: "Bypass Permissions",
   plan: "Plan",
@@ -22,6 +23,7 @@ const MODE_NAMES: Record<PermissionMode, string> = {
 
 const MODE_OPTIONS: ModeInfo[] = [
   { id: "default", name: "Default", description: "Standard permission flow" },
+  { id: "auto", name: "Auto", description: "Model-classified permission approvals" },
   { id: "acceptEdits", name: "Accept Edits", description: "Auto-approve edit operations" },
   { id: "plan", name: "Plan", description: "No tool execution" },
   { id: "dontAsk", name: "Don't Ask", description: "Reject non-approved tools" },
@@ -435,6 +437,7 @@ function parseQuestionAnnotation(value: unknown): { preview?: string; notes?: st
 export function toPermissionMode(mode: string): PermissionMode | null {
   if (
     mode === "default" ||
+    mode === "auto" ||
     mode === "acceptEdits" ||
     mode === "bypassPermissions" ||
     mode === "plan" ||

--- a/agent-sdk/src/bridge/commands.ts
+++ b/agent-sdk/src/bridge/commands.ts
@@ -12,6 +12,7 @@ import type {
   SessionLaunchSettings,
 } from "../types.js";
 import type { SessionState } from "./session_lifecycle.js";
+import { resolveCurrentModel } from "./session_lifecycle.js";
 
 const MODE_NAMES: Record<PermissionMode, string> = {
   default: "Default",
@@ -39,8 +40,8 @@ const BASE_SUPPORTED_MODE_IDS: PermissionMode[] = [
 ];
 
 function currentModelSupportsAutoMode(session: SessionState): boolean {
-  const currentModel = session.availableModels.find((entry) => entry.id === session.model);
-  return currentModel?.supports_auto_mode === true;
+  const currentModel = session.currentModel ?? resolveCurrentModel(session);
+  return currentModel.supports_auto_mode === true;
 }
 
 function modeInfoForId(mode: PermissionMode): ModeInfo {
@@ -351,6 +352,16 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
         return {
           command: "get_status_snapshot",
           session_id: expectString(raw, "session_id", "get_status_snapshot"),
+        };
+      case "get_context_usage":
+        return {
+          command: "get_context_usage",
+          session_id: expectString(raw, "session_id", "get_context_usage"),
+        };
+      case "reload_plugins":
+        return {
+          command: "reload_plugins",
+          session_id: expectString(raw, "session_id", "reload_plugins"),
         };
       case "mcp_status":
       case "get_mcp_snapshot":

--- a/agent-sdk/src/bridge/commands.ts
+++ b/agent-sdk/src/bridge/commands.ts
@@ -11,6 +11,7 @@ import type {
   QuestionOutcome,
   SessionLaunchSettings,
 } from "../types.js";
+import type { SessionState } from "./session_lifecycle.js";
 
 const MODE_NAMES: Record<PermissionMode, string> = {
   default: "Default",
@@ -29,6 +30,82 @@ const MODE_OPTIONS: ModeInfo[] = [
   { id: "dontAsk", name: "Don't Ask", description: "Reject non-approved tools" },
   { id: "bypassPermissions", name: "Bypass Permissions", description: "Auto-approve all tools" },
 ];
+
+const BASE_SUPPORTED_MODE_IDS: PermissionMode[] = [
+  "default",
+  "acceptEdits",
+  "plan",
+  "dontAsk",
+];
+
+function currentModelSupportsAutoMode(session: SessionState): boolean {
+  const currentModel = session.availableModels.find((entry) => entry.id === session.model);
+  return currentModel?.supports_auto_mode === true;
+}
+
+function modeInfoForId(mode: PermissionMode): ModeInfo {
+  return MODE_OPTIONS.find((entry) => entry.id === mode) ?? {
+    id: mode,
+    name: MODE_NAMES[mode],
+  };
+}
+
+function uniqueModeIds(modeIds: PermissionMode[]): PermissionMode[] {
+  const unique = new Set(modeIds);
+  const ordered = MODE_OPTIONS.map((entry) => entry.id as PermissionMode).filter((mode) =>
+    unique.has(mode),
+  );
+  const extras = Array.from(unique).filter((mode) => !ordered.includes(mode));
+  return [...ordered, ...extras];
+}
+
+function computedSupportedModeIds(session: SessionState): PermissionMode[] {
+  const supported = [...BASE_SUPPORTED_MODE_IDS];
+  if (currentModelSupportsAutoMode(session)) {
+    supported.push("auto");
+  }
+  if (session.supportsBypassPermissionsMode) {
+    supported.push("bypassPermissions");
+  }
+  if (session.mode) {
+    supported.push(session.mode);
+  }
+  return uniqueModeIds(supported);
+}
+
+export function refreshSupportedModesForSession(session: SessionState): void {
+  const computed = computedSupportedModeIds(session);
+  session.supportedModeIds = computed.filter(
+    (mode) => mode === session.mode || !session.runtimeUnavailableModeIds.includes(mode),
+  );
+}
+
+export function markModeUnavailableForSession(
+  session: SessionState,
+  mode: PermissionMode,
+): boolean {
+  if (session.runtimeUnavailableModeIds.includes(mode)) {
+    return false;
+  }
+  session.runtimeUnavailableModeIds = [...session.runtimeUnavailableModeIds, mode];
+  refreshSupportedModesForSession(session);
+  return true;
+}
+
+export function permissionModeFailureLooksUnsupported(
+  mode: PermissionMode,
+  message: string,
+): boolean {
+  const normalizedMessage = message.toLowerCase();
+  return (
+    normalizedMessage.includes("cannot set permission mode to") &&
+    normalizedMessage.includes(mode.toLowerCase())
+  );
+}
+
+export function availableModesForSession(session: SessionState): ModeInfo[] {
+  return session.supportedModeIds.map(modeInfoForId);
+}
 
 function asRecord(value: unknown, context: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -448,11 +525,11 @@ export function toPermissionMode(mode: string): PermissionMode | null {
   return null;
 }
 
-export function buildModeState(mode: PermissionMode): ModeState {
+export function buildModeState(session: SessionState, mode: PermissionMode): ModeState {
   return {
     current_mode_id: mode,
     current_mode_name: MODE_NAMES[mode],
-    available_modes: MODE_OPTIONS,
+    available_modes: availableModesForSession(session),
   };
 }
 

--- a/agent-sdk/src/bridge/events.ts
+++ b/agent-sdk/src/bridge/events.ts
@@ -8,7 +8,7 @@ import type {
 import { buildModeState } from "./commands.js";
 import { mapSdkSessions } from "./history.js";
 import { bridgeLogger, LOG_TARGETS, logBridgeEventSent } from "./logger.js";
-import type { SessionState } from "./session_lifecycle.js";
+import { resolveCurrentModel, type SessionState } from "./session_lifecycle.js";
 
 const SESSION_LIST_LIMIT = 50;
 let sessionListingDir: string | undefined;
@@ -44,6 +44,18 @@ export function failConnection(message: string, requestId?: string): void {
 
 export function slashError(sessionId: string, message: string, requestId?: string): void {
   writeEvent({ event: "slash_error", session_id: sessionId, message }, requestId);
+}
+
+export function emitRuntimeReloadCompleted(sessionId: string, requestId?: string): void {
+  writeEvent({ event: "runtime_reload_completed", session_id: sessionId }, requestId);
+}
+
+export function emitRuntimeReloadFailed(
+  sessionId: string,
+  message: string,
+  requestId?: string,
+): void {
+  writeEvent({ event: "runtime_reload_failed", session_id: sessionId, message }, requestId);
 }
 
 export function emitMcpOperationError(
@@ -131,7 +143,7 @@ function buildConnectBridgeEvent(
         event: "session_replaced",
         session_id: session.sessionId,
         cwd: session.cwd,
-        model_name: session.model,
+        current_model: session.currentModel ?? resolveCurrentModel(session),
         available_models: session.availableModels,
         mode: session.mode ? buildModeState(session, session.mode) : null,
         ...(historyUpdates && historyUpdates.length > 0 ? { history_updates: historyUpdates } : {}),
@@ -140,7 +152,7 @@ function buildConnectBridgeEvent(
         event: "connected",
         session_id: session.sessionId,
         cwd: session.cwd,
-        model_name: session.model,
+        current_model: session.currentModel ?? resolveCurrentModel(session),
         available_models: session.availableModels,
         mode: session.mode ? buildModeState(session, session.mode) : null,
         ...(historyUpdates && historyUpdates.length > 0 ? { history_updates: historyUpdates } : {}),

--- a/agent-sdk/src/bridge/events.ts
+++ b/agent-sdk/src/bridge/events.ts
@@ -133,7 +133,7 @@ function buildConnectBridgeEvent(
         cwd: session.cwd,
         model_name: session.model,
         available_models: session.availableModels,
-        mode: session.mode ? buildModeState(session.mode) : null,
+        mode: session.mode ? buildModeState(session, session.mode) : null,
         ...(historyUpdates && historyUpdates.length > 0 ? { history_updates: historyUpdates } : {}),
       }
     : {
@@ -142,7 +142,7 @@ function buildConnectBridgeEvent(
         cwd: session.cwd,
         model_name: session.model,
         available_models: session.availableModels,
-        mode: session.mode ? buildModeState(session.mode) : null,
+        mode: session.mode ? buildModeState(session, session.mode) : null,
         ...(historyUpdates && historyUpdates.length > 0 ? { history_updates: historyUpdates } : {}),
       };
 }

--- a/agent-sdk/src/bridge/history.ts
+++ b/agent-sdk/src/bridge/history.ts
@@ -96,7 +96,7 @@ export function mapSdkSessionInfo(info: SDKSessionInfo): SessionListEntry {
     session_id: info.sessionId,
     summary: summaryFromSession(info),
     last_modified_ms: info.lastModified,
-    file_size_bytes: info.fileSize,
+    file_size_bytes: info.fileSize ?? 0,
     ...(nonEmptyTrimmed(info.cwd) ? { cwd: info.cwd?.trim() } : {}),
     ...(nonEmptyTrimmed(info.gitBranch) ? { git_branch: info.gitBranch?.trim() } : {}),
     ...(nonEmptyTrimmed(info.customTitle) ? { custom_title: info.customTitle?.trim() } : {}),

--- a/agent-sdk/src/bridge/history.ts
+++ b/agent-sdk/src/bridge/history.ts
@@ -39,6 +39,7 @@ function pushResumeToolUse(
   updates: SessionUpdate[],
   toolCalls: Map<string, ToolCall>,
   block: Record<string, unknown>,
+  parentToolUseId: string | null,
 ): void {
   const toolUseId = typeof block.id === "string" ? block.id : "";
   if (!toolUseId) {
@@ -47,7 +48,7 @@ function pushResumeToolUse(
   const name = typeof block.name === "string" ? block.name : "Tool";
   const input = asRecordOrNull(block.input) ?? {};
 
-  const toolCall = createToolCall(toolUseId, name, input);
+  const toolCall = createToolCall(toolUseId, name, input, parentToolUseId);
   toolCall.status = "in_progress";
   toolCalls.set(toolUseId, toolCall);
   updates.push({ type: "tool_call", tool_call: toolCall });
@@ -130,6 +131,12 @@ export function mapSessionMessagesToUpdates(messages: SessionMessage[]): Session
     for (const message of messageCandidates(entry.message)) {
       const roleCandidate = message.role;
       const role = roleCandidate === "assistant" || roleCandidate === "user" ? roleCandidate : fallbackRole;
+      const parentToolUseId =
+        typeof entry.parent_tool_use_id === "string"
+          ? entry.parent_tool_use_id
+          : typeof message.parent_tool_use_id === "string"
+            ? message.parent_tool_use_id
+            : null;
 
       const content = Array.isArray(message.content) ? message.content : [];
       for (const item of content) {
@@ -146,7 +153,7 @@ export function mapSessionMessagesToUpdates(messages: SessionMessage[]): Session
           continue;
         }
         if (isToolUseBlockType(blockType) && role === "assistant") {
-          pushResumeToolUse(updates, toolCalls, block);
+          pushResumeToolUse(updates, toolCalls, block, parentToolUseId);
           continue;
         }
         if (TOOL_RESULT_TYPES.has(blockType)) {

--- a/agent-sdk/src/bridge/logger.ts
+++ b/agent-sdk/src/bridge/logger.ts
@@ -136,6 +136,8 @@ function commandToolCallId(command: BridgeCommand): string | undefined {
     case "new_session":
     case "elicitation_response":
     case "get_status_snapshot":
+    case "get_context_usage":
+    case "reload_plugins":
     case "mcp_status":
     case "mcp_reconnect":
     case "mcp_toggle":
@@ -164,10 +166,13 @@ function eventToolCallId(event: BridgeEvent): string | undefined {
     case "turn_complete":
     case "turn_error":
     case "slash_error":
+    case "runtime_reload_completed":
+    case "runtime_reload_failed":
     case "session_replaced":
     case "initialized":
     case "sessions_listed":
     case "status_snapshot":
+    case "context_usage":
     case "mcp_snapshot":
       return undefined;
   }
@@ -198,6 +203,7 @@ function protocolEventLevel(event: BridgeEvent): LogLevel {
     case "mcp_operation_error":
     case "turn_error":
     case "slash_error":
+    case "runtime_reload_failed":
       return "warn";
     case "session_update":
     case "permission_request":
@@ -209,6 +215,8 @@ function protocolEventLevel(event: BridgeEvent): LogLevel {
       return "trace";
     case "sessions_listed":
     case "status_snapshot":
+    case "context_usage":
+    case "runtime_reload_completed":
     case "mcp_snapshot":
       return "debug";
   }

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -153,6 +153,24 @@ export function handleTaskSystemMessage(
     session.taskToolUseIds.set(taskId, explicitToolUseId);
   }
   const toolUseId = resolveTaskToolUseId(session, msg);
+  bridgeLogger.debug({
+    target: LOG_TARGETS.APP_TOOL,
+    eventName: "sdk_task_linkage_observed",
+    message: "SDK task lifecycle linkage observed",
+    outcome: toolUseId ? "resolved" : "unresolved",
+    sessionId: session.sessionId,
+    toolCallId: toolUseId || explicitToolUseId || undefined,
+    fields: {
+      sdk_subtype: subtype,
+      task_id: taskId || undefined,
+      explicit_tool_use_id: explicitToolUseId || undefined,
+      resolved_tool_use_id: toolUseId || undefined,
+      task_status: typeof msg.status === "string" ? msg.status : undefined,
+      has_description: typeof msg.description === "string" && msg.description.length > 0,
+      has_summary: typeof msg.summary === "string" && msg.summary.length > 0,
+      last_tool_name: typeof msg.last_tool_name === "string" ? msg.last_tool_name : undefined,
+    },
+  });
   if (subtype === "task_updated") {
     bridgeLogger.debug({
       target: LOG_TARGETS.APP_TOOL,
@@ -264,7 +282,43 @@ export function handleTaskSystemMessage(
   }
 }
 
-export function handleContentBlock(session: SessionState, block: Record<string, unknown>): void {
+type ContentBlockLinkage = {
+  source: "assistant" | "stream_event" | "user";
+  parentToolUseId?: string;
+};
+
+function logContentBlockLinkage(
+  session: SessionState,
+  blockType: string,
+  toolUseId: string,
+  toolName: string | undefined,
+  linkage: ContentBlockLinkage | undefined,
+): void {
+  if (!toolUseId && !linkage?.parentToolUseId) {
+    return;
+  }
+  bridgeLogger.debug({
+    target: LOG_TARGETS.APP_TOOL,
+    eventName: "sdk_tool_linkage_observed",
+    message: "SDK tool linkage observed",
+    outcome: linkage?.parentToolUseId ? "child" : "root_or_unknown",
+    sessionId: session.sessionId,
+    toolCallId: toolUseId || undefined,
+    fields: {
+      source: linkage?.source,
+      block_type: blockType || undefined,
+      tool_name: toolName,
+      tool_use_id: toolUseId || undefined,
+      parent_tool_use_id: linkage?.parentToolUseId,
+    },
+  });
+}
+
+export function handleContentBlock(
+  session: SessionState,
+  block: Record<string, unknown>,
+  linkage?: ContentBlockLinkage,
+): void {
   const blockType = typeof block.type === "string" ? block.type : "";
 
   if (blockType === "text") {
@@ -291,8 +345,9 @@ export function handleContentBlock(session: SessionState, block: Record<string, 
     if (!toolUseId) {
       return;
     }
+    logContentBlockLinkage(session, blockType, toolUseId, name, linkage);
     emitPlanIfTodoWrite(session, name, input);
-    emitToolCall(session, toolUseId, name, input);
+    emitToolCall(session, toolUseId, name, input, linkage?.parentToolUseId ?? null);
     return;
   }
 
@@ -301,17 +356,25 @@ export function handleContentBlock(session: SessionState, block: Record<string, 
     if (!toolUseId) {
       return;
     }
+    logContentBlockLinkage(session, blockType, toolUseId, undefined, linkage);
     const isError = Boolean(block.is_error);
     emitToolResultUpdate(session, toolUseId, isError, block.content, block);
   }
 }
 
-export function handleStreamEvent(session: SessionState, event: Record<string, unknown>): void {
+export function handleStreamEvent(
+  session: SessionState,
+  event: Record<string, unknown>,
+  parentToolUseId?: string,
+): void {
   const eventType = typeof event.type === "string" ? event.type : "";
 
   if (eventType === "content_block_start") {
     if (event.content_block && typeof event.content_block === "object") {
-      handleContentBlock(session, event.content_block as Record<string, unknown>);
+      handleContentBlock(session, event.content_block as Record<string, unknown>, {
+        source: "stream_event",
+        parentToolUseId,
+      });
     }
     return;
   }
@@ -362,7 +425,9 @@ export function handleAssistantMessage(session: SessionState, message: Record<st
       blockType === "mcp_tool_use" ||
       TOOL_RESULT_TYPES.has(blockType)
     ) {
-      handleContentBlock(session, blockRecord);
+      const parentToolUseId =
+        typeof message.parent_tool_use_id === "string" ? message.parent_tool_use_id : undefined;
+      handleContentBlock(session, blockRecord, { source: "assistant", parentToolUseId });
     }
   }
 }
@@ -383,7 +448,9 @@ export function handleUserToolResultBlocks(session: SessionState, message: Recor
     const blockRecord = block as Record<string, unknown>;
     const blockType = typeof blockRecord.type === "string" ? blockRecord.type : "";
     if (TOOL_RESULT_TYPES.has(blockType)) {
-      handleContentBlock(session, blockRecord);
+      const parentToolUseId =
+        typeof message.parent_tool_use_id === "string" ? message.parent_tool_use_id : undefined;
+      handleContentBlock(session, blockRecord, { source: "user", parentToolUseId });
     }
   }
 }
@@ -645,7 +712,9 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
 
   if (type === "stream_event") {
     if (msg.event && typeof msg.event === "object") {
-      handleStreamEvent(session, msg.event as Record<string, unknown>);
+      const parentToolUseId =
+        typeof msg.parent_tool_use_id === "string" ? msg.parent_tool_use_id : undefined;
+      handleStreamEvent(session, msg.event as Record<string, unknown>, parentToolUseId);
     }
     return;
   }
@@ -653,6 +722,21 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
   if (type === "tool_progress") {
     const toolUseId = typeof msg.tool_use_id === "string" ? msg.tool_use_id : "";
     const toolName = typeof msg.tool_name === "string" ? msg.tool_name : "Tool";
+    bridgeLogger.debug({
+      target: LOG_TARGETS.APP_TOOL,
+      eventName: "sdk_tool_progress_linkage_observed",
+      message: "SDK tool progress linkage observed",
+      outcome: typeof msg.parent_tool_use_id === "string" ? "child" : "root_or_unknown",
+      sessionId: session.sessionId,
+      toolCallId: toolUseId || undefined,
+      fields: {
+        tool_name: toolName,
+        tool_use_id: toolUseId || undefined,
+        parent_tool_use_id:
+          typeof msg.parent_tool_use_id === "string" ? msg.parent_tool_use_id : undefined,
+        task_id: typeof msg.task_id === "string" ? msg.task_id : undefined,
+      },
+    });
     if (toolUseId) {
       emitToolProgressUpdate(session, toolUseId, toolName);
     }

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -29,7 +29,7 @@ import {
   taskUpdatedFields,
 } from "./tool_calls.js";
 import { emitAuthRequired, classifyTurnErrorKind, emitFastModeUpdateIfChanged } from "./error_classification.js";
-import { mapAvailableAgents, mapAvailableAgentsFromNames, emitAvailableAgentsIfChanged, refreshAvailableAgents } from "./agents.js";
+import { mapAvailableAgentsFromNames, emitAvailableAgentsIfChanged, refreshAvailableAgents } from "./agents.js";
 import {
   buildApiRetryUpdate,
   buildRateLimitUpdate,
@@ -39,7 +39,7 @@ import {
 } from "./state_parsing.js";
 import { looksLikeAuthRequired } from "./auth.js";
 import type { SessionState } from "./session_lifecycle.js";
-import { refreshCurrentModel, updateSessionId } from "./session_lifecycle.js";
+import { emitCurrentModelUpdate, refreshCurrentModel, updateSessionId } from "./session_lifecycle.js";
 import { bridgeLogger, LOG_TARGETS } from "./logger.js";
 
 export function textFromPrompt(command: Extract<BridgeCommand, { command: "prompt" }>): string {
@@ -564,10 +564,7 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         emitSessionReplacedEvent(session);
       } else {
         if (currentModelChanged) {
-          emitSessionUpdate(session.sessionId, {
-            type: "current_model_update",
-            current_model: session.currentModel!,
-          });
+          emitCurrentModelUpdate(session);
         }
         if (incomingMode) {
           emitSessionUpdate(session.sessionId, {

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -1,4 +1,5 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { ContentBlockParam } from "@anthropic-ai/sdk/resources/messages/messages";
 import type { AvailableCommand, BridgeCommand, ToolCallUpdateFields } from "../types.js";
 import { asRecordOrNull } from "./shared.js";
 import { toPermissionMode, buildModeState } from "./commands.js";
@@ -52,6 +53,8 @@ const SUPPORTED_IMAGE_MIME_TYPES = new Set([
   "image/webp",
 ]);
 
+type SupportedImageMimeType = "image/png" | "image/jpeg" | "image/gif" | "image/webp";
+
 /** Fast check that a string looks like valid base64 (non-empty, correct charset & padding). */
 function isValidBase64(data: string): boolean {
   if (!data) return false;
@@ -67,9 +70,9 @@ function isValidBase64(data: string): boolean {
  */
 export function contentFromPrompt(
   command: Extract<BridgeCommand, { command: "prompt" }>,
-): Array<Record<string, unknown>> {
+): ContentBlockParam[] {
   const chunks = command.chunks ?? [];
-  const content: Array<Record<string, unknown>> = [];
+  const content: ContentBlockParam[] = [];
 
   for (const chunk of chunks) {
     if (chunk.kind === "text") {
@@ -103,11 +106,12 @@ export function contentFromPrompt(
         });
         continue;
       }
+      const supportedMimeType = mimeType as SupportedImageMimeType;
       content.push({
         type: "image",
         source: {
           type: "base64",
-          media_type: mimeType,
+          media_type: supportedMimeType,
           data,
         },
       });

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -30,7 +30,13 @@ import {
 } from "./tool_calls.js";
 import { emitAuthRequired, classifyTurnErrorKind, emitFastModeUpdateIfChanged } from "./error_classification.js";
 import { mapAvailableAgents, mapAvailableAgentsFromNames, emitAvailableAgentsIfChanged, refreshAvailableAgents } from "./agents.js";
-import { buildRateLimitUpdate, numberField } from "./state_parsing.js";
+import {
+  buildApiRetryUpdate,
+  buildRateLimitUpdate,
+  normalizeSettingsParseErrors,
+  numberField,
+  parseRuntimeSessionState,
+} from "./state_parsing.js";
 import { looksLikeAuthRequired } from "./auth.js";
 import type { SessionState } from "./session_lifecycle.js";
 import { refreshCurrentModel, updateSessionId } from "./session_lifecycle.js";
@@ -451,6 +457,25 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
 
   if (type === "system") {
     const subtype = typeof msg.subtype === "string" ? msg.subtype : "";
+    if (subtype === "api_retry") {
+      const update = buildApiRetryUpdate(msg);
+      if (update) {
+        emitSessionUpdate(session.sessionId, update);
+      }
+      return;
+    }
+
+    if (subtype === "session_state_changed") {
+      const state = parseRuntimeSessionState(msg.state);
+      if (state) {
+        emitSessionUpdate(session.sessionId, {
+          type: "runtime_session_state_update",
+          state,
+        });
+      }
+      return;
+    }
+
     if (subtype === "init") {
       const previousSessionId = session.sessionId;
       const incomingSessionId = typeof msg.session_id === "string" ? msg.session_id : session.sessionId;
@@ -512,6 +537,14 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
           // Best-effort only; slash commands from init were already emitted.
         });
       refreshAvailableAgents(session);
+      for (const settingsError of normalizeSettingsParseErrors(
+        msg.settings_errors ?? msg.settingsErrors,
+      )) {
+        emitSessionUpdate(session.sessionId, {
+          type: "settings_parse_error",
+          ...settingsError,
+        });
+      }
       return;
     }
 
@@ -577,6 +610,24 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
     }
 
     handleTaskSystemMessage(session, subtype, msg);
+    return;
+  }
+
+  if (type === "prompt_suggestion") {
+    const suggestion = typeof msg.suggestion === "string" ? msg.suggestion.trim() : "";
+    if (suggestion) {
+      emitSessionUpdate(session.sessionId, { type: "prompt_suggestion_update", suggestion });
+    }
+    return;
+  }
+
+  if (type === "settings_parse_error") {
+    for (const settingsError of normalizeSettingsParseErrors(msg)) {
+      emitSessionUpdate(session.sessionId, {
+        type: "settings_parse_error",
+        ...settingsError,
+      });
+    }
     return;
   }
 

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -26,13 +26,14 @@ import {
   ensureToolCallVisible,
   resolveTaskToolUseId,
   taskProgressText,
+  taskUpdatedFields,
 } from "./tool_calls.js";
 import { emitAuthRequired, classifyTurnErrorKind, emitFastModeUpdateIfChanged } from "./error_classification.js";
 import { mapAvailableAgents, mapAvailableAgentsFromNames, emitAvailableAgentsIfChanged, refreshAvailableAgents } from "./agents.js";
 import { buildRateLimitUpdate, numberField } from "./state_parsing.js";
 import { looksLikeAuthRequired } from "./auth.js";
 import type { SessionState } from "./session_lifecycle.js";
-import { updateSessionId } from "./session_lifecycle.js";
+import { refreshCurrentModel, updateSessionId } from "./session_lifecycle.js";
 import { bridgeLogger, LOG_TARGETS } from "./logger.js";
 
 export function textFromPrompt(command: Extract<BridgeCommand, { command: "prompt" }>): string {
@@ -131,7 +132,12 @@ export function handleTaskSystemMessage(
   subtype: string,
   msg: Record<string, unknown>,
 ): void {
-  if (subtype !== "task_started" && subtype !== "task_progress" && subtype !== "task_notification") {
+  if (
+    subtype !== "task_started" &&
+    subtype !== "task_progress" &&
+    subtype !== "task_updated" &&
+    subtype !== "task_notification"
+  ) {
     return;
   }
 
@@ -141,7 +147,35 @@ export function handleTaskSystemMessage(
     session.taskToolUseIds.set(taskId, explicitToolUseId);
   }
   const toolUseId = resolveTaskToolUseId(session, msg);
+  if (subtype === "task_updated") {
+    bridgeLogger.debug({
+      target: LOG_TARGETS.APP_TOOL,
+      eventName: "task_updated_received",
+      message: "task update received",
+      outcome: toolUseId ? "resolved" : "unresolved",
+      sessionId: session.sessionId,
+      toolCallId: toolUseId || undefined,
+      fields: {
+        task_id: taskId,
+        explicit_tool_use_id: explicitToolUseId || undefined,
+        patch_keys:
+          msg.patch && typeof msg.patch === "object"
+            ? Object.keys(msg.patch as Record<string, unknown>).sort()
+            : undefined,
+      },
+    });
+  }
   if (!toolUseId) {
+    if (subtype === "task_updated" && taskId) {
+      bridgeLogger.debug({
+        target: LOG_TARGETS.APP_TOOL,
+        eventName: "task_updated_unlinked",
+        message: "task update skipped because no visible tool call was linked",
+        outcome: "skipped",
+        sessionId: session.sessionId,
+        fields: { task_id: taskId, subtype },
+      });
+    }
     return;
   }
 
@@ -186,9 +220,33 @@ export function handleTaskSystemMessage(
     return;
   }
 
+  if (subtype === "task_updated") {
+    const fields = taskUpdatedFields(msg);
+    if (Object.keys(fields).length === 0) {
+      return;
+    }
+    bridgeLogger.debug({
+      target: LOG_TARGETS.APP_TOOL,
+      eventName: "task_updated_emitted",
+      message: "task update mapped to tool call update",
+      outcome: "success",
+      sessionId: session.sessionId,
+      toolCallId: toolUseId,
+      fields: {
+        task_id: taskId,
+        mapped_status: fields.status,
+        has_description: fields.content !== undefined,
+        has_error: Boolean(fields.task_metadata?.error),
+        is_backgrounded: fields.task_metadata?.is_backgrounded,
+      },
+    });
+    emitToolCallUpdate(session, toolUseId, fields, "task_updated");
+    return;
+  }
+
   const status = typeof msg.status === "string" ? msg.status : "";
   const summary = typeof msg.summary === "string" ? msg.summary : "";
-  const finalStatus = status === "completed" ? "completed" : "failed";
+  const finalStatus = status === "completed" ? "completed" : status === "stopped" ? "killed" : "failed";
   const fields: ToolCallUpdateFields = { status: finalStatus };
   if (summary) {
     fields.raw_output = summary;
@@ -397,9 +455,9 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
       const previousSessionId = session.sessionId;
       const incomingSessionId = typeof msg.session_id === "string" ? msg.session_id : session.sessionId;
       updateSessionId(session, incomingSessionId);
-      const previousModelName = session.model;
       const modelName = typeof msg.model === "string" ? msg.model : session.model;
       session.model = modelName;
+      const currentModelChanged = refreshCurrentModel(session, false);
 
       const incomingMode = typeof msg.permissionMode === "string" ? toPermissionMode(msg.permissionMode) : null;
       if (incomingMode) {
@@ -413,11 +471,10 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
       } else if (previousSessionId !== session.sessionId) {
         emitSessionReplacedEvent(session);
       } else {
-        if (session.model !== previousModelName) {
+        if (currentModelChanged) {
           emitSessionUpdate(session.sessionId, {
-            type: "config_option_update",
-            option_id: "model",
-            value: session.model,
+            type: "current_model_update",
+            current_model: session.currentModel!,
           });
         }
         if (incomingMode) {
@@ -565,7 +622,46 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
   }
 
   if (type === "rate_limit_event") {
+    const rateLimitInfo = asRecordOrNull(msg.rate_limit_info);
     const update = buildRateLimitUpdate(msg.rate_limit_info);
+    bridgeLogger.debug({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "sdk_rate_limit_event_received",
+      message: "SDK rate limit event received",
+      outcome: update ? "success" : "dropped",
+      sessionId: session.sessionId,
+      fields: {
+        raw_status: typeof rateLimitInfo?.status === "string" ? rateLimitInfo.status : undefined,
+        raw_rate_limit_type:
+          typeof rateLimitInfo?.rateLimitType === "string" ? rateLimitInfo.rateLimitType : undefined,
+        raw_utilization: numberField(rateLimitInfo ?? {}, "utilization"),
+        raw_resets_at: numberField(rateLimitInfo ?? {}, "resetsAt"),
+        raw_overage_status:
+          typeof rateLimitInfo?.overageStatus === "string" ? rateLimitInfo.overageStatus : undefined,
+        raw_overage_resets_at: numberField(rateLimitInfo ?? {}, "overageResetsAt"),
+        raw_is_using_overage:
+          typeof rateLimitInfo?.isUsingOverage === "boolean" ? rateLimitInfo.isUsingOverage : undefined,
+        raw_surpassed_threshold: numberField(rateLimitInfo ?? {}, "surpassedThreshold"),
+        parsed_status: update?.status,
+        parsed_rate_limit_type: update?.rate_limit_type,
+        parsed_utilization: update?.utilization,
+        parsed_resets_at: update?.resets_at,
+        parsed_overage_status: update?.overage_status,
+        parsed_overage_resets_at: update?.overage_resets_at,
+        parsed_is_using_overage: update?.is_using_overage,
+        parsed_surpassed_threshold: update?.surpassed_threshold,
+      },
+    });
+    bridgeLogger.debug({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "sdk_rate_limit_event_raw",
+      message: "SDK rate limit event raw payload",
+      outcome: rateLimitInfo ? "success" : "dropped",
+      sessionId: session.sessionId,
+      fields: {
+        raw_rate_limit_info: msg.rate_limit_info,
+      },
+    });
     if (update) {
       emitSessionUpdate(session.sessionId, update);
     }

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -1,8 +1,13 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { ContentBlockParam } from "@anthropic-ai/sdk/resources/messages/messages";
-import type { AvailableCommand, BridgeCommand, ToolCallUpdateFields } from "../types.js";
+import type {
+  AvailableCommand,
+  BridgeCommand,
+  TerminalReason,
+  ToolCallUpdateFields,
+} from "../types.js";
 import { asRecordOrNull } from "./shared.js";
-import { toPermissionMode, buildModeState } from "./commands.js";
+import { toPermissionMode, buildModeState, refreshSupportedModesForSession } from "./commands.js";
 import {
   writeEvent,
   emitSessionUpdate,
@@ -321,12 +326,17 @@ export function handleUserToolResultBlocks(session: SessionState, message: Recor
 
 export function handleResultMessage(session: SessionState, message: Record<string, unknown>): void {
   emitFastModeUpdateIfChanged(session, message.fast_mode_state);
+  const terminalReason = terminalReasonFromValue(message.terminal_reason);
 
   const subtype = typeof message.subtype === "string" ? message.subtype : "";
   if (subtype === "success") {
     session.lastAssistantError = undefined;
     finalizeOpenToolCalls(session, "completed");
-    writeEvent({ event: "turn_complete", session_id: session.sessionId });
+    writeEvent({
+      event: "turn_complete",
+      session_id: session.sessionId,
+      ...(terminalReason ? { terminal_reason: terminalReason } : {}),
+    });
     return;
   }
 
@@ -352,8 +362,29 @@ export function handleResultMessage(session: SessionState, message: Record<strin
     error_kind: errorKind,
     ...(subtype ? { sdk_result_subtype: subtype } : {}),
     ...(assistantError ? { assistant_error: assistantError } : {}),
+    ...(terminalReason ? { terminal_reason: terminalReason } : {}),
   });
   session.lastAssistantError = undefined;
+}
+
+function terminalReasonFromValue(value: unknown): TerminalReason | undefined {
+  switch (value) {
+    case "blocking_limit":
+    case "rapid_refill_breaker":
+    case "prompt_too_long":
+    case "image_error":
+    case "model_error":
+    case "aborted_streaming":
+    case "aborted_tools":
+    case "stop_hook_prevented":
+    case "hook_stopped":
+    case "tool_deferred":
+    case "max_turns":
+    case "completed":
+      return value;
+    default:
+      return undefined;
+  }
 }
 
 export function handleSdkMessage(session: SessionState, message: SDKMessage): void {
@@ -374,6 +405,7 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
       if (incomingMode) {
         session.mode = incomingMode;
       }
+      refreshSupportedModesForSession(session);
       emitFastModeUpdateIfChanged(session, msg.fast_mode_state);
 
       if (!session.connected) {
@@ -391,7 +423,7 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         if (incomingMode) {
           emitSessionUpdate(session.sessionId, {
             type: "mode_state_update",
-            mode: buildModeState(incomingMode),
+            mode: buildModeState(session, incomingMode),
           });
         }
       }
@@ -431,6 +463,7 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         typeof msg.permissionMode === "string" ? toPermissionMode(msg.permissionMode) : null;
       if (mode) {
         session.mode = mode;
+        refreshSupportedModesForSession(session);
         emitSessionUpdate(session.sessionId, { type: "current_mode_update", current_mode_id: mode });
       }
       if (msg.status === "compacting") {

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -5,6 +5,7 @@ import {
   getSessionMessages,
   listSessions,
   query,
+  type AccountInfo,
   type CanUseTool,
   type ModelInfo,
   type PermissionMode,
@@ -131,6 +132,18 @@ type QueryWithInternalControlHandling = Query & {
 const requestUserDialogInterceptorInstalled = Symbol("requestUserDialogInterceptorInstalled");
 
 export const sessions = new Map<string, SessionState>();
+
+function nonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function shouldEmitStartupAuthRequiredForAccount(account: AccountInfo): boolean {
+  const provider = account.apiProvider;
+  if (nonEmptyString(provider) && provider !== "firstParty") {
+    return false;
+  }
+  return !nonEmptyString(account.email) && !nonEmptyString(account.apiKeySource);
+}
 const DEFAULT_SETTING_SOURCES: SettingSource[] = ["user", "project", "local"];
 const DEFAULT_MODEL_NAME = "default";
 const DEFAULT_PERMISSION_MODE: PermissionMode = "default";
@@ -586,11 +599,7 @@ export async function createSession(params: {
       }
       // Proactively detect missing auth from account info so the UI can
       // show the login hint immediately, without waiting for the first prompt.
-      const acct = result.account;
-      const hasCredentials =
-        (typeof acct.email === "string" && acct.email.trim().length > 0) ||
-        (typeof acct.apiKeySource === "string" && acct.apiKeySource.trim().length > 0);
-      if (!hasCredentials) {
+      if (shouldEmitStartupAuthRequiredForAccount(result.account)) {
         emitAuthRequired(session);
       }
       emitFastModeUpdateIfChanged(session, result.fast_mode_state);

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -25,6 +25,7 @@ import type {
   FastModeState,
   Json,
   PermissionOutcome,
+  PermissionDisplay,
   PermissionRequest,
   QuestionOutcome,
   SessionLaunchSettings,
@@ -63,6 +64,22 @@ import { mapAvailableAgents, emitAvailableAgentsIfChanged, refreshAvailableAgent
 import { emitAuthRequired, emitFastModeUpdateIfChanged } from "./error_classification.js";
 
 export type ConnectEventKind = "connected" | "session_replaced";
+
+function permissionDisplayFromCanUseOptions(
+  options: Parameters<CanUseTool>[2],
+): PermissionDisplay | undefined {
+  const title = typeof options.title === "string" ? options.title.trim() : "";
+  const displayName = typeof options.displayName === "string" ? options.displayName.trim() : "";
+  const description = typeof options.description === "string" ? options.description.trim() : "";
+  if (!title && !displayName && !description) {
+    return undefined;
+  }
+  return {
+    ...(title ? { title } : {}),
+    ...(displayName ? { display_name: displayName } : {}),
+    ...(description ? { description } : {}),
+  };
+}
 
 export type PendingPermission = {
   resolve?: (result: PermissionResult) => void;
@@ -405,9 +422,11 @@ export async function createSession(params: {
       );
     }
 
+    const display = permissionDisplayFromCanUseOptions(options);
     const request: PermissionRequest = {
       tool_call: existing,
       options: permissionOptionsFromSuggestions(options.suggestions),
+      ...(display ? { display } : {}),
     };
     bridgeLogger.info({
       target: LOG_TARGETS.BRIDGE_PERMISSION,

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -16,6 +16,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import type {
   AvailableCommand,
+  CurrentModel,
   AvailableModel,
   BridgeCommand,
   ElicitationAction,
@@ -89,6 +90,9 @@ export type SessionState = {
   sessionId: string;
   cwd: string;
   model: string;
+  requestedModelId?: string;
+  resolvedRuntimeModelId?: string;
+  currentModel?: CurrentModel;
   availableModels: AvailableModel[];
   mode: PermissionMode | null;
   supportedModeIds: PermissionMode[];
@@ -112,6 +116,19 @@ export type SessionState = {
   sessionsToCloseAfterConnect?: SessionState[];
   resumeUpdates?: SessionUpdate[];
 };
+
+type QueryWithInternalControlHandling = Query & {
+  processControlRequest?: (
+    request: {
+      request_id: string;
+      request: Record<string, unknown>;
+    },
+    signal: AbortSignal,
+  ) => Promise<Record<string, unknown> | undefined>;
+  [requestUserDialogInterceptorInstalled]?: boolean;
+};
+
+const requestUserDialogInterceptorInstalled = Symbol("requestUserDialogInterceptorInstalled");
 
 export const sessions = new Map<string, SessionState>();
 const DEFAULT_SETTING_SOURCES: SettingSource[] = ["user", "project", "local"];
@@ -189,6 +206,93 @@ export function updateSessionId(session: SessionState, newSessionId: string): vo
   sessions.delete(session.sessionId);
   session.sessionId = newSessionId;
   sessions.set(newSessionId, session);
+}
+
+function isRequestUserDialogControlRequest(
+  value: unknown,
+): value is {
+  request_id: string;
+  request: {
+    subtype: "request_user_dialog";
+    dialog_kind: string;
+    payload: Record<string, unknown>;
+    tool_use_id?: string;
+  };
+} {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  const request = record.request;
+  if (!request || typeof request !== "object") {
+    return false;
+  }
+  const inner = request as Record<string, unknown>;
+  const payload = inner.payload;
+  return (
+    typeof record.request_id === "string" &&
+    inner.subtype === "request_user_dialog" &&
+    typeof inner.dialog_kind === "string" &&
+    Boolean(payload && typeof payload === "object" && !Array.isArray(payload))
+  );
+}
+
+export function attachRequestUserDialogInterceptor(
+  query: Query,
+  sessionIdForLogs: () => string,
+): boolean {
+  const internalQuery = query as QueryWithInternalControlHandling;
+  if (internalQuery[requestUserDialogInterceptorInstalled]) {
+    return true;
+  }
+  if (typeof internalQuery.processControlRequest !== "function") {
+    bridgeLogger.warn({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "request_user_dialog_interceptor_unavailable",
+      message: "request_user_dialog interceptor could not be installed",
+      outcome: "failure",
+      sessionId: sessionIdForLogs(),
+    });
+    return false;
+  }
+
+  const originalProcessControlRequest = internalQuery.processControlRequest.bind(query);
+  internalQuery.processControlRequest = async (request, signal) => {
+    if (isRequestUserDialogControlRequest(request)) {
+      bridgeLogger.warn({
+        target: LOG_TARGETS.APP_SESSION,
+        eventName: "request_user_dialog_received",
+        message: "request_user_dialog control request received",
+        outcome: "failure",
+        sessionId: sessionIdForLogs(),
+        requestId: request.request_id,
+        ...(typeof request.request.tool_use_id === "string"
+          ? { toolCallId: request.request.tool_use_id }
+          : {}),
+        fields: {
+          dialog_kind: request.request.dialog_kind,
+          raw_payload: request.request.payload,
+          raw_request: request.request,
+        },
+      });
+      // TODO(request_user_dialog): Revisit this when a real claude-rs host flow needs it.
+      // For now we only log the full control request and reject it explicitly because
+      // normal TUI sessions do not appear to exercise these dialog kinds.
+      throw new Error(
+        `request_user_dialog is not supported by claude-rs yet (dialog_kind: ${request.request.dialog_kind})`,
+      );
+    }
+    return await originalProcessControlRequest(request, signal);
+  };
+  internalQuery[requestUserDialogInterceptorInstalled] = true;
+  bridgeLogger.info({
+    target: LOG_TARGETS.APP_SESSION,
+    eventName: "request_user_dialog_interceptor_installed",
+    message: "request_user_dialog interceptor installed",
+    outcome: "success",
+    sessionId: sessionIdForLogs(),
+  });
+  return true;
 }
 
 export async function closeSession(session: SessionState): Promise<void> {
@@ -355,6 +459,7 @@ export async function createSession(params: {
         sessionIdForLogs,
       }),
     });
+    attachRequestUserDialogInterceptor(queryHandle, sessionIdForLogs);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     bridgeLogger.error({
@@ -381,6 +486,7 @@ export async function createSession(params: {
     sessionId: provisionalSessionId,
     cwd: params.cwd,
     model: initialModel,
+    ...(initialModel ? { requestedModelId: initialModel } : {}),
     availableModels: [],
     mode: initialMode,
     supportedModeIds: [],
@@ -406,6 +512,7 @@ export async function createSession(params: {
       ? { sessionsToCloseAfterConnect: params.sessionsToCloseAfterConnect }
       : {}),
   };
+  refreshCurrentModel(session);
   const { refreshSupportedModesForSession } = await import("./commands.js");
   refreshSupportedModesForSession(session);
   sessions.set(provisionalSessionId, session);
@@ -456,15 +563,21 @@ export async function createSession(params: {
         },
       });
       session.availableModels = mapAvailableModels(result.models);
+      const currentModelChanged = refreshCurrentModel(session);
       const { buildModeState, refreshSupportedModesForSession } = await import("./commands.js");
       refreshSupportedModesForSession(session);
       if (!session.connected) {
         emitConnectEvent(session);
-      } else if (session.mode) {
-        emitSessionUpdate(session.sessionId, {
-          type: "mode_state_update",
-          mode: buildModeState(session, session.mode),
-        });
+      } else {
+        if (currentModelChanged) {
+          emitCurrentModelUpdate(session);
+        }
+        if (session.mode) {
+          emitSessionUpdate(session.sessionId, {
+            type: "mode_state_update",
+            mode: buildModeState(session, session.mode),
+          });
+        }
       }
       // Proactively detect missing auth from account info so the UI can
       // show the login hint immediately, without waiting for the first prompt.
@@ -1114,4 +1227,282 @@ export function handleElicitationResponse(
       content: normalizeSdkElicitationContent(command.content),
     } : {}),
   });
+}
+type NormalizedModelKey = {
+  original: string;
+  family: "opus" | "sonnet" | "haiku" | "unknown" | "default";
+  versionParts: number[];
+  variantParts: string[];
+  contextSuffix?: string;
+};
+
+function normalizeModelKey(id: string): NormalizedModelKey {
+  const original = id.trim();
+  if (!original || original === DEFAULT_MODEL_NAME) {
+    return { original, family: "default", versionParts: [], variantParts: [] };
+  }
+
+  const lower = original.toLowerCase();
+  const contextMatch = lower.match(/\[([^\]]+)\]$/);
+  const contextSuffix = contextMatch?.[1];
+  const withoutContext = contextMatch ? lower.slice(0, contextMatch.index) : lower;
+  const withoutPrefix = withoutContext.startsWith("claude-")
+    ? withoutContext.slice("claude-".length)
+    : withoutContext;
+  const parts = withoutPrefix.split("-").filter((part) => part.length > 0);
+  const familyPart = parts[0] ?? "";
+  const family =
+    familyPart === "opus" || familyPart === "sonnet" || familyPart === "haiku"
+      ? familyPart
+      : "unknown";
+  const versionParts =
+    family === "unknown"
+      ? []
+      : parts
+          .slice(1)
+          .filter((part) => /^\d+$/.test(part))
+          .map((part) => Number.parseInt(part, 10))
+          .filter((part) => Number.isFinite(part));
+  const variantParts =
+    family === "unknown"
+      ? []
+      : parts
+          .slice(1)
+          .filter((part) => !/^\d+$/.test(part));
+
+  return {
+    original,
+    family,
+    versionParts,
+    variantParts,
+    ...(contextSuffix ? { contextSuffix } : {}),
+  };
+}
+
+function modelKeysAreCompatible(leftId: string, rightId: string): boolean {
+  const left = normalizeModelKey(leftId);
+  const right = normalizeModelKey(rightId);
+  if (left.family === "default" || right.family === "default") {
+    return false;
+  }
+  if (left.family === "unknown" || right.family === "unknown") {
+    return left.original.toLowerCase() === right.original.toLowerCase();
+  }
+  if (left.family !== right.family) {
+    return false;
+  }
+  if (left.variantParts.join(".") !== right.variantParts.join(".")) {
+    return false;
+  }
+  if (left.versionParts.length === 0 || right.versionParts.length === 0) {
+    return true;
+  }
+  return left.versionParts.join(".") === right.versionParts.join(".");
+}
+
+function sameContextSuffix(leftId: string, rightId: string): boolean {
+  const left = normalizeModelKey(leftId);
+  const right = normalizeModelKey(rightId);
+  return (left.contextSuffix?.toLowerCase() ?? "") === (right.contextSuffix?.toLowerCase() ?? "");
+}
+
+function sameFamilyAndVersion(leftId: string, rightId: string): boolean {
+  const left = normalizeModelKey(leftId);
+  const right = normalizeModelKey(rightId);
+  if (left.family === "default" || right.family === "default") {
+    return false;
+  }
+  if (left.family === "unknown" || right.family === "unknown") {
+    return left.original.toLowerCase() === right.original.toLowerCase();
+  }
+  if (left.family !== right.family) {
+    return false;
+  }
+  if (left.versionParts.length === 0 || right.versionParts.length === 0) {
+    return left.versionParts.length === right.versionParts.length;
+  }
+  return left.versionParts.join(".") === right.versionParts.join(".");
+}
+
+function hasVariantSiblingConflict(
+  availableModels: AvailableModel[],
+  candidateId: string,
+  resolvedId: string,
+): boolean {
+  if (sameContextSuffix(candidateId, resolvedId)) {
+    return false;
+  }
+
+  const resolvedContext = normalizeModelKey(resolvedId).contextSuffix?.toLowerCase() ?? "";
+  if (!resolvedContext) {
+    return false;
+  }
+
+  return availableModels.some((entry) => {
+    if (entry.id === candidateId) {
+      return false;
+    }
+    if (!sameFamilyAndVersion(entry.id, resolvedId)) {
+      return false;
+    }
+    const entryContext = normalizeModelKey(entry.id).contextSuffix?.toLowerCase() ?? "";
+    return entryContext === resolvedContext;
+  });
+}
+
+function humanizeModelId(id: string): string {
+  const normalized = normalizeModelKey(id);
+  if (normalized.family === "default") {
+    return "Default";
+  }
+  if (normalized.family === "unknown") {
+    return id;
+  }
+
+  const familyLabel =
+    normalized.family === "opus"
+      ? "Opus"
+      : normalized.family === "sonnet"
+        ? "Sonnet"
+        : "Haiku";
+  const versionLabel =
+    normalized.versionParts.length > 0 ? ` ${normalized.versionParts.join(".")}` : "";
+  const contextLabel =
+    normalized.contextSuffix?.toLowerCase() === "1m"
+      ? " [1M]"
+      : normalized.contextSuffix
+        ? ` [${normalized.contextSuffix}]`
+        : "";
+  return `${familyLabel}${versionLabel}${contextLabel}`;
+}
+
+function shortDisplayNameForModelId(id: string): string {
+  const normalized = normalizeModelKey(id);
+  if (normalized.family === "default") {
+    return "Default";
+  }
+  if (normalized.family === "unknown") {
+    return id;
+  }
+  const familyLabel = normalized.family === "opus"
+    ? "Opus"
+    : normalized.family === "sonnet"
+      ? "Sonnet"
+      : "Haiku";
+  const contextLabel =
+    normalized.contextSuffix?.toLowerCase() === "1m"
+      ? " [1M]"
+      : normalized.contextSuffix
+        ? ` [${normalized.contextSuffix}]`
+        : "";
+  return `${familyLabel}${contextLabel}`;
+}
+
+function currentModelIsAuthoritative(
+  resolvedId: string,
+  requestedId: string | undefined,
+): boolean {
+  const resolved = resolvedId.trim();
+  if (!resolved || resolved === DEFAULT_MODEL_NAME || resolved === "Connecting...") {
+    return Boolean(requestedId && requestedId.trim() && requestedId.trim() !== DEFAULT_MODEL_NAME);
+  }
+  return true;
+}
+
+function resolveCatalogModel(
+  availableModels: AvailableModel[],
+  resolvedId: string,
+  requestedId: string | undefined,
+): AvailableModel | undefined {
+  const exactResolved = availableModels.find((entry) => entry.id === resolvedId);
+  if (exactResolved) {
+    return exactResolved;
+  }
+
+  if (requestedId) {
+    const exactRequested = availableModels.find((entry) => entry.id === requestedId);
+    if (
+      exactRequested &&
+      modelKeysAreCompatible(exactRequested.id, resolvedId) &&
+      !hasVariantSiblingConflict(availableModels, exactRequested.id, resolvedId)
+    ) {
+      return exactRequested;
+    }
+  }
+
+  const compatible = availableModels.filter(
+    (entry) =>
+      modelKeysAreCompatible(entry.id, resolvedId) &&
+      !hasVariantSiblingConflict(availableModels, entry.id, resolvedId),
+  );
+  return compatible.length === 1 ? compatible[0] : undefined;
+}
+
+export function resolveCurrentModel(session: SessionState): CurrentModel {
+  const requestedId = session.requestedModelId?.trim() || undefined;
+  const resolvedId =
+    session.resolvedRuntimeModelId?.trim() ||
+    session.model.trim() ||
+    requestedId ||
+    DEFAULT_MODEL_NAME;
+  const catalogModel = resolveCatalogModel(session.availableModels, resolvedId, requestedId);
+  const runtimeDisplayId = resolvedId || requestedId || DEFAULT_MODEL_NAME;
+  const displayNameShort = shortDisplayNameForModelId(runtimeDisplayId);
+  const displayNameLong = humanizeModelId(runtimeDisplayId);
+  const currentModel: CurrentModel = {
+    resolved_id: resolvedId,
+    display_name_short: displayNameShort,
+    display_name_long: displayNameLong,
+    supports_effort: catalogModel?.supports_effort === true,
+    supported_effort_levels: catalogModel?.supported_effort_levels ?? [],
+    is_authoritative: currentModelIsAuthoritative(resolvedId, requestedId),
+    ...(requestedId ? { requested_id: requestedId } : {}),
+    ...(catalogModel ? { catalog_id: catalogModel.id } : {}),
+    ...(catalogModel?.supports_fast_mode !== undefined
+      ? { supports_fast_mode: catalogModel.supports_fast_mode }
+      : {}),
+    ...(catalogModel?.supports_auto_mode !== undefined
+      ? { supports_auto_mode: catalogModel.supports_auto_mode }
+      : {}),
+    ...(catalogModel?.supports_adaptive_thinking !== undefined
+      ? { supports_adaptive_thinking: catalogModel.supports_adaptive_thinking }
+      : {}),
+  };
+  return currentModel;
+}
+
+export function shouldInvalidateResolvedRuntimeModel(
+  previousRequestedId: string | undefined,
+  previousSessionModel: string,
+  nextRequestedId: string,
+): boolean {
+  const previousRequested = previousRequestedId?.trim() || previousSessionModel.trim();
+  return previousRequested !== nextRequestedId.trim();
+}
+
+function currentModelsEqual(left: CurrentModel | undefined, right: CurrentModel): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function emitCurrentModelUpdate(session: SessionState): boolean {
+  if (!session.connected || !session.currentModel) {
+    return false;
+  }
+  emitSessionUpdate(session.sessionId, {
+    type: "current_model_update",
+    current_model: session.currentModel,
+  });
+  return true;
+}
+
+export function refreshCurrentModel(session: SessionState, emitUpdate = false): boolean {
+  const nextModel = resolveCurrentModel(session);
+  if (currentModelsEqual(session.currentModel, nextModel)) {
+    return false;
+  }
+  session.currentModel = nextModel;
+  if (emitUpdate) {
+    emitCurrentModelUpdate(session);
+  }
+  return true;
 }

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -91,6 +91,9 @@ export type SessionState = {
   model: string;
   availableModels: AvailableModel[];
   mode: PermissionMode | null;
+  supportedModeIds: PermissionMode[];
+  runtimeUnavailableModeIds: PermissionMode[];
+  supportsBypassPermissionsMode: boolean;
   fastModeState: FastModeState;
   query: Query;
   input: AsyncQueue<SDKUserMessage>;
@@ -148,6 +151,31 @@ function settingsObjectFromLaunchSettings(
   launchSettings: SessionLaunchSettings,
 ): Record<string, unknown> | undefined {
   return launchSettings.settings;
+}
+
+function normalizedSettingsFromLaunchSettings(
+  launchSettings: SessionLaunchSettings,
+): Record<string, unknown> | undefined {
+  const settings = settingsObjectFromLaunchSettings(launchSettings);
+  if (!settings) {
+    return undefined;
+  }
+
+  const sandbox =
+    settings.sandbox && typeof settings.sandbox === "object" && !Array.isArray(settings.sandbox)
+      ? (settings.sandbox as Record<string, unknown>)
+      : undefined;
+  if (sandbox?.enabled === true && sandbox.failIfUnavailable === undefined) {
+    return {
+      ...settings,
+      sandbox: {
+        ...sandbox,
+        failIfUnavailable: false,
+      },
+    };
+  }
+
+  return settings;
 }
 
 export function sessionById(sessionId: string): SessionState | null {
@@ -232,6 +260,8 @@ export async function createSession(params: {
   const provisionalSessionId = params.resume ?? randomUUID();
   const initialModel = initialSessionModel(params.launchSettings);
   const initialMode = initialSessionMode(params.launchSettings);
+  const supportsBypassPermissionsMode =
+    startupPermissionModeOptions(params.launchSettings).allowDangerouslySkipPermissions === true;
   const historyUpdateCount = params.resumeUpdates?.length ?? 0;
   const staleSessionCount = params.sessionsToCloseAfterConnect?.length ?? 0;
 
@@ -353,6 +383,9 @@ export async function createSession(params: {
     model: initialModel,
     availableModels: [],
     mode: initialMode,
+    supportedModeIds: [],
+    runtimeUnavailableModeIds: [],
+    supportsBypassPermissionsMode,
     fastModeState: "off",
     query: queryHandle,
     input,
@@ -373,6 +406,8 @@ export async function createSession(params: {
       ? { sessionsToCloseAfterConnect: params.sessionsToCloseAfterConnect }
       : {}),
   };
+  const { refreshSupportedModesForSession } = await import("./commands.js");
+  refreshSupportedModesForSession(session);
   sessions.set(provisionalSessionId, session);
   bridgeLogger.info({
     target: LOG_TARGETS.APP_SESSION,
@@ -406,7 +441,7 @@ export async function createSession(params: {
   // before the first user prompt.
   void session.query
     .initializationResult()
-    .then((result) => {
+    .then(async (result) => {
       bridgeLogger.info({
         target: LOG_TARGETS.APP_SESSION,
         eventName: "session_initialization_completed",
@@ -421,8 +456,15 @@ export async function createSession(params: {
         },
       });
       session.availableModels = mapAvailableModels(result.models);
+      const { buildModeState, refreshSupportedModesForSession } = await import("./commands.js");
+      refreshSupportedModesForSession(session);
       if (!session.connected) {
         emitConnectEvent(session);
+      } else if (session.mode) {
+        emitSessionUpdate(session.sessionId, {
+          type: "mode_state_update",
+          mode: buildModeState(session, session.mode),
+        });
       }
       // Proactively detect missing auth from account info so the UI can
       // show the login hint immediately, without waiting for the first prompt.
@@ -580,6 +622,7 @@ function permissionModeFromSettingsValue(rawMode: unknown): PermissionMode | und
   }
   switch (rawMode) {
     case "default":
+    case "auto":
     case "acceptEdits":
     case "bypassPermissions":
     case "plan":
@@ -665,12 +708,13 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
   const systemPrompt = systemPromptFromLaunchSettings(params.launchSettings);
   const modelOption = startupModelOption(params.launchSettings);
   const permissionModeOptions = startupPermissionModeOptions(params.launchSettings);
+  const settings = normalizedSettingsFromLaunchSettings(params.launchSettings);
   return {
     cwd: params.cwd,
     includePartialMessages: true,
     executable: "node" as const,
     ...(params.resume ? {} : { sessionId: params.provisionalSessionId }),
-    ...(params.launchSettings.settings ? { settings: params.launchSettings.settings } : {}),
+    ...(settings ? { settings } : {}),
     ...modelOption,
     ...permissionModeOptions,
     toolConfig: { askUserQuestion: { previewFormat: "markdown" as const } },

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -406,6 +406,7 @@ export async function createSession(params: {
       count: request.options.length,
       fields: {
         tool_name: toolName,
+        agent_id: options.agentID,
         blocked_path: options.blockedPath ?? "<none>",
         decision_reason: options.decisionReason ?? "<none>",
       },

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -258,6 +258,10 @@ export function attachRequestUserDialogInterceptor(
 
   const originalProcessControlRequest = internalQuery.processControlRequest.bind(query);
   internalQuery.processControlRequest = async (request, signal) => {
+    // SDK 0.2.104 also added cancel_async_message and seed_read_state control
+    // requests. Keep those delegated to the SDK internals: claude-rs does not
+    // own the SDK async-message queue or read-state cache, so TUI-level commands
+    // for them would add unsupported host behavior without user-visible value.
     if (isRequestUserDialogControlRequest(request)) {
       bridgeLogger.warn({
         target: LOG_TARGETS.APP_SESSION,
@@ -825,6 +829,7 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
   return {
     cwd: params.cwd,
     includePartialMessages: true,
+    promptSuggestions: true,
     executable: "node" as const,
     ...(params.resume ? {} : { sessionId: params.provisionalSessionId }),
     ...(settings ? { settings } : {}),

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -2,8 +2,6 @@ import { randomUUID } from "node:crypto";
 import { spawn as spawnChild } from "node:child_process";
 import fs from "node:fs";
 import {
-  getSessionMessages,
-  listSessions,
   query,
   type AccountInfo,
   type CanUseTool,
@@ -16,7 +14,6 @@ import {
   type SettingSource,
 } from "@anthropic-ai/claude-agent-sdk";
 import type {
-  AvailableCommand,
   CurrentModel,
   AvailableModel,
   BridgeCommand,
@@ -38,15 +35,10 @@ import {
   permissionOptionsFromSuggestions,
   permissionResultFromOutcome,
 } from "./permissions.js";
-import { mapSessionMessagesToUpdates } from "./history.js";
 import {
-  writeEvent,
   failConnection,
-  slashError,
   emitSessionUpdate,
   emitConnectEvent,
-  emitSessionsList,
-  refreshSessionsList,
   emitPermissionRequestEvent,
   emitElicitationRequestEvent,
 } from "./events.js";
@@ -1438,7 +1430,7 @@ function currentModelIsAuthoritative(
 ): boolean {
   const resolved = resolvedId.trim();
   if (!resolved || resolved === DEFAULT_MODEL_NAME || resolved === "Connecting...") {
-    return Boolean(requestedId && requestedId.trim() && requestedId.trim() !== DEFAULT_MODEL_NAME);
+    return Boolean(requestedId?.trim() && requestedId.trim() !== DEFAULT_MODEL_NAME);
   }
   return true;
 }

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -79,7 +79,7 @@ export type PendingQuestion = {
 export type PendingElicitation = {
   resolve: (result: {
     action: ElicitationAction;
-    content?: Record<string, unknown>;
+    content?: Record<string, string | number | boolean | string[]>;
   }) => void;
   serverName: string;
   elicitationId?: string;
@@ -114,6 +114,30 @@ export const sessions = new Map<string, SessionState>();
 const DEFAULT_SETTING_SOURCES: SettingSource[] = ["user", "project", "local"];
 const DEFAULT_MODEL_NAME = "default";
 const DEFAULT_PERMISSION_MODE: PermissionMode = "default";
+
+function isSdkElicitationContentValue(value: Json): value is string | number | boolean | string[] {
+  return (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    (Array.isArray(value) && value.every((entry) => typeof entry === "string"))
+  );
+}
+
+function normalizeSdkElicitationContent(
+  content: Record<string, Json> | undefined,
+): Record<string, string | number | boolean | string[]> | undefined {
+  if (!content) {
+    return undefined;
+  }
+  const normalized: Record<string, string | number | boolean | string[]> = {};
+  for (const [key, value] of Object.entries(content)) {
+    if (isSdkElicitationContentValue(value)) {
+      normalized[key] = value;
+    }
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
 
 type CloseSessionOptions = {
   reason?: string;
@@ -754,7 +778,7 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
       emitElicitationRequestEvent(params.sessionIdForLogs(), normalized);
       return await new Promise<{
         action: ElicitationAction;
-        content?: Record<string, unknown>;
+        content?: Record<string, string | number | boolean | string[]>;
       }>((resolve) => {
         const currentSession = sessions.get(params.sessionIdForLogs());
         if (!currentSession) {
@@ -1042,6 +1066,8 @@ export function handleElicitationResponse(
   });
   pending.resolve({
     action: command.action,
-    ...(command.content ? { content: command.content } : {}),
+    ...(normalizeSdkElicitationContent(command.content) ? {
+      content: normalizeSdkElicitationContent(command.content),
+    } : {}),
   });
 }

--- a/agent-sdk/src/bridge/state_parsing.ts
+++ b/agent-sdk/src/bridge/state_parsing.ts
@@ -48,7 +48,6 @@ export function parseApiRetryError(value: unknown): ApiRetryError {
     case "server_error":
     case "max_output_tokens":
       return value;
-    case "unknown":
     default:
       return "unknown";
   }

--- a/agent-sdk/src/bridge/state_parsing.ts
+++ b/agent-sdk/src/bridge/state_parsing.ts
@@ -1,4 +1,11 @@
-import type { FastModeState, RateLimitStatus, SessionUpdate } from "../types.js";
+import type {
+  ApiRetryError,
+  FastModeState,
+  RateLimitStatus,
+  RuntimeSessionState,
+  SessionUpdate,
+  SettingsParseErrorUpdate,
+} from "../types.js";
 import { asRecordOrNull } from "./shared.js";
 
 export function numberField(record: Record<string, unknown>, ...keys: string[]): number | undefined {
@@ -23,6 +30,28 @@ export function parseRateLimitStatus(value: unknown): RateLimitStatus | null {
     return value;
   }
   return null;
+}
+
+export function parseRuntimeSessionState(value: unknown): RuntimeSessionState | null {
+  if (value === "idle" || value === "running" || value === "requires_action") {
+    return value;
+  }
+  return null;
+}
+
+export function parseApiRetryError(value: unknown): ApiRetryError {
+  switch (value) {
+    case "authentication_failed":
+    case "billing_error":
+    case "rate_limit":
+    case "invalid_request":
+    case "server_error":
+    case "max_output_tokens":
+      return value;
+    case "unknown":
+    default:
+      return "unknown";
+  }
 }
 
 export function buildRateLimitUpdate(
@@ -81,4 +110,53 @@ export function buildRateLimitUpdate(
   }
 
   return update;
+}
+
+export function buildApiRetryUpdate(
+  message: Record<string, unknown>,
+): Extract<SessionUpdate, { type: "api_retry_update" }> | null {
+  const attempt = numberField(message, "attempt");
+  const maxRetries = numberField(message, "max_retries", "maxRetries");
+  const retryDelayMs = numberField(message, "retry_delay_ms", "retryDelayMs");
+  if (attempt === undefined || maxRetries === undefined || retryDelayMs === undefined) {
+    return null;
+  }
+
+  const rawStatus = message.error_status ?? message.errorStatus;
+  const errorStatus = typeof rawStatus === "number" && Number.isFinite(rawStatus) ? rawStatus : null;
+
+  return {
+    type: "api_retry_update",
+    attempt,
+    max_retries: maxRetries,
+    retry_delay_ms: retryDelayMs,
+    error_status: errorStatus,
+    error: parseApiRetryError(message.error),
+  };
+}
+
+export function normalizeSettingsParseError(value: unknown): SettingsParseErrorUpdate | null {
+  const record = asRecordOrNull(value);
+  if (!record) {
+    return null;
+  }
+  const message = typeof record.message === "string" ? record.message.trim() : "";
+  if (!message) {
+    return null;
+  }
+  const path = typeof record.path === "string" ? record.path : "";
+  const file = typeof record.file === "string" && record.file.trim() ? record.file : undefined;
+  return {
+    ...(file ? { file } : {}),
+    path,
+    message,
+  };
+}
+
+export function normalizeSettingsParseErrors(value: unknown): SettingsParseErrorUpdate[] {
+  const entries = Array.isArray(value) ? value : [value];
+  return entries.flatMap((entry) => {
+    const normalized = normalizeSettingsParseError(entry);
+    return normalized ? [normalized] : [];
+  });
 }

--- a/agent-sdk/src/bridge/tool_calls.ts
+++ b/agent-sdk/src/bridge/tool_calls.ts
@@ -1,4 +1,4 @@
-import type { PlanEntry, ToolCall, ToolCallUpdateFields } from "../types.js";
+import type { PlanEntry, TaskMetadata, ToolCall, ToolCallUpdateFields } from "../types.js";
 import { emitSessionUpdate } from "./events.js";
 import { bridgeLogger, LOG_TARGETS } from "./logger.js";
 import type { SessionState } from "./session_lifecycle.js";
@@ -14,6 +14,7 @@ type ToolUpdateKind =
   | "finalize"
   | "task_started"
   | "task_progress"
+  | "task_updated"
   | "task_notification";
 
 function jsonSize(value: unknown): number | undefined {
@@ -73,6 +74,7 @@ function updateOutcome(status: ToolCall["status"] | undefined): string {
     case "completed":
       return "success";
     case "failed":
+    case "killed":
       return "failure";
     case "in_progress":
       return "partial";
@@ -81,6 +83,19 @@ function updateOutcome(status: ToolCall["status"] | undefined): string {
     default:
       return "partial";
   }
+}
+
+function mergeTaskMetadata(
+  current: ToolCall["task_metadata"] | undefined,
+  update: ToolCallUpdateFields["task_metadata"],
+): ToolCall["task_metadata"] {
+  if (update === undefined) {
+    return current;
+  }
+  return {
+    ...(current ?? {}),
+    ...update,
+  };
 }
 
 function applyFieldsToBase(base: ToolCall, fields: ToolCallUpdateFields): void {
@@ -104,6 +119,9 @@ function applyFieldsToBase(base: ToolCall, fields: ToolCallUpdateFields): void {
   }
   if (fields.output_metadata !== undefined) {
     base.output_metadata = fields.output_metadata;
+  }
+  if (fields.task_metadata !== undefined) {
+    base.task_metadata = mergeTaskMetadata(base.task_metadata, fields.task_metadata);
   }
   if (fields.meta !== undefined) {
     base.meta = fields.meta;
@@ -167,11 +185,12 @@ function logToolCallUpdateEmitted(
       location_count: fields.locations?.length,
       raw_output_chars: rawOutput?.length,
       has_output_metadata: fields.output_metadata !== undefined || base?.output_metadata !== undefined,
+      has_task_metadata: fields.task_metadata !== undefined || base?.task_metadata !== undefined,
       failure_kind: failureKind,
     },
   } as const;
 
-  if (nextStatus === "failed") {
+  if (nextStatus === "failed" || nextStatus === "killed") {
     bridgeLogger.warn(commonEvent);
     return;
   }
@@ -306,7 +325,8 @@ export function emitToolProgressUpdate(session: SessionState, toolUseId: string,
   if (
     existing.status === "in_progress" ||
     existing.status === "completed" ||
-    existing.status === "failed"
+    existing.status === "failed" ||
+    existing.status === "killed"
   ) {
     return;
   }
@@ -320,7 +340,7 @@ export function emitToolSummaryUpdate(session: SessionState, toolUseId: string, 
     return;
   }
   const fields: ToolCallUpdateFields = {
-    status: base.status === "failed" ? "failed" : "completed",
+    status: base.status === "failed" || base.status === "killed" ? base.status : "completed",
     raw_output: summary,
     content: [{ type: "content", content: { type: "text", text: summary } }],
   };
@@ -330,7 +350,7 @@ export function emitToolSummaryUpdate(session: SessionState, toolUseId: string, 
 export function setToolCallStatus(
   session: SessionState,
   toolUseId: string,
-  status: "pending" | "in_progress" | "completed" | "failed",
+  status: "pending" | "in_progress" | "completed" | "failed" | "killed",
   message?: string,
 ): void {
   const base = session.toolCalls.get(toolUseId);
@@ -369,4 +389,69 @@ export function taskProgressText(msg: Record<string, unknown>): string {
     return `${description} (last tool: ${lastTool})`;
   }
   return description || lastTool;
+}
+
+function taskPatchStatus(value: unknown): "pending" | "in_progress" | "completed" | "failed" | "killed" | undefined {
+  switch (value) {
+    case "pending":
+      return "pending";
+    case "running":
+      return "in_progress";
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "killed":
+      return "killed";
+    default:
+      return undefined;
+  }
+}
+
+function buildTaskMetadata(patch: Record<string, unknown>): TaskMetadata | undefined {
+  const taskMetadata: TaskMetadata = {};
+  if (typeof patch.error === "string" && patch.error.length > 0) {
+    taskMetadata.error = patch.error;
+  }
+  if (typeof patch.is_backgrounded === "boolean") {
+    taskMetadata.is_backgrounded = patch.is_backgrounded;
+  }
+  if (typeof patch.end_time === "number" && Number.isFinite(patch.end_time) && patch.end_time >= 0) {
+    taskMetadata.end_time = Math.trunc(patch.end_time);
+  }
+  if (
+    typeof patch.total_paused_ms === "number" &&
+    Number.isFinite(patch.total_paused_ms) &&
+    patch.total_paused_ms >= 0
+  ) {
+    taskMetadata.total_paused_ms = Math.trunc(patch.total_paused_ms);
+  }
+  return Object.keys(taskMetadata).length > 0 ? taskMetadata : undefined;
+}
+
+export function taskUpdatedFields(msg: Record<string, unknown>): ToolCallUpdateFields {
+  const patch =
+    msg.patch && typeof msg.patch === "object" ? (msg.patch as Record<string, unknown>) : {};
+  const fields: ToolCallUpdateFields = {};
+  const status = taskPatchStatus(patch.status);
+  const description = typeof patch.description === "string" ? patch.description : "";
+  const error = typeof patch.error === "string" ? patch.error : "";
+
+  if (status) {
+    fields.status = status;
+  }
+  if (description) {
+    fields.raw_output = description;
+    fields.content = [{ type: "content", content: { type: "text", text: description } }];
+  } else if ((status === "failed" || status === "killed") && error) {
+    fields.raw_output = error;
+    fields.content = [{ type: "content", content: { type: "text", text: error } }];
+  }
+
+  const taskMetadata = buildTaskMetadata(patch);
+  if (taskMetadata) {
+    fields.task_metadata = taskMetadata;
+  }
+
+  return fields;
 }

--- a/agent-sdk/src/bridge/tool_calls.ts
+++ b/agent-sdk/src/bridge/tool_calls.ts
@@ -85,6 +85,19 @@ function updateOutcome(status: ToolCall["status"] | undefined): string {
   }
 }
 
+function parentToolUseIdFromMeta(meta: ToolCall["meta"] | undefined): string | null {
+  if (!meta || typeof meta !== "object") {
+    return null;
+  }
+  const claudeCode =
+    "claudeCode" in meta && meta.claudeCode && typeof meta.claudeCode === "object" ? meta.claudeCode : undefined;
+  const parentToolUseId =
+    claudeCode && "parentToolUseId" in claudeCode && typeof claudeCode.parentToolUseId === "string"
+      ? claudeCode.parentToolUseId
+      : null;
+  return parentToolUseId;
+}
+
 function mergeTaskMetadata(
   current: ToolCall["task_metadata"] | undefined,
   update: ToolCallUpdateFields["task_metadata"],
@@ -232,12 +245,19 @@ export function emitToolCallUpdate(
   }
 }
 
-export function emitToolCall(session: SessionState, toolUseId: string, name: string, input: Record<string, unknown>): void {
-  const toolCall = createToolCall(toolUseId, name, input);
+export function emitToolCall(
+  session: SessionState,
+  toolUseId: string,
+  name: string,
+  input: Record<string, unknown>,
+  parentToolUseId: string | null = null,
+): void {
+  const existing = session.toolCalls.get(toolUseId);
+  const resolvedParentToolUseId = parentToolUseId ?? parentToolUseIdFromMeta(existing?.meta);
+  const toolCall = createToolCall(toolUseId, name, input, resolvedParentToolUseId);
   const status: ToolCall["status"] = "in_progress";
   toolCall.status = status;
 
-  const existing = session.toolCalls.get(toolUseId);
   if (!existing) {
     emitInitialToolCall(session, toolCall);
     return;
@@ -262,12 +282,18 @@ export function ensureToolCallVisible(
   toolUseId: string,
   toolName: string,
   input: Record<string, unknown>,
+  parentToolUseId: string | null = null,
 ): ToolCall {
   const existing = session.toolCalls.get(toolUseId);
   if (existing) {
+    const existingParentToolUseId = parentToolUseIdFromMeta(existing.meta);
+    if (parentToolUseId && existingParentToolUseId !== parentToolUseId) {
+      const refreshed = createToolCall(toolUseId, toolName, input, parentToolUseId);
+      emitToolCallUpdate(session, toolUseId, { meta: refreshed.meta }, "refresh");
+    }
     return existing;
   }
-  const toolCall = createToolCall(toolUseId, toolName, input);
+  const toolCall = createToolCall(toolUseId, toolName, input, parentToolUseId);
   emitInitialToolCall(session, toolCall);
   return toolCall;
 }

--- a/agent-sdk/src/bridge/tooling.ts
+++ b/agent-sdk/src/bridge/tooling.ts
@@ -120,7 +120,12 @@ function editDiffContent(name: string, input: Record<string, unknown>): ToolCall
   return [];
 }
 
-export function createToolCall(toolUseId: string, name: string, input: Record<string, unknown>): ToolCall {
+export function createToolCall(
+  toolUseId: string,
+  name: string,
+  input: Record<string, unknown>,
+  parentToolUseId: string | null = null,
+): ToolCall {
   return {
     tool_call_id: toolUseId,
     title: toolTitle(name, input),
@@ -132,6 +137,7 @@ export function createToolCall(toolUseId: string, name: string, input: Record<st
     meta: {
       claudeCode: {
         toolName: name,
+        parentToolUseId,
       },
     },
   };

--- a/agent-sdk/src/bridge/tooling.ts
+++ b/agent-sdk/src/bridge/tooling.ts
@@ -153,19 +153,35 @@ function resultRecordCandidates(rawResult: unknown, rawContent: unknown): Record
     }
   };
 
+  const pushRecords = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        pushRecord(entry);
+      }
+      return;
+    }
+    pushRecord(value);
+  };
+
   const pushNestedRecords = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        pushNestedRecords(entry);
+      }
+      return;
+    }
     const record = asRecordOrNull(value);
     if (!record) {
       return;
     }
-    pushRecord(record.result);
-    pushRecord(record.data);
-    pushRecord(record.content);
+    pushRecords(record.result);
+    pushRecords(record.data);
+    pushRecords(record.content);
   };
 
-  pushRecord(rawResult);
+  pushRecords(rawResult);
   pushNestedRecords(rawResult);
-  pushRecord(rawContent);
+  pushRecords(rawContent);
   pushNestedRecords(rawContent);
 
   return candidates;
@@ -270,28 +286,12 @@ function extractToolOutputMetadata(
   if (toolName === "Bash") {
     for (const candidate of candidates) {
       const hasAssistantAutoBackgrounded = typeof candidate.assistantAutoBackgrounded === "boolean";
-      const hasTokenSaverOutput =
-        typeof candidate.tokenSaverOutput === "string" && candidate.tokenSaverOutput.length > 0;
-      if (hasAssistantAutoBackgrounded || hasTokenSaverOutput) {
+      if (hasAssistantAutoBackgrounded) {
         const bashMetadata: import("../types.js").BashOutputMetadata = {};
-        if (hasAssistantAutoBackgrounded) {
-          bashMetadata.assistant_auto_backgrounded = candidate.assistantAutoBackgrounded as boolean;
-        }
-        if (hasTokenSaverOutput) {
-          bashMetadata.token_saver_active = true;
-        }
+        bashMetadata.assistant_auto_backgrounded = candidate.assistantAutoBackgrounded as boolean;
         return {
           bash: bashMetadata,
         };
-      }
-    }
-    return undefined;
-  }
-
-  if (toolName === "ExitPlanMode") {
-    for (const candidate of candidates) {
-      if (typeof candidate.isUltraplan === "boolean") {
-        return { exit_plan_mode: { is_ultraplan: candidate.isUltraplan } };
       }
     }
     return undefined;
@@ -558,8 +558,7 @@ function findBashResultRecord(
       "stderr" in candidate ||
       "backgroundTaskId" in candidate ||
       "backgroundedByUser" in candidate ||
-      "assistantAutoBackgrounded" in candidate ||
-      "tokenSaverOutput" in candidate,
+      "assistantAutoBackgrounded" in candidate,
   );
 }
 
@@ -598,6 +597,30 @@ function buildBashDisplayOutput(record: Record<string, unknown>): string {
   return segments.join("\n");
 }
 
+function fileUnchangedResultText(rawResult: unknown, rawContent: unknown): string {
+  for (const candidate of resultRecordCandidates(rawResult, rawContent)) {
+    if (candidate.type !== "file_unchanged") {
+      continue;
+    }
+    const file = asRecordOrNull(candidate.file);
+    const filePath = typeof file?.filePath === "string" ? file.filePath.trim() : "";
+    if (filePath) {
+      return `File unchanged: ${filePath}`;
+    }
+  }
+  return "";
+}
+
+function agentTitleFromAgentOutput(rawResult: unknown, rawContent: unknown): string {
+  for (const candidate of resultRecordCandidates(rawResult, rawContent)) {
+    const agentType = typeof candidate.agentType === "string" ? candidate.agentType.trim() : "";
+    if (agentType) {
+      return agentType;
+    }
+  }
+  return "";
+}
+
 export function buildToolResultFields(
   isError: boolean,
   rawContent: unknown,
@@ -605,14 +628,24 @@ export function buildToolResultFields(
   rawResult?: unknown,
 ): ToolCallUpdateFields {
   const toolName = resolveToolName(base);
+  const fields: ToolCallUpdateFields = {
+    status: isError ? "failed" : "completed",
+  };
+  const fileUnchangedText = !isError && toolName === "Read" ? fileUnchangedResultText(rawResult, rawContent) : "";
+  if (fileUnchangedText) {
+    fields.raw_output = fileUnchangedText;
+    fields.content = [{ type: "content", content: { type: "text", text: fileUnchangedText } }];
+    return fields;
+  }
+  const agentTitle = !isError && toolName === "Agent" ? agentTitleFromAgentOutput(rawResult, rawContent) : "";
+  if (agentTitle) {
+    fields.title = agentTitle;
+  }
   const bashResultRecord = toolName === "Bash" ? findBashResultRecord(rawResult, rawContent) : undefined;
   const normalizedRawOutput = normalizeToolResultText(rawContent, isError);
   const rawOutput = bashResultRecord
     ? buildBashDisplayOutput(bashResultRecord)
     : normalizedRawOutput || JSON.stringify(rawContent);
-  const fields: ToolCallUpdateFields = {
-    status: isError ? "failed" : "completed",
-  };
   if (rawOutput) {
     fields.raw_output = rawOutput;
   }

--- a/agent-sdk/src/bridge/user_interaction.ts
+++ b/agent-sdk/src/bridge/user_interaction.ts
@@ -7,7 +7,6 @@ import type {
   QuestionAnnotation,
   QuestionOption,
   QuestionOutcome,
-  QuestionPrompt,
   QuestionRequest,
   ToolCall,
   ToolCallUpdateFields,

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -84,6 +84,23 @@ export interface RateLimitUpdate {
   surpassed_threshold?: number;
 }
 
+export type ApiRetryError =
+  | "authentication_failed"
+  | "billing_error"
+  | "rate_limit"
+  | "invalid_request"
+  | "server_error"
+  | "unknown"
+  | "max_output_tokens";
+
+export type RuntimeSessionState = "idle" | "running" | "requires_action";
+
+export interface SettingsParseErrorUpdate {
+  file?: string;
+  path: string;
+  message: string;
+}
+
 export type ContentBlock =
   | { type: "text"; text: string }
   | { type: "image"; mime_type?: string; uri?: string; data?: string };
@@ -190,6 +207,17 @@ export type SessionUpdate =
   | { type: "config_option_update"; option_id: string; value: Json }
   | { type: "fast_mode_update"; fast_mode_state: FastModeState }
   | ({ type: "rate_limit_update" } & RateLimitUpdate)
+  | {
+      type: "api_retry_update";
+      attempt: number;
+      max_retries: number;
+      retry_delay_ms: number;
+      error_status: number | null;
+      error: ApiRetryError;
+    }
+  | { type: "prompt_suggestion_update"; suggestion: string }
+  | { type: "runtime_session_state_update"; state: RuntimeSessionState }
+  | ({ type: "settings_parse_error" } & SettingsParseErrorUpdate)
   | { type: "session_status_update"; status: "compacting" | "idle" }
   | { type: "compaction_boundary"; trigger: "manual" | "auto"; pre_tokens: number };
 

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -123,22 +123,16 @@ export type ToolCallContent =
       blob_saved_to?: string;
     };
 
-export interface ExitPlanModeOutputMetadata {
-  is_ultraplan?: boolean;
-}
-
 export interface TodoWriteOutputMetadata {
   verification_nudge_needed?: boolean;
 }
 
 export interface BashOutputMetadata {
   assistant_auto_backgrounded?: boolean;
-  token_saver_active?: boolean;
 }
 
 export interface ToolOutputMetadata {
   bash?: BashOutputMetadata;
-  exit_plan_mode?: ExitPlanModeOutputMetadata;
   todo_write?: TodoWriteOutputMetadata;
 }
 
@@ -231,6 +225,13 @@ export interface PermissionOption {
 export interface PermissionRequest {
   tool_call: ToolCall;
   options: PermissionOption[];
+  display?: PermissionDisplay;
+}
+
+export interface PermissionDisplay {
+  title?: string;
+  display_name?: string;
+  description?: string;
 }
 
 export type ElicitationMode = "form" | "url";

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -42,6 +42,20 @@ export interface AvailableModel {
   supports_auto_mode?: boolean;
 }
 
+export interface CurrentModel {
+  requested_id?: string;
+  resolved_id: string;
+  display_name_short: string;
+  display_name_long: string;
+  catalog_id?: string;
+  supports_effort: boolean;
+  supported_effort_levels: EffortLevel[];
+  supports_fast_mode?: boolean;
+  supports_auto_mode?: boolean;
+  supports_adaptive_thinking?: boolean;
+  is_authoritative: boolean;
+}
+
 export type FastModeState = "off" | "cooldown" | "on";
 export type RateLimitStatus = "allowed" | "allowed_warning" | "rejected";
 export type TerminalReason =
@@ -111,6 +125,13 @@ export interface ToolOutputMetadata {
   todo_write?: TodoWriteOutputMetadata;
 }
 
+export interface TaskMetadata {
+  end_time?: number;
+  total_paused_ms?: number;
+  error?: string;
+  is_backgrounded?: boolean;
+}
+
 export interface ToolLocation {
   path: string;
   line?: number;
@@ -125,6 +146,7 @@ export interface ToolCall {
   raw_input?: Json;
   raw_output?: string;
   output_metadata?: ToolOutputMetadata;
+  task_metadata?: TaskMetadata;
   locations: ToolLocation[];
   meta?: Json;
 }
@@ -137,6 +159,7 @@ export interface ToolCallUpdateFields {
   raw_input?: Json;
   raw_output?: string;
   output_metadata?: ToolOutputMetadata;
+  task_metadata?: TaskMetadata;
   locations?: ToolLocation[];
   meta?: Json;
 }
@@ -163,6 +186,7 @@ export type SessionUpdate =
   | { type: "available_agents_update"; agents: AvailableAgent[] }
   | { type: "mode_state_update"; mode: ModeState }
   | { type: "current_mode_update"; current_mode_id: string }
+  | { type: "current_model_update"; current_model: CurrentModel }
   | { type: "config_option_update"; option_id: string; value: Json }
   | { type: "fast_mode_update"; fast_mode_state: FastModeState }
   | ({ type: "rate_limit_update" } & RateLimitUpdate)
@@ -428,6 +452,14 @@ export type BridgeCommand =
       session_id: string;
     }
   | {
+      command: "get_context_usage";
+      session_id: string;
+    }
+  | {
+      command: "reload_plugins";
+      session_id: string;
+    }
+  | {
       command: "mcp_status";
       session_id: string;
     }
@@ -492,7 +524,7 @@ export type BridgeEvent =
       event: "connected";
       session_id: string;
       cwd: string;
-      model_name: string;
+      current_model: CurrentModel;
       available_models: AvailableModel[];
       mode: ModeState | null;
       history_updates?: SessionUpdate[];
@@ -517,11 +549,13 @@ export type BridgeEvent =
       terminal_reason?: TerminalReason;
     }
   | { event: "slash_error"; session_id: string; message: string }
+  | { event: "runtime_reload_completed"; session_id: string }
+  | { event: "runtime_reload_failed"; session_id: string; message: string }
   | {
       event: "session_replaced";
       session_id: string;
       cwd: string;
-      model_name: string;
+      current_model: CurrentModel;
       available_models: AvailableModel[];
       mode: ModeState | null;
       history_updates?: SessionUpdate[];
@@ -529,6 +563,11 @@ export type BridgeEvent =
   | { event: "initialized"; result: InitializeResult }
   | { event: "sessions_listed"; sessions: SessionListEntry[] }
   | { event: "status_snapshot"; session_id: string; account: AccountInfo }
+  | {
+      event: "context_usage";
+      session_id: string;
+      percentage?: number;
+    }
   | {
       event: "mcp_snapshot";
       session_id: string;

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -319,6 +319,7 @@ export interface AccountInfo {
   subscription_type?: string;
   token_source?: string;
   api_key_source?: string;
+  api_provider?: string;
 }
 
 export type McpServerConnectionStatus =

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -44,6 +44,19 @@ export interface AvailableModel {
 
 export type FastModeState = "off" | "cooldown" | "on";
 export type RateLimitStatus = "allowed" | "allowed_warning" | "rejected";
+export type TerminalReason =
+  | "blocking_limit"
+  | "rapid_refill_breaker"
+  | "prompt_too_long"
+  | "image_error"
+  | "model_error"
+  | "aborted_streaming"
+  | "aborted_tools"
+  | "stop_hook_prevented"
+  | "hook_stopped"
+  | "tool_deferred"
+  | "max_turns"
+  | "completed";
 
 export interface RateLimitUpdate {
   status: RateLimitStatus;
@@ -493,7 +506,7 @@ export type BridgeEvent =
   | { event: "elicitation_complete"; session_id: string; completion: ElicitationComplete }
   | { event: "mcp_auth_redirect"; session_id: string; redirect: McpAuthRedirect }
   | { event: "mcp_operation_error"; session_id: string; error: McpOperationError }
-  | { event: "turn_complete"; session_id: string }
+  | { event: "turn_complete"; session_id: string; terminal_reason?: TerminalReason }
   | {
       event: "turn_error";
       session_id: string;
@@ -501,6 +514,7 @@ export type BridgeEvent =
       error_kind?: TurnErrorKind;
       sdk_result_subtype?: string;
       assistant_error?: string;
+      terminal_reason?: TerminalReason;
     }
   | { event: "slash_error"; session_id: string; message: string }
   | {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.74"
+        "@anthropic-ai/claude-agent-sdk": "0.2.104"
       },
       "bin": {
         "claude-rs": "bin/claude-rs.js"
@@ -20,10 +20,14 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.74",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.74.tgz",
-      "integrity": "sha512-S/SFSSbZHPL1HiQxAqCCxU3iHuE5nM+ir0OK1n0bZ+9hlVUH7OOn88AsV9s54E0c1kvH9YF4/foWH8J9kICsBw==",
+      "version": "0.2.104",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.104.tgz",
+      "integrity": "sha512-lVm+nS79r6WWlDnv5AgRzTtAlbP8O6M6kkWmDZAWE3nt9agmngxls9frJFvH55uzws2+6l0yyup/JYspfijkzw==",
       "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
       "engines": {
         "node": ">=18.0.0"
       },
@@ -40,6 +44,47 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -346,14 +391,1134 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.74"
+    "@anthropic-ai/claude-agent-sdk": "0.2.104"
   },
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -421,6 +421,20 @@ impl AgentConnection {
         })
     }
 
+    pub fn get_context_usage(&self, session_id: String) -> anyhow::Result<()> {
+        self.send(CommandEnvelope {
+            request_id: None,
+            command: BridgeCommand::GetContextUsage { session_id },
+        })
+    }
+
+    pub fn reload_plugins(&self, session_id: String) -> anyhow::Result<()> {
+        self.send(CommandEnvelope {
+            request_id: None,
+            command: BridgeCommand::ReloadPlugins { session_id },
+        })
+    }
+
     pub fn get_mcp_snapshot(&self, session_id: String) -> anyhow::Result<()> {
         self.send(CommandEnvelope {
             request_id: None,
@@ -594,6 +608,34 @@ mod tests {
         assert_eq!(
             envelope.command,
             BridgeCommand::GetMcpSnapshot { session_id: "session-1".to_owned() }
+        );
+    }
+
+    #[test]
+    fn get_context_usage_sends_bridge_command() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let conn = AgentConnection::new(tx);
+
+        conn.get_context_usage("session-1".to_owned()).expect("context usage");
+
+        let envelope = rx.try_recv().expect("command");
+        assert_eq!(
+            envelope.command,
+            BridgeCommand::GetContextUsage { session_id: "session-1".to_owned() }
+        );
+    }
+
+    #[test]
+    fn reload_plugins_sends_bridge_command() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let conn = AgentConnection::new(tx);
+
+        conn.reload_plugins("session-1".to_owned()).expect("reload plugins");
+
+        let envelope = rx.try_recv().expect("command");
+        assert_eq!(
+            envelope.command,
+            BridgeCommand::ReloadPlugins { session_id: "session-1".to_owned() }
         );
     }
 

--- a/src/agent/events.rs
+++ b/src/agent/events.rs
@@ -50,7 +50,7 @@ pub enum ClientEvent {
     Connected {
         session_id: model::SessionId,
         cwd: String,
-        model_name: String,
+        current_model: model::CurrentModel,
         available_models: Vec<model::AvailableModel>,
         mode: Option<crate::app::ModeState>,
         history_updates: Vec<model::SessionUpdate>,
@@ -61,11 +61,15 @@ pub enum ClientEvent {
     AuthRequired { method_name: String, method_description: String },
     /// Slash-command execution failed with a user-facing error.
     SlashCommandError(String),
+    /// Session runtime plugin reload completed successfully.
+    RuntimeReloadCompleted { session_id: String },
+    /// Session runtime plugin reload failed after dispatch.
+    RuntimeReloadFailed { session_id: String, message: String },
     /// Custom slash command replaced the active session.
     SessionReplaced {
         session_id: model::SessionId,
         cwd: String,
-        model_name: String,
+        current_model: model::CurrentModel,
         available_models: Vec<model::AvailableModel>,
         mode: Option<crate::app::ModeState>,
         history_updates: Vec<model::SessionUpdate>,
@@ -82,6 +86,8 @@ pub enum ClientEvent {
     LogoutCompleted,
     /// Status snapshot received from bridge (account info).
     StatusSnapshotReceived { session_id: String, account: crate::agent::types::AccountInfo },
+    /// Session context window usage received from bridge.
+    ContextUsageReceived { session_id: String, percentage: Option<u8> },
     /// MCP server snapshot received from bridge.
     McpSnapshotReceived {
         session_id: String,

--- a/src/agent/events.rs
+++ b/src/agent/events.rs
@@ -35,13 +35,17 @@ pub enum ClientEvent {
     /// MCP operation failed and should be surfaced in the MCP config UI.
     McpOperationError { error: crate::agent::types::McpOperationError },
     /// A prompt turn completed successfully.
-    TurnComplete,
+    TurnComplete { terminal_reason: Option<crate::agent::types::TerminalReason> },
     /// `cancel` notification was accepted by the bridge.
     TurnCancelled,
     /// A prompt turn failed with an error.
-    TurnError(String),
+    TurnError { message: String, terminal_reason: Option<crate::agent::types::TerminalReason> },
     /// A prompt turn failed with bridge-provided classification metadata.
-    TurnErrorClassified { message: String, class: TurnErrorClass },
+    TurnErrorClassified {
+        message: String,
+        class: TurnErrorClass,
+        terminal_reason: Option<crate::agent::types::TerminalReason>,
+    },
     /// Background connection completed successfully.
     Connected {
         session_id: model::SessionId,

--- a/src/agent/model.rs
+++ b/src/agent/model.rs
@@ -140,6 +140,7 @@ pub enum ToolCallStatus {
     InProgress,
     Completed,
     Failed,
+    Killed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -265,6 +266,7 @@ pub struct ToolCall {
     pub raw_input: Option<serde_json::Value>,
     pub raw_output: Option<serde_json::Value>,
     pub output_metadata: Option<ToolOutputMetadata>,
+    pub task_metadata: Option<TaskMetadata>,
     pub locations: Vec<ToolCallLocation>,
     pub meta: Option<serde_json::Value>,
 }
@@ -281,6 +283,7 @@ impl ToolCall {
             raw_input: None,
             raw_output: None,
             output_metadata: None,
+            task_metadata: None,
             locations: Vec::new(),
             meta: None,
         }
@@ -323,6 +326,12 @@ impl ToolCall {
     }
 
     #[must_use]
+    pub fn task_metadata(mut self, task_metadata: TaskMetadata) -> Self {
+        self.task_metadata = Some(task_metadata);
+        self
+    }
+
+    #[must_use]
     pub fn locations(mut self, locations: Vec<ToolCallLocation>) -> Self {
         self.locations = locations;
         self
@@ -344,6 +353,7 @@ pub struct ToolCallUpdateFields {
     pub raw_input: Option<serde_json::Value>,
     pub raw_output: Option<serde_json::Value>,
     pub output_metadata: Option<ToolOutputMetadata>,
+    pub task_metadata: Option<TaskMetadata>,
     pub locations: Option<Vec<ToolCallLocation>>,
 }
 
@@ -392,6 +402,12 @@ impl ToolCallUpdateFields {
     #[must_use]
     pub fn output_metadata(mut self, output_metadata: ToolOutputMetadata) -> Self {
         self.output_metadata = Some(output_metadata);
+        self
+    }
+
+    #[must_use]
+    pub fn task_metadata(mut self, task_metadata: TaskMetadata) -> Self {
+        self.task_metadata = Some(task_metadata);
         self
     }
 
@@ -492,6 +508,45 @@ pub struct ToolOutputMetadata {
     pub bash: Option<BashOutputMetadata>,
     pub exit_plan_mode: Option<ExitPlanModeOutputMetadata>,
     pub todo_write: Option<TodoWriteOutputMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TaskMetadata {
+    pub end_time: Option<u64>,
+    pub total_paused_ms: Option<u64>,
+    pub error: Option<String>,
+    pub is_backgrounded: Option<bool>,
+}
+
+impl TaskMetadata {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn end_time(mut self, end_time: Option<u64>) -> Self {
+        self.end_time = end_time;
+        self
+    }
+
+    #[must_use]
+    pub fn total_paused_ms(mut self, total_paused_ms: Option<u64>) -> Self {
+        self.total_paused_ms = total_paused_ms;
+        self
+    }
+
+    #[must_use]
+    pub fn error(mut self, error: Option<String>) -> Self {
+        self.error = error;
+        self
+    }
+
+    #[must_use]
+    pub fn backgrounded(mut self, is_backgrounded: Option<bool>) -> Self {
+        self.is_backgrounded = is_backgrounded;
+        self
+    }
 }
 
 impl ToolOutputMetadata {
@@ -729,6 +784,92 @@ impl AvailableModel {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CurrentModel {
+    pub requested_id: Option<String>,
+    pub resolved_id: String,
+    pub display_name_short: String,
+    pub display_name_long: String,
+    pub catalog_id: Option<String>,
+    pub supports_effort: bool,
+    pub supported_effort_levels: Vec<EffortLevel>,
+    pub supports_fast_mode: Option<bool>,
+    pub supports_auto_mode: Option<bool>,
+    pub supports_adaptive_thinking: Option<bool>,
+    pub is_authoritative: bool,
+}
+
+impl CurrentModel {
+    #[must_use]
+    pub fn new(
+        resolved_id: impl Into<String>,
+        display_name_short: impl Into<String>,
+        display_name_long: impl Into<String>,
+    ) -> Self {
+        Self {
+            requested_id: None,
+            resolved_id: resolved_id.into(),
+            display_name_short: display_name_short.into(),
+            display_name_long: display_name_long.into(),
+            catalog_id: None,
+            supports_effort: false,
+            supported_effort_levels: Vec::new(),
+            supports_fast_mode: None,
+            supports_auto_mode: None,
+            supports_adaptive_thinking: None,
+            is_authoritative: false,
+        }
+    }
+
+    #[must_use]
+    pub fn requested_id(mut self, requested_id: impl Into<String>) -> Self {
+        self.requested_id = Some(requested_id.into());
+        self
+    }
+
+    #[must_use]
+    pub fn catalog_id(mut self, catalog_id: impl Into<String>) -> Self {
+        self.catalog_id = Some(catalog_id.into());
+        self
+    }
+
+    #[must_use]
+    pub fn supports_effort(mut self, supports_effort: bool) -> Self {
+        self.supports_effort = supports_effort;
+        self
+    }
+
+    #[must_use]
+    pub fn supported_effort_levels(mut self, supported_effort_levels: Vec<EffortLevel>) -> Self {
+        self.supported_effort_levels = supported_effort_levels;
+        self
+    }
+
+    #[must_use]
+    pub fn supports_adaptive_thinking(mut self, supports_adaptive_thinking: Option<bool>) -> Self {
+        self.supports_adaptive_thinking = supports_adaptive_thinking;
+        self
+    }
+
+    #[must_use]
+    pub fn supports_fast_mode(mut self, supports_fast_mode: Option<bool>) -> Self {
+        self.supports_fast_mode = supports_fast_mode;
+        self
+    }
+
+    #[must_use]
+    pub fn supports_auto_mode(mut self, supports_auto_mode: Option<bool>) -> Self {
+        self.supports_auto_mode = supports_auto_mode;
+        self
+    }
+
+    #[must_use]
+    pub fn authoritative(mut self, is_authoritative: bool) -> Self {
+        self.is_authoritative = is_authoritative;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AvailableAgentsUpdate {
     pub available_agents: Vec<AvailableAgent>,
 }
@@ -749,6 +890,18 @@ impl CurrentModeUpdate {
     #[must_use]
     pub fn new(current_mode_id: impl Into<SessionModeId>) -> Self {
         Self { current_mode_id: current_mode_id.into() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CurrentModelUpdate {
+    pub current_model: CurrentModel,
+}
+
+impl CurrentModelUpdate {
+    #[must_use]
+    pub fn new(current_model: CurrentModel) -> Self {
+        Self { current_model }
     }
 }
 
@@ -819,6 +972,7 @@ pub enum SessionUpdate {
     AvailableAgentsUpdate(AvailableAgentsUpdate),
     ModeStateUpdate(crate::app::ModeState),
     CurrentModeUpdate(CurrentModeUpdate),
+    CurrentModelUpdate(CurrentModelUpdate),
     ConfigOptionUpdate(ConfigOptionUpdate),
     FastModeUpdate(FastModeState),
     RateLimitUpdate(RateLimitUpdate),

--- a/src/agent/model.rs
+++ b/src/agent/model.rs
@@ -440,24 +440,6 @@ impl ToolCallUpdate {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct ExitPlanModeOutputMetadata {
-    pub is_ultraplan: Option<bool>,
-}
-
-impl ExitPlanModeOutputMetadata {
-    #[must_use]
-    pub fn new() -> Self {
-        Self { is_ultraplan: None }
-    }
-
-    #[must_use]
-    pub fn ultraplan(mut self, is_ultraplan: Option<bool>) -> Self {
-        self.is_ultraplan = is_ultraplan;
-        self
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct TodoWriteOutputMetadata {
     pub verification_nudge_needed: Option<bool>,
 }
@@ -478,13 +460,12 @@ impl TodoWriteOutputMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct BashOutputMetadata {
     pub assistant_auto_backgrounded: Option<bool>,
-    pub token_saver_active: Option<bool>,
 }
 
 impl BashOutputMetadata {
     #[must_use]
     pub fn new() -> Self {
-        Self { assistant_auto_backgrounded: None, token_saver_active: None }
+        Self { assistant_auto_backgrounded: None }
     }
 
     #[must_use]
@@ -495,18 +476,11 @@ impl BashOutputMetadata {
         self.assistant_auto_backgrounded = assistant_auto_backgrounded;
         self
     }
-
-    #[must_use]
-    pub fn token_saver_active(mut self, token_saver_active: Option<bool>) -> Self {
-        self.token_saver_active = token_saver_active;
-        self
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ToolOutputMetadata {
     pub bash: Option<BashOutputMetadata>,
-    pub exit_plan_mode: Option<ExitPlanModeOutputMetadata>,
     pub todo_write: Option<TodoWriteOutputMetadata>,
 }
 
@@ -558,12 +532,6 @@ impl ToolOutputMetadata {
     #[must_use]
     pub fn bash(mut self, bash: Option<BashOutputMetadata>) -> Self {
         self.bash = bash;
-        self
-    }
-
-    #[must_use]
-    pub fn exit_plan_mode(mut self, exit_plan_mode: Option<ExitPlanModeOutputMetadata>) -> Self {
-        self.exit_plan_mode = exit_plan_mode;
         self
     }
 
@@ -1200,6 +1168,7 @@ pub struct RequestPermissionRequest {
     pub session_id: SessionId,
     pub tool_call: ToolCallUpdate,
     pub options: Vec<PermissionOption>,
+    pub display: Option<PermissionDisplay>,
 }
 
 impl RequestPermissionRequest {
@@ -1208,8 +1177,48 @@ impl RequestPermissionRequest {
         session_id: impl Into<SessionId>,
         tool_call: ToolCallUpdate,
         options: Vec<PermissionOption>,
+        display: Option<PermissionDisplay>,
     ) -> Self {
-        Self { session_id: session_id.into(), tool_call, options }
+        Self { session_id: session_id.into(), tool_call, options, display }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PermissionDisplay {
+    pub title: Option<String>,
+    pub display_name: Option<String>,
+    pub description: Option<String>,
+}
+
+impl PermissionDisplay {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn title(mut self, title: Option<String>) -> Self {
+        self.title = title;
+        self
+    }
+
+    #[must_use]
+    pub fn display_name(mut self, display_name: Option<String>) -> Self {
+        self.display_name = display_name;
+        self
+    }
+
+    #[must_use]
+    pub fn description(mut self, description: Option<String>) -> Self {
+        self.description = description;
+        self
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.title.as_ref().is_none_or(|value| value.trim().is_empty())
+            && self.display_name.as_ref().is_none_or(|value| value.trim().is_empty())
+            && self.description.as_ref().is_none_or(|value| value.trim().is_empty())
     }
 }
 

--- a/src/agent/model.rs
+++ b/src/agent/model.rs
@@ -927,6 +927,24 @@ pub enum RateLimitStatus {
     Rejected,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ApiRetryError {
+    AuthenticationFailed,
+    BillingError,
+    RateLimit,
+    InvalidRequest,
+    ServerError,
+    MaxOutputTokens,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RuntimeSessionState {
+    Idle,
+    Running,
+    RequiresAction,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RateLimitUpdate {
     pub status: RateLimitStatus,
@@ -976,6 +994,20 @@ pub enum SessionUpdate {
     ConfigOptionUpdate(ConfigOptionUpdate),
     FastModeUpdate(FastModeState),
     RateLimitUpdate(RateLimitUpdate),
+    ApiRetryUpdate {
+        attempt: u64,
+        max_retries: u64,
+        retry_delay_ms: u64,
+        error_status: Option<u16>,
+        error: ApiRetryError,
+    },
+    PromptSuggestionUpdate(String),
+    RuntimeSessionStateUpdate(RuntimeSessionState),
+    SettingsParseError {
+        file: Option<String>,
+        path: String,
+        message: String,
+    },
     SessionStatusUpdate(SessionStatus),
     CompactionBoundary(CompactionBoundary),
 }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -85,6 +85,34 @@ pub enum RateLimitStatus {
     Rejected,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApiRetryError {
+    AuthenticationFailed,
+    BillingError,
+    RateLimit,
+    InvalidRequest,
+    ServerError,
+    MaxOutputTokens,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeSessionState {
+    Idle,
+    Running,
+    RequiresAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SettingsParseErrorUpdate {
+    pub file: Option<String>,
+    pub path: String,
+    pub message: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RateLimitUpdate {
     pub status: RateLimitStatus,
@@ -273,6 +301,24 @@ pub enum SessionUpdate {
         overage_disabled_reason: Option<String>,
         is_using_overage: Option<bool>,
         surpassed_threshold: Option<f64>,
+    },
+    ApiRetryUpdate {
+        attempt: u64,
+        max_retries: u64,
+        retry_delay_ms: u64,
+        error_status: Option<u16>,
+        error: ApiRetryError,
+    },
+    PromptSuggestionUpdate {
+        suggestion: String,
+    },
+    RuntimeSessionStateUpdate {
+        state: RuntimeSessionState,
+    },
+    SettingsParseError {
+        file: Option<String>,
+        path: String,
+        message: String,
     },
     SessionStatusUpdate {
         status: SessionStatus,
@@ -584,4 +630,27 @@ pub struct McpSetServersResult {
     pub removed: Vec<String>,
     #[serde(default)]
     pub errors: BTreeMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ApiRetryError, SessionUpdate};
+
+    #[test]
+    fn api_retry_update_deserializes_unknown_error_defensively() {
+        let update: SessionUpdate = serde_json::from_value(serde_json::json!({
+            "type": "api_retry_update",
+            "attempt": 1,
+            "max_retries": 4,
+            "retry_delay_ms": 1000,
+            "error_status": null,
+            "error": "transport_timeout"
+        }))
+        .expect("deserialize api retry update");
+
+        assert!(matches!(
+            update,
+            SessionUpdate::ApiRetryUpdate { error: ApiRetryError::Unknown, .. }
+        ));
+    }
 }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -526,6 +526,7 @@ pub struct AccountInfo {
     pub subscription_type: Option<String>,
     pub token_source: Option<String>,
     pub api_key_source: Option<String>,
+    pub api_provider: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -190,11 +190,6 @@ pub struct ToolLocation {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct ExitPlanModeOutputMetadata {
-    pub is_ultraplan: Option<bool>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct TodoWriteOutputMetadata {
     pub verification_nudge_needed: Option<bool>,
 }
@@ -202,13 +197,11 @@ pub struct TodoWriteOutputMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct BashOutputMetadata {
     pub assistant_auto_backgrounded: Option<bool>,
-    pub token_saver_active: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ToolOutputMetadata {
     pub bash: Option<BashOutputMetadata>,
-    pub exit_plan_mode: Option<ExitPlanModeOutputMetadata>,
     pub todo_write: Option<TodoWriteOutputMetadata>,
 }
 
@@ -341,6 +334,14 @@ pub struct PermissionOption {
 pub struct PermissionRequest {
     pub tool_call: ToolCall,
     pub options: Vec<PermissionOption>,
+    pub display: Option<PermissionDisplay>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PermissionDisplay {
+    pub title: Option<String>,
+    pub display_name: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -358,6 +358,43 @@ pub struct McpOperationError {
     pub message: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalReason {
+    BlockingLimit,
+    RapidRefillBreaker,
+    PromptTooLong,
+    ImageError,
+    ModelError,
+    AbortedStreaming,
+    AbortedTools,
+    StopHookPrevented,
+    HookStopped,
+    ToolDeferred,
+    MaxTurns,
+    Completed,
+}
+
+impl TerminalReason {
+    #[must_use]
+    pub const fn as_stored(self) -> &'static str {
+        match self {
+            Self::BlockingLimit => "blocking_limit",
+            Self::RapidRefillBreaker => "rapid_refill_breaker",
+            Self::PromptTooLong => "prompt_too_long",
+            Self::ImageError => "image_error",
+            Self::ModelError => "model_error",
+            Self::AbortedStreaming => "aborted_streaming",
+            Self::AbortedTools => "aborted_tools",
+            Self::StopHookPrevented => "stop_hook_prevented",
+            Self::HookStopped => "hook_stopped",
+            Self::ToolDeferred => "tool_deferred",
+            Self::MaxTurns => "max_turns",
+            Self::Completed => "completed",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthMethod {
     pub id: String,

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -53,6 +53,22 @@ pub struct AvailableModel {
     pub supports_auto_mode: Option<bool>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CurrentModel {
+    pub requested_id: Option<String>,
+    pub resolved_id: String,
+    pub display_name_short: String,
+    pub display_name_long: String,
+    pub catalog_id: Option<String>,
+    pub supports_effort: bool,
+    #[serde(default)]
+    pub supported_effort_levels: Vec<EffortLevel>,
+    pub supports_fast_mode: Option<bool>,
+    pub supports_auto_mode: Option<bool>,
+    pub supports_adaptive_thinking: Option<bool>,
+    pub is_authoritative: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FastModeState {
@@ -114,6 +130,7 @@ pub struct ToolCall {
     pub raw_input: Option<serde_json::Value>,
     pub raw_output: Option<String>,
     pub output_metadata: Option<ToolOutputMetadata>,
+    pub task_metadata: Option<TaskMetadata>,
     pub locations: Vec<ToolLocation>,
     pub meta: Option<serde_json::Value>,
 }
@@ -133,6 +150,7 @@ pub struct ToolCallUpdateFields {
     pub raw_input: Option<serde_json::Value>,
     pub raw_output: Option<String>,
     pub output_metadata: Option<ToolOutputMetadata>,
+    pub task_metadata: Option<TaskMetadata>,
     pub locations: Option<Vec<ToolLocation>>,
     pub meta: Option<serde_json::Value>,
 }
@@ -164,6 +182,14 @@ pub struct ToolOutputMetadata {
     pub bash: Option<BashOutputMetadata>,
     pub exit_plan_mode: Option<ExitPlanModeOutputMetadata>,
     pub todo_write: Option<TodoWriteOutputMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TaskMetadata {
+    pub end_time: Option<u64>,
+    pub total_paused_ms: Option<u64>,
+    pub error: Option<String>,
+    pub is_backgrounded: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -226,6 +252,9 @@ pub enum SessionUpdate {
     },
     CurrentModeUpdate {
         current_mode_id: String,
+    },
+    CurrentModelUpdate {
+        current_model: CurrentModel,
     },
     ConfigOptionUpdate {
         option_id: String,

--- a/src/agent/wire.rs
+++ b/src/agent/wire.rs
@@ -278,6 +278,8 @@ pub enum BridgeEvent {
     },
     TurnComplete {
         session_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        terminal_reason: Option<types::TerminalReason>,
     },
     TurnError {
         session_id: String,
@@ -285,6 +287,8 @@ pub enum BridgeEvent {
         error_kind: Option<String>,
         sdk_result_subtype: Option<String>,
         assistant_error: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        terminal_reason: Option<types::TerminalReason>,
     },
     SlashError {
         session_id: String,
@@ -353,7 +357,7 @@ impl BridgeEvent {
             | Self::ElicitationComplete { session_id, .. }
             | Self::McpAuthRedirect { session_id, .. }
             | Self::McpOperationError { session_id, .. }
-            | Self::TurnComplete { session_id }
+            | Self::TurnComplete { session_id, .. }
             | Self::TurnError { session_id, .. }
             | Self::SlashError { session_id, .. }
             | Self::SessionReplaced { session_id, .. }
@@ -418,11 +422,9 @@ mod tests {
     fn event_envelope_roundtrip_json() {
         let env = EventEnvelope {
             request_id: None,
-            event: BridgeEvent::SessionUpdate {
+            event: BridgeEvent::TurnComplete {
                 session_id: "session-1".to_owned(),
-                update: types::SessionUpdate::CurrentModeUpdate {
-                    current_mode_id: "default".to_owned(),
-                },
+                terminal_reason: Some(types::TerminalReason::Completed),
             },
         };
         let json = serde_json::to_string(&env).expect("serialize");

--- a/src/agent/wire.rs
+++ b/src/agent/wire.rs
@@ -103,6 +103,12 @@ pub enum BridgeCommand {
     GetStatusSnapshot {
         session_id: String,
     },
+    GetContextUsage {
+        session_id: String,
+    },
+    ReloadPlugins {
+        session_id: String,
+    },
     GetMcpSnapshot {
         session_id: String,
     },
@@ -154,6 +160,8 @@ impl BridgeCommand {
             Self::QuestionResponse { .. } => "question_response",
             Self::ElicitationResponse { .. } => "elicitation_response",
             Self::GetStatusSnapshot { .. } => "get_status_snapshot",
+            Self::GetContextUsage { .. } => "get_context_usage",
+            Self::ReloadPlugins { .. } => "reload_plugins",
             Self::GetMcpSnapshot { .. } => "get_mcp_snapshot",
             Self::McpReconnect { .. } => "mcp_reconnect",
             Self::McpToggle { .. } => "mcp_toggle",
@@ -179,6 +187,8 @@ impl BridgeCommand {
             | Self::QuestionResponse { session_id, .. }
             | Self::ElicitationResponse { session_id, .. }
             | Self::GetStatusSnapshot { session_id }
+            | Self::GetContextUsage { session_id }
+            | Self::ReloadPlugins { session_id }
             | Self::GetMcpSnapshot { session_id }
             | Self::McpReconnect { session_id, .. }
             | Self::McpToggle { session_id, .. }
@@ -208,6 +218,8 @@ impl BridgeCommand {
             | Self::NewSession { .. }
             | Self::ElicitationResponse { .. }
             | Self::GetStatusSnapshot { .. }
+            | Self::GetContextUsage { .. }
+            | Self::ReloadPlugins { .. }
             | Self::GetMcpSnapshot { .. }
             | Self::McpReconnect { .. }
             | Self::McpToggle { .. }
@@ -234,7 +246,7 @@ pub enum BridgeEvent {
     Connected {
         session_id: String,
         cwd: String,
-        model_name: String,
+        current_model: types::CurrentModel,
         #[serde(default)]
         available_models: Vec<types::AvailableModel>,
         mode: Option<types::ModeState>,
@@ -294,10 +306,17 @@ pub enum BridgeEvent {
         session_id: String,
         message: String,
     },
+    RuntimeReloadCompleted {
+        session_id: String,
+    },
+    RuntimeReloadFailed {
+        session_id: String,
+        message: String,
+    },
     SessionReplaced {
         session_id: String,
         cwd: String,
-        model_name: String,
+        current_model: types::CurrentModel,
         #[serde(default)]
         available_models: Vec<types::AvailableModel>,
         mode: Option<types::ModeState>,
@@ -312,6 +331,10 @@ pub enum BridgeEvent {
     StatusSnapshot {
         session_id: String,
         account: types::AccountInfo,
+    },
+    ContextUsage {
+        session_id: String,
+        percentage: Option<u8>,
     },
     McpSnapshot {
         session_id: String,
@@ -338,10 +361,13 @@ impl BridgeEvent {
             Self::TurnComplete { .. } => "turn_complete",
             Self::TurnError { .. } => "turn_error",
             Self::SlashError { .. } => "slash_error",
+            Self::RuntimeReloadCompleted { .. } => "runtime_reload_completed",
+            Self::RuntimeReloadFailed { .. } => "runtime_reload_failed",
             Self::SessionReplaced { .. } => "session_replaced",
             Self::Initialized { .. } => "initialized",
             Self::SessionsListed { .. } => "sessions_listed",
             Self::StatusSnapshot { .. } => "status_snapshot",
+            Self::ContextUsage { .. } => "context_usage",
             Self::McpSnapshot { .. } => "mcp_snapshot",
         }
     }
@@ -360,8 +386,11 @@ impl BridgeEvent {
             | Self::TurnComplete { session_id, .. }
             | Self::TurnError { session_id, .. }
             | Self::SlashError { session_id, .. }
+            | Self::RuntimeReloadCompleted { session_id, .. }
+            | Self::RuntimeReloadFailed { session_id, .. }
             | Self::SessionReplaced { session_id, .. }
             | Self::StatusSnapshot { session_id, .. }
+            | Self::ContextUsage { session_id, .. }
             | Self::McpSnapshot { session_id, .. } => Some(session_id.as_str()),
             Self::AuthRequired { .. }
             | Self::ConnectionFailed { .. }
@@ -388,10 +417,13 @@ impl BridgeEvent {
             | Self::TurnComplete { .. }
             | Self::TurnError { .. }
             | Self::SlashError { .. }
+            | Self::RuntimeReloadCompleted { .. }
+            | Self::RuntimeReloadFailed { .. }
             | Self::SessionReplaced { .. }
             | Self::Initialized { .. }
             | Self::SessionsListed { .. }
             | Self::StatusSnapshot { .. }
+            | Self::ContextUsage { .. }
             | Self::McpSnapshot { .. } => None,
         }
     }

--- a/src/app/config/mcp.rs
+++ b/src/app/config/mcp.rs
@@ -136,6 +136,7 @@ pub(super) fn handle_mcp_key(app: &mut App, key: KeyEvent) -> bool {
             if matches!(ch, 'r' | 'R')
                 && (modifiers.is_empty() || modifiers == KeyModifiers::SHIFT) =>
         {
+            crate::app::session_runtime::request_runtime_reload(app);
             refresh_mcp_snapshot(app);
             true
         }

--- a/src/app/config/mcp_edit.rs
+++ b/src/app/config/mcp_edit.rs
@@ -92,7 +92,10 @@ fn execute_selected_mcp_overlay_action(app: &mut App) {
     }
 
     match action {
-        McpServerActionKind::RefreshSnapshot => refresh_mcp_snapshot(app),
+        McpServerActionKind::RefreshSnapshot => {
+            crate::app::session_runtime::request_runtime_reload(app);
+            refresh_mcp_snapshot(app);
+        }
         McpServerActionKind::Authenticate => {
             authenticate_mcp_server(app, &overlay.server_name);
         }
@@ -235,6 +238,7 @@ fn execute_mcp_auth_redirect_overlay_action(app: &mut App) {
     };
     match action {
         McpAuthRedirectAction::Refresh => {
+            crate::app::session_runtime::request_runtime_reload(app);
             refresh_mcp_snapshot(app);
             app.config.overlay = None;
         }

--- a/src/app/config/mod.rs
+++ b/src/app/config/mod.rs
@@ -179,6 +179,7 @@ pub struct SettingSpec {
 pub enum DefaultPermissionMode {
     #[default]
     Default,
+    Auto,
     AcceptEdits,
     Plan,
     DontAsk,
@@ -190,6 +191,7 @@ impl DefaultPermissionMode {
     pub const fn as_stored(self) -> &'static str {
         match self {
             Self::Default => "default",
+            Self::Auto => "auto",
             Self::AcceptEdits => "acceptEdits",
             Self::Plan => "plan",
             Self::DontAsk => "dontAsk",
@@ -201,6 +203,7 @@ impl DefaultPermissionMode {
     pub const fn label(self) -> &'static str {
         match self {
             Self::Default => "Default",
+            Self::Auto => "Auto",
             Self::AcceptEdits => "Accept Edits",
             Self::Plan => "Plan",
             Self::DontAsk => "Don't Ask",
@@ -212,6 +215,7 @@ impl DefaultPermissionMode {
     pub fn from_stored(value: &str) -> Option<Self> {
         match value {
             "default" => Some(Self::Default),
+            "auto" => Some(Self::Auto),
             "acceptEdits" => Some(Self::AcceptEdits),
             "plan" => Some(Self::Plan),
             "dontAsk" => Some(Self::DontAsk),
@@ -223,7 +227,8 @@ impl DefaultPermissionMode {
     #[must_use]
     pub const fn next(self) -> Self {
         match self {
-            Self::Default => Self::AcceptEdits,
+            Self::Default => Self::Auto,
+            Self::Auto => Self::AcceptEdits,
             Self::AcceptEdits => Self::Plan,
             Self::Plan => Self::DontAsk,
             Self::DontAsk => Self::BypassPermissions,
@@ -235,7 +240,8 @@ impl DefaultPermissionMode {
     pub const fn prev(self) -> Self {
         match self {
             Self::Default => Self::BypassPermissions,
-            Self::AcceptEdits => Self::Default,
+            Self::Auto => Self::Default,
+            Self::AcceptEdits => Self::Auto,
             Self::Plan => Self::AcceptEdits,
             Self::DontAsk => Self::Plan,
             Self::BypassPermissions => Self::DontAsk,
@@ -340,6 +346,7 @@ impl OutputStyle {
 
 const DEFAULT_PERMISSION_OPTIONS: &[SettingOption] = &[
     SettingOption { stored: "default", label: "Default" },
+    SettingOption { stored: "auto", label: "Auto" },
     SettingOption { stored: "acceptEdits", label: "Accept Edits" },
     SettingOption { stored: "plan", label: "Plan" },
     SettingOption { stored: "dontAsk", label: "Don't Ask" },

--- a/src/app/config/store.rs
+++ b/src/app/config/store.rs
@@ -588,6 +588,14 @@ mod tests {
     }
 
     #[test]
+    fn save_roundtrips_auto_permission_mode() {
+        let mut document = Value::Object(Map::new());
+        set_default_permission_mode(&mut document, DefaultPermissionMode::Auto);
+
+        assert_eq!(default_permission_mode(&document), Ok(DefaultPermissionMode::Auto));
+    }
+
+    #[test]
     fn set_language_trims_and_removes_whitespace_only_values() {
         let mut document = Value::Object(Map::new());
         set_language(&mut document, Some("  German  "));

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -783,7 +783,7 @@ fn handle_key_cycles_default_permission_mode() {
 
     assert_eq!(
         store::default_permission_mode(&app.config.committed_settings_document),
-        Ok(DefaultPermissionMode::AcceptEdits)
+        Ok(DefaultPermissionMode::Auto)
     );
 }
 

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -1311,6 +1311,11 @@ fn mcp_tab_refresh_key_requests_snapshot() {
 
     handle_key(&mut app, KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
 
+    let envelope = rx.try_recv().expect("runtime reload command");
+    assert_eq!(
+        envelope.command,
+        BridgeCommand::ReloadPlugins { session_id: "session-1".to_owned() }
+    );
     let envelope = rx.try_recv().expect("mcp snapshot command");
     assert_eq!(
         envelope.command,

--- a/src/app/connect/event_dispatch.rs
+++ b/src/app/connect/event_dispatch.rs
@@ -91,14 +91,20 @@ pub(super) fn handle_bridge_event(
         crate::agent::wire::BridgeEvent::McpOperationError { error, .. } => {
             let _ = event_tx.send(ClientEvent::McpOperationError { error });
         }
-        crate::agent::wire::BridgeEvent::TurnComplete { .. } => {
-            let _ = event_tx.send(ClientEvent::TurnComplete);
+        crate::agent::wire::BridgeEvent::TurnComplete { terminal_reason, .. } => {
+            let _ = event_tx.send(ClientEvent::TurnComplete { terminal_reason });
         }
-        crate::agent::wire::BridgeEvent::TurnError { message, error_kind, .. } => {
+        crate::agent::wire::BridgeEvent::TurnError {
+            message, error_kind, terminal_reason, ..
+        } => {
             if let Some(class) = error_kind.as_deref().and_then(parse_turn_error_class) {
-                let _ = event_tx.send(ClientEvent::TurnErrorClassified { message, class });
+                let _ = event_tx.send(ClientEvent::TurnErrorClassified {
+                    message,
+                    class,
+                    terminal_reason,
+                });
             } else {
-                let _ = event_tx.send(ClientEvent::TurnError(message));
+                let _ = event_tx.send(ClientEvent::TurnError { message, terminal_reason });
             }
         }
         crate::agent::wire::BridgeEvent::SlashError { message, .. } => {

--- a/src/app/connect/event_dispatch.rs
+++ b/src/app/connect/event_dispatch.rs
@@ -14,14 +14,14 @@ use tokio::sync::mpsc;
 
 use super::bridge_lifecycle::emit_connection_failed;
 use super::type_converters::{
-    convert_mode_state, map_available_models, map_permission_request, map_question_request,
-    map_session_update,
+    convert_current_model, convert_mode_state, map_available_models, map_permission_request,
+    map_question_request, map_session_update,
 };
 
 struct ConnectedEventData {
     session_id: String,
     cwd: String,
-    model_name: String,
+    current_model: types::CurrentModel,
     available_models: Vec<types::AvailableModel>,
     mode: Option<types::ModeState>,
     history_updates: Option<Vec<types::SessionUpdate>>,
@@ -39,7 +39,7 @@ pub(super) fn handle_bridge_event(
         crate::agent::wire::BridgeEvent::Connected {
             session_id,
             cwd,
-            model_name,
+            current_model,
             available_models,
             mode,
             history_updates,
@@ -50,7 +50,7 @@ pub(super) fn handle_bridge_event(
                 ConnectedEventData {
                     session_id,
                     cwd,
-                    model_name,
+                    current_model,
                     available_models,
                     mode,
                     history_updates,
@@ -117,10 +117,16 @@ pub(super) fn handle_bridge_event(
             }
             let _ = event_tx.send(ClientEvent::SlashCommandError(message));
         }
+        crate::agent::wire::BridgeEvent::RuntimeReloadCompleted { session_id } => {
+            let _ = event_tx.send(ClientEvent::RuntimeReloadCompleted { session_id });
+        }
+        crate::agent::wire::BridgeEvent::RuntimeReloadFailed { session_id, message } => {
+            let _ = event_tx.send(ClientEvent::RuntimeReloadFailed { session_id, message });
+        }
         crate::agent::wire::BridgeEvent::SessionReplaced {
             session_id,
             cwd,
-            model_name,
+            current_model,
             available_models,
             mode,
             history_updates,
@@ -133,7 +139,7 @@ pub(super) fn handle_bridge_event(
             let _ = event_tx.send(ClientEvent::SessionReplaced {
                 session_id: model::SessionId::new(session_id),
                 cwd,
-                model_name,
+                current_model: convert_current_model(current_model),
                 available_models: map_available_models(available_models),
                 mode: mode.map(convert_mode_state),
                 history_updates,
@@ -145,6 +151,9 @@ pub(super) fn handle_bridge_event(
         crate::agent::wire::BridgeEvent::Initialized { .. } => {}
         crate::agent::wire::BridgeEvent::StatusSnapshot { session_id, account } => {
             let _ = event_tx.send(ClientEvent::StatusSnapshotReceived { session_id, account });
+        }
+        crate::agent::wire::BridgeEvent::ContextUsage { session_id, percentage } => {
+            let _ = event_tx.send(ClientEvent::ContextUsageReceived { session_id, percentage });
         }
         crate::agent::wire::BridgeEvent::McpSnapshot { session_id, servers, error } => {
             let _ = event_tx.send(ClientEvent::McpSnapshotReceived { session_id, servers, error });
@@ -168,7 +177,7 @@ fn handle_connected_event(
         let _ = event_tx.send(ClientEvent::SessionReplaced {
             session_id: model::SessionId::new(event.session_id),
             cwd: event.cwd,
-            model_name: event.model_name,
+            current_model: convert_current_model(event.current_model),
             available_models: map_available_models(event.available_models),
             mode,
             history_updates,
@@ -178,7 +187,7 @@ fn handle_connected_event(
         let _ = event_tx.send(ClientEvent::Connected {
             session_id: model::SessionId::new(event.session_id),
             cwd: event.cwd,
-            model_name: event.model_name,
+            current_model: convert_current_model(event.current_model),
             available_models: map_available_models(event.available_models),
             mode,
             history_updates,

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -126,7 +126,12 @@ pub fn create_app(cli: &Cli) -> App {
         config: ConfigState::default(),
         trust: trust::TrustState::default(),
         settings_home_override: None,
-        messages: vec![super::ChatMessage::welcome_with_recent("Connecting...", &cwd_display, &[])],
+        messages: vec![super::ChatMessage::welcome(
+            env!("CARGO_PKG_VERSION"),
+            "-",
+            &cwd_display,
+            "-",
+        )],
         message_retained_bytes: Vec::new(),
         retained_history_bytes: 0,
         viewport: ChatViewport::new(),

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -166,8 +166,6 @@ pub fn create_app(cli: &Cli) -> App {
         tools_collapsed: true,
         active_task_ids: HashSet::new(),
         tool_call_scopes: HashMap::new(),
-        active_subagent_tool_ids: HashSet::new(),
-        subagent_idle_since: None,
         terminals,
         force_redraw: false,
         tool_call_index: HashMap::new(),

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -199,7 +199,6 @@ pub fn create_app(cli: &Cli) -> App {
         pending_submit: None,
         paste_burst: super::paste_burst::PasteBurstDetector::new(),
         pending_paste_text: String::new(),
-        pending_clipboard_paste_dedupe: None,
         pending_paste_session: None,
         active_paste_session: None,
         next_paste_session_id: 1,

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -208,6 +208,8 @@ pub fn create_app(cli: &Cli) -> App {
         usage: super::UsageState::default(),
         mcp: super::McpState::default(),
         fast_mode_state: model::FastModeState::Off,
+        runtime_session_state: None,
+        prompt_suggestion: None,
         last_rate_limit_update: None,
         turn_notice_refs: Vec::new(),
         is_compacting: false,

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -121,18 +121,12 @@ pub fn create_app(cli: &Cli) -> App {
     });
 
     let cwd_display = shorten_cwd(&cwd);
-    let initial_model_name = "Connecting...".to_owned();
-
     let mut app = App {
         active_view: ActiveView::Chat,
         config: ConfigState::default(),
         trust: trust::TrustState::default(),
         settings_home_override: None,
-        messages: vec![super::ChatMessage::welcome_with_recent(
-            &initial_model_name,
-            &cwd_display,
-            &[],
-        )],
+        messages: vec![super::ChatMessage::welcome_with_recent("Connecting...", &cwd_display, &[])],
         message_retained_bytes: Vec::new(),
         retained_history_bytes: 0,
         viewport: ChatViewport::new(),
@@ -146,8 +140,7 @@ pub fn create_app(cli: &Cli) -> App {
         session_id: None,
         conn: None,
         session_scope_epoch: 0,
-        model_name: initial_model_name,
-        welcome_model_resolved: false,
+        current_model: None,
         cwd_raw: cwd.to_string_lossy().to_string(),
         cwd: cwd_display,
         files_accessed: 0,

--- a/src/app/connect/session_start.rs
+++ b/src/app/connect/session_start.rs
@@ -102,6 +102,16 @@ fn build_session_settings_object(app: &App) -> Value {
                 .unwrap_or(true),
         ),
     );
+    if let Some(mut sandbox) =
+        app.config.committed_settings_document.get("sandbox").and_then(Value::as_object).cloned()
+    {
+        if sandbox.get("enabled").and_then(Value::as_bool) == Some(true)
+            && !sandbox.contains_key("failIfUnavailable")
+        {
+            sandbox.insert("failIfUnavailable".to_owned(), Value::Bool(false));
+        }
+        settings.insert("sandbox".to_owned(), Value::Object(sandbox));
+    }
 
     Value::Object(settings)
 }
@@ -213,6 +223,64 @@ mod tests {
         assert_setting_value(&launch_settings, "spinnerTipsEnabled", &Value::Bool(true));
         assert_setting_value(&launch_settings, "terminalProgressBarEnabled", &Value::Bool(true));
         assert_eq!(launch_settings.agent_progress_summaries, Some(true));
+    }
+
+    #[test]
+    fn persisted_launch_settings_include_auto_permission_mode() {
+        let mut app = App::test_default();
+        store::set_default_permission_mode(
+            &mut app.config.committed_settings_document,
+            DefaultPermissionMode::Auto,
+        );
+
+        let launch_settings = session_launch_settings_for_reason(&app, SessionStartReason::Startup);
+
+        assert_permission_mode(&launch_settings, "auto");
+    }
+
+    #[test]
+    fn persisted_launch_settings_preserve_sandbox_settings_and_make_fallback_explicit() {
+        let mut app = App::test_default();
+        app.config.committed_settings_document = serde_json::json!({
+            "sandbox": {
+                "enabled": true,
+                "allowUnsandboxedCommands": false
+            }
+        });
+
+        let launch_settings = session_launch_settings_for_reason(&app, SessionStartReason::Startup);
+
+        assert_setting_value(
+            &launch_settings,
+            "sandbox",
+            &serde_json::json!({
+                "enabled": true,
+                "allowUnsandboxedCommands": false,
+                "failIfUnavailable": false
+            }),
+        );
+    }
+
+    #[test]
+    fn persisted_launch_settings_preserve_explicit_sandbox_fail_if_unavailable() {
+        let mut app = App::test_default();
+        app.config.committed_settings_document = serde_json::json!({
+            "sandbox": {
+                "enabled": true,
+                "failIfUnavailable": true
+            }
+        });
+
+        let launch_settings = session_launch_settings_for_reason(&app, SessionStartReason::Startup);
+
+        assert_setting_value(
+            &launch_settings,
+            "sandbox",
+            &serde_json::json!({
+                "enabled": true,
+                "failIfUnavailable": true
+            }),
+        );
     }
 
     #[test]

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -29,6 +29,18 @@ pub(super) fn map_rate_limit_update(update: types::RateLimitUpdate) -> model::Ra
     }
 }
 
+pub(super) fn map_api_retry_error(error: types::ApiRetryError) -> model::ApiRetryError {
+    match error {
+        types::ApiRetryError::AuthenticationFailed => model::ApiRetryError::AuthenticationFailed,
+        types::ApiRetryError::BillingError => model::ApiRetryError::BillingError,
+        types::ApiRetryError::RateLimit => model::ApiRetryError::RateLimit,
+        types::ApiRetryError::InvalidRequest => model::ApiRetryError::InvalidRequest,
+        types::ApiRetryError::ServerError => model::ApiRetryError::ServerError,
+        types::ApiRetryError::MaxOutputTokens => model::ApiRetryError::MaxOutputTokens,
+        types::ApiRetryError::Unknown => model::ApiRetryError::Unknown,
+    }
+}
+
 pub(super) fn map_available_commands_update(
     commands: Vec<types::AvailableCommand>,
 ) -> model::AvailableCommandsUpdate {
@@ -211,6 +223,34 @@ pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::
                 surpassed_threshold,
             },
         ))),
+        types::SessionUpdate::ApiRetryUpdate {
+            attempt,
+            max_retries,
+            retry_delay_ms,
+            error_status,
+            error,
+        } => Some(model::SessionUpdate::ApiRetryUpdate {
+            attempt,
+            max_retries,
+            retry_delay_ms,
+            error_status,
+            error: map_api_retry_error(error),
+        }),
+        types::SessionUpdate::PromptSuggestionUpdate { suggestion } => {
+            Some(model::SessionUpdate::PromptSuggestionUpdate(suggestion))
+        }
+        types::SessionUpdate::RuntimeSessionStateUpdate { state } => {
+            Some(model::SessionUpdate::RuntimeSessionStateUpdate(match state {
+                types::RuntimeSessionState::Idle => model::RuntimeSessionState::Idle,
+                types::RuntimeSessionState::Running => model::RuntimeSessionState::Running,
+                types::RuntimeSessionState::RequiresAction => {
+                    model::RuntimeSessionState::RequiresAction
+                }
+            }))
+        }
+        types::SessionUpdate::SettingsParseError { file, path, message } => {
+            Some(model::SessionUpdate::SettingsParseError { file, path, message })
+        }
         types::SessionUpdate::SessionStatusUpdate { status } => {
             Some(model::SessionUpdate::SessionStatusUpdate(match status {
                 types::SessionStatus::Compacting => model::SessionStatus::Compacting,
@@ -589,7 +629,7 @@ pub(super) fn convert_mode_state(mode: types::ModeState) -> ModeState {
 mod tests {
     use super::{
         convert_tool_call, convert_tool_call_update_fields, map_available_models,
-        map_question_request,
+        map_question_request, map_session_update,
     };
     use crate::agent::{model, types};
 
@@ -641,6 +681,40 @@ mod tests {
                     .supports_fast_mode(None)
                     .supports_auto_mode(None),
             ]
+        );
+    }
+
+    #[test]
+    fn map_lifecycle_updates_preserves_new_sdk_state() {
+        assert_eq!(
+            map_session_update(types::SessionUpdate::ApiRetryUpdate {
+                attempt: 2,
+                max_retries: 4,
+                retry_delay_ms: 1500,
+                error_status: Some(529),
+                error: types::ApiRetryError::ServerError,
+            }),
+            Some(model::SessionUpdate::ApiRetryUpdate {
+                attempt: 2,
+                max_retries: 4,
+                retry_delay_ms: 1500,
+                error_status: Some(529),
+                error: model::ApiRetryError::ServerError,
+            })
+        );
+        assert_eq!(
+            map_session_update(types::SessionUpdate::RuntimeSessionStateUpdate {
+                state: types::RuntimeSessionState::RequiresAction,
+            }),
+            Some(model::SessionUpdate::RuntimeSessionStateUpdate(
+                model::RuntimeSessionState::RequiresAction,
+            ))
+        );
+        assert_eq!(
+            map_session_update(types::SessionUpdate::PromptSuggestionUpdate {
+                suggestion: "Add tests".to_owned(),
+            }),
+            Some(model::SessionUpdate::PromptSuggestionUpdate("Add tests".to_owned()))
         );
     }
 

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -312,6 +312,7 @@ pub(super) fn map_permission_request(
             model::SessionId::new(session_id),
             tool_call_update,
             options,
+            convert_permission_display(request.display),
         ),
         tool_call_id,
     )
@@ -538,15 +539,22 @@ fn convert_tool_output_metadata(
         .bash(output_metadata.bash.map(|bash| {
             model::BashOutputMetadata::new()
                 .assistant_auto_backgrounded(bash.assistant_auto_backgrounded)
-                .token_saver_active(bash.token_saver_active)
-        }))
-        .exit_plan_mode(output_metadata.exit_plan_mode.map(|exit_plan_mode| {
-            model::ExitPlanModeOutputMetadata::new().ultraplan(exit_plan_mode.is_ultraplan)
         }))
         .todo_write(output_metadata.todo_write.map(|todo_write| {
             model::TodoWriteOutputMetadata::new()
                 .verification_nudge_needed(todo_write.verification_nudge_needed)
         }))
+}
+
+fn convert_permission_display(
+    display: Option<types::PermissionDisplay>,
+) -> Option<model::PermissionDisplay> {
+    let display = display?;
+    let mapped = model::PermissionDisplay::new()
+        .title(display.title)
+        .display_name(display.display_name)
+        .description(display.description);
+    (!mapped.is_empty()).then_some(mapped)
 }
 
 fn convert_task_metadata(task_metadata: types::TaskMetadata) -> model::TaskMetadata {
@@ -629,7 +637,7 @@ pub(super) fn convert_mode_state(mode: types::ModeState) -> ModeState {
 mod tests {
     use super::{
         convert_tool_call, convert_tool_call_update_fields, map_available_models,
-        map_question_request, map_session_update,
+        map_permission_request, map_question_request, map_session_update,
     };
     use crate::agent::{model, types};
 
@@ -719,6 +727,50 @@ mod tests {
     }
 
     #[test]
+    fn map_permission_request_preserves_display_metadata() {
+        let (request, tool_call_id) = map_permission_request(
+            "session-1",
+            types::PermissionRequest {
+                tool_call: types::ToolCall {
+                    tool_call_id: "tool-1".to_owned(),
+                    title: "Bash npm test".to_owned(),
+                    kind: "execute".to_owned(),
+                    status: "in_progress".to_owned(),
+                    content: Vec::new(),
+                    raw_input: None,
+                    raw_output: None,
+                    output_metadata: None,
+                    task_metadata: None,
+                    locations: Vec::new(),
+                    meta: None,
+                },
+                options: vec![types::PermissionOption {
+                    option_id: "allow".to_owned(),
+                    name: "Allow".to_owned(),
+                    description: None,
+                    kind: "allow_once".to_owned(),
+                }],
+                display: Some(types::PermissionDisplay {
+                    title: Some("Claude wants to run tests".to_owned()),
+                    display_name: Some("Run tests".to_owned()),
+                    description: Some("This command reads project files".to_owned()),
+                }),
+            },
+        );
+
+        assert_eq!(tool_call_id, "tool-1");
+        assert_eq!(
+            request.display,
+            Some(
+                model::PermissionDisplay::new()
+                    .title(Some("Claude wants to run tests".to_owned()))
+                    .display_name(Some("Run tests".to_owned()))
+                    .description(Some("This command reads project files".to_owned())),
+            )
+        );
+    }
+
+    #[test]
     fn map_question_request_preserves_preview_and_annotation_shape() {
         let (request, tool_call_id) = map_question_request(
             "session-1",
@@ -802,13 +854,7 @@ mod tests {
         let fields = convert_tool_call_update_fields(types::ToolCallUpdateFields {
             status: Some("completed".to_owned()),
             output_metadata: Some(types::ToolOutputMetadata {
-                bash: Some(types::BashOutputMetadata {
-                    assistant_auto_backgrounded: Some(true),
-                    token_saver_active: Some(true),
-                }),
-                exit_plan_mode: Some(types::ExitPlanModeOutputMetadata {
-                    is_ultraplan: Some(true),
-                }),
+                bash: Some(types::BashOutputMetadata { assistant_auto_backgrounded: Some(true) }),
                 todo_write: Some(types::TodoWriteOutputMetadata {
                     verification_nudge_needed: Some(true),
                 }),
@@ -821,12 +867,7 @@ mod tests {
             Some(
                 model::ToolOutputMetadata::new()
                     .bash(Some(
-                        model::BashOutputMetadata::new()
-                            .assistant_auto_backgrounded(Some(true))
-                            .token_saver_active(Some(true)),
-                    ))
-                    .exit_plan_mode(Some(
-                        model::ExitPlanModeOutputMetadata::new().ultraplan(Some(true)),
+                        model::BashOutputMetadata::new().assistant_auto_backgrounded(Some(true)),
                     ))
                     .todo_write(Some(
                         model::TodoWriteOutputMetadata::new().verification_nudge_needed(Some(true)),

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -101,6 +101,37 @@ pub(super) fn map_available_models(
         .collect()
 }
 
+pub(super) fn convert_current_model(current_model: types::CurrentModel) -> model::CurrentModel {
+    let mut mapped = model::CurrentModel::new(
+        current_model.resolved_id,
+        current_model.display_name_short,
+        current_model.display_name_long,
+    )
+    .supports_effort(current_model.supports_effort)
+    .supported_effort_levels(
+        current_model
+            .supported_effort_levels
+            .into_iter()
+            .map(|level| match level {
+                types::EffortLevel::Low => model::EffortLevel::Low,
+                types::EffortLevel::Medium => model::EffortLevel::Medium,
+                types::EffortLevel::High => model::EffortLevel::High,
+            })
+            .collect(),
+    )
+    .supports_fast_mode(current_model.supports_fast_mode)
+    .supports_auto_mode(current_model.supports_auto_mode)
+    .supports_adaptive_thinking(current_model.supports_adaptive_thinking)
+    .authoritative(current_model.is_authoritative);
+    if let Some(requested_id) = current_model.requested_id {
+        mapped = mapped.requested_id(requested_id);
+    }
+    if let Some(catalog_id) = current_model.catalog_id {
+        mapped = mapped.catalog_id(catalog_id);
+    }
+    mapped
+}
+
 #[allow(clippy::too_many_lines)]
 pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::SessionUpdate> {
     match update {
@@ -137,6 +168,11 @@ pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::
         types::SessionUpdate::CurrentModeUpdate { current_mode_id } => {
             Some(model::SessionUpdate::CurrentModeUpdate(model::CurrentModeUpdate::new(
                 model::SessionModeId::new(current_mode_id),
+            )))
+        }
+        types::SessionUpdate::CurrentModelUpdate { current_model } => {
+            Some(model::SessionUpdate::CurrentModelUpdate(model::CurrentModelUpdate::new(
+                convert_current_model(current_model),
             )))
         }
         types::SessionUpdate::ConfigOptionUpdate { option_id, value } => {
@@ -312,6 +348,7 @@ pub(super) fn convert_tool_call(tool_call: types::ToolCall) -> model::ToolCall {
         raw_input,
         raw_output,
         output_metadata,
+        task_metadata,
         locations,
         meta,
     } = tool_call;
@@ -342,6 +379,9 @@ pub(super) fn convert_tool_call(tool_call: types::ToolCall) -> model::ToolCall {
     }
     if let Some(output_metadata) = output_metadata {
         tc = tc.output_metadata(convert_tool_output_metadata(output_metadata));
+    }
+    if let Some(task_metadata) = task_metadata {
+        tc = tc.task_metadata(convert_task_metadata(task_metadata));
     }
     if let Some(meta) = meta {
         tc = tc.meta(meta);
@@ -396,6 +436,9 @@ pub(super) fn convert_tool_call_to_fields(
     if let Some(output_metadata) = tool_call.output_metadata {
         fields = fields.output_metadata(convert_tool_output_metadata(output_metadata));
     }
+    if let Some(task_metadata) = tool_call.task_metadata {
+        fields = fields.task_metadata(convert_task_metadata(task_metadata));
+    }
 
     fields
 }
@@ -426,6 +469,9 @@ pub(super) fn convert_tool_call_update_fields(
     }
     if let Some(output_metadata) = fields.output_metadata {
         out = out.output_metadata(convert_tool_output_metadata(output_metadata));
+    }
+    if let Some(task_metadata) = fields.task_metadata {
+        out = out.task_metadata(convert_task_metadata(task_metadata));
     }
     if let Some(locations) = fields.locations {
         out = out.locations(
@@ -461,6 +507,14 @@ fn convert_tool_output_metadata(
             model::TodoWriteOutputMetadata::new()
                 .verification_nudge_needed(todo_write.verification_nudge_needed)
         }))
+}
+
+fn convert_task_metadata(task_metadata: types::TaskMetadata) -> model::TaskMetadata {
+    model::TaskMetadata::new()
+        .end_time(task_metadata.end_time)
+        .total_paused_ms(task_metadata.total_paused_ms)
+        .error(task_metadata.error)
+        .backgrounded(task_metadata.is_backgrounded)
 }
 
 fn convert_tool_call_content(
@@ -507,6 +561,7 @@ pub(super) fn convert_tool_status(status: &str) -> model::ToolCallStatus {
         "in_progress" => model::ToolCallStatus::InProgress,
         "completed" => model::ToolCallStatus::Completed,
         "failed" => model::ToolCallStatus::Failed,
+        "killed" => model::ToolCallStatus::Killed,
         _ => model::ToolCallStatus::Pending,
     }
 }
@@ -603,6 +658,7 @@ mod tests {
                     raw_input: Some(serde_json::json!({ "source": "ask_user_question" })),
                     raw_output: None,
                     output_metadata: None,
+                    task_metadata: None,
                     locations: Vec::new(),
                     meta: Some(
                         serde_json::json!({ "claudeCode": { "toolName": "AskUserQuestion" } }),
@@ -706,6 +762,69 @@ mod tests {
     }
 
     #[test]
+    fn convert_tool_status_maps_killed() {
+        assert_eq!(super::convert_tool_status("killed"), model::ToolCallStatus::Killed);
+    }
+
+    #[test]
+    fn convert_tool_call_update_fields_preserves_task_metadata() {
+        let fields = convert_tool_call_update_fields(types::ToolCallUpdateFields {
+            task_metadata: Some(types::TaskMetadata {
+                end_time: Some(123),
+                total_paused_ms: Some(45),
+                error: Some("Task stopped".to_owned()),
+                is_backgrounded: Some(true),
+            }),
+            ..types::ToolCallUpdateFields::default()
+        });
+
+        assert_eq!(
+            fields.task_metadata,
+            Some(
+                model::TaskMetadata::new()
+                    .end_time(Some(123))
+                    .total_paused_ms(Some(45))
+                    .error(Some("Task stopped".to_owned()))
+                    .backgrounded(Some(true)),
+            )
+        );
+    }
+
+    #[test]
+    fn convert_tool_call_preserves_task_metadata() {
+        let tool_call = convert_tool_call(types::ToolCall {
+            tool_call_id: "tool-task".to_owned(),
+            title: "Agent task".to_owned(),
+            kind: "think".to_owned(),
+            status: "killed".to_owned(),
+            content: Vec::new(),
+            raw_input: None,
+            raw_output: None,
+            output_metadata: None,
+            task_metadata: Some(types::TaskMetadata {
+                end_time: Some(77),
+                total_paused_ms: Some(11),
+                error: Some("Task stopped".to_owned()),
+                is_backgrounded: Some(false),
+            }),
+            locations: Vec::new(),
+            meta: None,
+        });
+
+        assert_eq!(tool_call.status, model::ToolCallStatus::Killed);
+        assert_eq!(
+            tool_call.task_metadata,
+            Some(
+                model::TaskMetadata::new()
+                    .end_time(Some(77))
+                    .total_paused_ms(Some(11))
+                    .error(Some("Task stopped".to_owned()))
+                    .backgrounded(Some(false)),
+            )
+        );
+    }
+
+    #[test]
     fn convert_tool_call_preserves_diff_repository() {
         let tool_call = convert_tool_call(types::ToolCall {
             tool_call_id: "tool-1".to_owned(),
@@ -722,6 +841,7 @@ mod tests {
             raw_input: None,
             raw_output: None,
             output_metadata: None,
+            task_metadata: None,
             locations: Vec::new(),
             meta: None,
         });
@@ -755,6 +875,7 @@ mod tests {
             raw_input: None,
             raw_output: None,
             output_metadata: None,
+            task_metadata: None,
             locations: Vec::new(),
             meta: None,
         });

--- a/src/app/events/api_retry.rs
+++ b/src/app/events/api_retry.rs
@@ -1,0 +1,86 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use super::notices::upsert_turn_notice;
+use crate::agent::model::ApiRetryError;
+use crate::app::{App, NoticeDedupKey, NoticeStage, SystemSeverity};
+
+pub(super) fn handle_api_retry_update(
+    app: &mut App,
+    attempt: u64,
+    max_retries: u64,
+    retry_delay_ms: u64,
+    error_status: Option<u16>,
+    error: ApiRetryError,
+) {
+    let message =
+        format_api_retry_message(attempt, max_retries, retry_delay_ms, error_status, error);
+    upsert_turn_notice(
+        app,
+        NoticeDedupKey::ApiRetry,
+        NoticeStage::Warning,
+        SystemSeverity::Warning,
+        &message,
+    );
+}
+
+fn format_api_retry_message(
+    attempt: u64,
+    max_retries: u64,
+    retry_delay_ms: u64,
+    error_status: Option<u16>,
+    error: ApiRetryError,
+) -> String {
+    let error_label = api_retry_error_label(error);
+    let status = error_status.map_or_else(String::new, |status| format!(" HTTP {status}"));
+    let delay = format_retry_delay(retry_delay_ms);
+    format!("API retry {attempt}/{max_retries} after {error_label}{status}, retrying in {delay}")
+}
+
+fn api_retry_error_label(error: ApiRetryError) -> &'static str {
+    match error {
+        ApiRetryError::AuthenticationFailed => "authentication_failed",
+        ApiRetryError::BillingError => "billing_error",
+        ApiRetryError::RateLimit => "rate_limit",
+        ApiRetryError::InvalidRequest => "invalid_request",
+        ApiRetryError::ServerError => "server_error",
+        ApiRetryError::MaxOutputTokens => "max_output_tokens",
+        ApiRetryError::Unknown => "connection error",
+    }
+}
+
+fn format_retry_delay(retry_delay_ms: u64) -> String {
+    if retry_delay_ms >= 1000 {
+        let tenths = (retry_delay_ms + 50) / 100;
+        format!("{}.{:01}s", tenths / 10, tenths % 10)
+    } else {
+        format!("{retry_delay_ms}ms")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_api_retry_message, format_retry_delay};
+    use crate::agent::model::ApiRetryError;
+
+    #[test]
+    fn formats_api_retry_http_status() {
+        assert_eq!(
+            format_api_retry_message(2, 4, 1500, Some(529), ApiRetryError::ServerError),
+            "API retry 2/4 after server_error HTTP 529, retrying in 1.5s",
+        );
+    }
+
+    #[test]
+    fn formats_api_retry_without_http_response() {
+        assert_eq!(
+            format_api_retry_message(1, 4, 250, None, ApiRetryError::Unknown),
+            "API retry 1/4 after connection error, retrying in 250ms",
+        );
+    }
+
+    #[test]
+    fn formats_second_delay_with_one_decimal() {
+        assert_eq!(format_retry_delay(1000), "1.0s");
+    }
+}

--- a/src/app/events/client.rs
+++ b/src/app/events/client.rs
@@ -52,6 +52,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                 &history_updates,
             );
             crate::app::config::refresh_mcp_snapshot(app);
+            crate::app::session_runtime::request_status_snapshot_refresh(app);
             crate::app::session_runtime::request_context_usage_refresh(app);
         }
         ClientEvent::SessionsListed { sessions } => {
@@ -100,6 +101,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                 &history_updates,
             );
             crate::app::config::refresh_mcp_snapshot(app);
+            crate::app::session_runtime::request_status_snapshot_refresh(app);
             crate::app::session_runtime::request_context_usage_refresh(app);
         }
         ClientEvent::UpdateAvailable { latest_version, current_version } => {
@@ -135,6 +137,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             let api_key_source = account.api_key_source.clone();
             let api_provider = account.api_provider.clone();
             app.account_info = Some(account);
+            app.sync_welcome_snapshot();
             app.needs_redraw = true;
             tracing::info!(
                 target: crate::logging::targets::APP_AUTH,

--- a/src/app/events/client.rs
+++ b/src/app/events/client.rs
@@ -37,7 +37,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
         ClientEvent::Connected {
             session_id,
             cwd,
-            model_name,
+            current_model,
             available_models,
             mode,
             history_updates,
@@ -46,12 +46,13 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                 app,
                 session_id,
                 cwd,
-                model_name,
+                current_model,
                 available_models,
                 mode,
                 &history_updates,
             );
             crate::app::config::refresh_mcp_snapshot(app);
+            crate::app::session_runtime::request_context_usage_refresh(app);
         }
         ClientEvent::SessionsListed { sessions } => {
             session::handle_sessions_listed_event(app, sessions);
@@ -65,10 +66,26 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
         ClientEvent::SlashCommandError(msg) => {
             session::handle_slash_command_error_event(app, &msg);
         }
+        ClientEvent::RuntimeReloadCompleted { session_id } => {
+            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+                != Some(session_id.as_str())
+            {
+                return;
+            }
+            crate::app::plugins::apply_runtime_reload_success(app);
+        }
+        ClientEvent::RuntimeReloadFailed { session_id, message } => {
+            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+                != Some(session_id.as_str())
+            {
+                return;
+            }
+            crate::app::plugins::apply_runtime_reload_failure(app, &message);
+        }
         ClientEvent::SessionReplaced {
             session_id,
             cwd,
-            model_name,
+            current_model,
             available_models,
             mode,
             history_updates,
@@ -77,12 +94,13 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                 app,
                 session_id,
                 cwd,
-                model_name,
+                current_model,
                 available_models,
                 mode,
                 &history_updates,
             );
             crate::app::config::refresh_mcp_snapshot(app);
+            crate::app::session_runtime::request_context_usage_refresh(app);
         }
         ClientEvent::UpdateAvailable { latest_version, current_version } => {
             session::handle_update_available_event(app, &latest_version, &current_version);
@@ -129,6 +147,22 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                 token_source = ?token_source,
                 api_key_source = ?api_key_source,
             );
+        }
+        ClientEvent::ContextUsageReceived { session_id, percentage } => {
+            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+                != Some(session_id.as_str())
+            {
+                tracing::debug!(
+                    target: crate::logging::targets::APP_SESSION,
+                    event_name = "context_usage_dropped",
+                    message = "context usage dropped for a stale session",
+                    outcome = "dropped",
+                    session_id = %session_id,
+                    reason = "stale_session",
+                );
+                return;
+            }
+            crate::app::session_runtime::apply_context_usage_snapshot(app, percentage);
         }
         ClientEvent::McpSnapshotReceived { session_id, servers, error } => {
             if app.session_id.as_ref().map(ToString::to_string).as_deref()

--- a/src/app/events/client.rs
+++ b/src/app/events/client.rs
@@ -25,10 +25,14 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             crate::app::config::handle_mcp_elicitation_completed(app, &elicitation_id, server_name);
         }
         ClientEvent::TurnCancelled => turn::handle_turn_cancelled_event(app),
-        ClientEvent::TurnComplete => turn::handle_turn_complete_event(app),
-        ClientEvent::TurnError(msg) => turn::handle_turn_error_event(app, &msg, None),
-        ClientEvent::TurnErrorClassified { message, class } => {
-            turn::handle_turn_error_event(app, &message, Some(class));
+        ClientEvent::TurnComplete { terminal_reason } => {
+            turn::handle_turn_complete_event(app, terminal_reason);
+        }
+        ClientEvent::TurnError { message, terminal_reason } => {
+            turn::handle_turn_error_event(app, &message, None, terminal_reason);
+        }
+        ClientEvent::TurnErrorClassified { message, class, terminal_reason } => {
+            turn::handle_turn_error_event(app, &message, Some(class), terminal_reason);
         }
         ClientEvent::Connected {
             session_id,

--- a/src/app/events/client.rs
+++ b/src/app/events/client.rs
@@ -133,6 +133,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             let subscription_type = account.subscription_type.clone();
             let token_source = account.token_source.clone();
             let api_key_source = account.api_key_source.clone();
+            let api_provider = account.api_provider.clone();
             app.account_info = Some(account);
             app.needs_redraw = true;
             tracing::info!(
@@ -146,6 +147,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                 subscription_type = ?subscription_type,
                 token_source = ?token_source,
                 api_key_source = ?api_key_source,
+                api_provider = ?api_provider,
             );
         }
         ClientEvent::ContextUsageReceived { session_id, percentage } => {

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -527,26 +527,39 @@ mod tests {
     }
 
     #[test]
-    fn register_tool_call_scope_treats_agent_as_task_scope() {
+    fn register_tool_call_scope_treats_agent_as_subagent_root() {
         let mut app = make_test_app();
-        let scope = tool_calls::register_tool_call_scope(&mut app, "tool-agent", "Agent");
-        assert_eq!(scope, ToolCallScope::Task);
-        assert!(app.active_task_ids.contains("tool-agent"));
+        let scope = tool_calls::register_tool_call_scope(&mut app, "tool-agent", "Agent", None);
+        assert_eq!(scope, ToolCallScope::SubagentRoot);
     }
 
     #[test]
-    fn register_tool_call_scope_treats_task_as_task_scope() {
+    fn register_tool_call_scope_treats_task_as_subagent_root() {
         let mut app = make_test_app();
-        let scope = tool_calls::register_tool_call_scope(&mut app, "tool-task", "Task");
-        assert_eq!(scope, ToolCallScope::Task);
-        assert!(app.active_task_ids.contains("tool-task"));
+        let scope = tool_calls::register_tool_call_scope(&mut app, "tool-task", "Task", None);
+        assert_eq!(scope, ToolCallScope::SubagentRoot);
+    }
+
+    #[test]
+    fn register_tool_call_scope_uses_explicit_parent_for_subagent_child() {
+        let mut app = make_test_app();
+        let scope = tool_calls::register_tool_call_scope(
+            &mut app,
+            "tool-child",
+            "Bash",
+            Some("tool-parent"),
+        );
+        assert_eq!(
+            scope,
+            ToolCallScope::SubagentChild { parent_tool_use_id: "tool-parent".to_owned() }
+        );
     }
 
     /// Regression: when a Task was cancelled mid-turn, `active_task_ids` was never cleared
     /// because `finalize_in_progress_tool_calls` doesn't call `remove_active_task` and
     /// `clear_tool_scope_tracking` (called on `TurnComplete`) did not clear `active_task_ids`.
     /// The leaked ID caused main-agent tools on the next turn to be classified as Subagent,
-    /// which eventually triggered the subagent thinking indicator spuriously.
+    /// which eventually caused main-agent tools to inherit the wrong scope.
     #[test]
     fn turn_complete_after_cancelled_task_leaves_no_stale_active_task_ids() {
         let mut app = make_test_app();
@@ -568,8 +581,6 @@ mod tests {
 
         // Stale task ID must be gone after turn boundary
         assert!(app.active_task_ids.is_empty(), "stale task id must not survive TurnComplete");
-        assert!(app.active_subagent_tool_ids.is_empty());
-        assert!(app.subagent_idle_since.is_none());
 
         // Next turn: a normal main-agent Glob must get MainAgent scope, not Subagent
         let glob_tc = model::ToolCall::new("glob-1", "Glob **/*.rs")
@@ -584,10 +595,6 @@ mod tests {
             app.tool_call_scope("glob-1"),
             Some(ToolCallScope::MainAgent),
             "main-agent tool must not be misclassified as Subagent after stale task is cleared"
-        );
-        assert!(
-            app.active_subagent_tool_ids.is_empty(),
-            "main-agent tool must not enter subagent tracking"
         );
     }
 
@@ -963,14 +970,17 @@ mod tests {
     }
 
     #[test]
-    fn late_tool_update_for_removed_tool_does_not_corrupt_active_subagent_set() {
+    fn late_tool_update_for_removed_tool_does_not_corrupt_active_task_set() {
         let mut app = make_test_app();
         app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
             "tool-stale",
             model::ToolCallStatus::Completed,
         )))]));
         app.index_tool_call("tool-stale".into(), 0, 0);
-        app.register_tool_call_scope("tool-stale".into(), ToolCallScope::Subagent);
+        app.register_tool_call_scope(
+            "tool-stale".into(),
+            ToolCallScope::SubagentChild { parent_tool_use_id: "task-1".to_owned() },
+        );
 
         let removed = app.remove_message_tracked(0);
         assert!(removed.is_some());
@@ -985,7 +995,6 @@ mod tests {
             ClientEvent::SessionUpdate(model::SessionUpdate::ToolCallUpdate(update)),
         );
 
-        assert!(app.active_subagent_tool_ids.is_empty());
         assert!(app.active_task_ids.is_empty());
     }
 
@@ -2408,7 +2417,6 @@ mod tests {
         );
 
         assert!(app.active_task_ids.is_empty());
-        assert!(app.active_subagent_tool_ids.is_empty());
         assert_eq!(app.tool_call_scope("resume-task"), None);
     }
 
@@ -2641,7 +2649,7 @@ mod tests {
             "task-1",
             model::ToolCallStatus::InProgress,
         )))]));
-        app.register_tool_call_scope("task-1".into(), ToolCallScope::Task);
+        app.register_tool_call_scope("task-1".into(), ToolCallScope::SubagentRoot);
         app.insert_active_task("task-1".into());
 
         handle_client_event(
@@ -2650,7 +2658,6 @@ mod tests {
         );
 
         assert!(app.active_task_ids.is_empty());
-        assert!(app.active_subagent_tool_ids.is_empty());
         assert_eq!(app.tool_call_scope("task-1"), None);
     }
 
@@ -2671,7 +2678,7 @@ mod tests {
             model::ToolCallStatus::InProgress,
         )))]));
         app.bind_active_turn_assistant(0);
-        app.register_tool_call_scope("task-1".into(), ToolCallScope::Task);
+        app.register_tool_call_scope("task-1".into(), ToolCallScope::SubagentRoot);
         app.insert_active_task("task-1".into());
         app.pending_interaction_ids.push("task-1".into());
         app.claim_focus_target(FocusTarget::Permission);
@@ -2741,7 +2748,7 @@ mod tests {
             model::ToolCallStatus::InProgress,
         )))]));
         app.bind_active_turn_assistant(0);
-        app.register_tool_call_scope("task-1".into(), ToolCallScope::Task);
+        app.register_tool_call_scope("task-1".into(), ToolCallScope::SubagentRoot);
         app.insert_active_task("task-1".into());
 
         handle_client_event(&mut app, ClientEvent::ConnectionFailed("bridge down".into()));
@@ -2763,7 +2770,7 @@ mod tests {
             model::ToolCallStatus::InProgress,
         )))]));
         app.bind_active_turn_assistant(0);
-        app.register_tool_call_scope("task-1".into(), ToolCallScope::Task);
+        app.register_tool_call_scope("task-1".into(), ToolCallScope::SubagentRoot);
         app.insert_active_task("task-1".into());
 
         handle_client_event(

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Simon Peter Rothgang
 // SPDX-License-Identifier: Apache-2.0
 
+mod api_retry;
 mod client;
 mod mouse;
 mod notices;
@@ -270,6 +271,31 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
         model::SessionUpdate::RateLimitUpdate(update) => {
             rate_limit::handle_rate_limit_update(app, &update);
         }
+        model::SessionUpdate::ApiRetryUpdate {
+            attempt,
+            max_retries,
+            retry_delay_ms,
+            error_status,
+            error,
+        } => {
+            api_retry::handle_api_retry_update(
+                app,
+                attempt,
+                max_retries,
+                retry_delay_ms,
+                error_status,
+                error,
+            );
+        }
+        model::SessionUpdate::PromptSuggestionUpdate(suggestion) => {
+            app.prompt_suggestion = (!suggestion.trim().is_empty()).then_some(suggestion);
+        }
+        model::SessionUpdate::RuntimeSessionStateUpdate(state) => {
+            handle_runtime_session_state_update(app, state);
+        }
+        model::SessionUpdate::SettingsParseError { file, path, message } => {
+            handle_settings_parse_error(app, file.as_deref(), &path, &message);
+        }
         model::SessionUpdate::SessionStatusUpdate(status) => {
             // TODO(runtime-verification): confirm in real SDK sessions that compaction
             // status updates are emitted consistently; if not, add a fallback indicator.
@@ -295,6 +321,42 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             rate_limit::handle_compaction_boundary_update(app, boundary);
         }
     }
+}
+
+fn handle_runtime_session_state_update(app: &mut App, state: model::RuntimeSessionState) {
+    app.runtime_session_state = Some(state);
+    match state {
+        model::RuntimeSessionState::Running => {
+            if matches!(app.status, AppStatus::Ready | AppStatus::Thinking | AppStatus::Running)
+                && !app.is_compacting
+            {
+                app.status = AppStatus::Running;
+            }
+        }
+        model::RuntimeSessionState::RequiresAction => {}
+        model::RuntimeSessionState::Idle => {
+            if matches!(app.status, AppStatus::Thinking | AppStatus::Running)
+                && !app.is_compacting
+                && app.pending_cancel_origin.is_none()
+            {
+                app.status = AppStatus::Ready;
+            }
+        }
+    }
+}
+
+fn handle_settings_parse_error(app: &mut App, file: Option<&str>, path: &str, message: &str) {
+    let trimmed = message.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    let rendered = match (file.filter(|value| !value.trim().is_empty()), path.trim()) {
+        (Some(file), "") => format!("Settings parse error in {file}: {trimmed}"),
+        (Some(file), path) => format!("Settings parse error in {file} at {path}: {trimmed}"),
+        (None, "") => format!("Settings parse error: {trimmed}"),
+        (None, path) => format!("Settings parse error at {path}: {trimmed}"),
+    };
+    push_system_message_with_severity(app, Some(SystemSeverity::Error), &rendered);
 }
 
 pub(crate) fn push_system_message_with_severity(
@@ -4448,6 +4510,113 @@ mod tests {
 
         assert_eq!(app.viewport.scroll_target, 4);
         assert!(app.selection.is_some());
+    }
+
+    #[test]
+    fn api_retry_updates_single_warning_notice() {
+        let mut app = make_test_app();
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(model::SessionUpdate::ApiRetryUpdate {
+                attempt: 1,
+                max_retries: 4,
+                retry_delay_ms: 1000,
+                error_status: None,
+                error: model::ApiRetryError::Unknown,
+            }),
+        );
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(model::SessionUpdate::ApiRetryUpdate {
+                attempt: 2,
+                max_retries: 4,
+                retry_delay_ms: 1500,
+                error_status: Some(529),
+                error: model::ApiRetryError::ServerError,
+            }),
+        );
+
+        assert_eq!(app.messages.len(), 1);
+        assert_eq!(app.turn_notice_refs.len(), 1);
+        let MessageBlock::Notice(notice) = &app.messages[0].blocks[0] else {
+            panic!("expected API retry notice");
+        };
+        assert_eq!(notice.severity, SystemSeverity::Warning);
+        assert_eq!(notice.text.text, "API retry 2/4 after server_error HTTP 529, retrying in 1.5s",);
+    }
+
+    #[test]
+    fn prompt_suggestion_tab_accepts_empty_input_only_after_todo_focus() {
+        let mut app = make_test_app();
+        app.prompt_suggestion = Some("Write focused tests".to_owned());
+
+        handle_normal_key(&mut app, KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+
+        assert_eq!(app.input.text(), "Write focused tests");
+        assert!(app.prompt_suggestion.is_none());
+    }
+
+    #[test]
+    fn prompt_suggestion_tab_does_not_steal_todo_focus_toggle() {
+        let mut app = make_test_app();
+        app.prompt_suggestion = Some("Write focused tests".to_owned());
+        app.show_todo_panel = true;
+        app.todos.push(TodoItem {
+            content: "todo".to_owned(),
+            status: TodoStatus::Pending,
+            active_form: String::new(),
+        });
+
+        handle_normal_key(&mut app, KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+
+        assert_eq!(app.focus_owner(), FocusOwner::TodoList);
+        assert!(app.input.is_empty());
+        assert_eq!(app.prompt_suggestion.as_deref(), Some("Write focused tests"));
+    }
+
+    #[test]
+    fn runtime_session_state_updates_status_with_guards() {
+        let mut app = make_test_app();
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(model::SessionUpdate::RuntimeSessionStateUpdate(
+                model::RuntimeSessionState::Running,
+            )),
+        );
+        assert_eq!(app.runtime_session_state, Some(model::RuntimeSessionState::Running));
+        assert!(matches!(app.status, AppStatus::Running));
+
+        app.status = AppStatus::Error;
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(model::SessionUpdate::RuntimeSessionStateUpdate(
+                model::RuntimeSessionState::Idle,
+            )),
+        );
+        assert!(matches!(app.status, AppStatus::Error));
+    }
+
+    #[test]
+    fn settings_parse_error_surfaces_system_error_message() {
+        let mut app = make_test_app();
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(model::SessionUpdate::SettingsParseError {
+                file: Some("C:/work/.claude/settings.json".to_owned()),
+                path: "permissions.allow".to_owned(),
+                message: "Expected array".to_owned(),
+            }),
+        );
+
+        assert_eq!(app.messages.len(), 1);
+        assert!(matches!(app.messages[0].role, MessageRole::System(Some(SystemSeverity::Error))));
+        let MessageBlock::Text(text) = &app.messages[0].blocks[0] else {
+            panic!("expected settings parse error text");
+        };
+        assert_eq!(
+            text.text,
+            "Settings parse error in C:/work/.claude/settings.json at permissions.allow: Expected array",
+        );
     }
 
     #[test]

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -244,7 +244,6 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             let next_display_long = update.current_model.display_name_long.clone();
             let pending_ack_before = format!("{:?}", app.pending_command_ack);
             app.current_model = Some(update.current_model);
-            app.update_welcome_model_once();
             let clearing_pending =
                 matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentModel));
             if matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentModel)) {
@@ -1396,9 +1395,9 @@ mod tests {
     }
 
     #[test]
-    fn connected_updates_welcome_model_while_pristine() {
+    fn connected_updates_welcome_session_id_while_pristine() {
         let mut app = make_test_app();
-        app.messages.push(ChatMessage::welcome("Connecting...", "/test"));
+        app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
 
         handle_client_event(&mut app, connected_event("claude-updated"));
 
@@ -1408,13 +1407,13 @@ mod tests {
         let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
             panic!("expected welcome block");
         };
-        assert_eq!(welcome.model_name, "claude-updated");
+        assert_eq!(welcome.session_id, "test-session");
     }
 
     #[test]
-    fn connected_updates_welcome_to_default_for_provisional_default_model() {
+    fn connected_keeps_subscription_placeholder_until_status_snapshot_arrives() {
         let mut app = make_test_app();
-        app.messages.push(ChatMessage::welcome("Connecting...", "/test"));
+        app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "old", "/test", "old"));
 
         handle_client_event(&mut app, connected_event("default"));
 
@@ -1424,7 +1423,7 @@ mod tests {
         let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
             panic!("expected welcome block");
         };
-        assert_eq!(welcome.model_name, "default");
+        assert_eq!(welcome.subscription, "-");
     }
 
     #[test]
@@ -1457,7 +1456,7 @@ mod tests {
     #[test]
     fn connected_updates_cwd_and_clears_resuming_marker() {
         let mut app = make_test_app();
-        app.messages.push(ChatMessage::welcome("Connecting...", "/test"));
+        app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
         app.resuming_session_id = Some("resume-123".into());
 
         handle_client_event(
@@ -1514,7 +1513,7 @@ mod tests {
     #[test]
     fn connected_updates_welcome_once_even_after_chat_started() {
         let mut app = make_test_app();
-        app.messages.push(ChatMessage::welcome("Connecting...", "/test"));
+        app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
         app.messages.push(user_msg("hello"));
 
         handle_client_event(&mut app, connected_event("claude-updated"));
@@ -1525,21 +1524,20 @@ mod tests {
         let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
             panic!("expected welcome block");
         };
-        assert_eq!(welcome.model_name, "claude-updated");
+        assert_eq!(welcome.session_id, "test-session");
     }
 
     #[test]
-    fn current_model_update_refreshes_welcome_after_settings_reconcile() {
+    fn current_model_update_does_not_mutate_welcome_snapshot_after_settings_reconcile() {
         let mut app = make_test_app();
         app.session_id = Some(model::SessionId::new("session-1"));
         app.current_model = Some(test_current_model("default"));
-        app.messages = vec![ChatMessage::welcome("default", "/test")];
+        app.messages =
+            vec![ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "session-1")];
         crate::app::config::store::set_model(
             &mut app.config.committed_settings_document,
             Some("default"),
         );
-
-        app.update_welcome_model_once();
 
         crate::app::config::store::set_model(
             &mut app.config.committed_settings_document,
@@ -1557,7 +1555,8 @@ mod tests {
         let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first() else {
             panic!("expected welcome block");
         };
-        assert_eq!(welcome.model_name, "claude-opus-4-6");
+        assert_eq!(welcome.session_id, "session-1");
+        assert_eq!(welcome.subscription, "-");
     }
 
     #[test]
@@ -1614,10 +1613,10 @@ mod tests {
     }
 
     #[test]
-    fn current_model_update_refreshes_welcome_after_provisional_default() {
+    fn current_model_update_leaves_existing_welcome_snapshot_unchanged() {
         let mut app = make_test_app();
         app.current_model = Some(test_current_model("default"));
-        app.messages.push(ChatMessage::welcome("Connecting...", "/test"));
+        app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
         app.messages.push(user_msg("hello"));
 
         handle_client_event(
@@ -1633,7 +1632,7 @@ mod tests {
         let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
             panic!("expected welcome block");
         };
-        assert_eq!(welcome.model_name, "claude-opus-4-6");
+        assert_eq!(welcome.session_id, "-");
 
         handle_client_event(
             &mut app,
@@ -1648,7 +1647,7 @@ mod tests {
         let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
             panic!("expected welcome block");
         };
-        assert_eq!(welcome.model_name, "claude-sonnet-4-5");
+        assert_eq!(welcome.session_id, "-");
     }
 
     #[test]
@@ -1834,24 +1833,22 @@ mod tests {
     }
 
     #[test]
-    fn connected_requests_status_snapshot_when_status_tab_is_open() {
+    fn connected_requests_status_snapshot_on_connect() {
         let (mut app, mut rx) = app_with_bridge_connection();
-        app.active_view = ActiveView::Config;
-        app.config.active_tab = crate::app::config::ConfigTab::Status;
 
         handle_client_event(&mut app, connected_event("claude-updated"));
 
-        let status = rx.try_recv().expect("status snapshot command");
-        assert_eq!(
-            status.command,
-            crate::agent::wire::BridgeCommand::GetStatusSnapshot {
-                session_id: "test-session".to_owned(),
-            }
-        );
         let mcp = rx.try_recv().expect("mcp snapshot command");
         assert_eq!(
             mcp.command,
             crate::agent::wire::BridgeCommand::GetMcpSnapshot {
+                session_id: "test-session".to_owned(),
+            }
+        );
+        let status = rx.try_recv().expect("status snapshot command");
+        assert_eq!(
+            status.command,
+            crate::agent::wire::BridgeCommand::GetStatusSnapshot {
                 session_id: "test-session".to_owned(),
             }
         );
@@ -1893,6 +1890,38 @@ mod tests {
         );
 
         assert!(app.account_info.is_none());
+    }
+
+    #[test]
+    fn status_snapshot_updates_welcome_subscription() {
+        let mut app = make_test_app();
+        app.messages.push(ChatMessage::welcome(
+            env!("CARGO_PKG_VERSION"),
+            "-",
+            "/test",
+            "session-1",
+        ));
+        app.session_id = Some(model::SessionId::new("session-1"));
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::StatusSnapshotReceived {
+                session_id: "session-1".into(),
+                account: crate::agent::types::AccountInfo {
+                    email: None,
+                    organization: None,
+                    subscription_type: Some("Claude Max".into()),
+                    token_source: None,
+                    api_key_source: None,
+                    api_provider: None,
+                },
+            },
+        );
+
+        let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first() else {
+            panic!("expected welcome block");
+        };
+        assert_eq!(welcome.subscription, "Claude Max");
     }
 
     #[test]

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -3618,8 +3618,13 @@ mod tests {
     ) -> oneshot::Receiver<model::RequestPermissionResponse> {
         let (response_tx, response_rx) = oneshot::channel();
         let mut tc = tool_call(tool_id, model::ToolCallStatus::InProgress);
-        tc.pending_permission =
-            Some(InlinePermission { options, response_tx, selected_index: 0, focused });
+        tc.pending_permission = Some(InlinePermission {
+            options,
+            display: None,
+            response_tx,
+            selected_index: 0,
+            focused,
+        });
         app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tc))]));
         let msg_idx = app.messages.len().saturating_sub(1);
         app.index_tool_call(tool_id.into(), msg_idx, 0);

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -1581,6 +1581,7 @@ mod tests {
             subscription_type: None,
             token_source: None,
             api_key_source: None,
+            api_provider: None,
         });
         app.plugins.installed.push(crate::app::plugins::InstalledPluginEntry {
             id: "old-plugin".into(),
@@ -1886,6 +1887,7 @@ mod tests {
                     subscription_type: None,
                     token_source: None,
                     api_key_source: None,
+                    api_provider: None,
                 },
             },
         );

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -115,16 +115,6 @@ fn dispatch_mouse_by_view(app: &mut App, mouse: crossterm::event::MouseEvent) {
 fn dispatch_paste_by_view(app: &mut App, text: &str) -> bool {
     match app.active_view {
         ActiveView::Chat => {
-            if app
-                .pending_clipboard_paste_dedupe
-                .as_deref()
-                .is_some_and(|expected| expected == text)
-            {
-                app.pending_clipboard_paste_dedupe = None;
-                tracing::debug!("paste_event: suppressed duplicate clipboard text paste");
-                return true;
-            }
-            app.pending_clipboard_paste_dedupe = None;
             if !matches!(
                 app.status,
                 AppStatus::Connecting | AppStatus::CommandPending | AppStatus::Error
@@ -4446,28 +4436,6 @@ mod tests {
             state: crossterm::event::KeyEventState::NONE,
         };
         assert!(!should_dispatch_key_event(key));
-    }
-
-    #[test]
-    fn matching_event_paste_is_suppressed_after_clipboard_fallback() {
-        let mut app = make_test_app();
-        app.pending_clipboard_paste_dedupe = Some("pasted".to_owned());
-
-        handle_terminal_event(&mut app, Event::Paste("pasted".into()));
-
-        assert!(app.pending_paste_text.is_empty());
-        assert!(app.pending_clipboard_paste_dedupe.is_none());
-    }
-
-    #[test]
-    fn non_matching_event_paste_is_not_suppressed() {
-        let mut app = make_test_app();
-        app.pending_clipboard_paste_dedupe = Some("clipboard".to_owned());
-
-        handle_terminal_event(&mut app, Event::Paste("terminal".into()));
-
-        assert_eq!(app.pending_paste_text, "terminal");
-        assert!(app.pending_clipboard_paste_dedupe.is_none());
     }
 
     #[test]

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -2345,6 +2345,59 @@ mod tests {
     }
 
     #[test]
+    fn resume_history_preserves_turn_order_between_user_and_assistant_messages() {
+        let mut app = make_test_app();
+        let history_updates = vec![
+            model::SessionUpdate::UserMessageChunk(model::ContentChunk::new(
+                model::ContentBlock::Text(model::TextContent::new("first user")),
+            )),
+            model::SessionUpdate::AgentMessageChunk(model::ContentChunk::new(
+                model::ContentBlock::Text(model::TextContent::new("first assistant")),
+            )),
+            model::SessionUpdate::UserMessageChunk(model::ContentChunk::new(
+                model::ContentBlock::Text(model::TextContent::new("second user")),
+            )),
+            model::SessionUpdate::AgentMessageChunk(model::ContentChunk::new(
+                model::ContentBlock::Text(model::TextContent::new("second assistant")),
+            )),
+        ];
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionReplaced {
+                session_id: model::SessionId::new("active-457"),
+                cwd: "/replacement".into(),
+                current_model: test_current_model("new-model"),
+                available_models: Vec::new(),
+                mode: None,
+                history_updates,
+            },
+        );
+
+        let rendered: Vec<(MessageRole, String)> = app
+            .messages
+            .iter()
+            .filter_map(|message| {
+                let text = message.blocks.iter().find_map(|block| match block {
+                    MessageBlock::Text(block) => Some(block.text.clone()),
+                    _ => None,
+                })?;
+                Some((message.role.clone(), text))
+            })
+            .collect();
+
+        assert_eq!(
+            rendered,
+            vec![
+                (MessageRole::User, "first user".to_owned()),
+                (MessageRole::Assistant, "first assistant".to_owned()),
+                (MessageRole::User, "second user".to_owned()),
+                (MessageRole::Assistant, "second assistant".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
     fn resume_history_forces_open_tool_calls_to_failed() {
         let mut app = make_test_app();
         let open_tool = model::ToolCall::new("resume-open", "Execute command")

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -489,7 +489,7 @@ mod tests {
 
         // User cancels then TurnComplete finalizes the turn
         handle_client_event(&mut app, ClientEvent::TurnCancelled);
-        handle_client_event(&mut app, ClientEvent::TurnComplete);
+        handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
         // Stale task ID must be gone after turn boundary
         assert!(app.active_task_ids.is_empty(), "stale task id must not survive TurnComplete");
@@ -1254,7 +1254,7 @@ mod tests {
         handle_client_event(&mut app, ClientEvent::TurnCancelled);
         assert!(app.cancelled_turn_pending_hint);
 
-        handle_client_event(&mut app, ClientEvent::TurnComplete);
+        handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
         assert!(!app.cancelled_turn_pending_hint);
         let last = app.messages.last().expect("expected interruption hint message");
@@ -1275,7 +1275,7 @@ mod tests {
         ))]));
         app.pending_cancel_origin = Some(CancelOrigin::Manual);
 
-        handle_client_event(&mut app, ClientEvent::TurnComplete);
+        handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
         assert!(matches!(app.status, AppStatus::Ready));
         assert!(!app.viewport.message_height_is_current(1));
@@ -1295,7 +1295,7 @@ mod tests {
         ))]));
         app.pending_cancel_origin = Some(CancelOrigin::AutoQueue);
 
-        handle_client_event(&mut app, ClientEvent::TurnComplete);
+        handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
         assert!(matches!(app.status, AppStatus::Ready));
         assert!(!app.viewport.message_height_is_current(1));
@@ -2356,7 +2356,7 @@ mod tests {
     #[test]
     fn turn_complete_without_cancel_does_not_render_interrupted_hint() {
         let mut app = make_test_app();
-        handle_client_event(&mut app, ClientEvent::TurnComplete);
+        handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
         assert!(app.messages.is_empty());
     }
 
@@ -2378,7 +2378,7 @@ mod tests {
         );
         assert!(app.pending_compact_clear);
 
-        handle_client_event(&mut app, ClientEvent::TurnComplete);
+        handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
         assert!(!app.pending_compact_clear);
         assert_eq!(app.messages.len(), 3);
@@ -2442,7 +2442,10 @@ mod tests {
         app.pending_compact_clear = true;
         app.messages.push(user_msg("/compact"));
 
-        handle_client_event(&mut app, ClientEvent::TurnError("adapter failed".into()));
+        handle_client_event(
+            &mut app,
+            ClientEvent::TurnError { message: "adapter failed".into(), terminal_reason: None },
+        );
 
         assert!(!app.pending_compact_clear);
         assert!(matches!(app.status, AppStatus::Error));
@@ -2489,7 +2492,10 @@ mod tests {
         app.is_compacting = true;
 
         handle_client_event(&mut app, ClientEvent::TurnCancelled);
-        handle_client_event(&mut app, ClientEvent::TurnError("cancelled".into()));
+        handle_client_event(
+            &mut app,
+            ClientEvent::TurnError { message: "cancelled".into(), terminal_reason: None },
+        );
 
         assert_eq!(app.messages.len(), 3);
         assert!(matches!(app.messages[1].role, MessageRole::System(Some(SystemSeverity::Info))));
@@ -2509,7 +2515,10 @@ mod tests {
 
         handle_client_event(
             &mut app,
-            ClientEvent::TurnError("HTTP 429 Too Many Requests: max turns exceeded".into()),
+            ClientEvent::TurnError {
+                message: "HTTP 429 Too Many Requests: max turns exceeded".into(),
+                terminal_reason: None,
+            },
         );
 
         assert!(matches!(app.status, AppStatus::Error));
@@ -2533,6 +2542,7 @@ mod tests {
             ClientEvent::TurnErrorClassified {
                 message: "turn failed".into(),
                 class: TurnErrorClass::PlanLimit,
+                terminal_reason: None,
             },
         );
 
@@ -2556,6 +2566,7 @@ mod tests {
             ClientEvent::TurnErrorClassified {
                 message: "auth required".into(),
                 class: TurnErrorClass::AuthRequired,
+                terminal_reason: None,
             },
         );
 
@@ -2574,7 +2585,10 @@ mod tests {
         app.register_tool_call_scope("task-1".into(), ToolCallScope::Task);
         app.insert_active_task("task-1".into());
 
-        handle_client_event(&mut app, ClientEvent::TurnError("boom".into()));
+        handle_client_event(
+            &mut app,
+            ClientEvent::TurnError { message: "boom".into(), terminal_reason: None },
+        );
 
         assert!(app.active_task_ids.is_empty());
         assert!(app.active_subagent_tool_ids.is_empty());
@@ -2853,6 +2867,7 @@ mod tests {
             ClientEvent::TurnErrorClassified {
                 message: "HTTP 429 Too Many Requests".to_owned(),
                 class: TurnErrorClass::PlanLimit,
+                terminal_reason: None,
             },
         );
 
@@ -2892,6 +2907,7 @@ mod tests {
             ClientEvent::TurnErrorClassified {
                 message: "HTTP 429 Too Many Requests".to_owned(),
                 class: TurnErrorClass::PlanLimit,
+                terminal_reason: None,
             },
         );
         assert_eq!(app.messages.len(), 2);
@@ -2960,7 +2976,7 @@ mod tests {
         );
 
         assert_eq!(app.turn_notice_refs.len(), 1);
-        handle_client_event(&mut app, ClientEvent::TurnComplete);
+        handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
         assert!(app.turn_notice_refs.is_empty());
 
         app.status = AppStatus::Thinking;
@@ -3009,7 +3025,10 @@ mod tests {
 
         handle_client_event(
             &mut app,
-            ClientEvent::TurnError("Error: Request was aborted.\n    at stack line".into()),
+            ClientEvent::TurnError {
+                message: "Error: Request was aborted.\n    at stack line".into(),
+                terminal_reason: None,
+            },
         );
 
         assert!(!app.cancelled_turn_pending_hint);
@@ -3037,7 +3056,10 @@ mod tests {
 
         handle_client_event(
             &mut app,
-            ClientEvent::TurnError("Error: Request was aborted.\n    at stack line".into()),
+            ClientEvent::TurnError {
+                message: "Error: Request was aborted.\n    at stack line".into(),
+                terminal_reason: None,
+            },
         );
 
         assert!(matches!(app.status, AppStatus::Ready));
@@ -3089,7 +3111,7 @@ mod tests {
             MessageBlock::ToolCall(Box::new(tool_call("tc2", model::ToolCallStatus::Pending))),
         ]));
 
-        handle_client_event(&mut app, ClientEvent::TurnComplete);
+        handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
         let Some(last) = app.messages.last() else {
             panic!("missing assistant message");

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -1398,6 +1398,10 @@ mod tests {
     fn connected_updates_welcome_session_id_while_pristine() {
         let mut app = make_test_app();
         app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
+        let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first_mut() else {
+            panic!("expected welcome block");
+        };
+        welcome.tip_seed = 7;
 
         handle_client_event(&mut app, connected_event("claude-updated"));
 
@@ -1408,6 +1412,7 @@ mod tests {
             panic!("expected welcome block");
         };
         assert_eq!(welcome.session_id, "test-session");
+        assert_eq!(welcome.tip_seed, 7);
     }
 
     #[test]
@@ -1514,6 +1519,10 @@ mod tests {
     fn connected_updates_welcome_once_even_after_chat_started() {
         let mut app = make_test_app();
         app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
+        let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first_mut() else {
+            panic!("expected welcome block");
+        };
+        welcome.tip_seed = 11;
         app.messages.push(user_msg("hello"));
 
         handle_client_event(&mut app, connected_event("claude-updated"));
@@ -1525,6 +1534,7 @@ mod tests {
             panic!("expected welcome block");
         };
         assert_eq!(welcome.session_id, "test-session");
+        assert_eq!(welcome.tip_seed, 11);
     }
 
     #[test]
@@ -1734,6 +1744,11 @@ mod tests {
     #[test]
     fn session_replaced_resets_chat_and_transient_state() {
         let mut app = make_test_app();
+        app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
+        let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first_mut() else {
+            panic!("expected welcome block");
+        };
+        welcome.tip_seed = 5;
         app.messages.push(user_msg("hello"));
         app.messages
             .push(assistant_msg(vec![MessageBlock::Text(TextBlock::from_complete("world"))]));
@@ -1793,6 +1808,7 @@ mod tests {
             panic!("expected welcome block");
         };
         assert_eq!(welcome.cwd, "/replacement");
+        assert_ne!(welcome.tip_seed, 5);
     }
 
     #[test]

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -218,7 +218,7 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
         }
         model::SessionUpdate::ModeStateUpdate(mode) => {
             app.mode = Some(mode);
-            if matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentModeUpdate)) {
+            if matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentMode)) {
                 session::clear_pending_command(app);
             }
         }
@@ -233,9 +233,33 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
                     mode.current_mode_id = mode_id;
                 }
             }
-            if matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentModeUpdate)) {
+            if matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentMode)) {
                 session::clear_pending_command(app);
             }
+        }
+        model::SessionUpdate::CurrentModelUpdate(update) => {
+            let next_resolved_id = update.current_model.resolved_id.clone();
+            let next_display_short = update.current_model.display_name_short.clone();
+            let next_display_long = update.current_model.display_name_long.clone();
+            let pending_ack_before = format!("{:?}", app.pending_command_ack);
+            app.current_model = Some(update.current_model);
+            app.update_welcome_model_once();
+            let clearing_pending =
+                matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentModel));
+            if matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentModel)) {
+                session::clear_pending_command(app);
+            }
+            tracing::debug!(
+                target: crate::logging::targets::APP_SESSION,
+                event_name = "current_model_update_applied",
+                message = "current model update applied",
+                outcome = "success",
+                resolved_id = %next_resolved_id,
+                display_name_short = %next_display_short,
+                display_name_long = %next_display_long,
+                clearing_pending = clearing_pending,
+                pending_ack_before = %pending_ack_before,
+            );
         }
         model::SessionUpdate::ConfigOptionUpdate(config) => {
             handle_config_option_update(app, config);
@@ -249,10 +273,14 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
         model::SessionUpdate::SessionStatusUpdate(status) => {
             // TODO(runtime-verification): confirm in real SDK sessions that compaction
             // status updates are emitted consistently; if not, add a fallback indicator.
+            let was_compacting = app.is_compacting;
             if matches!(status, model::SessionStatus::Compacting) {
                 app.is_compacting = true;
             } else {
                 clear_compaction_state(app, true);
+            }
+            if was_compacting && matches!(status, model::SessionStatus::Idle) {
+                crate::app::session_runtime::request_context_usage_refresh(app);
             }
             tracing::debug!(
                 target: crate::logging::targets::APP_SESSION,
@@ -302,8 +330,6 @@ pub(super) fn clear_compaction_state(app: &mut App, emit_manual_success: bool) {
 fn handle_config_option_update(app: &mut App, config: model::ConfigOptionUpdate) {
     let option_id = config.option_id;
     let value = config.value;
-    let model_name =
-        if option_id == "model" { value.as_str().map(ToOwned::to_owned) } else { None };
     let value_kind = match &value {
         serde_json::Value::Null => "null",
         serde_json::Value::Bool(_) => "bool",
@@ -322,23 +348,9 @@ fn handle_config_option_update(app: &mut App, config: model::ConfigOptionUpdate)
         value_kind,
     );
 
-    if let Some(model_name) = model_name {
-        app.model_name = model_name;
-        app.update_welcome_model_once();
-    } else if option_id == "model" {
-        tracing::warn!(
-            target: crate::logging::targets::APP_CONFIG,
-            event_name = "config_option_update_rejected",
-            message = "config option update carried an invalid model value",
-            outcome = "failure",
-            option_id = "model",
-            value_kind,
-        );
-    }
-
     if matches!(
         app.pending_command_ack.as_ref(),
-        Some(PendingCommandAck::ConfigOptionUpdate { option_id: expected }) if expected == &option_id
+        Some(PendingCommandAck::ConfigOption { option_id: expected }) if expected == &option_id
     ) {
         session::clear_pending_command(app);
     }
@@ -394,6 +406,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status,
             content: vec![],
             hidden: false,
@@ -750,11 +763,17 @@ mod tests {
         App::test_default()
     }
 
+    fn test_current_model(model_name: &str) -> model::CurrentModel {
+        let (short, long) =
+            if model_name == "default" { ("Default", "Default") } else { (model_name, model_name) };
+        model::CurrentModel::new(model_name, short, long).authoritative(model_name != "default")
+    }
+
     fn connected_event(model_name: &str) -> ClientEvent {
         ClientEvent::Connected {
             session_id: model::SessionId::new("test-session"),
             cwd: "/test".into(),
-            model_name: model_name.to_owned(),
+            current_model: test_current_model(model_name),
             available_models: Vec::new(),
             mode: None,
             history_updates: Vec::new(),
@@ -1308,7 +1327,6 @@ mod tests {
     #[test]
     fn connected_updates_welcome_model_while_pristine() {
         let mut app = make_test_app();
-        app.welcome_model_resolved = false;
         app.messages.push(ChatMessage::welcome("Connecting...", "/test"));
 
         handle_client_event(&mut app, connected_event("claude-updated"));
@@ -1325,7 +1343,6 @@ mod tests {
     #[test]
     fn connected_updates_welcome_to_default_for_provisional_default_model() {
         let mut app = make_test_app();
-        app.welcome_model_resolved = false;
         app.messages.push(ChatMessage::welcome("Connecting...", "/test"));
 
         handle_client_event(&mut app, connected_event("default"));
@@ -1337,7 +1354,6 @@ mod tests {
             panic!("expected welcome block");
         };
         assert_eq!(welcome.model_name, "default");
-        assert!(!app.welcome_model_resolved);
     }
 
     #[test]
@@ -1370,7 +1386,6 @@ mod tests {
     #[test]
     fn connected_updates_cwd_and_clears_resuming_marker() {
         let mut app = make_test_app();
-        app.welcome_model_resolved = false;
         app.messages.push(ChatMessage::welcome("Connecting...", "/test"));
         app.resuming_session_id = Some("resume-123".into());
 
@@ -1379,7 +1394,7 @@ mod tests {
             ClientEvent::Connected {
                 session_id: model::SessionId::new("session-cwd"),
                 cwd: "/changed".into(),
-                model_name: "claude-updated".into(),
+                current_model: test_current_model("claude-updated"),
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: Vec::new(),
@@ -1411,7 +1426,7 @@ mod tests {
             ClientEvent::Connected {
                 session_id: model::SessionId::new("session-trust"),
                 cwd: "/untrusted".into(),
-                model_name: "claude-updated".into(),
+                current_model: test_current_model("claude-updated"),
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: Vec::new(),
@@ -1428,7 +1443,6 @@ mod tests {
     #[test]
     fn connected_updates_welcome_once_even_after_chat_started() {
         let mut app = make_test_app();
-        app.welcome_model_resolved = false;
         app.messages.push(ChatMessage::welcome("Connecting...", "/test"));
         app.messages.push(user_msg("hello"));
 
@@ -1441,14 +1455,13 @@ mod tests {
             panic!("expected welcome block");
         };
         assert_eq!(welcome.model_name, "claude-updated");
-        assert!(app.welcome_model_resolved);
     }
 
     #[test]
-    fn persisted_model_change_reopens_welcome_model_reconciliation() {
+    fn current_model_update_refreshes_welcome_after_settings_reconcile() {
         let mut app = make_test_app();
         app.session_id = Some(model::SessionId::new("session-1"));
-        app.model_name = "default".into();
+        app.current_model = Some(test_current_model("default"));
         app.messages = vec![ChatMessage::welcome("default", "/test")];
         crate::app::config::store::set_model(
             &mut app.config.committed_settings_document,
@@ -1456,22 +1469,17 @@ mod tests {
         );
 
         app.update_welcome_model_once();
-        assert!(app.welcome_model_resolved);
 
         crate::app::config::store::set_model(
             &mut app.config.committed_settings_document,
             Some("haiku"),
         );
         app.reconcile_runtime_from_persisted_settings_change();
-        assert!(!app.welcome_model_resolved);
 
         handle_client_event(
             &mut app,
-            ClientEvent::SessionUpdate(model::SessionUpdate::ConfigOptionUpdate(
-                model::ConfigOptionUpdate {
-                    option_id: "model".into(),
-                    value: serde_json::Value::String("claude-opus-4-6".into()),
-                },
+            ClientEvent::SessionUpdate(model::SessionUpdate::CurrentModelUpdate(
+                model::CurrentModelUpdate::new(test_current_model("claude-opus-4-6")),
             )),
         );
 
@@ -1479,7 +1487,6 @@ mod tests {
             panic!("expected welcome block");
         };
         assert_eq!(welcome.model_name, "claude-opus-4-6");
-        assert!(app.welcome_model_resolved);
     }
 
     #[test]
@@ -1535,20 +1542,16 @@ mod tests {
     }
 
     #[test]
-    fn model_config_update_resolves_welcome_once_after_provisional_default() {
+    fn current_model_update_refreshes_welcome_after_provisional_default() {
         let mut app = make_test_app();
-        app.model_name = "default".into();
-        app.welcome_model_resolved = false;
+        app.current_model = Some(test_current_model("default"));
         app.messages.push(ChatMessage::welcome("Connecting...", "/test"));
         app.messages.push(user_msg("hello"));
 
         handle_client_event(
             &mut app,
-            ClientEvent::SessionUpdate(model::SessionUpdate::ConfigOptionUpdate(
-                model::ConfigOptionUpdate {
-                    option_id: "model".into(),
-                    value: serde_json::Value::String("claude-opus-4-6".into()),
-                },
+            ClientEvent::SessionUpdate(model::SessionUpdate::CurrentModelUpdate(
+                model::CurrentModelUpdate::new(test_current_model("claude-opus-4-6")),
             )),
         );
 
@@ -1559,15 +1562,11 @@ mod tests {
             panic!("expected welcome block");
         };
         assert_eq!(welcome.model_name, "claude-opus-4-6");
-        assert!(app.welcome_model_resolved);
 
         handle_client_event(
             &mut app,
-            ClientEvent::SessionUpdate(model::SessionUpdate::ConfigOptionUpdate(
-                model::ConfigOptionUpdate {
-                    option_id: "model".into(),
-                    value: serde_json::Value::String("claude-sonnet-4-5".into()),
-                },
+            ClientEvent::SessionUpdate(model::SessionUpdate::CurrentModelUpdate(
+                model::CurrentModelUpdate::new(test_current_model("claude-sonnet-4-5")),
             )),
         );
 
@@ -1577,7 +1576,7 @@ mod tests {
         let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
             panic!("expected welcome block");
         };
-        assert_eq!(welcome.model_name, "claude-opus-4-6");
+        assert_eq!(welcome.model_name, "claude-sonnet-4-5");
     }
 
     #[test]
@@ -1693,7 +1692,7 @@ mod tests {
             ClientEvent::SessionReplaced {
                 session_id: model::SessionId::new("replacement"),
                 cwd: "/replacement".into(),
-                model_name: "new-model".into(),
+                current_model: test_current_model("new-model"),
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: Vec::new(),
@@ -1705,7 +1704,10 @@ mod tests {
             app.session_id.as_ref().map(ToString::to_string).as_deref(),
             Some("replacement")
         );
-        assert_eq!(app.model_name, "new-model");
+        assert_eq!(
+            app.current_model.as_ref().map(|model| model.resolved_id.as_str()),
+            Some("new-model")
+        );
         assert_eq!(app.messages.len(), 1);
         assert!(matches!(app.messages[0].role, MessageRole::Welcome));
         assert_eq!(app.files_accessed, 0);
@@ -1741,7 +1743,7 @@ mod tests {
             ClientEvent::SessionReplaced {
                 session_id: model::SessionId::new("replacement"),
                 cwd: "/replacement".into(),
-                model_name: "new-model".into(),
+                current_model: test_current_model("new-model"),
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: Vec::new(),
@@ -2137,7 +2139,7 @@ mod tests {
         let mut app = make_test_app();
         app.status = AppStatus::CommandPending;
         app.pending_command_label = Some("Switching mode...".into());
-        app.pending_command_ack = Some(PendingCommandAck::CurrentModeUpdate);
+        app.pending_command_ack = Some(PendingCommandAck::CurrentMode);
         app.mode = Some(crate::app::ModeState {
             current_mode_id: "code".to_owned(),
             current_mode_name: "Code".to_owned(),
@@ -2163,29 +2165,24 @@ mod tests {
     }
 
     #[test]
-    fn model_config_option_update_updates_state_and_clears_pending_when_expected() {
+    fn current_model_update_updates_state_and_clears_pending_when_expected() {
         let mut app = make_test_app();
         app.status = AppStatus::CommandPending;
         app.pending_command_label = Some("Switching model...".into());
-        app.pending_command_ack =
-            Some(PendingCommandAck::ConfigOptionUpdate { option_id: "model".to_owned() });
-        app.model_name = "old-model".to_owned();
+        app.pending_command_ack = Some(PendingCommandAck::CurrentModel);
+        app.current_model = Some(test_current_model("old-model"));
 
         handle_client_event(
             &mut app,
-            ClientEvent::SessionUpdate(model::SessionUpdate::ConfigOptionUpdate(
-                model::ConfigOptionUpdate {
-                    option_id: "model".to_owned(),
-                    value: serde_json::Value::String("sonnet".to_owned()),
-                },
+            ClientEvent::SessionUpdate(model::SessionUpdate::CurrentModelUpdate(
+                model::CurrentModelUpdate::new(test_current_model("sonnet")),
             )),
         );
 
         assert!(matches!(app.status, AppStatus::Ready));
-        assert_eq!(app.model_name, "sonnet");
         assert_eq!(
-            app.config_options.get("model"),
-            Some(&serde_json::Value::String("sonnet".to_owned()))
+            app.current_model.as_ref().map(|model| model.resolved_id.as_str()),
+            Some("sonnet")
         );
         assert!(app.pending_command_label.is_none());
         assert!(app.pending_command_ack.is_none());
@@ -2197,7 +2194,7 @@ mod tests {
         app.status = AppStatus::CommandPending;
         app.pending_command_label = Some("Switching model...".into());
         app.pending_command_ack =
-            Some(PendingCommandAck::ConfigOptionUpdate { option_id: "model".to_owned() });
+            Some(PendingCommandAck::ConfigOption { option_id: "model".to_owned() });
 
         handle_client_event(
             &mut app,
@@ -2214,7 +2211,7 @@ mod tests {
         assert_eq!(app.pending_command_label.as_deref(), Some("Switching model..."));
         assert!(matches!(
             app.pending_command_ack.as_ref(),
-            Some(PendingCommandAck::ConfigOptionUpdate { option_id }) if option_id == "model"
+            Some(PendingCommandAck::ConfigOption { option_id }) if option_id == "model"
         ));
     }
 
@@ -2228,7 +2225,7 @@ mod tests {
             ClientEvent::SessionReplaced {
                 session_id: model::SessionId::new("active-456"),
                 cwd: "/replacement".into(),
-                model_name: "new-model".into(),
+                current_model: test_current_model("new-model"),
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: Vec::new(),
@@ -2258,7 +2255,7 @@ mod tests {
             ClientEvent::SessionReplaced {
                 session_id: model::SessionId::new("active-456"),
                 cwd: "/replacement".into(),
-                model_name: "new-model".into(),
+                current_model: test_current_model("new-model"),
                 available_models: Vec::new(),
                 mode: None,
                 history_updates,
@@ -2288,7 +2285,7 @@ mod tests {
             ClientEvent::SessionReplaced {
                 session_id: model::SessionId::new("active-789"),
                 cwd: "/replacement".into(),
-                model_name: "new-model".into(),
+                current_model: test_current_model("new-model"),
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: vec![model::SessionUpdate::ToolCall(open_tool)],
@@ -2314,7 +2311,7 @@ mod tests {
             ClientEvent::SessionReplaced {
                 session_id: model::SessionId::new("active-790"),
                 cwd: "/replacement".into(),
-                model_name: "new-model".into(),
+                current_model: test_current_model("new-model"),
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: vec![model::SessionUpdate::AgentMessageChunk(
@@ -2341,7 +2338,7 @@ mod tests {
             ClientEvent::SessionReplaced {
                 session_id: model::SessionId::new("active-791"),
                 cwd: "/replacement".into(),
-                model_name: "new-model".into(),
+                current_model: test_current_model("new-model"),
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: vec![model::SessionUpdate::ToolCall(task_tool)],
@@ -2600,7 +2597,7 @@ mod tests {
         let mut app = make_test_app();
         app.status = AppStatus::Running;
         app.session_id = Some(model::SessionId::new("session-auth"));
-        app.model_name = "claude-old".into();
+        app.current_model = Some(test_current_model("claude-old"));
         app.mode = Some(crate::app::ModeState {
             current_mode_id: "plan".into(),
             current_mode_name: "Plan".into(),
@@ -2634,7 +2631,7 @@ mod tests {
         };
         assert_eq!(tc.status, model::ToolCallStatus::Failed);
         assert!(app.session_id.is_none());
-        assert_eq!(app.model_name, "Connecting...");
+        assert!(app.current_model.is_none());
         assert!(app.mode.is_none());
         assert_eq!(app.fast_mode_state, model::FastModeState::Off);
     }
@@ -2643,7 +2640,7 @@ mod tests {
     fn logout_completed_clears_session_runtime_identity_caches() {
         let mut app = make_test_app();
         app.session_id = Some(model::SessionId::new("session-x"));
-        app.model_name = "claude-old".into();
+        app.current_model = Some(test_current_model("claude-old"));
         app.mode = Some(crate::app::ModeState {
             current_mode_id: "plan".into(),
             current_mode_name: "Plan".into(),
@@ -2654,7 +2651,7 @@ mod tests {
         handle_client_event(&mut app, ClientEvent::LogoutCompleted);
 
         assert!(app.session_id.is_none());
-        assert_eq!(app.model_name, "Connecting...");
+        assert!(app.current_model.is_none());
         assert!(app.mode.is_none());
         assert_eq!(app.fast_mode_state, model::FastModeState::Off);
     }
@@ -3006,7 +3003,7 @@ mod tests {
             ClientEvent::Connected {
                 session_id: model::SessionId::new("new-session"),
                 cwd: "/test".into(),
-                model_name: "claude".into(),
+                current_model: test_current_model("claude"),
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: Vec::new(),

--- a/src/app/events/rate_limit.rs
+++ b/src/app/events/rate_limit.rs
@@ -5,6 +5,8 @@ use super::super::{App, NoticeDedupKey, NoticeStage, RateLimitIncidentKey, Syste
 use crate::agent::model;
 use std::time::Duration;
 
+const EXTRA_USAGE_REQUIRED_MESSAGE: &str = "Extra usage is required for 1M context. Run /extra-usage to enable it, or /model to switch to standard context.";
+
 fn format_rate_limit_type(raw: &str) -> &str {
     match raw {
         "five_hour" => "5-hour",
@@ -46,7 +48,22 @@ fn format_resets_at(epoch_secs: f64) -> String {
     format!("{countdown} at {h:02}:{m:02} UTC")
 }
 
+fn has_primary_rate_limit_context(update: &model::RateLimitUpdate) -> bool {
+    update.utilization.is_some() || update.rate_limit_type.is_some() || update.resets_at.is_some()
+}
+
+fn is_org_level_disabled_extra_usage_case(update: &model::RateLimitUpdate) -> bool {
+    matches!(update.status, model::RateLimitStatus::Rejected)
+        && !has_primary_rate_limit_context(update)
+        && update.is_using_overage == Some(false)
+        && update.overage_disabled_reason.as_deref() == Some("org_level_disabled")
+}
+
 pub(super) fn format_rate_limit_summary(update: &model::RateLimitUpdate) -> String {
+    if is_org_level_disabled_extra_usage_case(update) {
+        return EXTRA_USAGE_REQUIRED_MESSAGE.to_owned();
+    }
+
     let is_rejected = matches!(update.status, model::RateLimitStatus::Rejected);
 
     // Intro
@@ -108,6 +125,21 @@ fn reset_bucket_from_epoch_secs(value: f64) -> Option<u64> {
 
 pub(super) fn handle_rate_limit_update(app: &mut App, update: &model::RateLimitUpdate) {
     app.last_rate_limit_update = Some(update.clone());
+    tracing::debug!(
+        target: crate::logging::targets::APP_SESSION,
+        event_name = "rate_limit_update_applied",
+        message = "rate limit update applied",
+        outcome = "success",
+        status = ?update.status,
+        utilization = update.utilization,
+        rate_limit_type = update.rate_limit_type.as_deref().unwrap_or(""),
+        resets_at = update.resets_at.unwrap_or_default(),
+        overage_status = ?update.overage_status,
+        overage_resets_at = update.overage_resets_at.unwrap_or_default(),
+        overage_disabled_reason = update.overage_disabled_reason.as_deref().unwrap_or(""),
+        is_using_overage = ?update.is_using_overage,
+        surpassed_threshold = update.surpassed_threshold.unwrap_or_default(),
+    );
 
     match update.status {
         model::RateLimitStatus::Allowed => {}
@@ -149,4 +181,50 @@ pub(super) fn handle_compaction_boundary_update(
         boundary.trigger,
         boundary.pre_tokens
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_rate_limit_summary;
+    use crate::agent::model::{RateLimitStatus, RateLimitUpdate};
+
+    #[test]
+    fn org_level_disabled_without_primary_context_uses_extra_usage_message() {
+        let update = RateLimitUpdate {
+            status: RateLimitStatus::Rejected,
+            resets_at: None,
+            utilization: None,
+            rate_limit_type: None,
+            overage_status: None,
+            overage_resets_at: None,
+            overage_disabled_reason: Some("org_level_disabled".to_owned()),
+            is_using_overage: Some(false),
+            surpassed_threshold: None,
+        };
+
+        assert_eq!(
+            format_rate_limit_summary(&update),
+            "Extra usage is required for 1M context. Run /extra-usage to enable it, or /model to switch to standard context."
+        );
+    }
+
+    #[test]
+    fn org_level_disabled_with_primary_context_keeps_normal_rate_limit_message() {
+        let update = RateLimitUpdate {
+            status: RateLimitStatus::Rejected,
+            resets_at: Some(1_741_280_000.0),
+            utilization: None,
+            rate_limit_type: Some("five_hour".to_owned()),
+            overage_status: None,
+            overage_resets_at: None,
+            overage_disabled_reason: Some("org_level_disabled".to_owned()),
+            is_using_overage: Some(false),
+            surpassed_threshold: None,
+        };
+
+        let summary = format_rate_limit_summary(&update);
+        assert!(summary.contains("Rate limit reached"));
+        assert!(summary.contains("5-hour rate limit"));
+        assert!(!summary.contains("Extra usage is required for 1M context"));
+    }
 }

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -24,7 +24,7 @@ pub(super) fn handle_connected_client_event(
     app: &mut App,
     session_id: model::SessionId,
     cwd: String,
-    model_name: String,
+    current_model: model::CurrentModel,
     available_models: Vec<model::AvailableModel>,
     mode: Option<super::super::ModeState>,
     history_updates: &[model::SessionUpdate],
@@ -36,7 +36,7 @@ pub(super) fn handle_connected_client_event(
         app.conn = Some(slot.conn);
     }
     apply_session_cwd(app, cwd);
-    reset_for_new_session(app, session_id, model_name, mode);
+    reset_for_new_session(app, session_id, current_model, mode);
     app.available_models = available_models;
     app.update_welcome_model_once();
     app.sync_welcome_recent_sessions();
@@ -56,7 +56,7 @@ pub(super) fn handle_connected_client_event(
         outcome = "success",
         session_id = %session_id_for_log,
         cwd = %app.cwd_raw,
-        model_name = %app.model_name,
+        current_model = ?app.current_model.as_ref().map(|model| model.resolved_id.clone()),
         history_update_count,
         available_model_count,
     );
@@ -294,7 +294,7 @@ pub(super) fn handle_session_replaced_event(
     app: &mut App,
     session_id: model::SessionId,
     cwd: String,
-    model_name: String,
+    current_model: model::CurrentModel,
     available_models: Vec<model::AvailableModel>,
     mode: Option<super::super::ModeState>,
     history_updates: &[model::SessionUpdate],
@@ -307,7 +307,7 @@ pub(super) fn handle_session_replaced_event(
     app.pending_auto_submit_after_cancel = false;
     apply_session_cwd(app, cwd);
     app.available_models = available_models;
-    reset_for_new_session(app, session_id, model_name, mode);
+    reset_for_new_session(app, session_id, current_model, mode);
     if !history_updates.is_empty() {
         load_resume_history(app, history_updates);
     }
@@ -322,7 +322,7 @@ pub(super) fn handle_session_replaced_event(
         outcome = "success",
         session_id = %session_id_for_log,
         cwd = %app.cwd_raw,
-        model_name = %app.model_name,
+        current_model = ?app.current_model.as_ref().map(|model| model.resolved_id.clone()),
         history_update_count,
         available_model_count,
     );
@@ -524,7 +524,7 @@ mod tests {
             &mut app,
             model::SessionId::new("session-1"),
             dir.path().to_string_lossy().into_owned(),
-            "model".to_owned(),
+            model::CurrentModel::new("model", "model", "model").authoritative(true),
             Vec::new(),
             None,
             &[],
@@ -558,7 +558,7 @@ mod tests {
             &mut app,
             model::SessionId::new("session-2"),
             dir.path().to_string_lossy().into_owned(),
-            "model".to_owned(),
+            model::CurrentModel::new("model", "model", "model").authoritative(true),
             Vec::new(),
             None,
             &[],

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -6,8 +6,7 @@ use super::super::connect::{SessionStartReason, start_new_session};
 use super::super::state::RecentSessionInfo;
 use super::super::view::{self, ActiveView};
 use super::super::{
-    App, AppStatus, ChatMessage, InvalidationLevel, LoginHint, MessageBlock, MessageRole,
-    SystemSeverity, TextBlock,
+    App, AppStatus, ChatMessage, LoginHint, MessageBlock, MessageRole, SystemSeverity, TextBlock,
 };
 use super::push_system_message_with_severity;
 use super::session_reset::{load_resume_history, reset_for_new_session};
@@ -38,8 +37,7 @@ pub(super) fn handle_connected_client_event(
     apply_session_cwd(app, cwd);
     reset_for_new_session(app, session_id, current_model, mode);
     app.available_models = available_models;
-    app.update_welcome_model_once();
-    app.sync_welcome_recent_sessions();
+    app.sync_welcome_snapshot();
     if !history_updates.is_empty() {
         load_resume_history(app, history_updates);
     }
@@ -110,7 +108,6 @@ pub(super) fn handle_sessions_listed_event(
     }
     app.startup_recent_sessions_loaded = true;
     reconcile_session_picker_selection(app, selected_session_id.as_deref());
-    app.sync_welcome_recent_sessions();
     maybe_open_startup_session_picker(app);
     tracing::info!(
         target: crate::logging::targets::APP_SESSION,
@@ -308,6 +305,7 @@ pub(super) fn handle_session_replaced_event(
     apply_session_cwd(app, cwd);
     app.available_models = available_models;
     reset_for_new_session(app, session_id, current_model, mode);
+    app.sync_welcome_snapshot();
     if !history_updates.is_empty() {
         load_resume_history(app, history_updates);
     }
@@ -410,20 +408,7 @@ fn shorten_cwd_display(cwd_raw: &str) -> String {
 }
 
 fn sync_welcome_cwd(app: &mut App) {
-    let Some(first) = app.messages.first_mut() else {
-        return;
-    };
-    if !matches!(first.role, MessageRole::Welcome) {
-        return;
-    }
-    let Some(MessageBlock::Welcome(welcome)) = first.blocks.first_mut() else {
-        return;
-    };
-    welcome.cwd.clone_from(&app.cwd);
-    welcome.cache.invalidate();
-    app.sync_render_cache_slot(0, 0);
-    app.recompute_message_retained_bytes(0);
-    app.invalidate_layout(InvalidationLevel::MessagesFrom(0));
+    app.sync_welcome_snapshot();
 }
 
 pub(super) fn apply_session_cwd(app: &mut App, cwd_raw: String) {

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -35,7 +35,7 @@ pub(super) fn handle_connected_client_event(
         app.conn = Some(slot.conn);
     }
     apply_session_cwd(app, cwd);
-    reset_for_new_session(app, session_id, current_model, mode);
+    reset_for_new_session(app, session_id, current_model, mode, true);
     app.available_models = available_models;
     app.sync_welcome_snapshot();
     if !history_updates.is_empty() {
@@ -304,7 +304,7 @@ pub(super) fn handle_session_replaced_event(
     app.pending_auto_submit_after_cancel = false;
     apply_session_cwd(app, cwd);
     app.available_models = available_models;
-    reset_for_new_session(app, session_id, current_model, mode);
+    reset_for_new_session(app, session_id, current_model, mode, false);
     app.sync_welcome_snapshot();
     if !history_updates.is_empty() {
         load_resume_history(app, history_updates);

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -42,6 +42,8 @@ fn reset_session_identity_state(
     super::clear_compaction_state(app, false);
     app.session_usage = super::super::SessionUsageState::default();
     app.fast_mode_state = model::FastModeState::Off;
+    app.runtime_session_state = None;
+    app.prompt_suggestion = None;
     app.last_rate_limit_update = None;
     app.should_quit = false;
     app.files_accessed = 0;

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -173,6 +173,7 @@ pub(super) fn load_resume_history(app: &mut App, history_updates: &[model::Sessi
     for update in history_updates {
         match update {
             model::SessionUpdate::UserMessageChunk(chunk) => {
+                app.clear_active_turn_assistant();
                 append_resume_user_message_chunk(app, chunk);
             }
             _ => super::handle_session_update(app, update.clone()),

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -56,12 +56,8 @@ fn reset_session_identity_state(
 fn reset_messages_for_new_session(app: &mut App) {
     app.clear_messages_tracked();
     app.history_retention_stats = super::super::state::HistoryRetentionStats::default();
-    app.push_message_tracked(ChatMessage::welcome_with_recent(
-        app.model_display_name(),
-        &app.cwd,
-        &app.recent_sessions,
-    ));
-    app.update_welcome_model_once();
+    app.push_message_tracked(app.build_welcome_message());
+    app.sync_welcome_snapshot();
     app.viewport = super::super::ChatViewport::new();
 }
 
@@ -164,12 +160,8 @@ fn append_resume_user_message_chunk(app: &mut App, chunk: &model::ContentChunk) 
 pub(super) fn load_resume_history(app: &mut App, history_updates: &[model::SessionUpdate]) {
     app.clear_messages_tracked();
     app.history_retention_stats = super::super::state::HistoryRetentionStats::default();
-    app.push_message_tracked(ChatMessage::welcome_with_recent(
-        app.model_display_name(),
-        &app.cwd,
-        &app.recent_sessions,
-    ));
-    app.update_welcome_model_once();
+    app.push_message_tracked(app.build_welcome_message());
+    app.sync_welcome_snapshot();
     for update in history_updates {
         match update {
             model::SessionUpdate::UserMessageChunk(chunk) => {

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -12,11 +12,12 @@ pub(super) fn reset_for_new_session(
     session_id: model::SessionId,
     current_model: model::CurrentModel,
     mode: Option<super::super::ModeState>,
+    preserve_current_welcome_tip: bool,
 ) {
     crate::agent::events::kill_all_terminals(&app.terminals);
 
     reset_session_identity_state(app, session_id, current_model, mode);
-    reset_messages_for_new_session(app);
+    reset_messages_for_new_session(app, preserve_current_welcome_tip);
     reset_input_state_for_new_session(app);
     reset_interaction_state_for_new_session(app);
     reset_render_state_for_new_session(app);
@@ -53,10 +54,16 @@ fn reset_session_identity_state(
     app.account_info = None;
 }
 
-fn reset_messages_for_new_session(app: &mut App) {
+fn reset_messages_for_new_session(app: &mut App, preserve_current_welcome_tip: bool) {
+    let preserved_tip_seed =
+        preserve_current_welcome_tip.then(|| app.current_welcome_tip_seed()).flatten();
     app.clear_messages_tracked();
     app.history_retention_stats = super::super::state::HistoryRetentionStats::default();
-    app.push_message_tracked(app.build_welcome_message());
+    let mut welcome = app.build_welcome_message();
+    if let Some(tip_seed) = preserved_tip_seed {
+        App::apply_welcome_tip_seed(&mut welcome, tip_seed);
+    }
+    app.push_message_tracked(welcome);
     app.sync_welcome_snapshot();
     app.viewport = super::super::ChatViewport::new();
 }
@@ -158,9 +165,14 @@ fn append_resume_user_message_chunk(app: &mut App, chunk: &model::ContentChunk) 
 }
 
 pub(super) fn load_resume_history(app: &mut App, history_updates: &[model::SessionUpdate]) {
+    let preserved_tip_seed = app.current_welcome_tip_seed();
     app.clear_messages_tracked();
     app.history_retention_stats = super::super::state::HistoryRetentionStats::default();
-    app.push_message_tracked(app.build_welcome_message());
+    let mut welcome = app.build_welcome_message();
+    if let Some(tip_seed) = preserved_tip_seed {
+        App::apply_welcome_tip_seed(&mut welcome, tip_seed);
+    }
+    app.push_message_tracked(welcome);
     app.sync_welcome_snapshot();
     for update in history_updates {
         match update {

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -73,7 +73,6 @@ fn reset_input_state_for_new_session(app: &mut App) {
     app.help_open = false;
     app.pending_submit = None;
     app.pending_paste_text.clear();
-    app.pending_clipboard_paste_dedupe = None;
     app.pending_paste_session = None;
     app.active_paste_session = None;
     app.pending_images.clear();

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -10,12 +10,12 @@ use crate::agent::model;
 pub(super) fn reset_for_new_session(
     app: &mut App,
     session_id: model::SessionId,
-    model_name: String,
+    current_model: model::CurrentModel,
     mode: Option<super::super::ModeState>,
 ) {
     crate::agent::events::kill_all_terminals(&app.terminals);
 
-    reset_session_identity_state(app, session_id, model_name, mode);
+    reset_session_identity_state(app, session_id, current_model, mode);
     reset_messages_for_new_session(app);
     reset_input_state_for_new_session(app);
     reset_interaction_state_for_new_session(app);
@@ -27,16 +27,17 @@ pub(super) fn reset_for_new_session(
 fn reset_session_identity_state(
     app: &mut App,
     session_id: model::SessionId,
-    model_name: String,
+    current_model: model::CurrentModel,
     mode: Option<super::super::ModeState>,
 ) {
     app.bump_session_scope_epoch();
     app.session_id = Some(session_id);
-    app.model_name = model_name;
+    app.current_model = Some(current_model.clone());
     app.mode = mode;
     app.config_options.clear();
-    app.config_options
-        .insert("model".to_owned(), serde_json::Value::String(app.model_name.clone()));
+    if let Some(requested_id) = current_model.requested_id {
+        app.config_options.insert("model".to_owned(), serde_json::Value::String(requested_id));
+    }
     app.login_hint = None;
     super::clear_compaction_state(app, false);
     app.session_usage = super::super::SessionUsageState::default();
@@ -53,7 +54,6 @@ fn reset_session_identity_state(
 fn reset_messages_for_new_session(app: &mut App) {
     app.clear_messages_tracked();
     app.history_retention_stats = super::super::state::HistoryRetentionStats::default();
-    app.welcome_model_resolved = false;
     app.push_message_tracked(ChatMessage::welcome_with_recent(
         app.model_display_name(),
         &app.cwd,
@@ -162,7 +162,6 @@ fn append_resume_user_message_chunk(app: &mut App, chunk: &model::ContentChunk) 
 pub(super) fn load_resume_history(app: &mut App, history_updates: &[model::SessionUpdate]) {
     app.clear_messages_tracked();
     app.history_retention_stats = super::super::state::HistoryRetentionStats::default();
-    app.welcome_model_resolved = false;
     app.push_message_tracked(ChatMessage::welcome_with_recent(
         app.model_display_name(),
         &app.cwd,

--- a/src/app/events/tool_calls.rs
+++ b/src/app/events/tool_calls.rs
@@ -453,7 +453,6 @@ pub(super) fn log_command_started(app: &App, tc: &ToolCallInfo) {
             has_command = tc.terminal_command.is_some(),
             terminal_output_bytes = u64::try_from(tc.terminal_output_len).unwrap_or_default(),
             assistant_auto_backgrounded = tc.assistant_auto_backgrounded(),
-            token_saver_active = tc.token_saver_active(),
         ),
         model::ToolCallStatus::Completed => tracing::info!(
             target: crate::logging::targets::APP_COMMAND,
@@ -470,7 +469,6 @@ pub(super) fn log_command_started(app: &App, tc: &ToolCallInfo) {
             has_command = tc.terminal_command.is_some(),
             terminal_output_bytes = u64::try_from(tc.terminal_output_len).unwrap_or_default(),
             assistant_auto_backgrounded = tc.assistant_auto_backgrounded(),
-            token_saver_active = tc.token_saver_active(),
         ),
         model::ToolCallStatus::Failed | model::ToolCallStatus::Killed => tracing::warn!(
             target: crate::logging::targets::APP_COMMAND,
@@ -496,7 +494,6 @@ pub(super) fn log_command_started(app: &App, tc: &ToolCallInfo) {
             has_command = tc.terminal_command.is_some(),
             terminal_output_bytes = u64::try_from(tc.terminal_output_len).unwrap_or_default(),
             assistant_auto_backgrounded = tc.assistant_auto_backgrounded(),
-            token_saver_active = tc.token_saver_active(),
         ),
     }
 }
@@ -518,7 +515,6 @@ pub(super) fn log_terminal_spawned(app: &App, tc: &ToolCallInfo, source: &str) {
         spawn_source = source,
         has_command = tc.terminal_command.is_some(),
         assistant_auto_backgrounded = tc.assistant_auto_backgrounded(),
-        token_saver_active = tc.token_saver_active(),
     );
 }
 

--- a/src/app/events/tool_calls.rs
+++ b/src/app/events/tool_calls.rs
@@ -144,7 +144,9 @@ pub(super) fn update_subagent_scope_state(
         ) => app.mark_subagent_tool_started(id),
         (
             ToolCallScope::Subagent,
-            model::ToolCallStatus::Completed | model::ToolCallStatus::Failed,
+            model::ToolCallStatus::Completed
+            | model::ToolCallStatus::Failed
+            | model::ToolCallStatus::Killed,
         ) => app.mark_subagent_tool_finished(id, Instant::now()),
         _ => app.refresh_subagent_idle_since(Instant::now()),
     }
@@ -175,6 +177,7 @@ fn build_tool_info_from_tool_call(
         raw_input: tc.raw_input,
         raw_input_bytes: 0,
         output_metadata: tc.output_metadata,
+        task_metadata: tc.task_metadata,
         status: tc.status,
         content: tc.content,
         hidden: false,
@@ -267,6 +270,7 @@ fn update_existing_tool_call(app: &mut App, mi: usize, bi: usize, tool_info: &To
         changed |= sync_if_changed(&mut existing.sdk_tool_name, &tool_info.sdk_tool_name);
         changed |= existing.set_raw_input(tool_info.raw_input.clone());
         changed |= sync_if_changed(&mut existing.output_metadata, &tool_info.output_metadata);
+        changed |= sync_if_changed(&mut existing.task_metadata, &tool_info.task_metadata);
         if tool_info.terminal_id.is_some() {
             changed |= sync_if_changed(&mut existing.terminal_id, &tool_info.terminal_id);
         }
@@ -463,10 +467,18 @@ pub(super) fn log_command_started(app: &App, tc: &ToolCallInfo) {
             assistant_auto_backgrounded = tc.assistant_auto_backgrounded(),
             token_saver_active = tc.token_saver_active(),
         ),
-        model::ToolCallStatus::Failed => tracing::warn!(
+        model::ToolCallStatus::Failed | model::ToolCallStatus::Killed => tracing::warn!(
             target: crate::logging::targets::APP_COMMAND,
-            event_name = "command_failed",
-            message = "command execution failed",
+            event_name = if matches!(tc.status, model::ToolCallStatus::Killed) {
+                "command_killed"
+            } else {
+                "command_failed"
+            },
+            message = if matches!(tc.status, model::ToolCallStatus::Killed) {
+                "command execution killed"
+            } else {
+                "command execution failed"
+            },
             outcome = "failure",
             session_id = %current_session_id(app),
             tool_call_id = %tc.id,

--- a/src/app/events/tool_calls.rs
+++ b/src/app/events/tool_calls.rs
@@ -8,17 +8,17 @@ use super::super::{
 use super::tool_updates::raw_output_to_terminal_text;
 use crate::agent::model;
 use crate::app::todos::{parse_todos_if_present, set_todos};
-use std::time::Instant;
 
 pub(super) fn handle_tool_call(app: &mut App, tc: model::ToolCall) {
     let id_str = tc.tool_call_id.clone();
     let sdk_tool_name = resolve_sdk_tool_name(tc.kind, tc.meta.as_ref());
-    let scope = register_tool_call_scope(app, &id_str, &sdk_tool_name);
-    log_tool_call_received(app, &tc, scope, &sdk_tool_name);
+    let parent_tool_use_id = parent_tool_use_id_from_meta(tc.meta.as_ref());
+    let scope = register_tool_call_scope(app, &id_str, &sdk_tool_name, parent_tool_use_id);
+    log_tool_call_received(app, &tc, &scope, &sdk_tool_name);
     maybe_apply_todo_write_from_tool_call(app, &id_str, &sdk_tool_name, tc.raw_input.as_ref());
-    update_subagent_scope_state(app, scope, tc.status, &id_str);
+    update_subagent_scope_state(app, &scope, tc.status, &id_str);
 
-    let tool_info = build_tool_info_from_tool_call(app, tc, sdk_tool_name);
+    let tool_info = build_tool_info_from_tool_call(app, tc, sdk_tool_name, &scope);
     log_command_started(app, &tool_info);
     log_terminal_spawned(app, &tool_info, "initial");
     if should_jump_on_large_write(&tool_info) {
@@ -33,7 +33,7 @@ pub(super) fn handle_tool_call(app: &mut App, tc: model::ToolCall) {
 fn log_tool_call_received(
     app: &App,
     tc: &model::ToolCall,
-    scope: ToolCallScope,
+    scope: &ToolCallScope,
     sdk_tool_name: &str,
 ) {
     let session_id = current_session_id(app);
@@ -62,22 +62,18 @@ pub(super) fn register_tool_call_scope(
     app: &mut App,
     id: &str,
     sdk_tool_name: &str,
+    parent_tool_use_id: Option<&str>,
 ) -> ToolCallScope {
-    // TODO: When the bridge exposes an explicit Task/Agent <-> child-tool relation,
-    // redesign subagent rendering so the parent Task/Agent summary block becomes
-    // the primary visible surface and child agent tools are not rendered directly.
-    let is_task = matches!(sdk_tool_name, "Task" | "Agent");
-    let scope = if is_task {
-        ToolCallScope::Task
-    } else if app.active_task_ids.is_empty() {
-        ToolCallScope::MainAgent
+    let scope = if let Some(parent_tool_use_id) =
+        parent_tool_use_id.filter(|parent| !parent.trim().is_empty())
+    {
+        ToolCallScope::SubagentChild { parent_tool_use_id: parent_tool_use_id.to_owned() }
+    } else if matches!(sdk_tool_name, "Task" | "Agent") {
+        ToolCallScope::SubagentRoot
     } else {
-        ToolCallScope::Subagent
+        ToolCallScope::MainAgent
     };
-    app.register_tool_call_scope(id.to_owned(), scope);
-    if is_task {
-        app.insert_active_task(id.to_owned());
-    }
+    app.register_tool_call_scope(id.to_owned(), scope.clone());
     scope
 }
 
@@ -133,22 +129,22 @@ fn maybe_apply_todo_write_from_tool_call(
 
 pub(super) fn update_subagent_scope_state(
     app: &mut App,
-    scope: ToolCallScope,
+    scope: &ToolCallScope,
     status: model::ToolCallStatus,
     id: &str,
 ) {
-    match (scope, status) {
-        (
-            ToolCallScope::Subagent,
-            model::ToolCallStatus::InProgress | model::ToolCallStatus::Pending,
-        ) => app.mark_subagent_tool_started(id),
-        (
-            ToolCallScope::Subagent,
+    match scope {
+        ToolCallScope::SubagentChild { .. } | ToolCallScope::MainAgent => {}
+        ToolCallScope::SubagentRoot => match status {
+            model::ToolCallStatus::InProgress | model::ToolCallStatus::Pending => {
+                app.insert_active_task(id.to_owned());
+            }
             model::ToolCallStatus::Completed
             | model::ToolCallStatus::Failed
-            | model::ToolCallStatus::Killed,
-        ) => app.mark_subagent_tool_finished(id, Instant::now()),
-        _ => app.refresh_subagent_idle_since(Instant::now()),
+            | model::ToolCallStatus::Killed => {
+                app.remove_active_task(id);
+            }
+        },
     }
 }
 
@@ -156,6 +152,7 @@ fn build_tool_info_from_tool_call(
     app: &App,
     tc: model::ToolCall,
     sdk_tool_name: String,
+    scope: &ToolCallScope,
 ) -> ToolCallInfo {
     let terminal_id = tc.content.iter().find_map(|content| match content {
         model::ToolCallContent::Terminal(term) => Some(term.terminal_id.clone()),
@@ -180,7 +177,7 @@ fn build_tool_info_from_tool_call(
         task_metadata: tc.task_metadata,
         status: tc.status,
         content: tc.content,
-        hidden: false,
+        hidden: matches!(scope, ToolCallScope::SubagentChild { .. }),
         terminal_id,
         terminal_command,
         terminal_output: None,
@@ -268,6 +265,7 @@ fn update_existing_tool_call(app: &mut App, mi: usize, bi: usize, tool_info: &To
         changed |= sync_if_changed(&mut existing.status, &tool_info.status);
         changed |= sync_if_changed(&mut existing.content, &tool_info.content);
         changed |= sync_if_changed(&mut existing.sdk_tool_name, &tool_info.sdk_tool_name);
+        changed |= sync_if_changed(&mut existing.hidden, &tool_info.hidden);
         changed |= existing.set_raw_input(tool_info.raw_input.clone());
         changed |= sync_if_changed(&mut existing.output_metadata, &tool_info.output_metadata);
         changed |= sync_if_changed(&mut existing.task_metadata, &tool_info.task_metadata);
@@ -327,6 +325,13 @@ pub(super) fn sync_if_changed<T: PartialEq + Clone>(dst: &mut T, src: &T) -> boo
 
 pub(super) fn sdk_tool_name_from_meta(meta: Option<&serde_json::Value>) -> Option<&str> {
     meta.and_then(|m| m.get("claudeCode")).and_then(|v| v.get("toolName")).and_then(|v| v.as_str())
+}
+
+pub(super) fn parent_tool_use_id_from_meta(meta: Option<&serde_json::Value>) -> Option<&str> {
+    meta.and_then(|m| m.get("claudeCode"))
+        .and_then(|v| v.get("parentToolUseId"))
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.trim().is_empty())
 }
 
 fn fallback_sdk_tool_name(kind: model::ToolKind) -> &'static str {
@@ -527,11 +532,11 @@ pub(super) fn json_value_size(value: Option<&serde_json::Value>) -> Option<u64> 
         .and_then(|bytes| u64::try_from(bytes.len()).ok())
 }
 
-pub(super) fn tool_scope_name(scope: ToolCallScope) -> &'static str {
+pub(super) fn tool_scope_name(scope: &ToolCallScope) -> &'static str {
     match scope {
-        ToolCallScope::Task => "task",
+        ToolCallScope::SubagentRoot => "subagent_root",
         ToolCallScope::MainAgent => "main_agent",
-        ToolCallScope::Subagent => "subagent",
+        ToolCallScope::SubagentChild { .. } => "subagent_child",
     }
 }
 

--- a/src/app/events/tool_updates.rs
+++ b/src/app/events/tool_updates.rs
@@ -4,11 +4,11 @@
 use super::super::{App, AppStatus, InvalidationLevel, MessageBlock, ToolCallInfo, ToolCallScope};
 use super::tool_calls::{
     current_session_id, has_in_progress_tool_calls, json_value_size, log_terminal_spawned,
-    sdk_tool_name_from_meta, should_jump_on_large_write, tool_scope_name,
+    parent_tool_use_id_from_meta, sdk_tool_name_from_meta, should_jump_on_large_write,
+    tool_scope_name,
 };
 use crate::agent::model;
 use crate::app::todos::{parse_todos_if_present, set_todos};
-use std::time::Instant;
 
 pub(super) fn handle_tool_call_update_session(app: &mut App, tcu: &model::ToolCallUpdate) {
     let id_str = tcu.tool_call_id.clone();
@@ -24,6 +24,12 @@ pub(super) fn handle_tool_call_update_session(app: &mut App, tcu: &model::ToolCa
         );
         return;
     };
+    if let Some(parent_tool_use_id) = parent_tool_use_id_from_meta(tcu.meta.as_ref()) {
+        app.register_tool_call_scope(
+            id_str.clone(),
+            ToolCallScope::SubagentChild { parent_tool_use_id: parent_tool_use_id.to_owned() },
+        );
+    }
     let tool_scope = app.tool_call_scope(&id_str);
     let previous_status = app.messages.get(mi).and_then(|message| message.blocks.get(bi)).and_then(
         |block| match block {
@@ -38,14 +44,21 @@ pub(super) fn handle_tool_call_update_session(app: &mut App, tcu: &model::ToolCa
                 _ => None,
             },
         );
-    apply_tool_scope_status_update(app, &id_str, tool_scope, tcu.fields.status);
+    apply_tool_scope_status_update(app, &id_str, tool_scope.as_ref(), tcu.fields.status);
 
     let update_outcome = apply_tool_call_update_to_indexed_block(app, mi, bi, &id_str, tcu);
     if let Some(mi) = update_outcome.layout_dirty_idx {
         app.recompute_message_retained_bytes(mi);
         app.invalidate_layout(InvalidationLevel::MessageChanged(mi));
     }
-    log_tool_call_update_applied(app, &id_str, tcu, tool_scope, previous_status, &update_outcome);
+    log_tool_call_update_applied(
+        app,
+        &id_str,
+        tcu,
+        tool_scope.as_ref(),
+        previous_status,
+        &update_outcome,
+    );
     log_command_update_applied(app, &id_str, previous_status, previous_terminal_id.as_deref());
     if let Some(todos) = update_outcome.pending_todos {
         set_todos(app, todos);
@@ -58,35 +71,24 @@ pub(super) fn handle_tool_call_update_session(app: &mut App, tcu: &model::ToolCa
 fn apply_tool_scope_status_update(
     app: &mut App,
     id_str: &str,
-    tool_scope: Option<ToolCallScope>,
+    tool_scope: Option<&ToolCallScope>,
     status: Option<model::ToolCallStatus>,
 ) {
     let Some(status) = status else {
         return;
     };
     match tool_scope {
-        Some(ToolCallScope::Subagent) => match status {
+        Some(ToolCallScope::SubagentRoot) => match status {
             model::ToolCallStatus::Pending | model::ToolCallStatus::InProgress => {
-                app.mark_subagent_tool_started(id_str);
-            }
-            model::ToolCallStatus::Completed
-            | model::ToolCallStatus::Failed
-            | model::ToolCallStatus::Killed => {
-                app.mark_subagent_tool_finished(id_str, Instant::now());
-            }
-        },
-        Some(ToolCallScope::Task) => match status {
-            model::ToolCallStatus::Pending | model::ToolCallStatus::InProgress => {
-                app.refresh_subagent_idle_since(Instant::now());
+                app.insert_active_task(id_str.to_owned());
             }
             model::ToolCallStatus::Completed
             | model::ToolCallStatus::Failed
             | model::ToolCallStatus::Killed => {
                 app.remove_active_task(id_str);
-                app.refresh_subagent_idle_since(Instant::now());
             }
         },
-        Some(ToolCallScope::MainAgent) | None => {}
+        Some(ToolCallScope::SubagentChild { .. } | ToolCallScope::MainAgent) | None => {}
     }
 }
 
@@ -128,6 +130,7 @@ fn apply_tool_call_update_to_indexed_block(
         changed |= apply_tool_call_task_metadata_update(tc, tcu.fields.task_metadata.as_ref());
         changed |= apply_tool_call_raw_output_update(tc, tcu.fields.raw_output.as_ref());
         changed |= apply_tool_call_name_update(tc, tcu.meta.as_ref());
+        changed |= apply_tool_call_hidden_update(tc, tcu.meta.as_ref());
         out.pending_todos = extract_todo_updates_from_tool_call_update(
             id_str,
             &session_id,
@@ -301,6 +304,14 @@ fn apply_tool_call_name_update(tc: &mut ToolCallInfo, meta: Option<&serde_json::
     true
 }
 
+fn apply_tool_call_hidden_update(tc: &mut ToolCallInfo, meta: Option<&serde_json::Value>) -> bool {
+    if parent_tool_use_id_from_meta(meta).is_none() || tc.hidden {
+        return false;
+    }
+    tc.hidden = true;
+    true
+}
+
 fn detach_terminal_if_final(tc: &mut ToolCallInfo) -> bool {
     if !tc.is_execute_tool()
         || matches!(tc.status, model::ToolCallStatus::Pending | model::ToolCallStatus::InProgress)
@@ -377,7 +388,7 @@ fn log_tool_call_update_applied(
     app: &App,
     id_str: &str,
     tcu: &model::ToolCallUpdate,
-    tool_scope: Option<ToolCallScope>,
+    tool_scope: Option<&ToolCallScope>,
     previous_status: Option<model::ToolCallStatus>,
     update_outcome: &ToolCallUpdateApplyOutcome,
 ) {
@@ -967,7 +978,7 @@ mod tests {
             None,
         ));
         app.index_tool_call(tool_id.to_owned(), 0, 0);
-        app.register_tool_call_scope(tool_id.to_owned(), ToolCallScope::Task);
+        app.register_tool_call_scope(tool_id.to_owned(), ToolCallScope::SubagentRoot);
         app.insert_active_task(tool_id.to_owned());
 
         let update = model::ToolCallUpdate::new(

--- a/src/app/events/tool_updates.rs
+++ b/src/app/events/tool_updates.rs
@@ -69,7 +69,9 @@ fn apply_tool_scope_status_update(
             model::ToolCallStatus::Pending | model::ToolCallStatus::InProgress => {
                 app.mark_subagent_tool_started(id_str);
             }
-            model::ToolCallStatus::Completed | model::ToolCallStatus::Failed => {
+            model::ToolCallStatus::Completed
+            | model::ToolCallStatus::Failed
+            | model::ToolCallStatus::Killed => {
                 app.mark_subagent_tool_finished(id_str, Instant::now());
             }
         },
@@ -77,7 +79,9 @@ fn apply_tool_scope_status_update(
             model::ToolCallStatus::Pending | model::ToolCallStatus::InProgress => {
                 app.refresh_subagent_idle_since(Instant::now());
             }
-            model::ToolCallStatus::Completed | model::ToolCallStatus::Failed => {
+            model::ToolCallStatus::Completed
+            | model::ToolCallStatus::Failed
+            | model::ToolCallStatus::Killed => {
                 app.remove_active_task(id_str);
                 app.refresh_subagent_idle_since(Instant::now());
             }
@@ -121,6 +125,7 @@ fn apply_tool_call_update_to_indexed_block(
         );
         changed |= apply_tool_call_raw_input_update(tc, tcu.fields.raw_input.as_ref());
         changed |= apply_tool_call_output_metadata_update(tc, tcu.fields.output_metadata.as_ref());
+        changed |= apply_tool_call_task_metadata_update(tc, tcu.fields.task_metadata.as_ref());
         changed |= apply_tool_call_raw_output_update(tc, tcu.fields.raw_output.as_ref());
         changed |= apply_tool_call_name_update(tc, tcu.meta.as_ref());
         out.pending_todos = extract_todo_updates_from_tool_call_update(
@@ -232,6 +237,33 @@ fn apply_tool_call_output_metadata_update(
         return false;
     }
     tc.output_metadata = Some(output_metadata.clone());
+    true
+}
+
+fn apply_tool_call_task_metadata_update(
+    tc: &mut ToolCallInfo,
+    task_metadata: Option<&model::TaskMetadata>,
+) -> bool {
+    let Some(task_metadata) = task_metadata else {
+        return false;
+    };
+    let mut merged = tc.task_metadata.clone().unwrap_or_default();
+    if task_metadata.end_time.is_some() {
+        merged.end_time = task_metadata.end_time;
+    }
+    if task_metadata.total_paused_ms.is_some() {
+        merged.total_paused_ms = task_metadata.total_paused_ms;
+    }
+    if task_metadata.error.is_some() {
+        merged.error.clone_from(&task_metadata.error);
+    }
+    if task_metadata.is_backgrounded.is_some() {
+        merged.is_backgrounded = task_metadata.is_backgrounded;
+    }
+    if tc.task_metadata.as_ref() == Some(&merged) {
+        return false;
+    }
+    tc.task_metadata = Some(merged);
     true
 }
 
@@ -391,6 +423,7 @@ fn log_tool_call_update_applied(
             content_block_count,
             raw_output_chars = raw_output_chars.unwrap_or_default(),
             has_output_metadata = tc.output_metadata.is_some(),
+            has_task_metadata = tc.task_metadata.is_some(),
         ),
         ToolUpdateLogLevel::Warn => tracing::warn!(
             target: crate::logging::targets::APP_TOOL,
@@ -407,6 +440,7 @@ fn log_tool_call_update_applied(
             content_block_count,
             raw_output_chars = raw_output_chars.unwrap_or_default(),
             has_output_metadata = tc.output_metadata.is_some(),
+            has_task_metadata = tc.task_metadata.is_some(),
         ),
         ToolUpdateLogLevel::Debug => tracing::debug!(
             target: crate::logging::targets::APP_TOOL,
@@ -423,6 +457,7 @@ fn log_tool_call_update_applied(
             content_block_count,
             raw_output_chars = raw_output_chars.unwrap_or_default(),
             has_output_metadata = tc.output_metadata.is_some(),
+            has_task_metadata = tc.task_metadata.is_some(),
             title_changed = tcu.fields.title.is_some(),
             status_changed = tcu.fields.status != previous_status,
             raw_input_bytes,
@@ -470,7 +505,7 @@ fn tool_update_log_spec(
             },
             outcome: "success",
         },
-        model::ToolCallStatus::Failed => {
+        model::ToolCallStatus::Failed | model::ToolCallStatus::Killed => {
             if !entered_final_status(previous_status, tc.status) {
                 return ToolUpdateLogSpec {
                     level: ToolUpdateLogLevel::Debug,
@@ -507,8 +542,16 @@ fn tool_update_log_spec(
             }
             ToolUpdateLogSpec {
                 level: ToolUpdateLogLevel::Warn,
-                event_name: "tool_call_failed",
-                message: "tool call failed",
+                event_name: if matches!(tc.status, model::ToolCallStatus::Killed) {
+                    "tool_call_killed"
+                } else {
+                    "tool_call_failed"
+                },
+                message: if matches!(tc.status, model::ToolCallStatus::Killed) {
+                    "tool call killed"
+                } else {
+                    "tool call failed"
+                },
                 outcome: "failure",
             }
         }
@@ -525,8 +568,12 @@ fn entered_final_status(
     previous_status: Option<model::ToolCallStatus>,
     current_status: model::ToolCallStatus,
 ) -> bool {
-    matches!(current_status, model::ToolCallStatus::Completed | model::ToolCallStatus::Failed)
-        && !matches!(previous_status, Some(status) if status == current_status)
+    matches!(
+        current_status,
+        model::ToolCallStatus::Completed
+            | model::ToolCallStatus::Failed
+            | model::ToolCallStatus::Killed
+    ) && !matches!(previous_status, Some(status) if status == current_status)
 }
 
 fn log_command_update_applied(
@@ -554,11 +601,15 @@ fn log_command_update_applied(
         log_terminal_spawned(app, tc, "update");
     }
 
-    let transitioned_to_final =
-        matches!(
-            previous_status,
-            Some(model::ToolCallStatus::Pending | model::ToolCallStatus::InProgress)
-        ) && matches!(tc.status, model::ToolCallStatus::Completed | model::ToolCallStatus::Failed);
+    let transitioned_to_final = matches!(
+        previous_status,
+        Some(model::ToolCallStatus::Pending | model::ToolCallStatus::InProgress)
+    ) && matches!(
+        tc.status,
+        model::ToolCallStatus::Completed
+            | model::ToolCallStatus::Failed
+            | model::ToolCallStatus::Killed
+    );
     if !transitioned_to_final {
         return;
     }
@@ -579,10 +630,18 @@ fn log_command_update_applied(
             assistant_auto_backgrounded = tc.assistant_auto_backgrounded(),
             token_saver_active = tc.token_saver_active(),
         ),
-        model::ToolCallStatus::Failed => tracing::warn!(
+        model::ToolCallStatus::Failed | model::ToolCallStatus::Killed => tracing::warn!(
             target: crate::logging::targets::APP_COMMAND,
-            event_name = "command_failed",
-            message = "command execution failed",
+            event_name = if matches!(tc.status, model::ToolCallStatus::Killed) {
+                "command_killed"
+            } else {
+                "command_failed"
+            },
+            message = if matches!(tc.status, model::ToolCallStatus::Killed) {
+                "command execution killed"
+            } else {
+                "command execution failed"
+            },
             outcome = "failure",
             session_id = %current_session_id(app),
             tool_call_id = %tc.id,
@@ -632,6 +691,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status,
             content: Vec::new(),
             hidden: false,
@@ -655,6 +715,36 @@ mod tests {
 
     fn terminal_content(terminal_id: &str) -> Vec<model::ToolCallContent> {
         vec![model::ToolCallContent::Terminal(model::TerminalToolCallContent::new(terminal_id))]
+    }
+
+    fn make_task_tool_call(id: &str, status: model::ToolCallStatus) -> ToolCallInfo {
+        ToolCallInfo {
+            id: id.to_owned(),
+            title: format!("task {id}"),
+            sdk_tool_name: "Agent".to_owned(),
+            raw_input: None,
+            raw_input_bytes: 0,
+            output_metadata: None,
+            task_metadata: None,
+            status,
+            content: Vec::new(),
+            hidden: false,
+            terminal_id: None,
+            terminal_command: None,
+            terminal_output: None,
+            terminal_output_len: 0,
+            terminal_bytes_seen: 0,
+            terminal_snapshot_mode: TerminalSnapshotMode::AppendOnly,
+            render_epoch: 0,
+            layout_epoch: 0,
+            last_measured_width: 0,
+            last_measured_height: 0,
+            last_measured_layout_epoch: 0,
+            last_measured_layout_generation: 0,
+            cache: BlockCache::default(),
+            pending_permission: None,
+            pending_question: None,
+        }
     }
 
     #[test]
@@ -777,5 +867,120 @@ mod tests {
         assert!(matches!(spec.level, ToolUpdateLogLevel::Info));
         assert_eq!(spec.event_name, "tool_call_completed");
         assert_eq!(spec.outcome, "success");
+    }
+
+    #[test]
+    fn task_metadata_update_is_applied_to_tool_call() {
+        let mut app = App::test_default();
+        let tool_id = "task-1";
+        app.messages.push(ChatMessage::new(
+            MessageRole::Assistant,
+            vec![MessageBlock::ToolCall(Box::new(make_task_tool_call(
+                tool_id,
+                model::ToolCallStatus::InProgress,
+            )))],
+            None,
+        ));
+        app.index_tool_call(tool_id.to_owned(), 0, 0);
+
+        let update = model::ToolCallUpdate::new(
+            tool_id,
+            model::ToolCallUpdateFields::new().task_metadata(
+                model::TaskMetadata::new()
+                    .error(Some("Task paused".to_owned()))
+                    .backgrounded(Some(true)),
+            ),
+        );
+
+        handle_tool_call_update_session(&mut app, &update);
+
+        let MessageBlock::ToolCall(tc) = &app.messages[0].blocks[0] else {
+            panic!("expected tool call block");
+        };
+        assert_eq!(
+            tc.task_metadata,
+            Some(
+                model::TaskMetadata::new()
+                    .error(Some("Task paused".to_owned()))
+                    .backgrounded(Some(true)),
+            )
+        );
+    }
+
+    #[test]
+    fn task_metadata_update_merges_partial_patches() {
+        let mut app = App::test_default();
+        let tool_id = "task-1";
+        app.messages.push(ChatMessage::new(
+            MessageRole::Assistant,
+            vec![MessageBlock::ToolCall(Box::new(make_task_tool_call(
+                tool_id,
+                model::ToolCallStatus::InProgress,
+            )))],
+            None,
+        ));
+        app.index_tool_call(tool_id.to_owned(), 0, 0);
+
+        let backgrounded_update = model::ToolCallUpdate::new(
+            tool_id,
+            model::ToolCallUpdateFields::new()
+                .task_metadata(model::TaskMetadata::new().backgrounded(Some(true))),
+        );
+        handle_tool_call_update_session(&mut app, &backgrounded_update);
+
+        let timing_update = model::ToolCallUpdate::new(
+            tool_id,
+            model::ToolCallUpdateFields::new().task_metadata(
+                model::TaskMetadata::new()
+                    .error(Some("Task stopped by parent agent".to_owned()))
+                    .end_time(Some(1234))
+                    .total_paused_ms(Some(250)),
+            ),
+        );
+        handle_tool_call_update_session(&mut app, &timing_update);
+
+        let MessageBlock::ToolCall(tc) = &app.messages[0].blocks[0] else {
+            panic!("expected tool call block");
+        };
+        assert_eq!(
+            tc.task_metadata,
+            Some(
+                model::TaskMetadata::new()
+                    .error(Some("Task stopped by parent agent".to_owned()))
+                    .end_time(Some(1234))
+                    .total_paused_ms(Some(250))
+                    .backgrounded(Some(true)),
+            )
+        );
+    }
+
+    #[test]
+    fn killed_task_update_clears_active_task_scope() {
+        let mut app = App::test_default();
+        let tool_id = "task-1";
+        app.messages.push(ChatMessage::new(
+            MessageRole::Assistant,
+            vec![MessageBlock::ToolCall(Box::new(make_task_tool_call(
+                tool_id,
+                model::ToolCallStatus::InProgress,
+            )))],
+            None,
+        ));
+        app.index_tool_call(tool_id.to_owned(), 0, 0);
+        app.register_tool_call_scope(tool_id.to_owned(), ToolCallScope::Task);
+        app.insert_active_task(tool_id.to_owned());
+
+        let update = model::ToolCallUpdate::new(
+            tool_id,
+            model::ToolCallUpdateFields::new().status(model::ToolCallStatus::Killed),
+        );
+
+        handle_tool_call_update_session(&mut app, &update);
+
+        let MessageBlock::ToolCall(tc) = &app.messages[0].blocks[0] else {
+            panic!("expected tool call block");
+        };
+        assert_eq!(tc.status, model::ToolCallStatus::Killed);
+        assert!(!app.active_task_ids.contains(tool_id));
     }
 }

--- a/src/app/events/tool_updates.rs
+++ b/src/app/events/tool_updates.rs
@@ -639,7 +639,6 @@ fn log_command_update_applied(
             terminal_output_bytes = u64::try_from(tc.terminal_output_len).unwrap_or_default(),
             has_terminal = tc.terminal_id.is_some(),
             assistant_auto_backgrounded = tc.assistant_auto_backgrounded(),
-            token_saver_active = tc.token_saver_active(),
         ),
         model::ToolCallStatus::Failed | model::ToolCallStatus::Killed => tracing::warn!(
             target: crate::logging::targets::APP_COMMAND,
@@ -662,7 +661,6 @@ fn log_command_update_applied(
             terminal_output_bytes = u64::try_from(tc.terminal_output_len).unwrap_or_default(),
             has_terminal = tc.terminal_id.is_some(),
             assistant_auto_backgrounded = tc.assistant_auto_backgrounded(),
-            token_saver_active = tc.token_saver_active(),
         ),
         model::ToolCallStatus::Pending | model::ToolCallStatus::InProgress => {}
     }

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -296,6 +296,7 @@ pub(super) fn handle_turn_complete_event(
         model::ToolCallStatus::Completed
     };
     finish_ready_turn_exit(app, exit, tool_status);
+    crate::app::session_runtime::request_context_usage_refresh(app);
     if turn_was_active {
         app.notifications.notify(
             app.config.preferred_notification_channel_effective(),
@@ -327,6 +328,7 @@ pub(super) fn handle_turn_error_event(
         );
         app.pending_submit = None;
         finish_ready_turn_exit(app, exit, model::ToolCallStatus::Failed);
+        crate::app::session_runtime::request_context_usage_refresh(app);
         if app.active_view == super::super::ActiveView::Chat {
             super::super::input_submit::maybe_auto_submit_after_cancel(app);
         }
@@ -398,6 +400,7 @@ pub(super) fn handle_turn_error_event(
     }
     app.clear_active_turn_assistant();
     super::notices::clear_turn_notice_tracking(app);
+    crate::app::session_runtime::request_context_usage_refresh(app);
 }
 
 fn push_interrupted_hint(app: &mut App) {

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -275,9 +275,21 @@ fn finish_ready_turn_exit(app: &mut App, exit: TurnExitState, tool_status: model
     super::notices::clear_turn_notice_tracking(app);
 }
 
-pub(super) fn handle_turn_complete_event(app: &mut App) {
+pub(super) fn handle_turn_complete_event(
+    app: &mut App,
+    terminal_reason: Option<crate::agent::types::TerminalReason>,
+) {
     let exit = begin_turn_exit(app, true);
     let turn_was_active = exit.turn_was_active;
+    if let Some(reason) = terminal_reason {
+        tracing::debug!(
+            target: crate::logging::targets::APP_SESSION,
+            event_name = "turn_complete_terminal_reason",
+            message = "turn completed with SDK terminal reason",
+            outcome = "success",
+            terminal_reason = reason.as_stored(),
+        );
+    }
     let tool_status = if exit.cancelled_requested.is_some() {
         model::ToolCallStatus::Failed
     } else {
@@ -299,6 +311,7 @@ pub(super) fn handle_turn_error_event(
     app: &mut App,
     msg: &str,
     classified: Option<TurnErrorClass>,
+    terminal_reason: Option<crate::agent::types::TerminalReason>,
 ) {
     let exit = begin_turn_exit(app, true);
 
@@ -310,6 +323,7 @@ pub(super) fn handle_turn_error_event(
             message = "turn error suppressed after cancellation request",
             outcome = "cancelled",
             error_preview = %summary,
+            terminal_reason = terminal_reason.map_or("", crate::agent::types::TerminalReason::as_stored),
         );
         app.pending_submit = None;
         finish_ready_turn_exit(app, exit, model::ToolCallStatus::Failed);
@@ -328,6 +342,7 @@ pub(super) fn handle_turn_error_event(
         outcome = "failure",
         error_class = ?error_class,
         error_preview = %summary,
+        terminal_reason = terminal_reason.map_or("", crate::agent::types::TerminalReason::as_stored),
     );
     match error_class {
         TurnErrorClass::PlanLimit => {
@@ -494,7 +509,7 @@ mod tests {
         app.messages.push(user_message("hello"));
         app.messages.push(empty_assistant_message());
 
-        handle_turn_complete_event(&mut app);
+        handle_turn_complete_event(&mut app, None);
 
         assert_eq!(app.messages.len(), 1);
         assert!(matches!(app.messages[0].role, MessageRole::User));
@@ -508,7 +523,7 @@ mod tests {
         app.messages.push(user_message("hello"));
         app.messages.push(empty_assistant_message());
 
-        handle_turn_error_event(&mut app, "cancelled", None);
+        handle_turn_error_event(&mut app, "cancelled", None, None);
 
         assert_eq!(app.messages.len(), 2);
         assert!(matches!(app.messages[0].role, MessageRole::User));
@@ -522,7 +537,7 @@ mod tests {
         app.messages.push(user_message("hello"));
         app.messages.push(empty_assistant_message());
 
-        handle_turn_error_event(&mut app, "boom", None);
+        handle_turn_error_event(&mut app, "boom", None, None);
 
         assert_eq!(app.messages.len(), 2);
         assert!(matches!(app.messages[0].role, MessageRole::User));

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -74,6 +74,7 @@ pub(super) fn handle_permission_request_event(
         let is_first = app.pending_interaction_ids.is_empty();
         tc.pending_permission = Some(InlinePermission {
             options: request.options,
+            display: request.display,
             response_tx,
             selected_index: 0,
             focused: is_first,

--- a/src/app/input_submit.rs
+++ b/src/app/input_submit.rs
@@ -175,7 +175,8 @@ fn dispatch_prompt_turn(app: &mut App, text: String) {
             );
         }
         Err(e) => {
-            let _ = tx.send(ClientEvent::TurnError(e.to_string()));
+            let _ =
+                tx.send(ClientEvent::TurnError { message: e.to_string(), terminal_reason: None });
         }
     }
 }

--- a/src/app/input_submit.rs
+++ b/src/app/input_submit.rs
@@ -164,6 +164,7 @@ fn dispatch_prompt_turn(app: &mut App, text: String) {
     // so the model can correlate user references with image attachments.
     match conn.prompt_with_images(sid.to_string(), text, images) {
         Ok(resp) => {
+            crate::app::session_runtime::request_context_usage_refresh(app);
             tracing::info!(
                 target: crate::logging::targets::APP_INPUT,
                 event_name = "prompt_dispatched",

--- a/src/app/input_submit.rs
+++ b/src/app/input_submit.rs
@@ -21,6 +21,7 @@ pub(super) fn submit_input(app: &mut App) {
     if text.trim().is_empty() {
         return;
     }
+    app.prompt_suggestion = None;
 
     // `/cancel` is an explicit control action: execute immediately.
     if slash::is_cancel_command(&text) {

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -348,6 +348,9 @@ fn handle_normal_key_actions(app: &mut App, key: KeyEvent) -> bool {
     if handle_focus_toggle_key(app, key) {
         return true;
     }
+    if handle_prompt_suggestion_key(app, key) {
+        return true;
+    }
     if handle_mode_cycle_key(app, key) {
         return true;
     }
@@ -510,6 +513,26 @@ fn handle_focus_toggle_key(app: &mut App, key: KeyEvent) -> bool {
         }
         _ => false,
     }
+}
+
+fn handle_prompt_suggestion_key(app: &mut App, key: KeyEvent) -> bool {
+    if !matches!(key.code, KeyCode::Tab)
+        || !key.modifiers.is_empty()
+        || app.focus_owner() != FocusOwner::Input
+        || !app.input.is_empty()
+    {
+        return false;
+    }
+
+    let Some(suggestion) = app.prompt_suggestion.take() else {
+        return false;
+    };
+    if suggestion.trim().is_empty() {
+        return false;
+    }
+    app.input.set_text(&suggestion);
+    app.sync_help_open_with_input();
+    true
 }
 
 fn handle_mode_cycle_key(app: &mut App, key: KeyEvent) -> bool {

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -13,7 +13,7 @@ use crate::app::inline_interactions::handle_inline_interaction_key;
 use crate::app::selection::{clear_selection, selection_text_from_rendered_lines};
 use crate::app::state::AutocompleteKind;
 use crate::app::{mention, slash, subagent};
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 #[cfg(test)]
 use std::cell::Cell;
 use std::rc::Rc;
@@ -588,6 +588,9 @@ fn handle_clipboard_paste_key(app: &mut App, key: KeyEvent) -> bool {
     if !is_clipboard_paste_shortcut(key) || app.focus_owner() == FocusOwner::TodoList {
         return false;
     }
+    if key.kind != KeyEventKind::Release {
+        return false;
+    }
 
     // Skip system clipboard access in tests to avoid flaky failures / segfaults.
     #[cfg(test)]
@@ -639,19 +642,7 @@ fn handle_clipboard_paste_key(app: &mut App, key: KeyEvent) -> bool {
             }
         }
 
-        // Fallback: paste text (for terminals without Event::Paste).
-        let Ok(text) = clipboard.get_text() else {
-            return false;
-        };
-        if text.is_empty() {
-            return false;
-        }
-        if app.pending_paste_text == text {
-            return true;
-        }
-        app.pending_clipboard_paste_dedupe = Some(text.clone());
-        app.queue_paste_text(&text);
-        true
+        false
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -338,7 +338,6 @@ async fn wait_for_shutdown_signal() -> std::io::Result<()> {
 
 /// Finalize queued `Event::Paste` chunks for this drain cycle.
 fn finalize_pending_paste_event(app: &mut App) {
-    app.pending_clipboard_paste_dedupe = None;
     let pasted = std::mem::take(&mut app.pending_paste_text);
     if pasted.is_empty() {
         return;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -24,6 +24,7 @@ mod questions;
 mod selection;
 mod service_status_check;
 pub(crate) mod session_picker;
+mod session_runtime;
 pub(crate) mod slash;
 mod state;
 pub(crate) mod subagent;

--- a/src/app/permissions.rs
+++ b/src/app/permissions.rs
@@ -413,8 +413,13 @@ mod tests {
         if let Some(MessageBlock::ToolCall(tc)) =
             app.messages.get_mut(msg_idx).and_then(|m| m.blocks.get_mut(0))
         {
-            tc.pending_permission =
-                Some(InlinePermission { options, response_tx: tx, selected_index: 0, focused });
+            tc.pending_permission = Some(InlinePermission {
+                options,
+                display: None,
+                response_tx: tx,
+                selected_index: 0,
+                focused,
+            });
         }
         app.pending_interaction_ids.push(tool_id.to_owned());
         rx

--- a/src/app/permissions.rs
+++ b/src/app/permissions.rs
@@ -357,6 +357,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status: model::ToolCallStatus::InProgress,
             content: Vec::new(),
             hidden: false,

--- a/src/app/plugins/mod.rs
+++ b/src/app/plugins/mod.rs
@@ -123,6 +123,8 @@ pub struct PluginsState {
     pub last_error: Option<String>,
     pub last_inventory_refresh_at: Option<Instant>,
     pub claude_path: Option<PathBuf>,
+    pub runtime_reload_after_refresh: bool,
+    pub pending_runtime_reload_success_message: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -255,6 +257,14 @@ pub(crate) fn handle_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyCode::Char(ch), modifiers)
+            if matches!(ch, 'r' | 'R')
+                && (modifiers.is_empty() || modifiers == KeyModifiers::SHIFT)
+                && !app.plugins.search_focused =>
+        {
+            request_inventory_refresh_manual(app);
+            true
+        }
+        (KeyCode::Char(ch), modifiers)
             if modifiers.is_empty() || modifiers == KeyModifiers::SHIFT =>
         {
             if search_enabled(app.plugins.active_tab)
@@ -282,6 +292,11 @@ pub(crate) fn request_inventory_refresh_if_needed(app: &mut App) {
         clamp_selection(app);
         return;
     }
+    request_inventory_refresh(app);
+}
+
+pub(crate) fn request_inventory_refresh_manual(app: &mut App) {
+    app.plugins.runtime_reload_after_refresh = true;
     request_inventory_refresh(app);
 }
 
@@ -323,6 +338,7 @@ pub(crate) fn apply_inventory_refresh_success(
     snapshot: PluginsInventorySnapshot,
     claude_path: PathBuf,
 ) {
+    let should_reload_runtime = std::mem::take(&mut app.plugins.runtime_reload_after_refresh);
     app.plugins.installed = snapshot.installed;
     app.plugins.marketplace = snapshot.marketplace;
     app.plugins.marketplaces = snapshot.marketplaces;
@@ -330,12 +346,20 @@ pub(crate) fn apply_inventory_refresh_success(
     app.plugins.last_error = None;
     app.plugins.last_inventory_refresh_at = Some(Instant::now());
     app.plugins.claude_path = Some(claude_path);
-    app.plugins.status_message = Some("Plugin inventory refreshed".to_owned());
     clamp_selection(app);
+    if should_reload_runtime {
+        start_runtime_reload(app, "Plugin inventory refreshed".to_owned());
+    } else {
+        app.plugins.status_message = Some("Plugin inventory refreshed".to_owned());
+        app.config.last_error = None;
+        app.config.status_message = Some("Plugin inventory refreshed".to_owned());
+    }
 }
 
 pub(crate) fn apply_inventory_refresh_failure(app: &mut App, message: String) {
     app.plugins.loading = false;
+    app.plugins.runtime_reload_after_refresh = false;
+    app.plugins.pending_runtime_reload_success_message = None;
     app.plugins.status_message = None;
     app.plugins.last_error = Some(message);
 }
@@ -349,6 +373,8 @@ pub(crate) fn reset_for_session_change(app: &mut App) {
     app.plugins.marketplace.clear();
     app.plugins.marketplaces.clear();
     app.plugins.claude_path = None;
+    app.plugins.runtime_reload_after_refresh = false;
+    app.plugins.pending_runtime_reload_success_message = None;
     clamp_selection(app);
 }
 
@@ -833,15 +859,58 @@ fn confirm_add_marketplace_overlay(app: &mut App) {
 }
 
 pub(crate) fn apply_cli_action_success(app: &mut App, result: PluginsCliActionSuccess) {
-    apply_inventory_refresh_success(app, result.snapshot, result.claude_path);
-    app.config.last_error = None;
-    app.config.status_message = Some(result.message);
+    app.plugins.installed = result.snapshot.installed;
+    app.plugins.marketplace = result.snapshot.marketplace;
+    app.plugins.marketplaces = result.snapshot.marketplaces;
+    app.plugins.last_error = None;
+    app.plugins.last_inventory_refresh_at = Some(Instant::now());
+    app.plugins.claude_path = Some(result.claude_path);
+    clamp_selection(app);
+    start_runtime_reload(app, result.message);
 }
 
 pub(crate) fn apply_cli_action_failure(app: &mut App, message: String) {
     app.plugins.loading = false;
+    app.plugins.pending_runtime_reload_success_message = None;
     app.config.status_message = None;
     app.config.last_error = Some(message);
+}
+
+pub(crate) fn apply_runtime_reload_success(app: &mut App) {
+    app.plugins.loading = false;
+    app.plugins.last_error = None;
+    if let Some(message) = app.plugins.pending_runtime_reload_success_message.take() {
+        app.plugins.status_message = Some(message.clone());
+        app.config.last_error = None;
+        app.config.status_message = Some(message);
+    }
+}
+
+pub(crate) fn apply_runtime_reload_failure(app: &mut App, message: &str) {
+    app.plugins.loading = false;
+    app.plugins.status_message = None;
+    app.plugins.last_error = Some(message.to_owned());
+    app.plugins.pending_runtime_reload_success_message = None;
+    app.config.status_message = None;
+    app.config.last_error = Some(format!("Failed to reload session plugins: {message}"));
+}
+
+fn start_runtime_reload(app: &mut App, success_message: String) {
+    app.plugins.loading = true;
+    app.plugins.status_message = Some("Reloading session plugins...".to_owned());
+    app.plugins.last_error = None;
+    app.plugins.pending_runtime_reload_success_message = Some(success_message);
+    app.config.last_error = None;
+    app.config.status_message = Some("Reloading session plugins...".to_owned());
+    match crate::app::session_runtime::request_runtime_reload(app) {
+        crate::app::session_runtime::RuntimeReloadRequestOutcome::Requested => {}
+        crate::app::session_runtime::RuntimeReloadRequestOutcome::Unavailable => {
+            apply_runtime_reload_success(app);
+        }
+        crate::app::session_runtime::RuntimeReloadRequestOutcome::Failed => {
+            apply_runtime_reload_failure(app, "failed to request session runtime plugin reload");
+        }
+    }
 }
 
 fn installed_action_command(
@@ -1227,6 +1296,36 @@ pub(crate) const fn search_enabled(tab: PluginsViewTab) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::model;
+    use crate::agent::wire::BridgeCommand;
+
+    fn app_with_connection()
+    -> (crate::app::App, tokio::sync::mpsc::UnboundedReceiver<crate::agent::wire::CommandEnvelope>)
+    {
+        let mut app = crate::app::App::test_default();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+        app.session_id = Some(model::SessionId::new("session-1"));
+        (app, rx)
+    }
+
+    fn sample_snapshot() -> PluginsInventorySnapshot {
+        PluginsInventorySnapshot {
+            installed: vec![InstalledPluginEntry {
+                id: "frontend-design@claude-plugins-official".to_owned(),
+                version: Some("1.0.0".to_owned()),
+                scope: "user".to_owned(),
+                enabled: true,
+                installed_at: None,
+                last_updated: None,
+                project_path: None,
+                capability: PluginCapability::Skill,
+            }],
+            marketplace: vec![],
+            marketplaces: vec![],
+        }
+    }
+
     #[test]
     fn plugins_tabs_wrap_in_both_directions() {
         assert_eq!(PluginsViewTab::Installed.prev(), PluginsViewTab::Marketplace);
@@ -1379,5 +1478,103 @@ mod tests {
                 "other-local@claude-plugins-official",
             ]
         );
+    }
+
+    #[test]
+    fn inventory_refresh_success_triggers_runtime_reload_when_requested() {
+        let (mut app, mut rx) = app_with_connection();
+        app.plugins.runtime_reload_after_refresh = true;
+
+        apply_inventory_refresh_success(
+            &mut app,
+            sample_snapshot(),
+            std::path::PathBuf::from("C:\\tools\\claude.exe"),
+        );
+
+        let envelope = rx.try_recv().expect("reload command");
+        assert!(matches!(
+            envelope.command,
+            BridgeCommand::ReloadPlugins { session_id } if session_id == "session-1"
+        ));
+        assert!(!app.plugins.runtime_reload_after_refresh);
+        assert_eq!(app.config.status_message.as_deref(), Some("Reloading session plugins..."));
+        assert_eq!(
+            app.plugins.pending_runtime_reload_success_message.as_deref(),
+            Some("Plugin inventory refreshed")
+        );
+    }
+
+    #[test]
+    fn cli_action_success_triggers_runtime_reload() {
+        let (mut app, mut rx) = app_with_connection();
+
+        apply_cli_action_success(
+            &mut app,
+            PluginsCliActionSuccess {
+                snapshot: sample_snapshot(),
+                message: "Updated plugin".to_owned(),
+                claude_path: std::path::PathBuf::from("C:\\tools\\claude.exe"),
+            },
+        );
+
+        let envelope = rx.try_recv().expect("reload command");
+        assert!(matches!(
+            envelope.command,
+            BridgeCommand::ReloadPlugins { session_id } if session_id == "session-1"
+        ));
+        assert_eq!(
+            app.plugins.pending_runtime_reload_success_message.as_deref(),
+            Some("Updated plugin")
+        );
+    }
+
+    #[test]
+    fn runtime_reload_success_applies_pending_success_message() {
+        let mut app = App::test_default();
+        app.plugins.loading = true;
+        app.plugins.pending_runtime_reload_success_message = Some("Updated plugin".to_owned());
+
+        apply_runtime_reload_success(&mut app);
+
+        assert!(!app.plugins.loading);
+        assert_eq!(app.config.status_message.as_deref(), Some("Updated plugin"));
+        assert!(app.config.last_error.is_none());
+        assert!(app.plugins.pending_runtime_reload_success_message.is_none());
+    }
+
+    #[test]
+    fn runtime_reload_failure_surfaces_visible_error() {
+        let mut app = App::test_default();
+        app.plugins.loading = true;
+        app.plugins.pending_runtime_reload_success_message = Some("Updated plugin".to_owned());
+
+        apply_runtime_reload_failure(&mut app, "boom");
+
+        assert!(!app.plugins.loading);
+        assert_eq!(
+            app.config.last_error.as_deref(),
+            Some("Failed to reload session plugins: boom")
+        );
+        assert!(app.config.status_message.is_none());
+        assert!(app.plugins.pending_runtime_reload_success_message.is_none());
+    }
+
+    #[test]
+    fn cli_action_success_without_active_session_keeps_success_message() {
+        let mut app = App::test_default();
+
+        apply_cli_action_success(
+            &mut app,
+            PluginsCliActionSuccess {
+                snapshot: sample_snapshot(),
+                message: "Updated plugin".to_owned(),
+                claude_path: std::path::PathBuf::from("C:\\tools\\claude.exe"),
+            },
+        );
+
+        assert!(!app.plugins.loading);
+        assert_eq!(app.config.status_message.as_deref(), Some("Updated plugin"));
+        assert!(app.config.last_error.is_none());
+        assert!(app.plugins.pending_runtime_reload_success_message.is_none());
     }
 }

--- a/src/app/questions.rs
+++ b/src/app/questions.rs
@@ -467,6 +467,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status: model::ToolCallStatus::InProgress,
             content: Vec::new(),
             hidden: false,

--- a/src/app/session_runtime.rs
+++ b/src/app/session_runtime.rs
@@ -1,0 +1,176 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::app::App;
+
+pub(crate) enum RuntimeReloadRequestOutcome {
+    Requested,
+    Unavailable,
+    Failed,
+}
+
+pub(crate) fn request_runtime_reload(app: &mut App) -> RuntimeReloadRequestOutcome {
+    let Some(conn) = app.conn.as_ref() else {
+        return RuntimeReloadRequestOutcome::Unavailable;
+    };
+    let Some(ref sid) = app.session_id else {
+        return RuntimeReloadRequestOutcome::Unavailable;
+    };
+    let session_id = sid.to_string();
+    match conn.reload_plugins(session_id.clone()) {
+        Ok(()) => {
+            tracing::debug!(
+                target: crate::logging::targets::APP_SESSION,
+                event_name = "runtime_reload_requested",
+                message = "session runtime plugin reload requested",
+                outcome = "start",
+                session_id = %session_id,
+            );
+            RuntimeReloadRequestOutcome::Requested
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: crate::logging::targets::APP_SESSION,
+                event_name = "runtime_reload_request_failed",
+                message = "failed to request session runtime plugin reload",
+                outcome = "failure",
+                session_id = %session_id,
+                error_message = %error,
+            );
+            RuntimeReloadRequestOutcome::Failed
+        }
+    }
+}
+
+pub(crate) fn request_context_usage_refresh(app: &mut App) {
+    if app.session_usage.context_usage_in_flight {
+        app.session_usage.context_usage_refresh_pending = true;
+        return;
+    }
+
+    let Some(conn) = app.conn.as_ref() else {
+        clear_context_usage_refresh_state(app);
+        return;
+    };
+    let Some(ref sid) = app.session_id else {
+        clear_context_usage_refresh_state(app);
+        return;
+    };
+
+    let session_id = sid.to_string();
+    app.session_usage.context_usage_in_flight = true;
+    app.session_usage.context_usage_refresh_pending = false;
+    match conn.get_context_usage(session_id.clone()) {
+        Ok(()) => tracing::debug!(
+            target: crate::logging::targets::APP_SESSION,
+            event_name = "context_usage_requested",
+            message = "session context usage requested",
+            outcome = "start",
+            session_id = %session_id,
+        ),
+        Err(error) => {
+            app.session_usage.context_usage_in_flight = false;
+            tracing::warn!(
+                target: crate::logging::targets::APP_SESSION,
+                event_name = "context_usage_request_failed",
+                message = "failed to request session context usage",
+                outcome = "failure",
+                session_id = %session_id,
+                error_message = %error,
+            );
+        }
+    }
+}
+
+pub(crate) fn apply_context_usage_snapshot(app: &mut App, percentage: Option<u8>) {
+    app.session_usage.context_usage_percent = percentage;
+    app.session_usage.context_usage_in_flight = false;
+    let refresh_pending = std::mem::take(&mut app.session_usage.context_usage_refresh_pending);
+    if refresh_pending {
+        request_context_usage_refresh(app);
+    }
+}
+
+fn clear_context_usage_refresh_state(app: &mut App) {
+    app.session_usage.context_usage_in_flight = false;
+    app.session_usage.context_usage_refresh_pending = false;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RuntimeReloadRequestOutcome, apply_context_usage_snapshot, request_context_usage_refresh,
+        request_runtime_reload,
+    };
+    use crate::agent::model;
+    use crate::agent::wire::BridgeCommand;
+    use crate::app::App;
+
+    fn app_with_connection()
+    -> (App, tokio::sync::mpsc::UnboundedReceiver<crate::agent::wire::CommandEnvelope>) {
+        let mut app = App::test_default();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+        app.session_id = Some(model::SessionId::new("session-1"));
+        (app, rx)
+    }
+
+    #[test]
+    fn request_runtime_reload_sends_bridge_command() {
+        let (mut app, mut rx) = app_with_connection();
+
+        assert!(matches!(request_runtime_reload(&mut app), RuntimeReloadRequestOutcome::Requested));
+
+        let envelope = rx.try_recv().expect("reload command");
+        assert!(matches!(
+            envelope.command,
+            BridgeCommand::ReloadPlugins { session_id } if session_id == "session-1"
+        ));
+    }
+
+    #[test]
+    fn request_runtime_reload_reports_unavailable_without_session_connection() {
+        let mut app = App::test_default();
+
+        assert!(matches!(
+            request_runtime_reload(&mut app),
+            RuntimeReloadRequestOutcome::Unavailable
+        ));
+    }
+
+    #[test]
+    fn request_context_usage_refresh_coalesces_in_flight_requests() {
+        let (mut app, mut rx) = app_with_connection();
+
+        request_context_usage_refresh(&mut app);
+        request_context_usage_refresh(&mut app);
+
+        assert!(app.session_usage.context_usage_in_flight);
+        assert!(app.session_usage.context_usage_refresh_pending);
+        let envelope = rx.try_recv().expect("context usage command");
+        assert!(matches!(
+            envelope.command,
+            BridgeCommand::GetContextUsage { session_id } if session_id == "session-1"
+        ));
+        assert!(rx.try_recv().is_err(), "coalesced refresh should not send twice");
+    }
+
+    #[test]
+    fn apply_context_usage_snapshot_replays_pending_refresh() {
+        let (mut app, mut rx) = app_with_connection();
+        request_context_usage_refresh(&mut app);
+        request_context_usage_refresh(&mut app);
+        let _ = rx.try_recv().expect("initial context usage command");
+
+        apply_context_usage_snapshot(&mut app, Some(62));
+
+        assert_eq!(app.session_usage.context_usage_percent, Some(62));
+        assert!(app.session_usage.context_usage_in_flight);
+        assert!(!app.session_usage.context_usage_refresh_pending);
+        let envelope = rx.try_recv().expect("replayed context usage command");
+        assert!(matches!(
+            envelope.command,
+            BridgeCommand::GetContextUsage { session_id } if session_id == "session-1"
+        ));
+    }
+}

--- a/src/app/session_runtime.rs
+++ b/src/app/session_runtime.rs
@@ -82,6 +82,34 @@ pub(crate) fn request_context_usage_refresh(app: &mut App) {
     }
 }
 
+pub(crate) fn request_status_snapshot_refresh(app: &mut App) {
+    let Some(conn) = app.conn.as_ref() else {
+        return;
+    };
+    let Some(ref sid) = app.session_id else {
+        return;
+    };
+
+    let session_id = sid.to_string();
+    match conn.get_status_snapshot(session_id.clone()) {
+        Ok(()) => tracing::debug!(
+            target: crate::logging::targets::APP_AUTH,
+            event_name = "status_snapshot_requested",
+            message = "session status snapshot requested",
+            outcome = "start",
+            session_id = %session_id,
+        ),
+        Err(error) => tracing::warn!(
+            target: crate::logging::targets::APP_AUTH,
+            event_name = "status_snapshot_request_failed",
+            message = "failed to request session status snapshot",
+            outcome = "failure",
+            session_id = %session_id,
+            error_message = %error,
+        ),
+    }
+}
+
 pub(crate) fn apply_context_usage_snapshot(app: &mut App, percentage: Option<u8>) {
     app.session_usage.context_usage_percent = percentage;
     app.session_usage.context_usage_in_flight = false;
@@ -100,7 +128,7 @@ fn clear_context_usage_refresh_state(app: &mut App) {
 mod tests {
     use super::{
         RuntimeReloadRequestOutcome, apply_context_usage_snapshot, request_context_usage_refresh,
-        request_runtime_reload,
+        request_runtime_reload, request_status_snapshot_refresh,
     };
     use crate::agent::model;
     use crate::agent::wire::BridgeCommand;
@@ -171,6 +199,19 @@ mod tests {
         assert!(matches!(
             envelope.command,
             BridgeCommand::GetContextUsage { session_id } if session_id == "session-1"
+        ));
+    }
+
+    #[test]
+    fn request_status_snapshot_refresh_sends_bridge_command() {
+        let (mut app, mut rx) = app_with_connection();
+
+        request_status_snapshot_refresh(&mut app);
+
+        let envelope = rx.try_recv().expect("status snapshot command");
+        assert!(matches!(
+            envelope.command,
+            BridgeCommand::GetStatusSnapshot { session_id } if session_id == "session-1"
         ));
     }
 }

--- a/src/app/slash/executors.rs
+++ b/src/app/slash/executors.rs
@@ -394,11 +394,7 @@ fn handle_mode_submit(app: &mut App, args: &[&str]) -> bool {
         return true;
     }
 
-    set_command_pending(
-        app,
-        "Switching mode...",
-        Some(crate::app::PendingCommandAck::CurrentModeUpdate),
-    );
+    set_command_pending(app, "Switching mode...", Some(crate::app::PendingCommandAck::CurrentMode));
 
     let tx = app.event_tx.clone();
     let requested_mode_owned = requested_mode.to_owned();
@@ -443,7 +439,7 @@ fn handle_model_submit(app: &mut App, args: &[&str]) -> bool {
     set_command_pending(
         app,
         "Switching model...",
-        Some(crate::app::PendingCommandAck::ConfigOptionUpdate { option_id: "model".to_owned() }),
+        Some(crate::app::PendingCommandAck::CurrentModel),
     );
 
     let tx = app.event_tx.clone();

--- a/src/app/slash/mod.rs
+++ b/src/app/slash/mod.rs
@@ -667,14 +667,17 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn model_sets_command_pending_and_config_ack_updates_model_and_restores_ready() {
+    async fn model_sets_command_pending_and_current_model_ack_updates_model_and_restores_ready() {
         tokio::task::LocalSet::new()
             .run_until(async {
                 let mut app = App::test_default();
                 let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
                 app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
                 app.session_id = Some("sess-1".into());
-                app.model_name = "old-model".to_owned();
+                app.current_model = Some(
+                    crate::agent::model::CurrentModel::new("old-model", "old-model", "old-model")
+                        .authoritative(true),
+                );
 
                 let consumed = try_handle_submit(&mut app, "/model sonnet");
                 assert!(consumed);
@@ -684,25 +687,33 @@ mod tests {
                     app.status
                 );
                 assert_eq!(app.pending_command_label.as_deref(), Some("Switching model..."));
-                assert_eq!(app.model_name, "old-model");
+                assert_eq!(
+                    app.current_model.as_ref().map(|model| model.resolved_id.as_str()),
+                    Some("old-model")
+                );
 
                 super::super::events::handle_client_event(
                     &mut app,
                     crate::agent::events::ClientEvent::SessionUpdate(
-                        crate::agent::model::SessionUpdate::ConfigOptionUpdate(
-                            crate::agent::model::ConfigOptionUpdate {
-                                option_id: "model".to_owned(),
-                                value: serde_json::Value::String("sonnet".to_owned()),
-                            },
+                        crate::agent::model::SessionUpdate::CurrentModelUpdate(
+                            crate::agent::model::CurrentModelUpdate::new(
+                                crate::agent::model::CurrentModel::new(
+                                    "sonnet", "sonnet", "sonnet",
+                                )
+                                .authoritative(true),
+                            ),
                         ),
                     ),
                 );
                 assert!(
                     matches!(app.status, AppStatus::Ready),
-                    "expected Ready after model config ack, got {:?}",
+                    "expected Ready after current model ack, got {:?}",
                     app.status
                 );
-                assert_eq!(app.model_name, "sonnet");
+                assert_eq!(
+                    app.current_model.as_ref().map(|model| model.resolved_id.as_str()),
+                    Some("sonnet")
+                );
                 assert!(app.pending_command_label.is_none());
             })
             .await;

--- a/src/app/state/history_retention.rs
+++ b/src/app/state/history_retention.rs
@@ -13,7 +13,7 @@ use super::messages::{
     WelcomeBlock,
 };
 use super::tool_call_info::{InlinePermission, InlineQuestion, ToolCallInfo};
-use super::types::{HistoryRetentionStats, MessageUsage, RecentSessionInfo};
+use super::types::{HistoryRetentionStats, MessageUsage};
 
 const HISTORY_HIDDEN_MARKER_PREFIX: &str = "Older messages hidden to keep memory bounded";
 
@@ -226,27 +226,10 @@ impl super::App {
                 MessageBlock::Welcome(welcome) => {
                     total = total
                         .saturating_add(size_of::<WelcomeBlock>())
-                        .saturating_add(welcome.model_name.capacity())
+                        .saturating_add(welcome.version.capacity())
+                        .saturating_add(welcome.subscription.capacity())
                         .saturating_add(welcome.cwd.capacity())
-                        .saturating_add(
-                            welcome
-                                .recent_sessions
-                                .capacity()
-                                .saturating_mul(size_of::<RecentSessionInfo>()),
-                        );
-                    for session in &welcome.recent_sessions {
-                        total = total
-                            .saturating_add(session.session_id.capacity())
-                            .saturating_add(session.summary.capacity())
-                            .saturating_add(session.cwd.as_ref().map_or(0, String::capacity))
-                            .saturating_add(session.git_branch.as_ref().map_or(0, String::capacity))
-                            .saturating_add(
-                                session.custom_title.as_ref().map_or(0, String::capacity),
-                            )
-                            .saturating_add(
-                                session.first_prompt.as_ref().map_or(0, String::capacity),
-                            );
-                    }
+                        .saturating_add(welcome.session_id.capacity());
                 }
                 MessageBlock::ImageAttachment(_) => {
                     total =

--- a/src/app/state/history_retention.rs
+++ b/src/app/state/history_retention.rs
@@ -216,6 +216,7 @@ impl super::App {
                             NoticeDedupKey::RateLimit(incident) => {
                                 incident.rate_limit_type.as_ref().map_or(0, String::capacity)
                             }
+                            NoticeDedupKey::ApiRetry => 0,
                         });
                     }
                 }

--- a/src/app/state/history_retention.rs
+++ b/src/app/state/history_retention.rs
@@ -373,12 +373,10 @@ impl super::App {
         self.tool_call_index.clear();
         self.clear_terminal_tool_call_tracking();
         self.active_task_ids.clear();
-        self.active_subagent_tool_ids.clear();
 
         let mut pending_interaction_ids = Vec::new();
         let mut terminal_tool_call_membership = HashSet::new();
         let mut terminal_tool_calls = Vec::new();
-        let previous_idle_since = self.subagent_idle_since;
         for (msg_idx, msg) in self.messages.iter_mut().enumerate() {
             for (block_idx, block) in msg.blocks.iter_mut().enumerate() {
                 if let MessageBlock::ToolCall(tc) = block {
@@ -416,23 +414,18 @@ impl super::App {
                 ) {
                     continue;
                 }
-                match self.tool_call_scopes.get(&tc.id).copied() {
-                    Some(super::ToolCallScope::Task) => {
+                match self.tool_call_scopes.get(&tc.id) {
+                    Some(super::ToolCallScope::SubagentRoot) => {
                         self.active_task_ids.insert(tc.id.clone());
                     }
-                    Some(super::ToolCallScope::Subagent) => {
-                        self.active_subagent_tool_ids.insert(tc.id.clone());
-                    }
-                    Some(super::ToolCallScope::MainAgent) | None => {}
+                    Some(
+                        super::ToolCallScope::SubagentChild { .. }
+                        | super::ToolCallScope::MainAgent,
+                    )
+                    | None => {}
                 }
             }
         }
-        self.subagent_idle_since =
-            if self.active_task_ids.is_empty() || !self.active_subagent_tool_ids.is_empty() {
-                None
-            } else {
-                previous_idle_since
-            };
 
         let interaction_set: HashSet<&str> =
             pending_interaction_ids.iter().map(String::as_str).collect();

--- a/src/app/state/messages.rs
+++ b/src/app/state/messages.rs
@@ -10,6 +10,7 @@ use std::cell::Cell;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::ops::Range;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub struct ChatMessage {
     pub role: MessageRole,
@@ -33,6 +34,7 @@ impl ChatMessage {
                 subscription: subscription.to_owned(),
                 cwd: cwd.to_owned(),
                 session_id: session_id.to_owned(),
+                tip_seed: random_welcome_tip_seed(),
                 cache: BlockCache::default(),
             })],
             None,
@@ -206,6 +208,13 @@ pub fn hash_welcome_block_content(block: &WelcomeBlock) -> u64 {
     block.subscription.hash(&mut hasher);
     block.cwd.hash(&mut hasher);
     block.session_id.hash(&mut hasher);
+    block.tip_seed.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn random_welcome_tip_seed() -> u64 {
+    let mut hasher = DefaultHasher::new();
+    SystemTime::now().duration_since(UNIX_EPOCH).ok().hash(&mut hasher);
     hasher.finish()
 }
 
@@ -539,5 +548,6 @@ pub struct WelcomeBlock {
     pub subscription: String,
     pub cwd: String,
     pub session_id: String,
+    pub tip_seed: u64,
     pub cache: BlockCache,
 }

--- a/src/app/state/messages.rs
+++ b/src/app/state/messages.rs
@@ -67,7 +67,6 @@ pub struct MessageRenderSignature {
     pub role: MessageRole,
     pub show_empty_thinking: bool,
     pub show_thinking: bool,
-    pub show_subagent_thinking: bool,
     pub show_compacting: bool,
     pub assistant_frame: Option<usize>,
     pub blocks: Vec<MessageBlockRenderSignature>,

--- a/src/app/state/messages.rs
+++ b/src/app/state/messages.rs
@@ -475,6 +475,7 @@ pub struct RateLimitIncidentKey {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum NoticeDedupKey {
     RateLimit(RateLimitIncidentKey),
+    ApiRetry,
 }
 
 pub struct NoticeBlock {

--- a/src/app/state/messages.rs
+++ b/src/app/state/messages.rs
@@ -3,7 +3,7 @@
 
 use super::block_cache::BlockCache;
 use super::tool_call_info::ToolCallInfo;
-use super::types::{MessageUsage, RecentSessionInfo};
+use super::types::MessageUsage;
 use ratatui::style::Color;
 use ratatui::text::Line;
 use std::cell::Cell;
@@ -25,22 +25,14 @@ impl ChatMessage {
     }
 
     #[must_use]
-    pub fn welcome(model_name: &str, cwd: &str) -> Self {
-        Self::welcome_with_recent(model_name, cwd, &[])
-    }
-
-    #[must_use]
-    pub fn welcome_with_recent(
-        model_name: &str,
-        cwd: &str,
-        recent_sessions: &[RecentSessionInfo],
-    ) -> Self {
+    pub fn welcome(version: &str, subscription: &str, cwd: &str, session_id: &str) -> Self {
         Self::new(
             MessageRole::Welcome,
             vec![MessageBlock::Welcome(WelcomeBlock {
-                model_name: model_name.to_owned(),
+                version: version.to_owned(),
+                subscription: subscription.to_owned(),
                 cwd: cwd.to_owned(),
-                recent_sessions: recent_sessions.to_vec(),
+                session_id: session_id.to_owned(),
                 cache: BlockCache::default(),
             })],
             None,
@@ -210,18 +202,10 @@ pub fn hash_text_block_content(text: &str, trailing_spacing: TextBlockSpacing) -
 #[must_use]
 pub fn hash_welcome_block_content(block: &WelcomeBlock) -> u64 {
     let mut hasher = DefaultHasher::new();
-    block.model_name.hash(&mut hasher);
+    block.version.hash(&mut hasher);
+    block.subscription.hash(&mut hasher);
     block.cwd.hash(&mut hasher);
-    for recent in &block.recent_sessions {
-        recent.session_id.hash(&mut hasher);
-        recent.summary.hash(&mut hasher);
-        recent.last_modified_ms.hash(&mut hasher);
-        recent.file_size_bytes.hash(&mut hasher);
-        recent.cwd.hash(&mut hasher);
-        recent.git_branch.hash(&mut hasher);
-        recent.custom_title.hash(&mut hasher);
-        recent.first_prompt.hash(&mut hasher);
-    }
+    block.session_id.hash(&mut hasher);
     hasher.finish()
 }
 
@@ -551,8 +535,9 @@ pub enum SystemSeverity {
 }
 
 pub struct WelcomeBlock {
-    pub model_name: String,
+    pub version: String,
+    pub subscription: String,
     pub cwd: String,
-    pub recent_sessions: Vec<RecentSessionInfo>,
+    pub session_id: String,
     pub cache: BlockCache,
 }

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -295,6 +295,10 @@ pub struct App {
     pub mcp: McpState,
     /// Fast mode state telemetry from the SDK.
     pub fast_mode_state: model::FastModeState,
+    /// Latest SDK runtime liveness state.
+    pub runtime_session_state: Option<model::RuntimeSessionState>,
+    /// Latest prompt suggestion from the SDK, shown in the input hint band.
+    pub prompt_suggestion: Option<String>,
     /// Latest rate-limit telemetry from the SDK.
     pub last_rate_limit_update: Option<model::RateLimitUpdate>,
     /// Turn-local inline/system notices that may upgrade in place during the active turn.
@@ -908,6 +912,8 @@ impl App {
             usage: UsageState::default(),
             mcp: McpState::default(),
             fast_mode_state: model::FastModeState::Off,
+            runtime_session_state: None,
+            prompt_suggestion: None,
             last_rate_limit_update: None,
             turn_notice_refs: Vec::new(),
             is_compacting: false,

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -264,9 +264,6 @@ pub struct App {
     /// Some terminals split one clipboard paste into multiple chunks; we merge
     /// them and apply placeholder threshold to the merged content once per cycle.
     pub pending_paste_text: String,
-    /// Pending duplicate-suppression marker for terminals that emit both a
-    /// clipboard shortcut key event and `Event::Paste` for the same text paste.
-    pub pending_clipboard_paste_dedupe: Option<String>,
     /// Pending paste session metadata for the currently queued `Event::Paste` payload.
     pub pending_paste_session: Option<PasteSessionState>,
     /// Most recent active placeholder paste session, used for safe chunk continuation.
@@ -888,7 +885,6 @@ impl App {
             pending_submit: None,
             paste_burst: super::paste_burst::PasteBurstDetector::new(),
             pending_paste_text: String::new(),
-            pending_clipboard_paste_dedupe: None,
             pending_paste_session: None,
             active_paste_session: None,
             next_paste_session_id: 1,

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -442,33 +442,53 @@ impl App {
         if self.messages.first().is_some_and(|m| matches!(m.role, MessageRole::Welcome)) {
             return;
         }
-        self.insert_message_tracked(
-            0,
-            ChatMessage::welcome_with_recent(
-                self.model_display_name(),
-                &self.cwd,
-                &self.recent_sessions,
-            ),
-        );
+        self.insert_message_tracked(0, self.build_welcome_message());
     }
 
     #[must_use]
-    pub fn model_display_name(&self) -> &str {
-        match self.current_model.as_ref() {
-            Some(current_model)
-                if current_model.is_authoritative
-                    || current_model.display_name_long.trim() != "Default" =>
-            {
-                &current_model.display_name_long
-            }
-            _ if self.session_id.is_none() => "Connecting...",
-            _ => "default",
-        }
+    fn welcome_subscription_display(&self) -> &str {
+        self.account_info
+            .as_ref()
+            .and_then(|account| account.subscription_type.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("-")
     }
 
-    /// Update the welcome message's model label from the current session model state.
-    pub fn update_welcome_model_once(&mut self) {
-        let welcome_model = self.model_display_name().to_owned();
+    #[must_use]
+    fn welcome_cwd_display(&self) -> &str {
+        let cwd = self.cwd.trim();
+        if cwd.is_empty() { "-" } else { cwd }
+    }
+
+    #[must_use]
+    fn welcome_session_id_display(&self) -> String {
+        self.session_id
+            .as_ref()
+            .map(std::string::ToString::to_string)
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "-".to_owned())
+    }
+
+    #[must_use]
+    pub(crate) fn build_welcome_message(&self) -> ChatMessage {
+        let subscription = self.welcome_subscription_display();
+        let session_id = self.welcome_session_id_display();
+        ChatMessage::welcome(
+            env!("CARGO_PKG_VERSION"),
+            subscription,
+            self.welcome_cwd_display(),
+            &session_id,
+        )
+    }
+
+    /// Update the welcome message with the latest session/account snapshot.
+    pub fn sync_welcome_snapshot(&mut self) {
+        let version = env!("CARGO_PKG_VERSION");
+        let subscription = self.welcome_subscription_display().to_owned();
+        let cwd = self.welcome_cwd_display().to_owned();
+        let session_id = self.welcome_session_id_display();
         let Some(first) = self.messages.first_mut() else {
             return;
         };
@@ -478,31 +498,20 @@ impl App {
         let Some(MessageBlock::Welcome(welcome)) = first.blocks.first_mut() else {
             return;
         };
-        if welcome.model_name != welcome_model {
-            welcome.model_name = welcome_model;
+        if welcome.version != version
+            || welcome.subscription != subscription
+            || welcome.cwd != cwd
+            || welcome.session_id != session_id
+        {
+            version.clone_into(&mut welcome.version);
+            welcome.subscription = subscription;
+            welcome.cwd = cwd;
+            welcome.session_id = session_id;
             welcome.cache.invalidate();
             self.sync_render_cache_slot(0, 0);
             self.recompute_message_retained_bytes(0);
             self.invalidate_layout(InvalidationLevel::MessagesFrom(0));
         }
-    }
-
-    /// Update the welcome message with latest discovered recent sessions.
-    pub fn sync_welcome_recent_sessions(&mut self) {
-        let Some(first) = self.messages.first_mut() else {
-            return;
-        };
-        if !matches!(first.role, MessageRole::Welcome) {
-            return;
-        }
-        let Some(MessageBlock::Welcome(welcome)) = first.blocks.first_mut() else {
-            return;
-        };
-        welcome.recent_sessions.clone_from(&self.recent_sessions);
-        welcome.cache.invalidate();
-        self.sync_render_cache_slot(0, 0);
-        self.recompute_message_retained_bytes(0);
-        self.invalidate_layout(InvalidationLevel::MessagesFrom(0));
     }
 
     /// Track a Task/Agent tool call as active (in-progress subagent).
@@ -1042,7 +1051,6 @@ impl App {
 
     pub fn reconcile_runtime_from_persisted_settings_change(&mut self) {
         self.reconcile_trust_state_from_preferences_and_cwd();
-        self.update_welcome_model_once();
     }
 
     pub(crate) fn shift_active_turn_assistant_for_insert(&mut self, idx: usize) {
@@ -1862,7 +1870,7 @@ mod tests {
     fn enforce_history_retention_noop_under_budget() {
         let mut app = make_test_app();
         app.messages = vec![
-            ChatMessage::welcome("model", "/cwd"),
+            ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
             user_text_message("small message"),
             user_text_message("another message"),
         ];
@@ -1878,7 +1886,7 @@ mod tests {
     fn enforce_history_retention_drops_oldest_and_adds_marker() {
         let mut app = make_test_app();
         app.messages = vec![
-            ChatMessage::welcome("model", "/cwd"),
+            ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
             user_text_message("first old message"),
             user_text_message("second old message"),
             user_text_message("third old message"),
@@ -1896,7 +1904,7 @@ mod tests {
     fn enforce_history_retention_preserves_in_progress_tool_message() {
         let mut app = make_test_app();
         app.messages = vec![
-            ChatMessage::welcome("model", "/cwd"),
+            ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
             user_text_message("droppable"),
             assistant_tool_message("tool-keep", model::ToolCallStatus::InProgress),
         ];
@@ -1919,7 +1927,7 @@ mod tests {
     fn enforce_history_retention_preserves_pending_tool_message() {
         let mut app = make_test_app();
         app.messages = vec![
-            ChatMessage::welcome("model", "/cwd"),
+            ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
             user_text_message("droppable"),
             assistant_tool_message("tool-pending", model::ToolCallStatus::Pending),
         ];
@@ -1938,7 +1946,7 @@ mod tests {
     fn enforce_history_retention_preserves_permission_tool_message() {
         let mut app = make_test_app();
         app.messages = vec![
-            ChatMessage::welcome("model", "/cwd"),
+            ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
             user_text_message("droppable"),
             assistant_tool_message_with_pending_permission("tool-perm"),
         ];
@@ -1957,7 +1965,7 @@ mod tests {
     fn enforce_history_retention_rebuilds_tool_index_after_prune() {
         let mut app = make_test_app();
         app.messages = vec![
-            ChatMessage::welcome("model", "/cwd"),
+            ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
             user_text_message("drop this"),
             assistant_bash_tool_message("tool-idx", model::ToolCallStatus::InProgress, "term-1"),
         ];
@@ -1979,7 +1987,7 @@ mod tests {
         let mut app = make_test_app();
         app.status = AppStatus::Thinking;
         app.messages = vec![
-            ChatMessage::welcome("model", "/cwd"),
+            ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
             user_text_message("drop this"),
             ChatMessage::new(MessageRole::Assistant, Vec::new(), None),
         ];
@@ -2019,7 +2027,10 @@ mod tests {
     #[test]
     fn enforce_history_retention_keeps_single_marker_on_repeat() {
         let mut app = make_test_app();
-        app.messages = vec![ChatMessage::welcome("model", "/cwd"), user_text_message("drop me")];
+        app.messages = vec![
+            ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
+            user_text_message("drop me"),
+        ];
         app.history_retention.max_bytes = 1;
 
         let first = app.enforce_history_retention();
@@ -2037,7 +2048,7 @@ mod tests {
     fn enforce_history_retention_preserves_manual_scroll_anchor_across_drop_and_marker_insert() {
         let mut app = make_test_app();
         app.messages = vec![
-            ChatMessage::welcome("model", "/cwd"),
+            ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
             user_text_message("drop me first"),
             user_text_message("keep this anchored"),
             user_text_message("tail"),

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -1581,6 +1581,7 @@ mod tests {
                         "Allow once",
                         model::PermissionOptionKind::AllowOnce,
                     )],
+                    display: None,
                     response_tx: tx,
                     selected_index: 0,
                     focused: false,

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -149,9 +149,7 @@ pub struct App {
     pub conn: Option<Rc<crate::agent::client::AgentConnection>>,
     /// Monotonic session authority epoch used to ignore stale async view data.
     pub session_scope_epoch: u64,
-    pub model_name: String,
-    /// True once the welcome banner has captured its one-time session model label.
-    pub welcome_model_resolved: bool,
+    pub current_model: Option<model::CurrentModel>,
     pub cwd: String,
     pub cwd_raw: String,
     pub files_accessed: usize,
@@ -447,54 +445,30 @@ impl App {
         self.insert_message_tracked(
             0,
             ChatMessage::welcome_with_recent(
-                self.welcome_model_display_name(),
+                self.model_display_name(),
                 &self.cwd,
                 &self.recent_sessions,
             ),
         );
-        self.welcome_model_resolved = self.model_name_is_authoritative();
-    }
-
-    fn model_name_is_authoritative(&self) -> bool {
-        let model_name = self.model_name.trim();
-        if model_name.is_empty() || model_name == "Connecting..." {
-            return false;
-        }
-        if model_name != "default" {
-            return true;
-        }
-        matches!(
-            crate::app::config::store::model(&self.config.committed_settings_document),
-            Ok(Some(configured_model)) if configured_model.trim() == "default"
-        )
     }
 
     #[must_use]
     pub fn model_display_name(&self) -> &str {
-        let model_name = self.model_name.trim();
-        if self.session_id.is_none()
-            && (model_name.is_empty() || model_name == "Connecting..." || model_name == "default")
-        {
-            "Connecting..."
-        } else if model_name.is_empty() || model_name == "Connecting..." {
-            "default"
-        } else {
-            &self.model_name
+        match self.current_model.as_ref() {
+            Some(current_model)
+                if current_model.is_authoritative
+                    || current_model.display_name_long.trim() != "Default" =>
+            {
+                &current_model.display_name_long
+            }
+            _ if self.session_id.is_none() => "Connecting...",
+            _ => "default",
         }
     }
 
-    #[must_use]
-    fn welcome_model_display_name(&self) -> &str {
-        self.model_display_name()
-    }
-
-    /// Update the welcome message's model name once, when the session model becomes authoritative.
+    /// Update the welcome message's model label from the current session model state.
     pub fn update_welcome_model_once(&mut self) {
-        if self.welcome_model_resolved {
-            return;
-        }
-        let welcome_model = self.welcome_model_display_name().to_owned();
-        let model_is_authoritative = self.model_name_is_authoritative();
+        let welcome_model = self.model_display_name().to_owned();
         let Some(first) = self.messages.first_mut() else {
             return;
         };
@@ -510,9 +484,6 @@ impl App {
             self.sync_render_cache_slot(0, 0);
             self.recompute_message_retained_bytes(0);
             self.invalidate_layout(InvalidationLevel::MessagesFrom(0));
-        }
-        if model_is_authoritative {
-            self.welcome_model_resolved = true;
         }
     }
 
@@ -866,8 +837,10 @@ impl App {
             session_id: None,
             conn: None,
             session_scope_epoch: 0,
-            model_name: "test-model".into(),
-            welcome_model_resolved: true,
+            current_model: Some(
+                model::CurrentModel::new("test-model", "test-model", "test-model")
+                    .authoritative(true),
+            ),
             cwd: "/test".into(),
             cwd_raw: "/test".into(),
             files_accessed: 0,
@@ -1073,10 +1046,10 @@ impl App {
 
     pub fn clear_session_runtime_identity(&mut self) {
         self.session_id = None;
-        "Connecting...".clone_into(&mut self.model_name);
+        self.current_model = None;
         self.mode = None;
         self.fast_mode_state = model::FastModeState::Off;
-        self.welcome_model_resolved = false;
+        self.session_usage = SessionUsageState::default();
     }
 
     pub fn reconcile_trust_state_from_preferences_and_cwd(&mut self) {
@@ -1099,7 +1072,6 @@ impl App {
     }
 
     pub fn reconcile_runtime_from_persisted_settings_change(&mut self) {
-        self.welcome_model_resolved = false;
         self.reconcile_trust_state_from_preferences_and_cwd();
         self.update_welcome_model_once();
     }
@@ -1394,6 +1366,32 @@ mod tests {
     }
 
     #[test]
+    fn clear_session_runtime_identity_resets_session_usage() {
+        let mut app = App::test_default();
+        app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+        app.current_model = Some(
+            crate::agent::model::CurrentModel::new("sonnet", "Claude Sonnet", "Claude Sonnet")
+                .authoritative(true),
+        );
+        app.mode = Some(crate::app::ModeState {
+            current_mode_id: "plan".to_owned(),
+            current_mode_name: "Plan".to_owned(),
+            available_modes: Vec::new(),
+        });
+        app.session_usage.context_usage_percent = Some(62);
+        app.session_usage.context_usage_in_flight = true;
+        app.session_usage.context_usage_refresh_pending = true;
+        app.session_usage.last_compaction_pre_tokens = Some(123_456);
+
+        app.clear_session_runtime_identity();
+
+        assert!(app.session_id.is_none());
+        assert!(app.current_model.is_none());
+        assert!(app.mode.is_none());
+        assert_eq!(app.session_usage, SessionUsageState::default());
+    }
+
+    #[test]
     fn cache_store_without_height_has_no_height() {
         let mut cache = BlockCache::default();
         cache.store(vec![Line::from("hello")]);
@@ -1518,6 +1516,7 @@ mod tests {
                 raw_input: None,
                 raw_input_bytes: 0,
                 output_metadata: None,
+                task_metadata: None,
                 status,
                 content: Vec::new(),
                 hidden: false,
@@ -1555,6 +1554,7 @@ mod tests {
                 raw_input: None,
                 raw_input_bytes: 0,
                 output_metadata: None,
+                task_metadata: None,
                 status,
                 content: Vec::new(),
                 hidden: false,
@@ -1589,6 +1589,7 @@ mod tests {
                 raw_input: None,
                 raw_input_bytes: 0,
                 output_metadata: None,
+                task_metadata: None,
                 status: model::ToolCallStatus::Completed,
                 content: Vec::new(),
                 hidden: false,

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -26,10 +26,9 @@ pub use tool_call_info::{
 pub use types::{
     AppStatus, CancelOrigin, ExtraUsage, HelpView, HistoryRetentionPolicy, HistoryRetentionStats,
     LoginHint, McpState, MessageUsage, ModeInfo, ModeState, PasteSessionState, PendingCommandAck,
-    RecentSessionInfo, RenderCacheBudget, SUBAGENT_THINKING_DEBOUNCE, ScrollbarDragState,
-    SelectionKind, SelectionPoint, SelectionState, SessionPickerState, SessionUsageState, TodoItem,
-    TodoStatus, ToolCallScope, UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState,
-    UsageWindow,
+    RecentSessionInfo, RenderCacheBudget, ScrollbarDragState, SelectionKind, SelectionPoint,
+    SelectionState, SessionPickerState, SessionUsageState, TodoItem, TodoStatus, ToolCallScope,
+    UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow,
 };
 pub use viewport::{
     ChatViewport, LayoutInvalidation, LayoutInvalidation as InvalidationLevel,
@@ -193,15 +192,12 @@ pub struct App {
     /// Session-level preference for collapsing non-Execute tool call bodies.
     /// Toggled by Ctrl+O and applied at render/layout time.
     pub tools_collapsed: bool,
-    /// IDs of Task/Agent tool calls currently `InProgress` -- their children get hidden.
+    /// IDs of root Task/Agent tool calls currently `InProgress`.
     /// Use `insert_active_task()`, `remove_active_task()`.
     pub active_task_ids: HashSet<String>,
-    /// Tool scope keyed by tool call ID; used to distinguish main-agent from subagent tools.
+    /// Tool scope keyed by tool call ID; used to distinguish main-agent, subagent roots,
+    /// and explicitly owned subagent child tools.
     pub tool_call_scopes: HashMap<String, ToolCallScope>,
-    /// IDs of non Task/Agent subagent tool calls currently `InProgress`/`Pending`.
-    pub active_subagent_tool_ids: HashSet<String>,
-    /// Timestamp when subagent entered an idle gap (no active child tool calls).
-    pub subagent_idle_since: Option<Instant>,
     /// Shared terminal process map - used to snapshot output on completion.
     pub terminals: crate::agent::events::TerminalMap,
     /// Force a full terminal clear on next render frame.
@@ -525,7 +521,7 @@ impl App {
 
     #[must_use]
     pub fn tool_call_scope(&self, id: &str) -> Option<ToolCallScope> {
-        self.tool_call_scopes.get(id).copied()
+        self.tool_call_scopes.get(id).cloned()
     }
 
     #[must_use]
@@ -539,40 +535,9 @@ impl App {
         .flatten()
     }
 
-    pub fn mark_subagent_tool_started(&mut self, id: &str) {
-        self.active_subagent_tool_ids.insert(id.to_owned());
-        self.subagent_idle_since = None;
-    }
-
-    pub fn mark_subagent_tool_finished(&mut self, id: &str, now: Instant) {
-        self.active_subagent_tool_ids.remove(id);
-        self.refresh_subagent_idle_since(now);
-    }
-
-    pub fn refresh_subagent_idle_since(&mut self, now: Instant) {
-        if self.active_task_ids.is_empty() || !self.active_subagent_tool_ids.is_empty() {
-            self.subagent_idle_since = None;
-            return;
-        }
-        if self.subagent_idle_since.is_none() {
-            self.subagent_idle_since = Some(now);
-        }
-    }
-
-    #[must_use]
-    pub fn should_show_subagent_thinking(&self, now: Instant) -> bool {
-        if self.active_task_ids.is_empty() || !self.active_subagent_tool_ids.is_empty() {
-            return false;
-        }
-        self.subagent_idle_since
-            .is_some_and(|since| now.saturating_duration_since(since) >= SUBAGENT_THINKING_DEBOUNCE)
-    }
-
     pub fn clear_tool_scope_tracking(&mut self) {
         self.tool_call_scopes.clear();
         self.active_task_ids.clear();
-        self.active_subagent_tool_ids.clear();
-        self.subagent_idle_since = None;
     }
 
     /// Look up the (`message_index`, `block_index`) for a tool call ID.
@@ -870,8 +835,6 @@ impl App {
             tools_collapsed: false,
             active_task_ids: HashSet::default(),
             tool_call_scopes: HashMap::default(),
-            active_subagent_tool_ids: HashSet::default(),
-            subagent_idle_since: None,
             terminals: std::rc::Rc::default(),
             force_redraw: false,
             tool_call_index: HashMap::default(),
@@ -1872,7 +1835,6 @@ mod tests {
             is_active_turn_assistant: false,
             show_empty_thinking: false,
             show_thinking: false,
-            show_subagent_thinking: false,
             show_compacting: false,
         };
 
@@ -2236,8 +2198,6 @@ mod tests {
         assert!(!app.active_task_ids.is_empty());
         app.clear_tool_scope_tracking();
         assert!(app.active_task_ids.is_empty(), "active_task_ids must be cleared at turn end");
-        assert!(app.active_subagent_tool_ids.is_empty());
-        assert!(app.subagent_idle_since.is_none());
     }
 
     #[test]
@@ -2324,7 +2284,10 @@ mod tests {
         let mut app = make_test_app();
         app.messages.push(assistant_tool_message("tool-1", model::ToolCallStatus::Completed));
         app.index_tool_call("tool-1".to_owned(), 0, 0);
-        app.register_tool_call_scope("tool-1".to_owned(), ToolCallScope::Subagent);
+        app.register_tool_call_scope(
+            "tool-1".to_owned(),
+            ToolCallScope::SubagentChild { parent_tool_use_id: "task-1".to_owned() },
+        );
 
         let removed = app.remove_message_tracked(0);
 

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -483,6 +483,22 @@ impl App {
         )
     }
 
+    #[must_use]
+    pub(crate) fn current_welcome_tip_seed(&self) -> Option<u64> {
+        let first = self.messages.first()?;
+        let MessageBlock::Welcome(welcome) = first.blocks.first()? else {
+            return None;
+        };
+        Some(welcome.tip_seed)
+    }
+
+    pub(crate) fn apply_welcome_tip_seed(message: &mut ChatMessage, tip_seed: u64) {
+        let Some(MessageBlock::Welcome(welcome)) = message.blocks.first_mut() else {
+            return;
+        };
+        welcome.tip_seed = tip_seed;
+    }
+
     /// Update the welcome message with the latest session/account snapshot.
     pub fn sync_welcome_snapshot(&mut self) {
         let version = env!("CARGO_PKG_VERSION");

--- a/src/app/state/tool_call_info.rs
+++ b/src/app/state/tool_call_info.rs
@@ -118,6 +118,25 @@ impl ToolCallInfo {
         self.task_metadata.as_ref().and_then(|metadata| metadata.is_backgrounded).unwrap_or(false)
     }
 
+    #[must_use]
+    pub fn hidden_unless_focused_interaction(&self) -> bool {
+        self.hidden
+            && !self.pending_permission.as_ref().is_some_and(|permission| permission.focused)
+            && !self.pending_question.as_ref().is_some_and(|question| question.focused)
+    }
+
+    #[must_use]
+    pub fn is_hidden_focused_interaction(&self) -> bool {
+        self.hidden
+            && (self.pending_permission.as_ref().is_some_and(|permission| permission.focused)
+                || self.pending_question.as_ref().is_some_and(|question| question.focused))
+    }
+
+    #[must_use]
+    pub fn is_subagent_root_tool(&self) -> bool {
+        !self.hidden && matches!(self.sdk_tool_name.as_str(), "Task" | "Agent")
+    }
+
     /// Mark render cache for this tool call as stale.
     pub fn mark_tool_call_render_dirty(&mut self) {
         crate::perf::mark("tc_invalidations_requested");

--- a/src/app/state/tool_call_info.rs
+++ b/src/app/state/tool_call_info.rs
@@ -13,6 +13,7 @@ pub struct ToolCallInfo {
     pub raw_input: Option<serde_json::Value>,
     pub raw_input_bytes: usize,
     pub output_metadata: Option<model::ToolOutputMetadata>,
+    pub task_metadata: Option<model::TaskMetadata>,
     pub status: model::ToolCallStatus,
     pub content: Vec<model::ToolCallContent>,
     /// Hidden tool calls are subagent children - not rendered directly.
@@ -110,6 +111,11 @@ impl ToolCallInfo {
             .and_then(|metadata| metadata.todo_write.as_ref())
             .and_then(|metadata| metadata.verification_nudge_needed)
             .unwrap_or(false)
+    }
+
+    #[must_use]
+    pub fn task_is_backgrounded(&self) -> bool {
+        self.task_metadata.as_ref().and_then(|metadata| metadata.is_backgrounded).unwrap_or(false)
     }
 
     /// Mark render cache for this tool call as stale.

--- a/src/app/state/tool_call_info.rs
+++ b/src/app/state/tool_call_info.rs
@@ -78,29 +78,11 @@ impl ToolCallInfo {
     }
 
     #[must_use]
-    pub fn is_ultraplan(&self) -> bool {
-        self.output_metadata
-            .as_ref()
-            .and_then(|metadata| metadata.exit_plan_mode.as_ref())
-            .and_then(|metadata| metadata.is_ultraplan)
-            .unwrap_or(false)
-    }
-
-    #[must_use]
     pub fn assistant_auto_backgrounded(&self) -> bool {
         self.output_metadata
             .as_ref()
             .and_then(|metadata| metadata.bash.as_ref())
             .and_then(|metadata| metadata.assistant_auto_backgrounded)
-            .unwrap_or(false)
-    }
-
-    #[must_use]
-    pub fn token_saver_active(&self) -> bool {
-        self.output_metadata
-            .as_ref()
-            .and_then(|metadata| metadata.bash.as_ref())
-            .and_then(|metadata| metadata.token_saver_active)
             .unwrap_or(false)
     }
 
@@ -198,6 +180,7 @@ pub fn is_exit_plan_mode_tool_name(tool_name: &str) -> bool {
 /// controls render inside the tool call block (unified edit/permission UX).
 pub struct InlinePermission {
     pub options: Vec<model::PermissionOption>,
+    pub display: Option<model::PermissionDisplay>,
     pub response_tx: tokio::sync::oneshot::Sender<model::RequestPermissionResponse>,
     pub selected_index: usize,
     /// Whether this permission currently has keyboard focus.

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -35,8 +35,9 @@ pub struct LoginHint {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PendingCommandAck {
-    CurrentModeUpdate,
-    ConfigOptionUpdate { option_id: String },
+    CurrentMode,
+    CurrentModel,
+    ConfigOption { option_id: String },
 }
 
 /// A single todo item from Claude's `TodoWrite` tool call.
@@ -146,6 +147,9 @@ pub struct UsageState {
 pub struct SessionUsageState {
     pub last_compaction_trigger: Option<model::CompactionTrigger>,
     pub last_compaction_pre_tokens: Option<u64>,
+    pub context_usage_percent: Option<u8>,
+    pub context_usage_in_flight: bool,
+    pub context_usage_refresh_pending: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -3,8 +3,6 @@
 
 use crate::agent::model;
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModeInfo {
     pub id: String,
@@ -162,8 +160,6 @@ pub struct McpState {
 
 pub const DEFAULT_RENDER_CACHE_BUDGET_BYTES: usize = 24 * 1024 * 1024;
 pub const DEFAULT_HISTORY_RETENTION_MAX_BYTES: usize = 64 * 1024 * 1024;
-pub const SUBAGENT_THINKING_DEBOUNCE: Duration = Duration::from_millis(1_500);
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RenderCacheBudget {
     pub max_bytes: usize,
@@ -226,11 +222,11 @@ pub enum AppStatus {
     Error,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolCallScope {
     MainAgent,
-    Subagent,
-    Task,
+    SubagentRoot,
+    SubagentChild { parent_tool_use_id: String },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/app/terminal.rs
+++ b/src/app/terminal.rs
@@ -165,6 +165,7 @@ mod tests {
                 raw_input: None,
                 raw_input_bytes: 0,
                 output_metadata: None,
+                task_metadata: None,
                 status: model::ToolCallStatus::InProgress,
                 content: Vec::new(),
                 hidden: false,

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -31,7 +31,6 @@ fn clear_transient_view_state(app: &mut App) {
     app.active_paste_session = None;
     app.pending_paste_session = None;
     app.pending_paste_text.clear();
-    app.pending_clipboard_paste_dedupe = None;
     app.pending_submit = None;
     app.help_open = false;
     app.help_view = crate::app::HelpView::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,5 +93,4 @@ fn maybe_print_resume_hint(app: &claude_code_rust::app::App, success: bool) {
         return;
     };
     eprintln!("Resume this session: claude-rs resume {session_id}");
-    eprintln!("Tip: Run `claude-rs resume` to pick from recent sessions");
 }

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -13,7 +13,6 @@ use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Text};
 use ratatui::widgets::{Paragraph, Widget, Wrap};
-use std::time::Instant;
 
 /// Minimum number of messages to render above/below the visible range as a margin.
 /// Heights are now exact (block-level wrapped heights), so no safety margin is needed.
@@ -87,9 +86,6 @@ fn msg_spinner(
         is_active_turn_assistant,
         show_empty_thinking: is_active_turn_assistant && base.show_empty_thinking,
         show_thinking: is_active_turn_assistant && base.show_thinking && has_blocks,
-        show_subagent_thinking: is_active_turn_assistant
-            && base.show_subagent_thinking
-            && has_blocks,
         show_compacting: is_active_turn_assistant && base.show_compacting,
         ..base
     }
@@ -203,8 +199,8 @@ fn sync_active_turn_height_state(
         let spinner = msg_spinner(base, idx, active_turn_assistant, message);
         let empty_indicator_visible =
             message.blocks.is_empty() && (spinner.show_compacting || spinner.show_empty_thinking);
-        let trailing_indicator_visible = !message.blocks.is_empty()
-            && (spinner.show_compacting || spinner.show_subagent_thinking || spinner.show_thinking);
+        let trailing_indicator_visible =
+            !message.blocks.is_empty() && (spinner.show_compacting || spinner.show_thinking);
         Some((idx, empty_indicator_visible, trailing_indicator_visible))
     });
 
@@ -287,13 +283,11 @@ fn measure_message_height(
 }
 
 fn build_base_spinner(app: &App) -> SpinnerState {
-    let show_subagent_thinking = app.should_show_subagent_thinking(Instant::now());
     SpinnerState {
         frame: app.spinner_frame,
         is_active_turn_assistant: false,
         show_empty_thinking: matches!(app.status, AppStatus::Thinking | AppStatus::Running),
         show_thinking: matches!(app.status, AppStatus::Thinking),
-        show_subagent_thinking,
         show_compacting: app.is_compacting,
     }
 }
@@ -929,7 +923,7 @@ mod tests {
     use super::{
         SCROLLBAR_MIN_THUMB_HEIGHT, clamp_scroll_to_content, paragraph_scroll_offset,
         render_culled_messages, render_lines_from_paragraph, render_scrolled,
-        smooth_scrollbar_geometry, sync_active_turn_height_state, update_visual_heights,
+        smooth_scrollbar_geometry, update_visual_heights,
     };
     use crate::app::{
         App, AppStatus, ChatMessage, ChatViewport, InvalidationLevel, MessageBlock, MessageRole,
@@ -973,7 +967,6 @@ mod tests {
             is_active_turn_assistant: false,
             show_empty_thinking: false,
             show_thinking: false,
-            show_subagent_thinking: false,
             show_compacting: false,
         }
     }
@@ -1016,30 +1009,6 @@ mod tests {
         let second_spinner = SpinnerState { frame: 1, show_thinking: true, ..idle_spinner() };
         let second = update_visual_heights(&mut app, second_spinner, 40, 8);
         assert_eq!(second.measured_msgs, 0);
-    }
-
-    #[test]
-    fn subagent_indicator_transition_invalidates_active_assistant_height() {
-        let mut app = App::test_default();
-        app.status = AppStatus::Running;
-        app.messages = vec![assistant_text_message("streaming body")];
-        app.bind_active_turn_assistant(0);
-
-        let _ = app.viewport.on_frame(40, 8);
-        let baseline_spinner = SpinnerState { frame: 0, show_thinking: false, ..idle_spinner() };
-        update_visual_heights(&mut app, baseline_spinner, 40, 8);
-        let base_height = app.viewport.message_height(0);
-        assert!(app.viewport.message_height_is_current(0));
-
-        let subagent_spinner =
-            SpinnerState { frame: 0, show_subagent_thinking: true, ..idle_spinner() };
-        let active_turn_assistant = app.active_turn_assistant_idx();
-        sync_active_turn_height_state(&mut app, subagent_spinner, active_turn_assistant);
-        assert!(!app.viewport.message_height_is_current(0));
-
-        let updated = update_visual_heights(&mut app, subagent_spinner, 40, 8);
-        assert_eq!(updated.measured_msgs, 1);
-        assert!(app.viewport.message_height(0) > base_height);
     }
 
     #[test]

--- a/src/ui/config/status.rs
+++ b/src/ui/config/status.rs
@@ -43,6 +43,11 @@ pub(crate) fn status_lines(app: &App) -> Vec<Line<'static>> {
     if let Some(ref account) = app.account_info {
         section_header(&mut lines, "Account");
         kv_line(&mut lines, "Login method", &login_method_label(account));
+        if let Some(ref provider) = account.api_provider
+            && !provider.trim().is_empty()
+        {
+            kv_line(&mut lines, "API provider", &api_provider_label(provider.trim()));
+        }
         if let Some(ref org) = account.organization
             && !org.is_empty()
         {
@@ -144,6 +149,12 @@ fn model_display(app: &App) -> String {
 }
 
 pub(crate) fn login_method_label(account: &crate::agent::types::AccountInfo) -> String {
+    if let Some(ref provider) = account.api_provider
+        && !provider.trim().is_empty()
+        && provider != "firstParty"
+    {
+        return "External provider".to_owned();
+    }
     if let Some(ref source) = account.api_key_source {
         match source.as_str() {
             "oauth" => return "Claude Max Account".to_owned(),
@@ -161,6 +172,18 @@ pub(crate) fn login_method_label(account: &crate::agent::types::AccountInfo) -> 
         return source.clone();
     }
     "Unknown".to_owned()
+}
+
+fn api_provider_label(provider: &str) -> String {
+    match provider {
+        "firstParty" => "First party".to_owned(),
+        "bedrock" => "Bedrock".to_owned(),
+        "vertex" => "Vertex".to_owned(),
+        "foundry" => "Foundry".to_owned(),
+        "anthropicAws" => "Anthropic AWS".to_owned(),
+        "mantle" => "Mantle".to_owned(),
+        other => other.to_owned(),
+    }
 }
 
 fn resolve_memory_path(app: &App) -> String {
@@ -289,6 +312,29 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(login_method_label(&account), "User API key");
+    }
+
+    #[test]
+    fn login_method_maps_external_provider() {
+        let account = crate::agent::types::AccountInfo {
+            api_provider: Some("bedrock".to_owned()),
+            ..Default::default()
+        };
+        assert_eq!(login_method_label(&account), "External provider");
+    }
+
+    #[test]
+    fn status_lines_render_api_provider() {
+        let mut app = App::test_default();
+        app.account_info = Some(crate::agent::types::AccountInfo {
+            api_provider: Some("mantle".to_owned()),
+            ..Default::default()
+        });
+
+        let text = lines_to_string(&status_lines(&app));
+
+        assert!(text.contains("API provider"));
+        assert!(text.contains("Mantle"));
     }
 
     #[test]

--- a/src/ui/config/status.rs
+++ b/src/ui/config/status.rs
@@ -64,6 +64,14 @@ pub(crate) fn status_lines(app: &App) -> Vec<Line<'static>> {
     // ---- Model ----
     section_header(&mut lines, "Model");
     kv_line(&mut lines, "Model", &model_display(app));
+    if let Some(current_model) = app.current_model.as_ref() {
+        kv_line(&mut lines, "Resolved model ID", &current_model.resolved_id);
+        if let Some(requested_id) = current_model.requested_id.as_deref()
+            && requested_id != current_model.resolved_id
+        {
+            kv_line(&mut lines, "Requested model", requested_id);
+        }
+    }
 
     if let Some(ref mode) = app.mode {
         kv_line(&mut lines, "Mode", &mode.current_mode_name);
@@ -129,18 +137,10 @@ fn derive_session_name(app: &App) -> String {
 }
 
 fn model_display(app: &App) -> String {
-    if app.model_name.is_empty() {
+    let Some(current_model) = app.current_model.as_ref() else {
         return "(not set)".to_owned();
-    }
-    if let Some(model) = app.available_models.iter().find(|m| m.id == app.model_name) {
-        let mut label = model.display_name.clone();
-        if let Some(ref desc) = model.description {
-            label.push_str(" - ");
-            label.push_str(desc);
-        }
-        return label;
-    }
-    app.model_name.clone()
+    };
+    current_model.display_name_long.clone()
 }
 
 pub(crate) fn login_method_label(account: &crate::agent::types::AccountInfo) -> String {
@@ -217,9 +217,13 @@ mod tests {
 
     #[test]
     fn status_lines_shows_model() {
-        let app = App::test_default();
+        let mut app = App::test_default();
+        app.current_model = Some(
+            crate::agent::model::CurrentModel::new("claude-sonnet-4-6", "Sonnet", "Sonnet 4.6")
+                .authoritative(true),
+        );
         let text = lines_to_string(&status_lines(&app));
-        assert!(text.contains(&app.model_name) || text.contains("(not set)"));
+        assert!(text.contains("Sonnet 4.6"));
     }
 
     #[test]

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -45,7 +45,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         PRIMARY_ROW_LEFT_MIN_WIDTH,
     );
 
-    let second_hint = footer_mcp_auth_hint(app);
+    let second_hint = footer_secondary_hint(app);
     let (second_left, second_right) = split_footer_columns_hint(
         second_row,
         second_hint.as_ref().map(|(text, _)| text.as_str()),
@@ -72,6 +72,17 @@ fn footer_mcp_auth_hint(app: &App) -> FooterItem {
     let needs_auth_count = mcp_needs_auth_count(app);
     (needs_auth_count > 0 && should_show_startup_mcp_hint(app))
         .then(|| (format!("{needs_auth_count} MCP NEEDS AUTH"), Color::Yellow))
+}
+
+fn footer_context_usage_hint(app: &App) -> FooterItem {
+    app.session_usage.context_usage_percent.map(|percentage| {
+        let remaining = 100_u8.saturating_sub(percentage);
+        (format!("{remaining}%"), FOOTER_CONTEXT_VALUE)
+    })
+}
+
+fn footer_secondary_hint(app: &App) -> FooterItem {
+    footer_mcp_auth_hint(app).or_else(|| footer_context_usage_hint(app))
 }
 
 fn render_footer_row(
@@ -136,23 +147,47 @@ fn build_primary_line(app: &App) -> Line<'static> {
     if let Some(ref mode) = app.mode {
         let color = mode_color(&mode.current_mode_id);
         let (fast_mode_text, fast_mode_color) = fast_mode_badge(app.fast_mode_state);
-        Line::from(vec![
-            Span::styled("[", Style::default().fg(color)),
-            Span::styled(mode.current_mode_name.clone(), Style::default().fg(color)),
-            Span::styled("]", Style::default().fg(color)),
-            Span::raw("  "),
-            Span::styled("[", Style::default().fg(fast_mode_color)),
-            Span::styled(fast_mode_text, Style::default().fg(fast_mode_color)),
-            Span::styled("]", Style::default().fg(fast_mode_color)),
-            Span::raw("  "),
-            Span::styled("?", Style::default().fg(Color::White)),
-            Span::styled(" : Help", Style::default().fg(theme::DIM)),
-        ])
+        let mut spans = Vec::new();
+        push_badge(&mut spans, mode.current_mode_name.clone(), color);
+        if let Some(model_badge) = footer_model_badge(app) {
+            spans.push(Span::raw("  "));
+            push_badge(&mut spans, model_badge, FOOTER_CONTEXT_VALUE);
+        }
+        spans.push(Span::raw("  "));
+        push_badge(&mut spans, fast_mode_text.to_owned(), fast_mode_color);
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled("?", Style::default().fg(Color::White)));
+        spans.push(Span::styled(" : Help", Style::default().fg(theme::DIM)));
+        Line::from(spans)
     } else {
         Line::from(vec![
             Span::styled("?", Style::default().fg(Color::White)),
             Span::styled(" : Help", Style::default().fg(theme::DIM)),
         ])
+    }
+}
+
+fn push_badge(spans: &mut Vec<Span<'static>>, text: String, color: Color) {
+    spans.push(Span::styled("[", Style::default().fg(color)));
+    spans.push(Span::styled(text, Style::default().fg(color)));
+    spans.push(Span::styled("]", Style::default().fg(color)));
+}
+
+fn footer_model_badge(app: &App) -> Option<String> {
+    let current_model = app.current_model.as_ref()?;
+    let mut badge = current_model.display_name_short.clone();
+    if current_model.supports_effort {
+        badge.push('/');
+        badge.push_str(footer_effort_label(app.config.thinking_effort_effective()));
+    }
+    Some(badge)
+}
+
+const fn footer_effort_label(effort: model::EffortLevel) -> &'static str {
+    match effort {
+        model::EffortLevel::Low => "Low",
+        model::EffortLevel::Medium => "Med",
+        model::EffortLevel::High => "High",
     }
 }
 
@@ -469,6 +504,7 @@ mod tests {
                 raw_input: None,
                 raw_input_bytes: 0,
                 output_metadata: None,
+                task_metadata: None,
                 status: model::ToolCallStatus::Pending,
                 content: vec![],
                 hidden: false,
@@ -510,6 +546,46 @@ mod tests {
     #[test]
     fn mode_color_handles_auto_explicitly() {
         assert_eq!(mode_color("auto"), Color::Yellow);
+    }
+
+    #[test]
+    fn footer_model_badge_uses_resolved_model_and_effort() {
+        let mut app = App::test_default();
+        app.current_model = Some(
+            model::CurrentModel::new("claude-sonnet-4-6", "Sonnet", "Sonnet 4.6")
+                .supports_effort(true)
+                .supported_effort_levels(vec![
+                    model::EffortLevel::Low,
+                    model::EffortLevel::Medium,
+                    model::EffortLevel::High,
+                ])
+                .authoritative(true),
+        );
+
+        assert_eq!(footer_model_badge(&app), Some("Sonnet/Med".to_owned()));
+    }
+
+    #[test]
+    fn footer_model_badge_hides_effort_for_models_without_support() {
+        let mut app = App::test_default();
+        app.current_model = Some(
+            model::CurrentModel::new("claude-haiku-4-5", "Haiku", "Haiku 4.5").authoritative(true),
+        );
+
+        assert_eq!(footer_model_badge(&app), Some("Haiku".to_owned()));
+    }
+
+    #[test]
+    fn footer_model_badge_falls_back_to_runtime_name_for_unknown_model() {
+        let mut app = App::test_default();
+        app.current_model = None;
+        assert_eq!(footer_model_badge(&app), None);
+
+        app.current_model = Some(
+            model::CurrentModel::new("unknown-model", "unknown-model", "unknown-model")
+                .authoritative(true),
+        );
+        assert_eq!(footer_model_badge(&app), Some("unknown-model".to_owned()));
     }
 
     #[test]
@@ -601,5 +677,38 @@ mod tests {
         });
 
         assert_eq!(footer_mcp_auth_hint(&app), None);
+    }
+
+    #[test]
+    fn footer_context_usage_hint_shows_percentage_only() {
+        let mut app = App::test_default();
+        app.session_usage.context_usage_percent = Some(62);
+
+        assert_eq!(footer_context_usage_hint(&app), Some(("38%".to_owned(), FOOTER_CONTEXT_VALUE)));
+    }
+
+    #[test]
+    fn footer_secondary_hint_prefers_mcp_auth_over_context_usage() {
+        let mut app = App::test_default();
+        app.session_usage.context_usage_percent = Some(62);
+        app.messages.push(ChatMessage::new(
+            MessageRole::Welcome,
+            vec![MessageBlock::Text(TextBlock::from_complete("welcome"))],
+            None,
+        ));
+        app.mcp.servers.push(McpServerStatus {
+            name: "calendar".into(),
+            status: McpServerConnectionStatus::NeedsAuth,
+            server_info: None,
+            error: None,
+            config: None,
+            scope: None,
+            tools: vec![],
+        });
+
+        assert_eq!(
+            footer_secondary_hint(&app),
+            Some(("1 MCP NEEDS AUTH".to_owned(), Color::Yellow))
+        );
     }
 }

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -353,8 +353,8 @@ fn should_show_startup_mcp_hint(app: &App) -> bool {
 fn mode_color(mode_id: &str) -> Color {
     match mode_id {
         "default" => theme::DIM,
+        "auto" | "acceptEdits" => Color::Yellow,
         "plan" => Color::Blue,
-        "acceptEdits" => Color::Yellow,
         "bypassPermissions" | "dontAsk" => Color::Red,
         _ => Color::Magenta,
     }
@@ -505,6 +505,11 @@ mod tests {
     fn fast_mode_badge_maps_cooldown_to_cd() {
         let (label, _) = fast_mode_badge(model::FastModeState::Cooldown);
         assert_eq!(label, "FAST:CD");
+    }
+
+    #[test]
+    fn mode_color_handles_auto_explicitly() {
+        assert_eq!(mode_color("auto"), Color::Yellow);
     }
 
     #[test]

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -523,6 +523,7 @@ mod tests {
                 cache: BlockCache::default(),
                 pending_permission: Some(InlinePermission {
                     options: vec![],
+                    display: None,
                     response_tx,
                     selected_index: 0,
                     focused: true,

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -4,7 +4,7 @@
 use crate::app::input::parse_paste_placeholder_ranges;
 use crate::app::mention;
 use crate::app::subagent;
-use crate::app::{App, AppStatus};
+use crate::app::{App, AppStatus, FocusOwner};
 use crate::ui::theme;
 use ratatui::Frame;
 use ratatui::buffer::Buffer;
@@ -43,6 +43,7 @@ const SPINNER_FRAMES: &[char] = &[
 /// calculation and rendering stay in sync.
 const LOGIN_HINT_LINES: u16 = 2;
 const CANCEL_HINT_LINES: u16 = 1;
+const PROMPT_SUGGESTION_HINT_LINES: u16 = 1;
 
 #[derive(Clone, Copy)]
 pub(crate) struct InputRenderGeometry {
@@ -61,10 +62,17 @@ fn has_cancel_hint(app: &App) -> bool {
     app.pending_cancel_origin.is_some()
 }
 
+fn has_prompt_suggestion_hint(app: &App) -> bool {
+    app.input.is_empty()
+        && app.focus_owner() == FocusOwner::Input
+        && app.prompt_suggestion.as_deref().is_some_and(|suggestion| !suggestion.trim().is_empty())
+}
+
 pub(crate) fn hint_line_count(app: &App) -> u16 {
     let login = if has_login_hint(app) { LOGIN_HINT_LINES } else { 0 };
     let cancel = if has_cancel_hint(app) { CANCEL_HINT_LINES } else { 0 };
-    login + cancel
+    let suggestion = if has_prompt_suggestion_hint(app) { PROMPT_SUGGESTION_HINT_LINES } else { 0 };
+    login + cancel + suggestion
 }
 
 pub(crate) fn compute_render_geometry(area: Rect, hint_lines: u16) -> InputRenderGeometry {
@@ -135,6 +143,24 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
             let cancel_area =
                 Rect { x: hint_pad.x, y: hint_y, width: hint_pad.width, height: CANCEL_HINT_LINES };
             frame.render_widget(Paragraph::new(cancel_line), cancel_area);
+            hint_y = hint_y.saturating_add(CANCEL_HINT_LINES);
+        }
+
+        if has_prompt_suggestion_hint(app)
+            && let Some(suggestion) = app.prompt_suggestion.as_deref()
+        {
+            let suggestion_line = Line::from(vec![
+                Span::styled("Suggestion: ", Style::default().fg(theme::DIM)),
+                Span::styled(suggestion.trim().to_owned(), Style::default().fg(Color::White)),
+                Span::styled("    Tab to accept", Style::default().fg(theme::DIM)),
+            ]);
+            let suggestion_area = Rect {
+                x: hint_pad.x,
+                y: hint_y,
+                width: hint_pad.width,
+                height: PROMPT_SUGGESTION_HINT_LINES,
+            };
+            frame.render_widget(Paragraph::new(suggestion_line), suggestion_area);
         }
     }
 
@@ -356,11 +382,11 @@ pub fn visual_line_count(app: &mut App, area_width: u16) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::{
-        CANCEL_HINT_LINES, LOGIN_HINT_LINES, MAX_INPUT_HEIGHT, slash_command_range,
-        visual_line_count,
+        CANCEL_HINT_LINES, LOGIN_HINT_LINES, MAX_INPUT_HEIGHT, PROMPT_SUGGESTION_HINT_LINES,
+        slash_command_range, visual_line_count,
     };
     use crate::app::subagent::find_subagent_spans;
-    use crate::app::{App, CancelOrigin, LoginHint};
+    use crate::app::{App, CancelOrigin, FocusTarget, LoginHint};
 
     #[test]
     fn slash_range_matches_leading_command_token() {
@@ -411,5 +437,34 @@ mod tests {
         let mut app = App::test_default();
         app.pending_cancel_origin = Some(CancelOrigin::AutoQueue);
         assert_eq!(visual_line_count(&mut app, 80), CANCEL_HINT_LINES + 1);
+    }
+
+    #[test]
+    fn visual_line_count_includes_prompt_suggestion_hint_row() {
+        let mut app = App::test_default();
+        app.prompt_suggestion = Some("Write tests for the retry flow".to_owned());
+        assert_eq!(visual_line_count(&mut app, 80), PROMPT_SUGGESTION_HINT_LINES + 1);
+    }
+
+    #[test]
+    fn visual_line_count_hides_prompt_suggestion_hint_when_input_not_empty() {
+        let mut app = App::test_default();
+        app.prompt_suggestion = Some("Write tests for the retry flow".to_owned());
+        app.input.set_text("draft");
+        assert_eq!(visual_line_count(&mut app, 80), 1);
+    }
+
+    #[test]
+    fn visual_line_count_hides_prompt_suggestion_hint_when_input_lacks_focus() {
+        let mut app = App::test_default();
+        app.prompt_suggestion = Some("Write tests for the retry flow".to_owned());
+        app.show_todo_panel = true;
+        app.todos.push(crate::app::TodoItem {
+            content: "todo".to_owned(),
+            status: crate::app::TodoStatus::Pending,
+            active_form: String::new(),
+        });
+        app.claim_focus_target(FocusTarget::TodoList);
+        assert_eq!(visual_line_count(&mut app, 80), 1);
     }
 }

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -993,14 +993,22 @@ fn welcome_lines(block: &WelcomeBlock, _width: u16) -> Vec<Line<'static>> {
     lines.push(Line::default());
 
     lines.push(Line::from(vec![
-        Span::styled(format!("{pad}Model: "), Style::default().fg(theme::DIM)),
+        Span::styled(format!("{pad}Version:      "), Style::default().fg(theme::DIM)),
+        Span::styled(block.version.clone(), Style::default().fg(theme::DIM)),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled(format!("{pad}Subscription: "), Style::default().fg(theme::DIM)),
         Span::styled(
-            block.model_name.clone(),
+            block.subscription.clone(),
             Style::default().fg(theme::RUST_ORANGE).add_modifier(Modifier::BOLD),
         ),
     ]));
     lines.push(Line::from(Span::styled(
-        format!("{pad}cwd:   {}", block.cwd),
+        format!("{pad}cwd:          {}", block.cwd),
+        Style::default().fg(theme::DIM),
+    )));
+    lines.push(Line::from(Span::styled(
+        format!("{pad}Session ID:   {}", block.session_id),
         Style::default().fg(theme::DIM),
     )));
 
@@ -1345,21 +1353,8 @@ mod tests {
     }
 
     #[test]
-    fn welcome_lines_do_not_render_recent_sessions_section() {
-        let message = ChatMessage::welcome_with_recent(
-            "claude-sonnet-4-5",
-            "/cwd",
-            &[crate::app::RecentSessionInfo {
-                session_id: "11111111-1111-1111-1111-111111111111".to_owned(),
-                summary: "Title".to_owned(),
-                last_modified_ms: 0,
-                file_size_bytes: 0,
-                cwd: Some("/a".to_owned()),
-                git_branch: None,
-                custom_title: Some("Title".to_owned()),
-                first_prompt: None,
-            }],
-        );
+    fn welcome_lines_render_expected_fields() {
+        let message = ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-");
         let MessageBlock::Welcome(block) = &message.blocks[0] else {
             panic!("expected welcome block");
         };
@@ -1368,7 +1363,10 @@ mod tests {
             .into_iter()
             .map(|line| line.spans.into_iter().map(|s| s.content).collect())
             .collect();
-        assert!(!lines.iter().any(|line| line.contains("Recent sessions")));
+        assert!(lines.iter().any(|line| line.contains("Version:")));
+        assert!(lines.iter().any(|line| line.contains("Subscription: -")));
+        assert!(lines.iter().any(|line| line.contains("cwd:          /cwd")));
+        assert!(lines.iter().any(|line| line.contains("Session ID:   -")));
     }
 
     // force_markdown_line_breaks
@@ -1551,8 +1549,8 @@ mod tests {
             .unwrap_or_else(|| panic!("expected line containing {needle:?}"))
     }
 
-    fn make_welcome_message(model_name: &str, cwd: &str) -> ChatMessage {
-        ChatMessage::welcome(model_name, cwd)
+    fn make_welcome_message(subscription: &str, cwd: &str, session_id: &str) -> ChatMessage {
+        ChatMessage::welcome(env!("CARGO_PKG_VERSION"), subscription, cwd, session_id)
     }
 
     fn idle_spinner() -> SpinnerState {
@@ -1620,8 +1618,8 @@ mod tests {
     #[test]
     fn welcome_role_label_wrap_height_matches_ground_truth() {
         let spinner = idle_spinner();
-        let mut measured_msg = make_welcome_message("claude-sonnet-4-5", "~/project");
-        let mut truth_msg = make_welcome_message("claude-sonnet-4-5", "~/project");
+        let mut measured_msg = make_welcome_message("Max", "~/project", "session-1");
+        let mut truth_msg = make_welcome_message("Max", "~/project", "session-1");
 
         let (h, _) = measure_message_height_cached(&mut measured_msg, &spinner, 4, 1);
         let truth = ground_truth_height(&mut truth_msg, &spinner, 4);
@@ -2006,8 +2004,8 @@ mod tests {
     #[test]
     fn welcome_height_matches_ground_truth() {
         let spinner = idle_spinner();
-        let mut measured_msg = make_welcome_message("claude-sonnet-4-5", "~/project");
-        let mut truth_msg = make_welcome_message("claude-sonnet-4-5", "~/project");
+        let mut measured_msg = make_welcome_message("Max", "~/project", "session-1");
+        let mut truth_msg = make_welcome_message("Max", "~/project", "session-1");
 
         let (h, _) = measure_message_height_cached(&mut measured_msg, &spinner, 52, 1);
         let truth = ground_truth_height(&mut truth_msg, &spinner, 52);

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -42,8 +42,6 @@ pub struct SpinnerState {
     pub show_empty_thinking: bool,
     /// True when this message should show the thinking indicator.
     pub show_thinking: bool,
-    /// True when this message should show the subagent-thinking indicator.
-    pub show_subagent_thinking: bool,
     /// True when this message should show the compaction indicator.
     pub show_compacting: bool,
 }
@@ -277,26 +275,35 @@ fn append_assistant_blocks(
     }
 
     let show_compacting = spinner.show_compacting;
-    let show_subagent_thinking = spinner.show_subagent_thinking && !show_compacting;
+    let deferred_interaction = deferred_hidden_interaction_render_after(&msg.blocks);
     let mut state = AssistantLayoutState::default();
-    for block in &mut msg.blocks {
-        match block {
-            MessageBlock::Text(block) => {
-                append_assistant_text_block(block, width, layout, &mut state);
-            }
-            MessageBlock::Notice(notice) => {
-                append_assistant_notice_block(notice, width, layout, &mut state);
-            }
-            MessageBlock::ToolCall(tc) => append_assistant_tool_block(
-                tc.as_mut(),
+    for idx in 0..msg.blocks.len() {
+        if deferred_interaction.is_some_and(|(deferred_idx, _)| deferred_idx == idx) {
+            continue;
+        }
+
+        append_assistant_block(
+            &mut msg.blocks[idx],
+            spinner,
+            width,
+            tools_collapsed,
+            layout_generation,
+            layout,
+            &mut state,
+        );
+
+        if let Some((deferred_idx, render_after_idx)) = deferred_interaction
+            && render_after_idx == idx
+        {
+            append_assistant_block(
+                &mut msg.blocks[deferred_idx],
                 spinner,
                 width,
                 tools_collapsed,
                 layout_generation,
                 layout,
                 &mut state,
-            ),
-            MessageBlock::Welcome(_) | MessageBlock::ImageAttachment(_) => {}
+            );
         }
     }
 
@@ -305,17 +312,57 @@ fn append_assistant_blocks(
             layout.push_blank();
         }
         layout.push_wrapped_line(compacting_line(spinner.frame), width);
-    } else if show_subagent_thinking {
-        if state.has_body_content {
-            layout.push_blank();
-        }
-        layout.push_wrapped_line(subagent_thinking_line(spinner.frame), width);
     }
-    if spinner.show_thinking && !show_subagent_thinking && !show_compacting {
+    if spinner.show_thinking && !show_compacting {
         if state.has_body_content {
             layout.push_blank();
         }
         layout.push_wrapped_line(thinking_line(spinner.frame), width);
+    }
+}
+
+fn deferred_hidden_interaction_render_after(blocks: &[MessageBlock]) -> Option<(usize, usize)> {
+    let deferred_idx = blocks.iter().position(
+        |block| matches!(block, MessageBlock::ToolCall(tc) if tc.is_hidden_focused_interaction()),
+    )?;
+    let render_after_idx = blocks
+        .iter()
+        .enumerate()
+        .skip(deferred_idx.saturating_add(1))
+        .filter_map(|(idx, block)| match block {
+            MessageBlock::ToolCall(tc) if tc.is_subagent_root_tool() => Some(idx),
+            _ => None,
+        })
+        .last()?;
+    Some((deferred_idx, render_after_idx))
+}
+
+fn append_assistant_block(
+    block: &mut MessageBlock,
+    spinner: &SpinnerState,
+    width: u16,
+    tools_collapsed: bool,
+    layout_generation: Option<u64>,
+    layout: &mut MessageLayout,
+    state: &mut AssistantLayoutState,
+) {
+    match block {
+        MessageBlock::Text(block) => {
+            append_assistant_text_block(block, width, layout, state);
+        }
+        MessageBlock::Notice(notice) => {
+            append_assistant_notice_block(notice, width, layout, state);
+        }
+        MessageBlock::ToolCall(tc) => append_assistant_tool_block(
+            tc.as_mut(),
+            spinner,
+            width,
+            tools_collapsed,
+            layout_generation,
+            layout,
+            state,
+        ),
+        MessageBlock::Welcome(_) | MessageBlock::ImageAttachment(_) => {}
     }
 }
 
@@ -380,7 +427,7 @@ fn append_assistant_tool_block(
     layout: &mut MessageLayout,
     state: &mut AssistantLayoutState,
 ) {
-    if tc.hidden {
+    if tc.hidden_unless_focused_interaction() {
         return;
     }
     if !state.prev_was_tool && state.has_body_content {
@@ -718,7 +765,6 @@ fn build_message_render_signature(
         role: msg.role.clone(),
         show_empty_thinking: spinner.show_empty_thinking,
         show_thinking: spinner.show_thinking,
-        show_subagent_thinking: spinner.show_subagent_thinking,
         show_compacting: spinner.show_compacting,
         assistant_frame,
         blocks,
@@ -760,10 +806,7 @@ fn build_message_block_render_signature(
 
 fn message_has_frame_dependent_assistant_lines(msg: &ChatMessage, spinner: &SpinnerState) -> bool {
     matches!(msg.role, MessageRole::Assistant)
-        && (spinner.show_empty_thinking
-            || spinner.show_thinking
-            || spinner.show_subagent_thinking
-            || spinner.show_compacting)
+        && (spinner.show_empty_thinking || spinner.show_thinking || spinner.show_compacting)
 }
 
 fn tool_call_needs_spinner_frame(tc: &crate::app::ToolCallInfo) -> bool {
@@ -934,14 +977,6 @@ fn compacting_line(frame: usize) -> Line<'static> {
         format!("{ch} Compacting context..."),
         Style::default().fg(theme::RUST_ORANGE),
     ))
-}
-
-fn subagent_thinking_line(frame: usize) -> Line<'static> {
-    let ch = SPINNER_FRAMES[frame % SPINNER_FRAMES.len()];
-    Line::from(vec![
-        Span::styled("  \u{2514}\u{2500} ", Style::default().fg(theme::DIM)),
-        Span::styled(format!("{ch} Thinking..."), Style::default().fg(theme::DIM)),
-    ])
 }
 
 fn welcome_lines(block: &WelcomeBlock, _width: u16) -> Vec<Line<'static>> {
@@ -1142,7 +1177,9 @@ fn force_markdown_line_breaks(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{ChatMessage, MessageBlock, NoticeBlock, TextBlock, TextBlockSpacing};
+    use crate::app::{
+        ChatMessage, InlinePermission, MessageBlock, NoticeBlock, TextBlock, TextBlockSpacing,
+    };
     use pretty_assertions::assert_eq;
     use ratatui::widgets::{Paragraph, Wrap};
 
@@ -1478,11 +1515,39 @@ mod tests {
         }
     }
 
+    fn pending_permission(focused: bool) -> InlinePermission {
+        let (response_tx, _response_rx) = tokio::sync::oneshot::channel();
+        InlinePermission {
+            options: vec![
+                crate::agent::model::PermissionOption::new(
+                    "allow",
+                    "Allow",
+                    crate::agent::model::PermissionOptionKind::AllowOnce,
+                ),
+                crate::agent::model::PermissionOption::new(
+                    "deny",
+                    "Deny",
+                    crate::agent::model::PermissionOptionKind::RejectOnce,
+                ),
+            ],
+            response_tx,
+            selected_index: 0,
+            focused,
+        }
+    }
+
     fn render_lines_to_strings(lines: &[Line<'static>]) -> Vec<String> {
         lines
             .iter()
             .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
             .collect()
+    }
+
+    fn line_index_containing(lines: &[String], needle: &str) -> usize {
+        lines
+            .iter()
+            .position(|line| line.contains(needle))
+            .unwrap_or_else(|| panic!("expected line containing {needle:?}"))
     }
 
     fn make_welcome_message(model_name: &str, cwd: &str) -> ChatMessage {
@@ -1495,7 +1560,6 @@ mod tests {
             is_active_turn_assistant: false,
             show_empty_thinking: false,
             show_thinking: false,
-            show_subagent_thinking: false,
             show_compacting: false,
         }
     }
@@ -1965,16 +2029,52 @@ mod tests {
     }
 
     #[test]
-    fn assistant_message_shows_subagent_indicator_when_enabled() {
-        let spinner = SpinnerState { show_subagent_thinking: true, ..idle_spinner() };
+    fn assistant_message_suppresses_hidden_subagent_child_tools() {
+        let spinner = idle_spinner();
+
+        for tools_collapsed in [false, true] {
+            let mut hidden_tool = make_tool_call_info(
+                "hidden-child",
+                "Bash",
+                crate::agent::model::ToolCallStatus::Completed,
+                "child output",
+            );
+            hidden_tool.hidden = true;
+            let mut msg = ChatMessage::new(
+                MessageRole::Assistant,
+                vec![MessageBlock::ToolCall(Box::new(hidden_tool))],
+                None,
+            );
+
+            let mut lines = Vec::new();
+            render_message_with_tools_collapsed(
+                &mut msg,
+                &spinner,
+                120,
+                tools_collapsed,
+                &mut lines,
+            );
+            let rendered = render_lines_to_strings(&lines);
+
+            assert!(!rendered.iter().any(|line| line.contains("hidden-child")));
+            assert!(!rendered.iter().any(|line| line.contains("child output")));
+        }
+    }
+
+    #[test]
+    fn assistant_message_renders_hidden_subagent_child_permission_prompt() {
+        let spinner = idle_spinner();
+        let mut hidden_tool = make_tool_call_info(
+            "hidden-permission",
+            "Bash",
+            crate::agent::model::ToolCallStatus::InProgress,
+            "",
+        );
+        hidden_tool.hidden = true;
+        hidden_tool.pending_permission = Some(pending_permission(true));
         let mut msg = ChatMessage::new(
             MessageRole::Assistant,
-            vec![MessageBlock::ToolCall(Box::new(make_tool_call_info(
-                "task-only",
-                "Task",
-                crate::agent::model::ToolCallStatus::InProgress,
-                "Research project",
-            )))],
+            vec![MessageBlock::ToolCall(Box::new(hidden_tool))],
             None,
         );
 
@@ -1982,7 +2082,160 @@ mod tests {
         render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
         let rendered = render_lines_to_strings(&lines);
 
-        assert!(rendered.iter().any(|line| line.contains("Thinking...")));
+        assert!(rendered.iter().any(|line| line.contains("hidden-permission")));
+        assert!(rendered.iter().any(|line| line.contains("Allow")));
+        assert!(rendered.iter().any(|line| line.contains("Deny")));
+    }
+
+    #[test]
+    fn assistant_message_renders_only_focused_hidden_subagent_child_permission_prompt() {
+        let spinner = idle_spinner();
+        let mut focused_tool = make_tool_call_info(
+            "focused-permission",
+            "Bash",
+            crate::agent::model::ToolCallStatus::InProgress,
+            "",
+        );
+        focused_tool.hidden = true;
+        focused_tool.pending_permission = Some(pending_permission(true));
+        let mut waiting_tool = make_tool_call_info(
+            "waiting-permission",
+            "Bash",
+            crate::agent::model::ToolCallStatus::InProgress,
+            "",
+        );
+        waiting_tool.hidden = true;
+        waiting_tool.pending_permission = Some(pending_permission(false));
+        let mut msg = ChatMessage::new(
+            MessageRole::Assistant,
+            vec![
+                MessageBlock::ToolCall(Box::new(focused_tool)),
+                MessageBlock::ToolCall(Box::new(waiting_tool)),
+            ],
+            None,
+        );
+
+        let mut lines = Vec::new();
+        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
+        let rendered = render_lines_to_strings(&lines);
+
+        assert!(rendered.iter().any(|line| line.contains("focused-permission")));
+        assert!(!rendered.iter().any(|line| line.contains("waiting-permission")));
+        assert!(!rendered.iter().any(|line| line.contains("Waiting for input")));
+    }
+
+    #[test]
+    fn assistant_message_keeps_unfocused_main_agent_permission_prompt_visible() {
+        let spinner = idle_spinner();
+        let mut main_tool = make_tool_call_info(
+            "main-permission",
+            "Bash",
+            crate::agent::model::ToolCallStatus::InProgress,
+            "",
+        );
+        main_tool.pending_permission = Some(pending_permission(false));
+        let mut msg = ChatMessage::new(
+            MessageRole::Assistant,
+            vec![MessageBlock::ToolCall(Box::new(main_tool))],
+            None,
+        );
+
+        let mut lines = Vec::new();
+        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
+        let rendered = render_lines_to_strings(&lines);
+
+        assert!(rendered.iter().any(|line| line.contains("main-permission")));
+        assert!(rendered.iter().any(|line| line.contains("Waiting for input")));
+    }
+
+    #[test]
+    fn assistant_message_defers_focused_hidden_child_permission_after_later_subagent_roots() {
+        let spinner = idle_spinner();
+        let root_a = make_tool_call_info(
+            "root-a",
+            "Task",
+            crate::agent::model::ToolCallStatus::InProgress,
+            "first subagent",
+        );
+        let mut focused_tool = make_tool_call_info(
+            "focused-permission",
+            "Bash",
+            crate::agent::model::ToolCallStatus::InProgress,
+            "",
+        );
+        focused_tool.hidden = true;
+        focused_tool.pending_permission = Some(pending_permission(true));
+        let root_b = make_tool_call_info(
+            "root-b",
+            "Agent",
+            crate::agent::model::ToolCallStatus::InProgress,
+            "second subagent",
+        );
+        let mut msg = ChatMessage::new(
+            MessageRole::Assistant,
+            vec![
+                MessageBlock::ToolCall(Box::new(root_a)),
+                MessageBlock::ToolCall(Box::new(focused_tool)),
+                MessageBlock::ToolCall(Box::new(root_b)),
+            ],
+            None,
+        );
+
+        let mut lines = Vec::new();
+        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
+        let rendered = render_lines_to_strings(&lines);
+
+        let first_root_line = line_index_containing(&rendered, "root-a");
+        let second_root_line = line_index_containing(&rendered, "root-b");
+        let focused_idx = line_index_containing(&rendered, "focused-permission");
+
+        assert!(first_root_line < second_root_line);
+        assert!(second_root_line < focused_idx);
+    }
+
+    #[test]
+    fn assistant_message_keeps_focused_hidden_child_permission_before_later_main_tool() {
+        let spinner = idle_spinner();
+        let root = make_tool_call_info(
+            "root",
+            "Task",
+            crate::agent::model::ToolCallStatus::InProgress,
+            "subagent",
+        );
+        let mut focused_tool = make_tool_call_info(
+            "focused-permission",
+            "Bash",
+            crate::agent::model::ToolCallStatus::InProgress,
+            "",
+        );
+        focused_tool.hidden = true;
+        focused_tool.pending_permission = Some(pending_permission(true));
+        let main_tool = make_tool_call_info(
+            "main-tool",
+            "Read",
+            crate::agent::model::ToolCallStatus::InProgress,
+            "main agent tool",
+        );
+        let mut msg = ChatMessage::new(
+            MessageRole::Assistant,
+            vec![
+                MessageBlock::ToolCall(Box::new(root)),
+                MessageBlock::ToolCall(Box::new(focused_tool)),
+                MessageBlock::ToolCall(Box::new(main_tool)),
+            ],
+            None,
+        );
+
+        let mut lines = Vec::new();
+        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
+        let rendered = render_lines_to_strings(&lines);
+
+        let root_idx = line_index_containing(&rendered, "root");
+        let focused_idx = line_index_containing(&rendered, "focused-permission");
+        let main_idx = line_index_containing(&rendered, "main-tool");
+
+        assert!(root_idx < focused_idx);
+        assert!(focused_idx < main_idx);
     }
 
     #[test]
@@ -2028,70 +2281,6 @@ mod tests {
             rendered.iter().position(|line| line.contains("Heading")).expect("heading");
         assert_eq!(heading_idx, 1);
         assert!(!rendered[heading_idx].is_empty());
-    }
-
-    #[test]
-    fn assistant_message_hides_subagent_indicator_when_disabled() {
-        let spinner = idle_spinner();
-        let mut msg = ChatMessage::new(
-            MessageRole::Assistant,
-            vec![
-                MessageBlock::ToolCall(Box::new(make_tool_call_info(
-                    "task-main",
-                    "Task",
-                    crate::agent::model::ToolCallStatus::InProgress,
-                    "Research project",
-                ))),
-                MessageBlock::ToolCall(Box::new(make_tool_call_info(
-                    "bash-child",
-                    "Bash",
-                    crate::agent::model::ToolCallStatus::InProgress,
-                    "",
-                ))),
-            ],
-            None,
-        );
-
-        let mut lines = Vec::new();
-        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
-        let rendered = render_lines_to_strings(&lines);
-
-        assert!(!rendered.iter().any(|line| line.contains("Thinking...")));
-    }
-
-    #[test]
-    fn assistant_message_places_subagent_indicator_after_visible_tool_blocks() {
-        let spinner = SpinnerState { show_subagent_thinking: true, ..idle_spinner() };
-        let mut msg = ChatMessage::new(
-            MessageRole::Assistant,
-            vec![
-                MessageBlock::ToolCall(Box::new(make_tool_call_info(
-                    "task-main",
-                    "Task",
-                    crate::agent::model::ToolCallStatus::InProgress,
-                    "Research project",
-                ))),
-                MessageBlock::ToolCall(Box::new(make_tool_call_info(
-                    "bash-done",
-                    "Bash",
-                    crate::agent::model::ToolCallStatus::Completed,
-                    "",
-                ))),
-            ],
-            None,
-        );
-
-        let mut lines = Vec::new();
-        render_message_with_tools_collapsed(&mut msg, &spinner, 120, false, &mut lines);
-        let rendered = render_lines_to_strings(&lines);
-
-        let bash_idx = rendered.iter().position(|line| line.contains("Bash")).expect("bash line");
-        let thinking_idx = rendered
-            .iter()
-            .position(|line| line.contains("Thinking..."))
-            .expect("subagent thinking line");
-
-        assert!(thinking_idx > bash_idx);
     }
 
     #[test]

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -1452,6 +1452,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status,
             content: if text.is_empty() {
                 Vec::new()

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -1530,6 +1530,7 @@ mod tests {
                     crate::agent::model::PermissionOptionKind::RejectOnce,
                 ),
             ],
+            display: None,
             response_tx,
             selected_index: 0,
             focused,

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -970,6 +970,8 @@ fn welcome_lines(block: &WelcomeBlock, _width: u16) -> Vec<Line<'static>> {
     )));
 
     lines.push(Line::default());
+    // TODO: Replace the hard-coded tip text with a small array of welcome tips
+    // and randomized selection once this becomes a first-class surface.
     lines.push(Line::from(Span::styled(
         format!(
             "{pad}Tips: Enter to send, Shift+Enter for newline, Ctrl+C copies selection or quits"

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -30,6 +30,33 @@ const FERRIS_SAYS: &[&str] = &[
     r"          / '-----' \ ",
 ];
 
+// Prepared for future randomized welcome-tip selection. Intentionally unused
+// until the welcome UI is switched from a single hard-coded tip.
+const WELCOME_TIPS: &[&str] = &[
+    "Use /mode plan before larger changes, then switch back to code once the plan is clear",
+    "Use /mcp to connect live tools and docs instead of pasting stale context into chat",
+    "Keep repo instructions short in CLAUDE.md and update them when mistakes repeat",
+    "Start prompts with the goal, relevant context, and constraints so Claude needs fewer corrections",
+    "Ask Claude for a plan first on multi-step work instead of jumping straight to edits",
+    "Give success criteria Claude can verify: tests, lint, screenshots, or exact outputs",
+    "For visual work, paste screenshots or mockups so Claude can verify UI changes instead of guessing",
+    "Start a fresh thread with /new-session when the task changes and old context is noise",
+    "Use /compact when a session gets long and you want to keep the thread but trim context",
+    "Use /resume <session_id> to jump back into earlier work without rebuilding context",
+    "Use /docs shortcuts to see the live keyboard shortcuts for the current app state",
+    "Use /docs commands to inspect the slash commands this app and the SDK expose",
+    "If Claude drifts, refine or restate the plan early instead of piling on corrective prompts",
+    "For tricky bugs, provide clear repro steps and runtime evidence instead of guessing fixes",
+    "Point Claude at the relevant files, errors, and constraints instead of pasting everything",
+    "If you do not know the exact file, let Claude search first and only pin the files that matter",
+    "Ask codebase questions first in unfamiliar areas instead of coding blind",
+    "Review diffs carefully even when the output looks plausible on first read",
+    "Use hooks for checks that must run every time instead of relying on reminder text alone",
+    "Turn repeated workflows into CLAUDE.md guidance only after they work reliably by hand",
+    "For larger features, let Claude clarify requirements and edge cases through structured questions",
+    "Use separate sessions for unrelated work so planning, debugging, and review stay clean",
+];
+
 /// Snapshot of the app state needed by the spinner -- extracted before
 /// the message loop so we don't need `&App` (which conflicts with `&mut msg`).
 #[derive(Clone, Copy)]
@@ -1016,14 +1043,22 @@ fn welcome_lines(block: &WelcomeBlock, _width: u16) -> Vec<Line<'static>> {
     // TODO: Replace the hard-coded tip text with a small array of welcome tips
     // and randomized selection once this becomes a first-class surface.
     lines.push(Line::from(Span::styled(
-        format!(
-            "{pad}Tips: Enter to send, Shift+Enter for newline, Ctrl+C copies selection or quits"
-        ),
+        format!("{pad}Tips: {}", selected_welcome_tip(block)),
         Style::default().fg(theme::DIM),
     )));
     lines.push(Line::default());
 
     lines
+}
+
+fn selected_welcome_tip(block: &WelcomeBlock) -> &'static str {
+    let Some(first_tip) = WELCOME_TIPS.first().copied() else {
+        return "Enter sends, Shift+Enter inserts a newline, and Ctrl+C copies a selection or quits";
+    };
+    let len_u64 = u64::try_from(WELCOME_TIPS.len()).unwrap_or(1);
+    let idx_u64 = block.tip_seed % len_u64;
+    let idx = usize::try_from(idx_u64).unwrap_or(0);
+    WELCOME_TIPS.get(idx).copied().unwrap_or(first_tip)
 }
 
 fn render_welcome_cached(block: &mut WelcomeBlock, width: u16, out: &mut Vec<Line<'static>>) {
@@ -1367,6 +1402,11 @@ mod tests {
         assert!(lines.iter().any(|line| line.contains("Subscription: -")));
         assert!(lines.iter().any(|line| line.contains("cwd:          /cwd")));
         assert!(lines.iter().any(|line| line.contains("Session ID:   -")));
+        assert!(lines.iter().any(|line| line.contains("Tips: ")));
+        assert!(
+            WELCOME_TIPS.iter().any(|tip| lines.iter().any(|line| line.contains(tip))),
+            "expected one welcome tip to be rendered"
+        );
     }
 
     // force_markdown_line_breaks
@@ -1550,7 +1590,13 @@ mod tests {
     }
 
     fn make_welcome_message(subscription: &str, cwd: &str, session_id: &str) -> ChatMessage {
-        ChatMessage::welcome(env!("CARGO_PKG_VERSION"), subscription, cwd, session_id)
+        let mut message =
+            ChatMessage::welcome(env!("CARGO_PKG_VERSION"), subscription, cwd, session_id);
+        let Some(MessageBlock::Welcome(block)) = message.blocks.first_mut() else {
+            panic!("expected welcome block");
+        };
+        block.tip_seed = 0;
+        message
     }
 
     fn idle_spinner() -> SpinnerState {

--- a/src/ui/tool_call/errors.rs
+++ b/src/ui/tool_call/errors.rs
@@ -36,7 +36,7 @@ pub(super) fn render_tool_use_error_content(message: &str) -> Vec<Line<'static>>
 }
 
 pub(super) fn debug_failed_tool_render(tc: &ToolCallInfo) {
-    if !matches!(tc.status, model::ToolCallStatus::Failed) {
+    if !matches!(tc.status, model::ToolCallStatus::Failed | model::ToolCallStatus::Killed) {
         return;
     }
 

--- a/src/ui/tool_call/execute.rs
+++ b/src/ui/tool_call/execute.rs
@@ -47,7 +47,7 @@ pub(super) fn render_execute_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
 
     if let Some(ref output) = tc.terminal_output {
         let stripped_output = highlight::strip_ansi(output);
-        if matches!(tc.status, model::ToolCallStatus::Failed)
+        if matches!(tc.status, model::ToolCallStatus::Failed | model::ToolCallStatus::Killed)
             && let Some(first_line) = failed_execute_first_line(&stripped_output)
         {
             body_lines.push(Line::from(Span::styled(

--- a/src/ui/tool_call/interactions.rs
+++ b/src/ui/tool_call/interactions.rs
@@ -392,6 +392,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status: ToolCallStatus::InProgress,
             content: Vec::new(),
             hidden: false,

--- a/src/ui/tool_call/interactions.rs
+++ b/src/ui/tool_call/interactions.rs
@@ -33,6 +33,11 @@ pub(super) fn render_permission_lines(
         ];
     }
 
+    let mut lines = vec![Line::default()];
+    if let Some(display) = permission_display_lines(perm) {
+        lines.extend(display);
+    }
+
     let mut spans: Vec<Span<'static>> = Vec::new();
     let dot = Span::styled("  \u{00b7}  ", Style::default().fg(theme::DIM));
 
@@ -93,14 +98,45 @@ pub(super) fn render_permission_lines(
         spans.push(Span::styled(shortcut, Style::default().fg(theme::DIM)));
     }
 
-    vec![
-        Line::default(),
-        Line::from(spans),
-        Line::from(Span::styled(
-            "\u{2190}\u{2192} select  \u{2191}\u{2193} next  enter confirm  esc reject",
-            Style::default().fg(theme::DIM),
-        )),
-    ]
+    lines.push(Line::from(spans));
+    lines.push(Line::from(Span::styled(
+        "\u{2190}\u{2192} select  \u{2191}\u{2193} next  enter confirm  esc reject",
+        Style::default().fg(theme::DIM),
+    )));
+    lines
+}
+
+fn permission_display_lines(perm: &InlinePermission) -> Option<Vec<Line<'static>>> {
+    let display = perm.display.as_ref()?;
+    let title = display.title.as_ref().map(|value| value.trim()).filter(|value| !value.is_empty());
+    let display_name =
+        display.display_name.as_ref().map(|value| value.trim()).filter(|value| !value.is_empty());
+    let description =
+        display.description.as_ref().map(|value| value.trim()).filter(|value| !value.is_empty());
+    if title.is_none() && display_name.is_none() && description.is_none() {
+        return None;
+    }
+
+    let mut lines = Vec::new();
+    if let Some(title) = title.or(display_name) {
+        lines.push(Line::from(vec![
+            Span::styled("  ! ", Style::default().fg(theme::RUST_ORANGE)),
+            Span::styled(
+                title.to_owned(),
+                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            ),
+        ]));
+    }
+    if let Some(description) = description {
+        lines.push(Line::from(vec![
+            Span::raw("    "),
+            Span::styled(description.to_owned(), Style::default().fg(theme::DIM)),
+        ]));
+    }
+    if !lines.is_empty() {
+        lines.push(Line::default());
+    }
+    Some(lines)
 }
 
 fn is_plan_approval_permission(perm: &InlinePermission) -> bool {
@@ -353,7 +389,8 @@ pub(super) fn render_question_lines(question: &InlineQuestion) -> Vec<Line<'stat
 mod tests {
     use super::{render_permission_lines, render_plan_approval_lines, render_question_lines};
     use crate::agent::model::{
-        PermissionOption, PermissionOptionKind, QuestionOption, QuestionPrompt, ToolCallStatus,
+        PermissionDisplay, PermissionOption, PermissionOptionKind, QuestionOption, QuestionPrompt,
+        ToolCallStatus,
     };
     use crate::app::{InlinePermission, InlineQuestion, ToolCallInfo};
     use crate::ui::theme;
@@ -421,6 +458,7 @@ mod tests {
                 PermissionOption::new("allow", "Allow", kind),
                 PermissionOption::new("deny", "Deny", PermissionOptionKind::RejectOnce),
             ],
+            display: None,
             response_tx,
             selected_index: 0,
             focused: true,
@@ -466,6 +504,28 @@ mod tests {
             .expect("selected permission label");
 
         assert_eq!(selected_label.style.fg, Some(theme::RUST_ORANGE));
+    }
+
+    #[test]
+    fn permission_display_metadata_renders_prompt_header() {
+        let tc = test_tool_call("Bash");
+        let mut perm = test_permission(PermissionOptionKind::AllowOnce);
+        perm.display = Some(
+            PermissionDisplay::new()
+                .title(Some("Claude wants to run tests".to_owned()))
+                .description(Some("This command reads project files".to_owned())),
+        );
+
+        let rendered = render_permission_lines(&tc, &perm)
+            .into_iter()
+            .map(|line| {
+                line.spans.into_iter().map(|span| span.content.into_owned()).collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Claude wants to run tests"));
+        assert!(rendered.contains("This command reads project files"));
     }
 
     #[test]

--- a/src/ui/tool_call/interactions.rs
+++ b/src/ui/tool_call/interactions.rs
@@ -34,7 +34,7 @@ pub(super) fn render_permission_lines(
     }
 
     let mut lines = vec![Line::default()];
-    if let Some(display) = permission_display_lines(perm) {
+    if let Some(display) = permission_display_lines(tc, perm) {
         lines.extend(display);
     }
 
@@ -106,7 +106,10 @@ pub(super) fn render_permission_lines(
     lines
 }
 
-fn permission_display_lines(perm: &InlinePermission) -> Option<Vec<Line<'static>>> {
+fn permission_display_lines(
+    tc: &ToolCallInfo,
+    perm: &InlinePermission,
+) -> Option<Vec<Line<'static>>> {
     let display = perm.display.as_ref()?;
     let title = display.title.as_ref().map(|value| value.trim()).filter(|value| !value.is_empty());
     let display_name =
@@ -117,15 +120,17 @@ fn permission_display_lines(perm: &InlinePermission) -> Option<Vec<Line<'static>
         return None;
     }
 
+    let header = title
+        .into_iter()
+        .chain(display_name)
+        .find(|value| !is_redundant_permission_header(tc, value));
+
     let mut lines = Vec::new();
-    if let Some(title) = title.or(display_name) {
-        lines.push(Line::from(vec![
-            Span::styled("  ! ", Style::default().fg(theme::RUST_ORANGE)),
-            Span::styled(
-                title.to_owned(),
-                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
-            ),
-        ]));
+    if let Some(title) = header {
+        lines.push(Line::from(Span::styled(
+            format!("  {title}"),
+            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+        )));
     }
     if let Some(description) = description {
         lines.push(Line::from(vec![
@@ -137,6 +142,18 @@ fn permission_display_lines(perm: &InlinePermission) -> Option<Vec<Line<'static>
         lines.push(Line::default());
     }
     Some(lines)
+}
+
+fn is_redundant_permission_header(tc: &ToolCallInfo, value: &str) -> bool {
+    let normalized = normalize_permission_header(value);
+    let tool_label = normalize_permission_header(theme::tool_name_label(&tc.sdk_tool_name).1);
+    let sdk_name = normalize_permission_header(&tc.sdk_tool_name);
+    let title = normalize_permission_header(&tc.title);
+    normalized == tool_label || normalized == sdk_name || normalized == title
+}
+
+fn normalize_permission_header(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
 }
 
 fn is_plan_approval_permission(perm: &InlinePermission) -> bool {
@@ -525,6 +542,28 @@ mod tests {
             .join("\n");
 
         assert!(rendered.contains("Claude wants to run tests"));
+        assert!(rendered.contains("This command reads project files"));
+    }
+
+    #[test]
+    fn permission_display_metadata_hides_redundant_tool_header() {
+        let tc = test_tool_call("Bash");
+        let mut perm = test_permission(PermissionOptionKind::AllowOnce);
+        perm.display = Some(
+            PermissionDisplay::new()
+                .title(Some("Bash".to_owned()))
+                .description(Some("This command reads project files".to_owned())),
+        );
+
+        let rendered = render_permission_lines(&tc, &perm)
+            .into_iter()
+            .map(|line| {
+                line.spans.into_iter().map(|span| span.content.into_owned()).collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(!rendered.contains("\n  Bash\n"));
         assert!(rendered.contains("This command reads project files"));
     }
 

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -47,7 +47,9 @@ pub fn status_icon(status: model::ToolCallStatus, spinner_frame: usize) -> (&'st
             (s, theme::RUST_ORANGE)
         }
         model::ToolCallStatus::Completed => (theme::ICON_COMPLETED, theme::RUST_ORANGE),
-        model::ToolCallStatus::Failed => (theme::ICON_FAILED, theme::STATUS_ERROR),
+        model::ToolCallStatus::Failed | model::ToolCallStatus::Killed => {
+            (theme::ICON_FAILED, theme::STATUS_ERROR)
+        }
     }
 }
 
@@ -256,6 +258,13 @@ fn tool_output_badge_spans(tc: &ToolCallInfo) -> Vec<Span<'static>> {
         ));
     }
 
+    if tc.task_is_backgrounded() {
+        badges.push(Span::styled(
+            "  [backgrounded]",
+            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        ));
+    }
+
     if tc.is_ultraplan() {
         badges.push(Span::styled(
             "  [ultraplan]",
@@ -295,6 +304,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status,
             content: Vec::new(),
             hidden: false,
@@ -342,6 +352,13 @@ mod tests {
     #[test]
     fn status_icon_failed() {
         let (icon, color) = status_icon(model::ToolCallStatus::Failed, 0);
+        assert_eq!(icon, theme::ICON_FAILED);
+        assert_eq!(color, theme::STATUS_ERROR);
+    }
+
+    #[test]
+    fn status_icon_killed() {
+        let (icon, color) = status_icon(model::ToolCallStatus::Killed, 0);
         assert_eq!(icon, theme::ICON_FAILED);
         assert_eq!(color, theme::STATUS_ERROR);
     }
@@ -401,6 +418,17 @@ mod tests {
     }
 
     #[test]
+    fn render_tool_call_title_shows_backgrounded_badge() {
+        let mut tc = test_tool_call("tc-bg", "Agent", model::ToolCallStatus::InProgress);
+        tc.task_metadata = Some(model::TaskMetadata::new().backgrounded(Some(true)));
+
+        let line = standard::render_tool_call_title(&tc, 80, 0);
+        let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+
+        assert!(rendered.contains("[backgrounded]"));
+    }
+
+    #[test]
     fn execute_top_border_does_not_wrap_for_long_title() {
         let tc = ToolCallInfo {
             id: "tc-1".into(),
@@ -410,6 +438,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status: model::ToolCallStatus::Pending,
             content: Vec::new(),
             hidden: false,
@@ -692,6 +721,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status: model::ToolCallStatus::Completed,
             content: Vec::new(),
             hidden: false,
@@ -723,6 +753,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status: model::ToolCallStatus::Failed,
             content: Vec::new(),
             hidden: false,
@@ -754,6 +785,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status: model::ToolCallStatus::Failed,
             content: Vec::new(),
             hidden: false,
@@ -787,6 +819,7 @@ mod tests {
             raw_input: None,
             raw_input_bytes: 0,
             output_metadata: None,
+            task_metadata: None,
             status: model::ToolCallStatus::Failed,
             content: Vec::new(),
             hidden: false,

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -791,6 +791,26 @@ mod tests {
     }
 
     #[test]
+    fn content_summary_uses_higher_limit_for_in_progress_agent() {
+        let mut tc = test_tool_call("tc-agent", "Agent", model::ToolCallStatus::InProgress);
+        let long_line = "a".repeat(150);
+        tc.content = vec![model::ToolCallContent::from(long_line.clone())];
+
+        assert_eq!(content_summary(&tc), long_line);
+    }
+
+    #[test]
+    fn content_summary_keeps_normal_limit_for_completed_agent() {
+        let mut tc = test_tool_call("tc-agent-done", "Agent", model::ToolCallStatus::Completed);
+        let long_line = "a".repeat(150);
+        tc.content = vec![model::ToolCallContent::from(long_line)];
+
+        let summary = content_summary(&tc);
+        assert_eq!(summary.chars().count(), 60);
+        assert!(summary.ends_with("..."));
+    }
+
+    #[test]
     fn render_execute_content_failed_surfaces_summary_before_full_output() {
         let tc = ToolCallInfo {
             id: "tc-3".into(),

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -265,13 +265,6 @@ fn tool_output_badge_spans(tc: &ToolCallInfo) -> Vec<Span<'static>> {
         ));
     }
 
-    if tc.is_ultraplan() {
-        badges.push(Span::styled(
-            "  [ultraplan]",
-            Style::default().fg(theme::RUST_ORANGE).add_modifier(Modifier::BOLD),
-        ));
-    }
-
     if tc.verification_nudge_needed() {
         badges.push(Span::styled(
             "  [verification needed]",
@@ -527,19 +520,6 @@ mod tests {
             measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 1, false);
         assert_eq!(recomputed_height, first_height);
         assert!(recompute_lines > 0);
-    }
-
-    #[test]
-    fn exit_plan_mode_title_renders_ultraplan_badge() {
-        let mut tc = test_tool_call("tc-plan", "ExitPlanMode", model::ToolCallStatus::Completed);
-        tc.output_metadata =
-            Some(model::ToolOutputMetadata::new().exit_plan_mode(Some(
-                model::ExitPlanModeOutputMetadata::new().ultraplan(Some(true)),
-            )));
-
-        let rendered = standard::render_tool_call_title(&tc, 80, 0);
-        let text: String = rendered.spans.iter().map(|span| span.content.as_ref()).collect();
-        assert!(text.contains("[ultraplan]"));
     }
 
     #[test]

--- a/src/ui/tool_call/standard.rs
+++ b/src/ui/tool_call/standard.rs
@@ -22,6 +22,8 @@ use super::{markdown_inline_spans, status_icon, tool_output_badge_spans};
 
 pub(super) const WRITE_DIFF_MAX_LINES: usize = 50;
 pub(super) const WRITE_DIFF_HEAD_LINES: usize = 10;
+const DEFAULT_COLLAPSED_TEXT_SUMMARY_LIMIT: usize = 60;
+const IN_PROGRESS_SUBAGENT_COLLAPSED_TEXT_SUMMARY_LIMIT: usize = 180;
 
 /// Render just the title line for a non-Execute tool call (the line containing the spinner icon).
 /// Used for in-progress tool calls where only the spinner changes each frame.
@@ -162,11 +164,7 @@ pub(super) fn content_summary(tc: &ToolCallInfo) -> String {
                 }
                 if let Some(text) = resource.text.as_deref() {
                     let first = text.lines().find(|line| !line.trim().is_empty()).unwrap_or("");
-                    if first.chars().count() > 60 {
-                        let truncated: String = first.chars().take(57).collect();
-                        return format!("{truncated}...");
-                    }
-                    return first.to_owned();
+                    return truncate_summary_line(first, DEFAULT_COLLAPSED_TEXT_SUMMARY_LIMIT);
                 }
                 return resource.uri.clone();
             }
@@ -181,18 +179,32 @@ pub(super) fn content_summary(tc: &ToolCallInfo) -> String {
                         return msg;
                     }
                     let first = stripped.lines().next().unwrap_or("");
-                    return if first.chars().count() > 60 {
-                        let truncated: String = first.chars().take(57).collect();
-                        format!("{truncated}...")
-                    } else {
-                        first.to_owned()
-                    };
+                    return truncate_summary_line(first, collapsed_text_summary_limit(tc));
                 }
             }
             model::ToolCallContent::Terminal(_) => {}
         }
     }
     String::new()
+}
+
+fn collapsed_text_summary_limit(tc: &ToolCallInfo) -> usize {
+    if matches!(tc.status, model::ToolCallStatus::InProgress)
+        && matches!(tc.sdk_tool_name.as_str(), "Agent" | "Task")
+    {
+        IN_PROGRESS_SUBAGENT_COLLAPSED_TEXT_SUMMARY_LIMIT
+    } else {
+        DEFAULT_COLLAPSED_TEXT_SUMMARY_LIMIT
+    }
+}
+
+fn truncate_summary_line(line: &str, max_chars: usize) -> String {
+    if line.chars().count() > max_chars {
+        let truncated: String = line.chars().take(max_chars.saturating_sub(3)).collect();
+        format!("{truncated}...")
+    } else {
+        line.to_owned()
+    }
 }
 
 /// Render the full content of a tool call as lines.

--- a/src/ui/tool_call/standard.rs
+++ b/src/ui/tool_call/standard.rs
@@ -117,7 +117,7 @@ pub(super) fn content_summary(tc: &ToolCallInfo) -> String {
     if tc.terminal_id.is_some() {
         if let Some(ref output) = tc.terminal_output {
             let stripped_output = highlight::strip_ansi(output);
-            if matches!(tc.status, model::ToolCallStatus::Failed)
+            if matches!(tc.status, model::ToolCallStatus::Failed | model::ToolCallStatus::Killed)
                 && let Some(first_line) = failed_execute_first_line(&stripped_output)
             {
                 return if first_line.chars().count() > 80 {
@@ -173,8 +173,10 @@ pub(super) fn content_summary(tc: &ToolCallInfo) -> String {
             model::ToolCallContent::Content(c) => {
                 if let model::ContentBlock::Text(text) = &c.content {
                     let stripped = strip_outer_code_fence(&text.text);
-                    if matches!(tc.status, model::ToolCallStatus::Failed)
-                        && let Some(msg) = extract_tool_use_error_message(&stripped)
+                    if matches!(
+                        tc.status,
+                        model::ToolCallStatus::Failed | model::ToolCallStatus::Killed
+                    ) && let Some(msg) = extract_tool_use_error_message(&stripped)
                     {
                         return msg;
                     }
@@ -202,7 +204,7 @@ fn render_tool_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
     if is_execute {
         if let Some(ref output) = tc.terminal_output {
             let stripped_output = highlight::strip_ansi(output);
-            if matches!(tc.status, model::ToolCallStatus::Failed)
+            if matches!(tc.status, model::ToolCallStatus::Failed | model::ToolCallStatus::Killed)
                 && let Some(first_line) = failed_execute_first_line(&stripped_output)
             {
                 lines.push(Line::from(Span::styled(
@@ -247,13 +249,15 @@ fn render_tool_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
 
 fn render_text_content(tc: &ToolCallInfo, text: &str, lines: &mut Vec<Line<'static>>) {
     let stripped = strip_outer_code_fence(text);
-    if matches!(tc.status, model::ToolCallStatus::Failed)
+    if matches!(tc.status, model::ToolCallStatus::Failed | model::ToolCallStatus::Killed)
         && let Some(msg) = extract_tool_use_error_message(&stripped)
     {
         lines.extend(render_tool_use_error_content(&msg));
         return;
     }
-    if matches!(tc.status, model::ToolCallStatus::Failed) && looks_like_internal_error(&stripped) {
+    if matches!(tc.status, model::ToolCallStatus::Failed | model::ToolCallStatus::Killed)
+        && looks_like_internal_error(&stripped)
+    {
         lines.extend(render_internal_failure_content(&stripped));
         return;
     }

--- a/tests/integration/caching_pipeline.rs
+++ b/tests/integration/caching_pipeline.rs
@@ -47,7 +47,7 @@ fn stream_text(app: &mut App, text: &str) {
 }
 
 fn complete_turn(app: &mut App) {
-    send_client_event(app, ClientEvent::TurnComplete);
+    send_client_event(app, ClientEvent::TurnComplete { terminal_reason: None });
 }
 
 /// Build a `ChatMessage` with a single text block for direct insertion.

--- a/tests/integration/caching_pipeline.rs
+++ b/tests/integration/caching_pipeline.rs
@@ -33,7 +33,6 @@ fn inactive_spinner() -> SpinnerState {
         is_active_turn_assistant: false,
         show_empty_thinking: false,
         show_thinking: false,
-        show_subagent_thinking: false,
         show_compacting: false,
     }
 }

--- a/tests/integration/permissions.rs
+++ b/tests/integration/permissions.rs
@@ -186,7 +186,7 @@ async fn turn_complete_resets_transient_state() {
     app.files_accessed = 5;
     app.spinner_frame = 42;
 
-    send_client_event(&mut app, ClientEvent::TurnComplete);
+    send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
     assert!(matches!(app.status, AppStatus::Ready));
     assert_eq!(app.files_accessed, 0, "files_accessed should reset");
@@ -207,7 +207,7 @@ async fn turn_complete_does_not_clear_messages() {
     );
     assert_eq!(app.messages.len(), 1);
 
-    send_client_event(&mut app, ClientEvent::TurnComplete);
+    send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
     assert_eq!(app.messages.len(), 1, "messages should persist across turns");
 }
@@ -221,7 +221,7 @@ async fn turn_complete_does_not_clear_tool_call_index() {
     send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
     assert!(app.tool_call_index.contains_key("tc-persist"));
 
-    send_client_event(&mut app, ClientEvent::TurnComplete);
+    send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
     assert!(
         app.tool_call_index.contains_key("tc-persist"),
@@ -241,7 +241,7 @@ async fn turn_complete_does_not_clear_todos() {
     }];
     app.show_todo_panel = true;
 
-    send_client_event(&mut app, ClientEvent::TurnComplete);
+    send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
     assert_eq!(app.todos.len(), 1, "todos should persist across turns");
     assert!(app.show_todo_panel, "todo panel state should persist");
@@ -260,7 +260,7 @@ async fn turn_complete_does_not_affect_mode() {
         }],
     });
 
-    send_client_event(&mut app, ClientEvent::TurnComplete);
+    send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
     assert!(app.mode.is_some(), "mode should persist across turns");
 }

--- a/tests/integration/permissions.rs
+++ b/tests/integration/permissions.rs
@@ -26,7 +26,8 @@ fn setup_permission(
     let (response_tx, response_rx) = oneshot::channel();
     let tool_call_update =
         model::ToolCallUpdate::new(tool_id.to_owned(), model::ToolCallUpdateFields::new());
-    let request = model::RequestPermissionRequest::new("test-session", tool_call_update, options);
+    let request =
+        model::RequestPermissionRequest::new("test-session", tool_call_update, options, None);
     send_client_event(app, ClientEvent::PermissionRequest { request, response_tx });
     response_rx
 }
@@ -79,7 +80,8 @@ async fn permission_for_unknown_tool_call_auto_rejects() {
     let tool_call_update =
         model::ToolCallUpdate::new("nonexistent", model::ToolCallUpdateFields::new());
     let options = allow_deny_options();
-    let request = model::RequestPermissionRequest::new("test-session", tool_call_update, options);
+    let request =
+        model::RequestPermissionRequest::new("test-session", tool_call_update, options, None);
     send_client_event(&mut app, ClientEvent::PermissionRequest { request, response_tx });
 
     // Should NOT be in pending queue
@@ -130,6 +132,7 @@ async fn duplicate_permission_request_is_rejected_without_duplicate_queue_entry(
         "test-session",
         tool_call_update,
         allow_deny_options(),
+        None,
     );
     send_client_event(&mut app, ClientEvent::PermissionRequest { request, response_tx });
 

--- a/tests/integration/state_transitions.rs
+++ b/tests/integration/state_transitions.rs
@@ -39,7 +39,7 @@ async fn full_turn_lifecycle_text_only() {
     assert!(matches!(app.status, AppStatus::Running));
 
     // Turn completes
-    send_client_event(&mut app, ClientEvent::TurnComplete);
+    send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
     assert!(matches!(app.status, AppStatus::Ready));
     assert_eq!(app.messages.len(), 1);
 }
@@ -83,7 +83,7 @@ async fn full_turn_lifecycle_with_tool_calls() {
     );
 
     // Turn completes
-    send_client_event(&mut app, ClientEvent::TurnComplete);
+    send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
     assert!(matches!(app.status, AppStatus::Ready));
 }
 
@@ -176,7 +176,10 @@ async fn todowrite_replaces_previous_items_and_clears_for_terminal_payloads() {
 async fn error_then_new_turn_recovers() {
     let mut app = test_app();
 
-    send_client_event(&mut app, ClientEvent::TurnError("timeout".into()));
+    send_client_event(
+        &mut app,
+        ClientEvent::TurnError { message: "timeout".into(), terminal_reason: None },
+    );
     assert!(matches!(app.status, AppStatus::Error));
 
     // New text chunk (simulates user retry) starts fresh
@@ -202,7 +205,7 @@ async fn chunks_across_turns_append_to_last_assistant_message() {
         &mut app,
         ClientEvent::SessionUpdate(model::SessionUpdate::AgentMessageChunk(c1)),
     );
-    send_client_event(&mut app, ClientEvent::TurnComplete);
+    send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
     assert_eq!(app.messages.len(), 1);
 
     // Second turn: chunks append to the last assistant message (no user message between turns)
@@ -399,7 +402,7 @@ async fn rapid_turn_complete_then_new_streaming() {
         &mut app,
         ClientEvent::SessionUpdate(model::SessionUpdate::AgentMessageChunk(c1)),
     );
-    send_client_event(&mut app, ClientEvent::TurnComplete);
+    send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
     assert!(matches!(app.status, AppStatus::Ready));
     assert_eq!(app.files_accessed, 0);
 
@@ -415,7 +418,7 @@ async fn rapid_turn_complete_then_new_streaming() {
     send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
     assert_eq!(app.files_accessed, 1);
 
-    send_client_event(&mut app, ClientEvent::TurnComplete);
+    send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
     assert!(matches!(app.status, AppStatus::Ready));
     assert_eq!(app.files_accessed, 0, "reset again on second TurnComplete");
 }
@@ -456,7 +459,10 @@ async fn error_during_tool_calls_leaves_tool_calls_intact() {
     let tc = model::ToolCall::new("tc-err", "Read file").status(model::ToolCallStatus::InProgress);
     send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
 
-    send_client_event(&mut app, ClientEvent::TurnError("crashed".into()));
+    send_client_event(
+        &mut app,
+        ClientEvent::TurnError { message: "crashed".into(), terminal_reason: None },
+    );
 
     assert!(matches!(app.status, AppStatus::Error));
     // Tool call should remain indexed and preserved in the original assistant message.
@@ -488,6 +494,6 @@ async fn files_accessed_accumulates_across_tool_calls_in_one_turn() {
     }
 
     assert_eq!(app.files_accessed, 3, "one per tool call");
-    send_client_event(&mut app, ClientEvent::TurnComplete);
+    send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
     assert_eq!(app.files_accessed, 0, "reset on turn complete");
 }

--- a/tests/integration/tool_lifecycle.rs
+++ b/tests/integration/tool_lifecycle.rs
@@ -7,14 +7,33 @@
 
 use claude_code_rust::agent::events::ClientEvent;
 use claude_code_rust::agent::model;
-use claude_code_rust::app::{App, AppStatus, MessageBlock, ToolCallInfo};
+use claude_code_rust::app::{App, AppStatus, MessageBlock, ToolCallInfo, ToolCallScope};
 use pretty_assertions::assert_eq;
 
 use crate::helpers::{send_client_event, test_app};
 
 fn task_meta() -> serde_json::Map<String, serde_json::Value> {
+    claude_meta("Task", None)
+}
+
+fn child_meta(parent_tool_use_id: &str) -> serde_json::Map<String, serde_json::Value> {
+    claude_meta("Bash", Some(parent_tool_use_id))
+}
+
+fn claude_meta(
+    tool_name: &str,
+    parent_tool_use_id: Option<&str>,
+) -> serde_json::Map<String, serde_json::Value> {
     let mut meta = serde_json::Map::new();
-    meta.insert("claudeCode".into(), serde_json::json!({"toolName": "Task"}));
+    let mut claude_code = serde_json::Map::new();
+    claude_code.insert("toolName".into(), serde_json::Value::String(tool_name.to_owned()));
+    if let Some(parent_tool_use_id) = parent_tool_use_id {
+        claude_code.insert(
+            "parentToolUseId".into(),
+            serde_json::Value::String(parent_tool_use_id.to_owned()),
+        );
+    }
+    meta.insert("claudeCode".into(), serde_json::Value::Object(claude_code));
     meta
 }
 
@@ -185,6 +204,61 @@ async fn task_tool_calls_leave_active_set_only_on_terminal_statuses() {
         )),
     );
     assert!(!app.active_task_ids.contains("task-fail"), "failed Task should also be removed");
+}
+
+#[tokio::test]
+async fn subagent_child_tools_use_explicit_parent_linkage_only() {
+    let mut app = test_app();
+
+    let root = model::ToolCall::new("task-root", "Research")
+        .kind(model::ToolKind::Think)
+        .status(model::ToolCallStatus::InProgress)
+        .meta(task_meta());
+    send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(root)));
+
+    let child = model::ToolCall::new("child-bash", "Run child command")
+        .kind(model::ToolKind::Execute)
+        .status(model::ToolCallStatus::InProgress)
+        .meta(child_meta("task-root"));
+    send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(child)));
+
+    let main = model::ToolCall::new("main-bash", "Run main command")
+        .kind(model::ToolKind::Execute)
+        .status(model::ToolCallStatus::InProgress);
+    send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(main)));
+
+    assert_eq!(app.tool_call_scope("task-root"), Some(ToolCallScope::SubagentRoot));
+    assert_eq!(
+        app.tool_call_scope("child-bash"),
+        Some(ToolCallScope::SubagentChild { parent_tool_use_id: "task-root".to_owned() })
+    );
+    assert_eq!(app.tool_call_scope("main-bash"), Some(ToolCallScope::MainAgent));
+    assert!(tool_call_block(&app, "child-bash").hidden);
+    assert!(!tool_call_block(&app, "main-bash").hidden);
+}
+
+#[tokio::test]
+async fn tool_call_update_parent_linkage_marks_existing_tool_hidden() {
+    let mut app = test_app();
+
+    let tc = model::ToolCall::new("child-late", "Run child command")
+        .kind(model::ToolKind::Execute)
+        .status(model::ToolCallStatus::InProgress);
+    send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
+    assert!(!tool_call_block(&app, "child-late").hidden);
+
+    let update = model::ToolCallUpdate::new("child-late", model::ToolCallUpdateFields::new())
+        .meta(child_meta("task-root"));
+    send_client_event(
+        &mut app,
+        ClientEvent::SessionUpdate(model::SessionUpdate::ToolCallUpdate(update)),
+    );
+
+    assert_eq!(
+        app.tool_call_scope("child-late"),
+        Some(ToolCallScope::SubagentChild { parent_tool_use_id: "task-root".to_owned() })
+    );
+    assert!(tool_call_block(&app, "child-late").hidden);
 }
 
 // --- Collapsed tool calls ---


### PR DESCRIPTION
## Summary

Upgrade the bundled Claude Agent SDK integration to `0.2.104` and realign the Rust and TypeScript bridge around the newer session, tool, and runtime contract.

**SDK and bridge contract**
- Upgrade `@anthropic-ai/claude-agent-sdk` to `0.2.104` in both the published package and the local `agent-sdk`
- Update bridge commands, events, and shared types to carry the newer runtime data the TUI now consumes, including current model snapshots, runtime session state, API retry updates, settings parse errors, terminal reasons, permission display metadata, task metadata, context-usage refreshes, and plugin reloads
- Refresh lifecycle and command handling so model and permission-mode changes are negotiated against the current SDK capabilities instead of assuming startup-time state

**Runtime and session behavior**
- Tighten connect, resume, and turn-lifecycle handling so session state stays ordered and consistent across reconnects, tool updates, and turn completion
- Preserve resumed history ordering and keep current-model, mode, and context-usage state synchronized with the runtime session
- Respect external API providers during auth validation and surface new runtime warnings and parse failures in the app state

**Tools and subagent UI**
- Propagate incremental task patches and task metadata through the bridge so tool cards can reflect updated task state, backgrounding, and terminal outcomes
- Collapse linked child tool calls under their subagent root while still surfacing focused hidden permission prompts when user input is required
- Normalize tool-result and permission-display metadata between the SDK and Rust UI, remove redundant permission headers, and show more useful collapsed summaries for in-progress subagents

**Startup, input, and docs**
- Replace the welcome model badge with a lightweight session snapshot and rotating startup tips
- Keep text paste on the normal paste path while making `Ctrl-V` exclusively trigger image paste
- Add a dedicated `agent-sdk` workflow with `audit`, `lint`, and `knip` checks, and document the current startup limitation in `README.md`

## Why

The branch needs the `0.2.104` SDK upgrade to stay compatible with the current Claude Agent SDK protocol. The rest of the changes align the TUI with that newer contract and tighten the runtime and UI behavior around sessions, tools, permissions, and startup state.

## Validation

- Passed: `cargo fmt --all -- --check`
- Passed: `cargo clippy --all-targets --all-features -- -D warnings`
- Passed: `cargo test --all-features`
- Passed: `cargo check --offline`
- Passed: `cargo fetch --locked`
- Passed: `agent-sdk` `npm.cmd run lint`
- Passed: `agent-sdk` `npm.cmd run knip`
- Failed: `agent-sdk` `npm.cmd run audit`
  Current result: 4 moderate vulnerabilities from transitive `hono` dependencies via `@anthropic-ai/claude-agent-sdk` -> `@modelcontextprotocol/sdk`, with `npm audit` reporting no fix available

## Notes

- The bridge and SDK contract changes in this branch are intended for the `0.2.104` integration and are not described as backward-compatible with the older `0.2.74` contract
