### PR TITLE
feat(slash): add folder-local 1m-context controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.1] - 2026-04-16 [Changes][v0.11.1]
+
+### Features
+
+- **Folder-local 1M context controls** (@srothgan): Add `/1m-context enable|disable|status` to persist `CLAUDE_CODE_DISABLE_1M_CONTEXT` in `.claude/settings.local.json`, preserve neighboring local env keys, surface status, and point 1M-context recovery guidance at the new folder-local fallback
+
 ## [0.11.0] - 2026-04-16 [Changes][v0.11.0]
 
 ### Features
@@ -484,6 +490,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.11.1]: https://github.com/srothgan/claude-code-rust/compare/v0.11.0...v0.11.1
 [v0.11.0]: https://github.com/srothgan/claude-code-rust/compare/v0.10.0...v0.11.0
 [v0.10.0]: https://github.com/srothgan/claude-code-rust/compare/v0.9.0...v0.10.0
 [v0.9.0]: https://github.com/srothgan/claude-code-rust/compare/v0.8.4...v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/src/app/config/store.rs
+++ b/src/app/config/store.rs
@@ -17,6 +17,7 @@ const SETTINGS_FILENAME: &str = "settings.json";
 const LOCAL_SETTINGS_FILENAME: &str = "settings.local.json";
 const PREFERENCES_FILENAME: &str = ".claude.json";
 const CLAUDE_DIR: &str = ".claude";
+const CLAUDE_CODE_DISABLE_1M_CONTEXT_ENV: &str = "CLAUDE_CODE_DISABLE_1M_CONTEXT";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PersistedSettingValue {
@@ -285,6 +286,26 @@ pub fn set_language(document: &mut Value, value: Option<&str>) {
             PersistedSettingValue::String(text.to_owned())
         });
     write_persisted_setting(document, setting_spec(SettingId::Language), persisted);
+}
+
+pub fn disable_1m_context(document: &Value) -> Result<bool, ()> {
+    match read_json_path(document, &["env", CLAUDE_CODE_DISABLE_1M_CONTEXT_ENV]) {
+        None => Ok(false),
+        Some(Value::String(value)) => Ok(value == "1"),
+        Some(_) => Err(()),
+    }
+}
+
+pub fn set_disable_1m_context(document: &mut Value, disabled: bool) {
+    if disabled {
+        set_json_path(
+            document,
+            &["env", CLAUDE_CODE_DISABLE_1M_CONTEXT_ENV],
+            Value::String("1".to_owned()),
+        );
+    } else {
+        remove_json_path(document, &["env", CLAUDE_CODE_DISABLE_1M_CONTEXT_ENV]);
+    }
 }
 
 pub fn respect_gitignore(document: &Value) -> Result<bool, ()> {
@@ -622,6 +643,39 @@ mod tests {
 
         assert_eq!(output_style(&saved), Ok(OutputStyle::Learning));
         assert_eq!(saved["spinnerTipsEnabled"], Value::Bool(true));
+    }
+
+    #[test]
+    fn set_disable_1m_context_preserves_neighboring_env_keys() {
+        let mut document = serde_json::json!({
+            "env": {
+                "KEEP_ME": "yes"
+            },
+            "other": true
+        });
+
+        set_disable_1m_context(&mut document, true);
+        assert_eq!(disable_1m_context(&document), Ok(true));
+        assert_eq!(document["env"]["KEEP_ME"], Value::String("yes".to_owned()));
+
+        set_disable_1m_context(&mut document, false);
+        assert_eq!(disable_1m_context(&document), Ok(false));
+        assert_eq!(document["env"]["KEEP_ME"], Value::String("yes".to_owned()));
+        assert_eq!(document["other"], Value::Bool(true));
+    }
+
+    #[test]
+    fn set_disable_1m_context_removes_empty_env_object() {
+        let mut document = serde_json::json!({
+            "env": {
+                "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1"
+            }
+        });
+
+        set_disable_1m_context(&mut document, false);
+
+        assert_eq!(disable_1m_context(&document), Ok(false));
+        assert!(document.get("env").is_none());
     }
 
     #[test]

--- a/src/app/events/rate_limit.rs
+++ b/src/app/events/rate_limit.rs
@@ -5,7 +5,7 @@ use super::super::{App, NoticeDedupKey, NoticeStage, RateLimitIncidentKey, Syste
 use crate::agent::model;
 use std::time::Duration;
 
-const EXTRA_USAGE_REQUIRED_MESSAGE: &str = "Extra usage is required for 1M context. Run /extra-usage to enable it, or /model to switch to standard context.";
+const EXTRA_USAGE_REQUIRED_MESSAGE: &str = "Extra usage is required for 1M context. Use /extra-usage to enable it, /model to switch models, or /1m-context disable to turn off 1M context for this folder.";
 
 fn format_rate_limit_type(raw: &str) -> &str {
     match raw {
@@ -204,7 +204,7 @@ mod tests {
 
         assert_eq!(
             format_rate_limit_summary(&update),
-            "Extra usage is required for 1M context. Run /extra-usage to enable it, or /model to switch to standard context."
+            "Extra usage is required for 1M context. Use /extra-usage to enable it, /model to switch models, or /1m-context disable to turn off 1M context for this folder."
         );
     }
 

--- a/src/app/slash/candidates.rs
+++ b/src/app/slash/candidates.rs
@@ -109,11 +109,12 @@ pub(super) fn find_advertised_command<'a>(
 }
 
 fn is_builtin_variable_input_command(command_name: &str) -> bool {
-    matches!(command_name, "/docs" | "/mode" | "/model" | "/resume")
+    matches!(command_name, "/1m-context" | "/docs" | "/mode" | "/model" | "/resume")
 }
 
 pub(super) fn builtin_argument_confirmation_closes(command_name: &str, arg_index: usize) -> bool {
-    arg_index == 0 && matches!(command_name, "/docs" | "/mode" | "/model" | "/resume")
+    arg_index == 0
+        && matches!(command_name, "/1m-context" | "/docs" | "/mode" | "/model" | "/resume")
 }
 
 pub(super) fn is_variable_input_command(app: &App, command_name: &str) -> bool {
@@ -130,6 +131,7 @@ pub(super) fn supported_command_candidates(app: &App) -> Vec<SlashCandidate> {
     use std::collections::BTreeMap;
 
     let mut by_name: BTreeMap<String, String> = BTreeMap::new();
+    by_name.insert("/1m-context".into(), "Manage 1M context for this folder".into());
     by_name.insert("/cancel".into(), "Cancel active turn".into());
     by_name.insert("/compact".into(), "Compact session context".into());
     by_name.insert("/config".into(), "Open settings".into());
@@ -258,6 +260,18 @@ pub(super) fn argument_candidates(
     }
 
     match command_name {
+        "/1m-context" => [
+            ("disable", "Disable 1M context for future sessions in this folder"),
+            ("enable", "Enable 1M context for future sessions in this folder"),
+            ("status", "Show the current 1M context setting for this folder"),
+        ]
+        .into_iter()
+        .map(|(value, description)| SlashCandidate {
+            insert_value: value.to_owned(),
+            primary: value.to_owned(),
+            secondary: Some(description.to_owned()),
+        })
+        .collect(),
         "/docs" => super::DOCS_TOPICS
             .iter()
             .map(|(topic, description)| SlashCandidate {
@@ -345,7 +359,8 @@ pub(super) fn build_slash_state(app: &App) -> Option<SlashState> {
 pub fn is_supported_command(app: &App, command_name: &str) -> bool {
     matches!(
         command_name,
-        "/cancel"
+        "/1m-context"
+            | "/cancel"
             | "/compact"
             | "/config"
             | "/mcp"

--- a/src/app/slash/executors.rs
+++ b/src/app/slash/executors.rs
@@ -8,10 +8,13 @@ use super::{
     set_command_pending,
 };
 use crate::agent::events::ClientEvent;
+use crate::app::config::{self, SettingFile, store};
 use crate::app::connect::{SessionStartReason, begin_resume_session, start_new_session};
 use crate::app::events::push_system_message_with_severity;
 use crate::app::{App, AppStatus, CancelOrigin, SystemSeverity};
 use std::fmt::Write as _;
+
+const ONE_M_CONTEXT_USAGE: &str = "Usage: /1m-context <enable|disable|status>";
 
 /// Handle slash command submission.
 ///
@@ -23,6 +26,7 @@ pub fn try_handle_submit(app: &mut App, text: &str) -> bool {
     };
 
     match parsed.name {
+        "/1m-context" => handle_1m_context_submit(app, &parsed.args),
         "/cancel" => handle_cancel_submit(app),
         "/compact" => handle_compact_submit(app, &parsed.args),
         "/config" => handle_config_submit(app, &parsed.args),
@@ -39,6 +43,107 @@ pub fn try_handle_submit(app: &mut App, text: &str) -> bool {
         "/resume" => handle_resume_submit(app, &parsed.args),
         _ => handle_unknown_submit(app, parsed.name),
     }
+}
+
+fn handle_1m_context_submit(app: &mut App, args: &[&str]) -> bool {
+    let [subcommand] = args else {
+        push_system_message(app, ONE_M_CONTEXT_USAGE);
+        return true;
+    };
+    let subcommand = subcommand.trim();
+    if subcommand.is_empty() || args.len() != 1 {
+        push_system_message(app, ONE_M_CONTEXT_USAGE);
+        return true;
+    }
+
+    match subcommand {
+        "status" => {
+            match current_1m_context_disabled(app) {
+                Ok(true) => push_system_message_with_severity(
+                    app,
+                    Some(SystemSeverity::Info),
+                    "1M context is disabled for future sessions in this folder via `.claude/settings.local.json`.",
+                ),
+                Ok(false) => push_system_message_with_severity(
+                    app,
+                    Some(SystemSeverity::Info),
+                    "1M context is enabled for future sessions in this folder.",
+                ),
+                Err(err) => {
+                    push_system_message(app, format!("Failed to read /1m-context status: {err}"));
+                }
+            }
+            true
+        }
+        "disable" => {
+            if let Err(err) = set_1m_context_disabled(app, true) {
+                push_system_message(app, format!("Failed to run /1m-context disable: {err}"));
+            }
+            true
+        }
+        "enable" => {
+            if let Err(err) = set_1m_context_disabled(app, false) {
+                push_system_message(app, format!("Failed to run /1m-context enable: {err}"));
+            }
+            true
+        }
+        _ => {
+            push_system_message(app, ONE_M_CONTEXT_USAGE);
+            true
+        }
+    }
+}
+
+fn current_1m_context_disabled(app: &mut App) -> Result<bool, String> {
+    config::initialize_shared_state(app)?;
+    store::disable_1m_context(&app.config.committed_local_settings_document).map_err(|()| {
+        "Expected `.claude/settings.local.json` env.CLAUDE_CODE_DISABLE_1M_CONTEXT to be a string"
+            .to_owned()
+    })
+}
+
+fn set_1m_context_disabled(app: &mut App, disabled: bool) -> Result<(), String> {
+    if !app.is_project_trusted() {
+        return Err(
+            "Project trust must be accepted before editing folder-local 1M context settings"
+                .to_owned(),
+        );
+    }
+
+    config::initialize_shared_state(app)?;
+    let Some(path) = app.config.path_for(SettingFile::LocalSettings).cloned() else {
+        return Err("Local settings path is not available".to_owned());
+    };
+
+    let current = store::disable_1m_context(&app.config.committed_local_settings_document)
+        .map_err(|()| {
+            "Expected `.claude/settings.local.json` env.CLAUDE_CODE_DISABLE_1M_CONTEXT to be a string"
+                .to_owned()
+        })?;
+
+    let mut next_document = app.config.committed_local_settings_document.clone();
+    store::set_disable_1m_context(&mut next_document, disabled);
+    store::save(&path, &next_document)?;
+    app.config.committed_local_settings_document = next_document;
+    app.reconcile_runtime_from_persisted_settings_change();
+    app.config.last_error = None;
+
+    let message = match (disabled, current == disabled) {
+        (true, true) => {
+            "1M context is already disabled for future sessions in this folder. Run /new-session to apply it."
+        }
+        (true, false) => {
+            "Disabled 1M context for future sessions in this folder. Run /new-session to apply it."
+        }
+        (false, true) => {
+            "1M context is already enabled for future sessions in this folder. Run /new-session to apply it."
+        }
+        (false, false) => {
+            "Enabled 1M context for future sessions in this folder. Run /new-session to apply it."
+        }
+    };
+    push_system_message_with_severity(app, Some(SystemSeverity::Info), message);
+    Ok(())
 }
 
 fn handle_cancel_submit(app: &mut App) -> bool {

--- a/src/app/slash/mod.rs
+++ b/src/app/slash/mod.rs
@@ -193,6 +193,7 @@ mod tests {
         let app = App::test_default();
         let names: Vec<String> =
             supported_command_candidates(&app).into_iter().map(|c| c.primary).collect();
+        assert!(names.iter().any(|n| n == "/1m-context"), "missing /1m-context");
         assert!(names.iter().any(|n| n == "/config"), "missing /config");
         assert!(names.iter().any(|n| n == "/docs"), "missing /docs");
         assert!(names.iter().any(|n| n == "/login"), "missing /login");
@@ -228,6 +229,88 @@ mod tests {
             panic!("expected text block");
         };
         assert_eq!(block.text, "Usage: /config");
+    }
+
+    #[test]
+    fn one_m_context_disable_persists_folder_local_override_and_hints_new_session() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = App::test_default();
+        app.settings_home_override = Some(dir.path().to_path_buf());
+        app.cwd_raw = dir.path().to_string_lossy().to_string();
+
+        let consumed = try_handle_submit(&mut app, "/1m-context disable");
+
+        assert!(consumed);
+        let settings_path = dir.path().join(".claude").join("settings.local.json");
+        let raw = std::fs::read_to_string(settings_path).expect("read settings.local.json");
+        assert!(raw.contains("\"CLAUDE_CODE_DISABLE_1M_CONTEXT\": \"1\""));
+        let Some(last) = app.messages.last() else {
+            panic!("expected success message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert!(block.text.contains("Disabled 1M context"));
+        assert!(block.text.contains("/new-session"));
+    }
+
+    #[test]
+    fn one_m_context_enable_removes_folder_local_override_and_hints_new_session() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_settings = dir.path().join(".claude").join("settings.local.json");
+        std::fs::create_dir_all(local_settings.parent().expect("settings parent"))
+            .expect("create dir");
+        std::fs::write(
+            &local_settings,
+            "{\n  \"env\": {\n    \"CLAUDE_CODE_DISABLE_1M_CONTEXT\": \"1\",\n    \"KEEP_ME\": \"yes\"\n  }\n}\n",
+        )
+        .expect("write settings");
+        let mut app = App::test_default();
+        app.settings_home_override = Some(dir.path().to_path_buf());
+        app.cwd_raw = dir.path().to_string_lossy().to_string();
+
+        let consumed = try_handle_submit(&mut app, "/1m-context enable");
+
+        assert!(consumed);
+        let raw = std::fs::read_to_string(local_settings).expect("read settings.local.json");
+        assert!(!raw.contains("CLAUDE_CODE_DISABLE_1M_CONTEXT"));
+        assert!(raw.contains("\"KEEP_ME\": \"yes\""));
+        let Some(last) = app.messages.last() else {
+            panic!("expected success message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert!(block.text.contains("Enabled 1M context"));
+        assert!(block.text.contains("/new-session"));
+    }
+
+    #[test]
+    fn one_m_context_status_reports_disabled_folder_local_override() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_settings = dir.path().join(".claude").join("settings.local.json");
+        std::fs::create_dir_all(local_settings.parent().expect("settings parent"))
+            .expect("create dir");
+        std::fs::write(
+            &local_settings,
+            "{\n  \"env\": {\n    \"CLAUDE_CODE_DISABLE_1M_CONTEXT\": \"1\"\n  }\n}\n",
+        )
+        .expect("write settings");
+        let mut app = App::test_default();
+        app.settings_home_override = Some(dir.path().to_path_buf());
+        app.cwd_raw = dir.path().to_string_lossy().to_string();
+
+        let consumed = try_handle_submit(&mut app, "/1m-context status");
+
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected status message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert!(block.text.contains("1M context is disabled"));
+        assert!(block.text.contains(".claude/settings.local.json"));
     }
 
     #[test]

--- a/src/ui/session_picker.rs
+++ b/src/ui/session_picker.rs
@@ -165,16 +165,13 @@ mod tests {
     use crate::app::{ActiveView, App, RecentSessionInfo};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn session(id: &str, title: &str) -> RecentSessionInfo {
-        let now_ms =
-            u64::try_from(SystemTime::now().duration_since(UNIX_EPOCH).expect("time").as_millis())
-                .expect("millis fit in u64");
         RecentSessionInfo {
             session_id: id.to_owned(),
             summary: format!("summary {title}"),
-            last_modified_ms: now_ms,
+            // Zero maps to the stable "just now" rendering path without depending on wall-clock timing.
+            last_modified_ms: 0,
             file_size_bytes: 1,
             cwd: Some("/test/project".to_owned()),
             git_branch: Some("main".to_owned()),


### PR DESCRIPTION
## Summary

- add folder-local `/1m-context enable|disable|status` controls to persist `CLAUDE_CODE_DISABLE_1M_CONTEXT` in `.claude/settings.local.json`
- preserve neighboring local `env` keys when toggling the 1M-context override and surface status plus recovery guidance in the slash flow and rate-limit notice
- prepare release `0.11.1` by updating `CHANGELOG.md`, bumping `Cargo.toml`, and refreshing `Cargo.lock`
- stabilize the session picker test fixture so release validation does not depend on wall-clock timing

## Why

- Anthropic 1M-context handling currently needs a reliable folder-local fallback when extra usage is unavailable or undesirable
- the release branch needs the version, changelog, and lockfile state aligned to the shipped `0.11.1` artifact
- the test suite should stay deterministic during release validation

Closes #

## Validation

- Automated: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test`; `cargo check --offline`
- Manual: not run
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: `CHANGELOG.md`
