### PR TITLE
fix(ui): rework plan and diff rendering for tool calls

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.89"
+components = ["clippy", "rustfmt"]

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -14,8 +14,8 @@ mod tool_updates;
 mod turn;
 
 use super::{
-    ActiveView, App, AppStatus, ChatMessage, MessageBlock, MessageRole, PendingCommandAck,
-    SystemSeverity, TextBlock,
+    ActiveView, App, AppStatus, ChatMessage, InvalidationLevel, MessageBlock, MessageRole,
+    PendingCommandAck, SystemSeverity, TextBlock,
 };
 use crate::agent::model;
 use crate::app::todos::apply_plan_todos;
@@ -208,14 +208,21 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             }
         }
         model::SessionUpdate::ModeStateUpdate(mode) => {
+            let mode_changed = app.mode.as_ref().map(|current| current.current_mode_id.as_str())
+                != Some(mode.current_mode_id.as_str());
             app.mode = Some(mode);
+            if mode_changed {
+                app.invalidate_layout(InvalidationLevel::Global);
+            }
             if matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentMode)) {
                 session::clear_pending_command(app);
             }
         }
         model::SessionUpdate::CurrentModeUpdate(update) => {
             let mode_id = update.current_mode_id.to_string();
+            let mut mode_changed = false;
             if let Some(ref mut mode) = app.mode {
+                mode_changed = mode.current_mode_id != mode_id;
                 if let Some(info) = mode.available_modes.iter().find(|m| m.id == mode_id) {
                     mode.current_mode_name.clone_from(&info.name);
                     mode.current_mode_id = mode_id;
@@ -223,6 +230,9 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
                     mode.current_mode_name.clone_from(&mode_id);
                     mode.current_mode_id = mode_id;
                 }
+            }
+            if mode_changed {
+                app.invalidate_layout(InvalidationLevel::Global);
             }
             if matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentMode)) {
                 session::clear_pending_command(app);
@@ -2256,6 +2266,8 @@ mod tests {
                 crate::app::ModeInfo { id: "plan".to_owned(), name: "Plan".to_owned() },
             ],
         });
+        app.messages.push(user_msg("seed"));
+        let layout_generation_before = app.viewport.layout_generation;
 
         handle_client_event(
             &mut app,
@@ -2270,6 +2282,38 @@ mod tests {
         let mode = app.mode.expect("mode should be present");
         assert_eq!(mode.current_mode_id, "plan");
         assert_eq!(mode.current_mode_name, "Plan");
+        assert_eq!(app.viewport.layout_generation, layout_generation_before + 1);
+    }
+
+    #[test]
+    fn mode_state_update_invalidates_layout_when_mode_changes() {
+        let mut app = make_test_app();
+        app.mode = Some(crate::app::ModeState {
+            current_mode_id: "code".to_owned(),
+            current_mode_name: "Code".to_owned(),
+            available_modes: vec![
+                crate::app::ModeInfo { id: "code".to_owned(), name: "Code".to_owned() },
+                crate::app::ModeInfo { id: "plan".to_owned(), name: "Plan".to_owned() },
+            ],
+        });
+        app.messages.push(user_msg("seed"));
+        let layout_generation_before = app.viewport.layout_generation;
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(model::SessionUpdate::ModeStateUpdate(
+                crate::app::ModeState {
+                    current_mode_id: "plan".to_owned(),
+                    current_mode_name: "Plan".to_owned(),
+                    available_modes: vec![
+                        crate::app::ModeInfo { id: "code".to_owned(), name: "Code".to_owned() },
+                        crate::app::ModeInfo { id: "plan".to_owned(), name: "Plan".to_owned() },
+                    ],
+                },
+            )),
+        );
+
+        assert_eq!(app.viewport.layout_generation, layout_generation_before + 1);
     }
 
     #[test]

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -4220,7 +4220,7 @@ mod tests {
     #[test]
     fn mouse_down_on_scrollbar_rail_starts_drag_and_scrolls() {
         let mut app = make_test_app();
-        app.rendered_chat_area = Rect::new(0, 0, 20, 10);
+        app.rendered_chat_area = Rect::new(0, 0, 19, 10);
         app.viewport.height_prefix_sums = vec![30];
         app.viewport.scrollbar_thumb_top = 0.0;
         app.viewport.scrollbar_thumb_size = 3.0;
@@ -4250,7 +4250,7 @@ mod tests {
     #[test]
     fn dragging_scrollbar_thumb_can_reach_bottom_and_top() {
         let mut app = make_test_app();
-        app.rendered_chat_area = Rect::new(0, 0, 20, 10);
+        app.rendered_chat_area = Rect::new(0, 0, 19, 10);
         app.viewport.height_prefix_sums = vec![30];
         app.viewport.scrollbar_thumb_top = 0.0;
         app.viewport.scrollbar_thumb_size = 3.0;
@@ -4301,7 +4301,7 @@ mod tests {
     #[test]
     fn dragging_uses_displayed_thumb_track_when_scrollbar_is_smoothed() {
         let mut app = make_test_app();
-        app.rendered_chat_area = Rect::new(0, 0, 20, 10);
+        app.rendered_chat_area = Rect::new(0, 0, 19, 10);
         app.viewport.height_prefix_sums = vec![30];
         app.viewport.scrollbar_thumb_top = 2.0;
         app.viewport.scrollbar_thumb_size = 6.0;

--- a/src/app/events/mouse.rs
+++ b/src/app/events/mouse.rs
@@ -188,7 +188,7 @@ fn mouse_on_scrollbar_rail(app: &App, mouse: MouseEvent) -> bool {
     if area.width == 0 || area.height == 0 {
         return false;
     }
-    let rail_x = area.right().saturating_sub(1);
+    let rail_x = area.right();
     mouse.column == rail_x && mouse.row >= area.y && mouse.row < area.bottom()
 }
 

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -581,6 +581,7 @@ fn handle_mode_cycle_key(app: &mut App, key: KeyEvent) -> bool {
         current_mode_name: next_name,
         available_modes: modes,
     });
+    app.invalidate_layout(InvalidationLevel::Global);
     true
 }
 

--- a/src/app/notify.rs
+++ b/src/app/notify.rs
@@ -33,6 +33,12 @@ pub struct NotificationManager {
     terminal_focused: bool,
 }
 
+impl Default for NotificationManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct NotificationPlan {
     ring_bell: bool,

--- a/src/app/service_status_check.rs
+++ b/src/app/service_status_check.rs
@@ -154,7 +154,7 @@ mod tests {
             name: name.to_owned(),
             components: component_names
                 .iter()
-                .map(|n| IncidentComponent { name: n.to_string() })
+                .map(|n| IncidentComponent { name: (*n).to_owned() })
                 .collect(),
         }
     }

--- a/src/app/state/block_cache.rs
+++ b/src/app/state/block_cache.rs
@@ -19,6 +19,7 @@ pub(crate) fn next_cache_access_tick() -> u64 {
 pub struct BlockCache {
     version: u64,
     lines: Option<Vec<ratatui::text::Line<'static>>>,
+    render_width: Option<u16>,
     /// Segmentation metadata for KB-sized cache chunks shared across message/tool caches.
     segments: Vec<CacheLineSegment>,
     /// Approximate UTF-8 byte size of cached rendered lines.
@@ -62,7 +63,20 @@ impl BlockCache {
     /// Get a reference to the cached lines, if fresh.
     #[must_use]
     pub fn get(&self) -> Option<&Vec<ratatui::text::Line<'static>>> {
-        if self.version == 0 {
+        if self.version == 0 && self.render_width.is_none() {
+            let lines = self.lines.as_ref();
+            if lines.is_some() {
+                self.touch();
+            }
+            lines
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn get_for_width(&self, width: u16) -> Option<&Vec<ratatui::text::Line<'static>>> {
+        if self.version == 0 && self.render_width == Some(width) {
             let lines = self.lines.as_ref();
             if lines.is_some() {
                 self.touch();
@@ -81,6 +95,20 @@ impl BlockCache {
 
     /// Store freshly rendered lines using a shared KB split policy.
     pub fn store_with_policy(
+        &mut self,
+        lines: Vec<ratatui::text::Line<'static>>,
+        policy: super::super::CacheSplitPolicy,
+    ) {
+        self.render_width = None;
+        self.store_with_policy_and_width(lines, policy);
+    }
+
+    pub fn store_for_width(&mut self, lines: Vec<ratatui::text::Line<'static>>, width: u16) {
+        self.render_width = Some(width);
+        self.store_with_policy_and_width(lines, *super::super::default_cache_split_policy());
+    }
+
+    fn store_with_policy_and_width(
         &mut self,
         lines: Vec<ratatui::text::Line<'static>>,
         policy: super::super::CacheSplitPolicy,
@@ -188,6 +216,7 @@ impl BlockCache {
             return 0;
         }
         self.lines = None;
+        self.render_width = None;
         self.segments.clear();
         self.cached_bytes = 0;
         self.wrapped_height = 0;

--- a/src/app/state/messages.rs
+++ b/src/app/state/messages.rs
@@ -83,6 +83,7 @@ pub enum MessageBlockRenderSignature {
         hidden: bool,
         status: crate::agent::model::ToolCallStatus,
         sdk_tool_name: String,
+        current_mode_id: Option<String>,
         pending_permission: bool,
         pending_question: bool,
         frame: Option<usize>,

--- a/src/app/usage/oauth.rs
+++ b/src/app/usage/oauth.rs
@@ -283,8 +283,8 @@ fn days_from_civil(year: i32, month: u32, day: u32) -> Option<i64> {
     year -= i64::from(month <= 2);
     let era = if year >= 0 { year } else { year - 399 } / 400;
     let yoe = year - era * 400;
-    let doy = (153 * (month + if month > 2 { -3 } else { 9 }) + 2) / 5 + day - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let day_of_year = (153 * (month + if month > 2 { -3 } else { 9 }) + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + day_of_year;
     Some(era * 146_097 + doe - 719_468)
 }
 

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -240,6 +240,7 @@ fn measure_message_height_at(
     let (h, rendered_lines) = measure_message_height(
         &mut app.messages[idx],
         &sp,
+        app.mode.as_ref().map(|mode| mode.current_mode_id.as_str()),
         width,
         app.viewport.layout_generation,
         app.tools_collapsed,
@@ -263,6 +264,7 @@ fn measure_message_height_at(
 fn measure_message_height(
     msg: &mut crate::app::ChatMessage,
     spinner: &SpinnerState,
+    current_mode_id: Option<&str>,
     width: u16,
     layout_generation: u64,
     tools_collapsed: bool,
@@ -270,9 +272,10 @@ fn measure_message_height(
 ) -> (usize, usize) {
     let _t = crate::perf::start_with("chat::measure_msg", "blocks", msg.blocks.len());
     let (h, wrapped_lines) =
-        message::measure_message_height_cached_with_tools_collapsed_and_separator(
+        message::measure_message_height_cached_with_tools_collapsed_and_separator_and_mode(
             msg,
             spinner,
+            current_mode_id,
             width,
             layout_generation,
             tools_collapsed,
@@ -635,15 +638,18 @@ fn render_culled_messages(
         let before = out.len();
         let message_height = app.viewport.message_height(i);
         if structural_skip > 0 {
-            let remaining_skip = message::render_message_from_offset_internal(
+            let remaining_skip = message::render_message_from_offset_internal_with_mode(
                 &mut app.messages[i],
                 &sp,
-                width,
-                app.viewport.layout_generation,
-                message::MessageRenderOptions {
-                    tools_collapsed: app.tools_collapsed,
-                    include_trailing_separator: i + 1 != msg_count,
-                },
+                message::MessageRenderContext::new(
+                    app.mode.as_ref().map(|mode| mode.current_mode_id.as_str()),
+                    width,
+                    app.viewport.layout_generation,
+                    message::MessageRenderOptions {
+                        tools_collapsed: app.tools_collapsed,
+                        include_trailing_separator: i + 1 != msg_count,
+                    },
+                ),
                 structural_skip,
                 out,
             );
@@ -653,13 +659,18 @@ fn render_culled_messages(
             local_scroll = remaining_skip;
             structural_skip = 0;
         } else {
-            message::render_message_with_tools_collapsed_and_separator_and_layout_generation(
+            message::render_message_with_tools_collapsed_and_separator_and_layout_generation_with_mode(
                 &mut app.messages[i],
                 &sp,
-                width,
-                app.viewport.layout_generation,
-                app.tools_collapsed,
-                i + 1 != msg_count,
+                message::MessageRenderContext::new(
+                    app.mode.as_ref().map(|mode| mode.current_mode_id.as_str()),
+                    width,
+                    app.viewport.layout_generation,
+                    message::MessageRenderOptions {
+                        tools_collapsed: app.tools_collapsed,
+                        include_trailing_separator: i + 1 != msg_count,
+                    },
+                ),
                 out,
             );
             rendered_rows = rendered_rows.saturating_add(message_height);

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -23,6 +23,7 @@ const SCROLLBAR_TOP_EASE: f32 = 0.35;
 const SCROLLBAR_SIZE_EASE: f32 = 0.2;
 const SCROLLBAR_EASE_EPSILON: f32 = 0.01;
 const OVERSCROLL_CLAMP_EASE: f32 = 0.2;
+const CHAT_SCROLLBAR_WIDTH: u16 = 1;
 
 #[derive(Clone, Copy, Default)]
 struct HeightUpdateStats {
@@ -71,6 +72,19 @@ struct ScrolledRenderData {
     stats: CulledRenderStats,
     max_scroll: usize,
     scroll_offset: usize,
+}
+
+fn chat_content_area(area: Rect) -> Rect {
+    Rect { width: area.width.saturating_sub(CHAT_SCROLLBAR_WIDTH), ..area }
+}
+
+fn chat_scrollbar_area(area: Rect) -> Option<Rect> {
+    (area.width > 0).then(|| Rect {
+        x: area.right().saturating_sub(CHAT_SCROLLBAR_WIDTH),
+        y: area.y,
+        width: CHAT_SCROLLBAR_WIDTH.min(area.width),
+        height: area.height,
+    })
 }
 /// Build a `SpinnerState` for a specific message index.
 fn msg_spinner(
@@ -699,10 +713,11 @@ fn render_culled_messages(
 pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     let _t = app.perf.as_ref().map(|p| p.start("chat::render"));
     crate::perf::mark_with("chat::message_count", "msgs", app.messages.len());
-    let width = area.width;
-    let viewport_height = area.height as usize;
+    let content_area = chat_content_area(area);
+    let width = content_area.width;
+    let viewport_height = content_area.height as usize;
     let base_spinner = build_base_spinner(app);
-    let content_height = sync_chat_layout(app, area, base_spinner);
+    let content_height = sync_chat_layout(app, content_area, base_spinner);
 
     if content_height <= viewport_height {
         crate::perf::mark_with("chat::path_short", "active", 1);
@@ -710,7 +725,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         crate::perf::mark_with("chat::path_scrolled", "active", 1);
     }
 
-    render_scrolled(frame, area, app, base_spinner, width, content_height, viewport_height);
+    render_scrolled(frame, content_area, app, base_spinner, width, content_height, viewport_height);
 
     if let Some(sel) = app.selection
         && sel.kind == SelectionKind::Chat
@@ -718,14 +733,16 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         frame.render_widget(SelectionOverlay { selection: sel }, app.rendered_chat_area);
     }
 
-    render_scrollbar_overlay(
-        frame,
-        &mut app.viewport,
-        app.config.prefers_reduced_motion_effective(),
-        area,
-        content_height,
-        viewport_height,
-    );
+    if let Some(scrollbar_area) = chat_scrollbar_area(area) {
+        render_scrollbar_overlay(
+            frame,
+            &mut app.viewport,
+            app.config.prefers_reduced_motion_effective(),
+            scrollbar_area,
+            content_height,
+            viewport_height,
+        );
+    }
 
     enforce_and_emit_cache_metrics(app);
 }
@@ -932,9 +949,9 @@ fn render_lines_from_paragraph(
 #[cfg(test)]
 mod tests {
     use super::{
-        SCROLLBAR_MIN_THUMB_HEIGHT, clamp_scroll_to_content, paragraph_scroll_offset,
-        render_culled_messages, render_lines_from_paragraph, render_scrolled,
-        smooth_scrollbar_geometry, update_visual_heights,
+        SCROLLBAR_MIN_THUMB_HEIGHT, chat_content_area, clamp_scroll_to_content,
+        paragraph_scroll_offset, render_culled_messages, render_lines_from_paragraph,
+        render_scrolled, smooth_scrollbar_geometry, update_visual_heights,
     };
     use crate::app::{
         App, AppStatus, ChatMessage, ChatViewport, InvalidationLevel, MessageBlock, MessageRole,
@@ -988,17 +1005,23 @@ mod tests {
         terminal
             .draw(|frame| {
                 let spinner = idle_spinner();
-                let _ = app.viewport.on_frame(width, height);
-                update_visual_heights(app, spinner, width, usize::from(height));
+                let content_area = chat_content_area(Rect::new(0, 0, width, height));
+                let _ = app.viewport.on_frame(content_area.width, content_area.height);
+                update_visual_heights(
+                    app,
+                    spinner,
+                    content_area.width,
+                    usize::from(content_area.height),
+                );
                 app.viewport.rebuild_prefix_sums();
                 render_scrolled(
                     frame,
-                    Rect::new(0, 0, width, height),
+                    content_area,
                     app,
                     spinner,
-                    width,
+                    content_area.width,
                     app.viewport.total_message_height(),
-                    usize::from(height),
+                    usize::from(content_area.height),
                 );
             })
             .expect("draw");
@@ -1067,6 +1090,12 @@ mod tests {
                 max_scroll: 9_990,
             })
         );
+    }
+
+    #[test]
+    fn chat_content_area_reserves_one_column_for_scrollbar() {
+        assert_eq!(chat_content_area(Rect::new(0, 0, 20, 10)), Rect::new(0, 0, 19, 10));
+        assert_eq!(chat_content_area(Rect::new(3, 4, 1, 5)), Rect::new(3, 4, 0, 5));
     }
 
     #[test]

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -1366,7 +1366,7 @@ mod tests {
             super::settings::settings_hint_height(20) > super::settings::settings_hint_height(40)
         );
         assert_eq!(super::settings::settings_hint_height(0), 0);
-        assert!(!SETTINGS_LIMITATION_HINT.is_empty());
+        assert!(SETTINGS_LIMITATION_HINT.contains("not all settings are supported"));
     }
 
     #[test]

--- a/src/ui/diff.rs
+++ b/src/ui/diff.rs
@@ -3,6 +3,7 @@
 
 use crate::agent::model;
 use crate::ui::theme;
+use crate::ui::wrap::{StyledChunk, wrap_styled_chunks};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use similar::TextDiff;
@@ -10,25 +11,20 @@ use similar::TextDiff;
 /// Render a diff with proper unified-style output using the `similar` crate.
 /// The model `Diff` struct provides `old_text`/`new_text` -- we compute the actual
 /// line-level changes and show only changed lines with context.
-pub fn render_diff(diff: &model::Diff) -> Vec<Line<'static>> {
+pub fn render_diff(diff: &model::Diff, width: u16) -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> = Vec::new();
-
-    // File path header
-    let name = diff.path.file_name().map_or_else(
-        || diff.path.to_string_lossy().into_owned(),
-        |f| f.to_string_lossy().into_owned(),
-    );
-    let mut header_spans =
-        vec![Span::styled(name, Style::default().fg(Color::White).add_modifier(Modifier::BOLD))];
     if let Some(repository) = diff.repository.as_deref() {
-        header_spans
-            .push(Span::styled(format!("  [{repository}]"), Style::default().fg(theme::DIM)));
+        lines.push(Line::from(Span::styled(
+            format!("[{repository}]"),
+            Style::default().fg(theme::DIM),
+        )));
     }
-    lines.push(Line::from(header_spans));
 
     let old = diff.old_text.as_deref().unwrap_or("");
     let new = &diff.new_text;
     let text_diff = TextDiff::from_lines(old, new);
+    let line_number_width = old.lines().count().max(new.lines().count()).max(1).to_string().len();
+    let content_width = usize::from(width).saturating_sub(line_number_width + 5).max(1);
 
     // Use unified diff with 3 lines of context -- only shows changed hunks
     // instead of the full file content.
@@ -40,19 +36,38 @@ pub fn render_diff(diff: &model::Diff) -> Vec<Line<'static>> {
             && header.starts_with("@@")
         {
             lines.push(Line::from(Span::styled(
-                header.to_owned(),
+                format_compact_hunk_header(header),
                 Style::default().fg(Color::Cyan),
             )));
         }
 
         for change in hunk.iter_changes() {
             let value = change.as_str().unwrap_or("").trim_end_matches('\n');
-            let (prefix, style) = match change.tag() {
-                similar::ChangeTag::Delete => ("-", Style::default().fg(Color::Red)),
-                similar::ChangeTag::Insert => ("+", Style::default().fg(Color::Green)),
-                similar::ChangeTag::Equal => (" ", Style::default().fg(theme::DIM)),
+            let (marker, style, line_number) = match change.tag() {
+                similar::ChangeTag::Delete => (
+                    "-",
+                    Style::default().fg(Color::Red),
+                    change.old_index().map(|index| index + 1),
+                ),
+                similar::ChangeTag::Insert => (
+                    "+",
+                    Style::default().fg(Color::Green),
+                    change.new_index().map(|index| index + 1),
+                ),
+                similar::ChangeTag::Equal => (
+                    " ",
+                    Style::default().fg(theme::DIM),
+                    change.new_index().map(|index| index + 1),
+                ),
             };
-            lines.push(Line::from(Span::styled(format!("{prefix} {value}"), style)));
+            lines.extend(render_wrapped_diff_row(
+                line_number,
+                line_number_width,
+                marker,
+                value,
+                style,
+                content_width,
+            ));
         }
     }
 
@@ -124,6 +139,92 @@ fn render_raw_diff_line(line: &str) -> Line<'static> {
     };
 
     Line::from(Span::styled(line.to_owned(), style))
+}
+
+#[derive(Clone, Copy)]
+struct HunkRange {
+    start: usize,
+    count: usize,
+}
+
+fn format_compact_hunk_header(header: &str) -> String {
+    parse_unified_hunk_header(header).map_or_else(
+        || header.to_owned(),
+        |(old_range, new_range)| {
+            let mut parts = Vec::with_capacity(2);
+            if old_range.count > 0 {
+                parts.push(format_range("-", old_range));
+            }
+            if new_range.count > 0 {
+                parts.push(format_range("+", new_range));
+            }
+            if parts.is_empty() { "lines".to_owned() } else { format!("lines {}", parts.join(" ")) }
+        },
+    )
+}
+
+fn parse_unified_hunk_header(header: &str) -> Option<(HunkRange, HunkRange)> {
+    let body = header.strip_prefix("@@ ")?.split(" @@").next()?;
+    let mut parts = body.split_whitespace();
+    let old_range = parse_prefixed_hunk_range(parts.next()?, '-')?;
+    let new_range = parse_prefixed_hunk_range(parts.next()?, '+')?;
+    Some((old_range, new_range))
+}
+
+fn parse_prefixed_hunk_range(token: &str, prefix: char) -> Option<HunkRange> {
+    let raw = token.strip_prefix(prefix)?;
+    let (start, count) = raw.split_once(',').map_or((raw, "1"), |(start, count)| (start, count));
+    Some(HunkRange { start: start.parse().ok()?, count: count.parse().ok()? })
+}
+
+fn format_range(prefix: &str, range: HunkRange) -> String {
+    if range.count <= 1 {
+        format!("{prefix}{}", range.start)
+    } else {
+        let end = range.start.saturating_add(range.count.saturating_sub(1));
+        format!("{prefix}{}-{end}", range.start)
+    }
+}
+
+fn render_wrapped_diff_row(
+    line_number: Option<usize>,
+    line_number_width: usize,
+    marker: &str,
+    value: &str,
+    style: Style,
+    content_width: usize,
+) -> Vec<Line<'static>> {
+    let number_style = Style::default().fg(theme::DIM);
+    let content_lines = if value.is_empty() {
+        vec![Line::default()]
+    } else {
+        wrap_styled_chunks(&[StyledChunk { text: value.to_owned(), style }], content_width)
+    };
+
+    let line_number_text = line_number.map_or_else(
+        || " ".repeat(line_number_width),
+        |line_number| format!("{line_number:>line_number_width$}"),
+    );
+    let continuation_prefix = " ".repeat(line_number_width + 5);
+
+    content_lines
+        .into_iter()
+        .enumerate()
+        .map(|(index, content_line)| {
+            let mut spans = if index == 0 {
+                vec![
+                    Span::styled(line_number_text.clone(), number_style),
+                    Span::styled("  ", number_style),
+                    Span::styled(marker.to_owned(), style),
+                    Span::styled("  ", number_style),
+                ]
+            } else {
+                vec![Span::styled(continuation_prefix.clone(), number_style)]
+            };
+            spans.extend(content_line.spans);
+            Line::from(spans)
+        })
+        .collect()
 }
 
 /// Check if a tool call title references a markdown file.
@@ -226,10 +327,11 @@ mod tests {
             &model::Diff::new("src/main.rs", "fn main() {}\n")
                 .old_text(Some("fn old() {}\n"))
                 .repository(Some("acme/project".to_owned())),
+            80,
         );
-        let header: String = lines[0].spans.iter().map(|span| span.content.as_ref()).collect();
-        assert!(header.contains("main.rs"));
-        assert!(header.contains("[acme/project]"));
+        let repository_line: String =
+            lines[0].spans.iter().map(|span| span.content.as_ref()).collect();
+        assert!(repository_line.contains("[acme/project]"));
     }
 
     #[test]
@@ -246,6 +348,33 @@ mod tests {
         assert_eq!(lines[1].spans[0].style.fg, Some(Color::Green));
         assert_eq!(lines[2].spans[0].style.fg, Some(Color::Cyan));
         assert_eq!(lines[4].spans[0].style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn render_diff_adds_line_numbers_and_hanging_indent() {
+        let lines = render_diff(
+            &model::Diff::new(
+                "tmp.md",
+                "This is a long added line that should wrap onto another visual line.\n".to_owned(),
+            ),
+            28,
+        );
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
+            .collect();
+
+        assert!(rendered.iter().any(|line| line.contains("lines +1")));
+        assert!(rendered.iter().any(|line| line.contains("1  +  This is a long")));
+        assert!(rendered.iter().any(|line| line.starts_with("      ")));
+        assert!(!rendered.iter().any(|line| line == "tmp.md"));
+    }
+
+    #[test]
+    fn compact_hunk_header_omits_empty_side_and_uses_ranges() {
+        assert_eq!(format_compact_hunk_header("@@ -0,0 +1,7 @@"), "lines +1-7");
+        assert_eq!(format_compact_hunk_header("@@ -4,3 +4,5 @@"), "lines -4-6 +4-8");
+        assert_eq!(format_compact_hunk_header("@@ -8 +8 @@"), "lines -8 +8");
     }
 
     #[test]

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -129,6 +129,30 @@ struct RenderedBlockLayout {
     wrapped_lines: usize,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct MessageRenderContext<'a> {
+    tool_render_context: tool_call::ToolCallRenderContext<'a>,
+    width: u16,
+    layout_generation: u64,
+    options: MessageRenderOptions,
+}
+
+impl<'a> MessageRenderContext<'a> {
+    pub(crate) fn new(
+        current_mode_id: Option<&'a str>,
+        width: u16,
+        layout_generation: u64,
+        options: MessageRenderOptions,
+    ) -> Self {
+        Self {
+            tool_render_context: tool_call::ToolCallRenderContext { current_mode_id },
+            width,
+            layout_generation,
+            options,
+        }
+    }
+}
+
 fn assistant_role_label_line() -> Line<'static> {
     let spans = vec![Span::styled(
         "Claude",
@@ -146,7 +170,13 @@ pub(crate) fn render_message_with_tools_collapsed(
     tools_collapsed: bool,
     out: &mut Vec<Line<'static>>,
 ) {
-    render_message_internal(msg, spinner, width, 0, tools_collapsed, true, out);
+    let render_context = MessageRenderContext::new(
+        None,
+        width,
+        0,
+        MessageRenderOptions { tools_collapsed, include_trailing_separator: true },
+    );
+    render_message_internal(msg, spinner, render_context, out);
 }
 
 #[cfg(test)]
@@ -158,17 +188,16 @@ pub(crate) fn render_message_with_tools_collapsed_and_separator(
     include_trailing_separator: bool,
     out: &mut Vec<Line<'static>>,
 ) {
-    render_message_internal(
-        msg,
-        spinner,
+    let render_context = MessageRenderContext::new(
+        None,
         width,
         0,
-        tools_collapsed,
-        include_trailing_separator,
-        out,
+        MessageRenderOptions { tools_collapsed, include_trailing_separator },
     );
+    render_message_internal(msg, spinner, render_context, out);
 }
 
+#[cfg(test)]
 pub(crate) fn render_message_with_tools_collapsed_and_separator_and_layout_generation(
     msg: &mut ChatMessage,
     spinner: &SpinnerState,
@@ -178,61 +207,57 @@ pub(crate) fn render_message_with_tools_collapsed_and_separator_and_layout_gener
     include_trailing_separator: bool,
     out: &mut Vec<Line<'static>>,
 ) {
-    render_message_internal(
-        msg,
-        spinner,
+    let render_context = MessageRenderContext::new(
+        None,
         width,
         layout_generation,
-        tools_collapsed,
-        include_trailing_separator,
+        MessageRenderOptions { tools_collapsed, include_trailing_separator },
+    );
+    render_message_with_tools_collapsed_and_separator_and_layout_generation_with_mode(
+        msg,
+        spinner,
+        render_context,
         out,
     );
+}
+
+pub(crate) fn render_message_with_tools_collapsed_and_separator_and_layout_generation_with_mode(
+    msg: &mut ChatMessage,
+    spinner: &SpinnerState,
+    render_context: MessageRenderContext<'_>,
+    out: &mut Vec<Line<'static>>,
+) {
+    render_message_internal(msg, spinner, render_context, out);
 }
 
 fn render_message_internal(
     msg: &mut ChatMessage,
     spinner: &SpinnerState,
-    width: u16,
-    layout_generation: u64,
-    tools_collapsed: bool,
-    include_trailing_separator: bool,
+    render_context: MessageRenderContext<'_>,
     out: &mut Vec<Line<'static>>,
 ) {
-    let cache = get_or_build_message_render_cache(
-        msg,
-        spinner,
-        width,
-        layout_generation,
-        MessageRenderOptions { tools_collapsed, include_trailing_separator },
-    );
+    let cache = get_or_build_message_render_cache(msg, spinner, render_context);
     render_cached_message(cache.segments(), out);
 }
 
 fn build_message_layout(
     msg: &mut ChatMessage,
     spinner: &SpinnerState,
-    width: u16,
-    options: MessageRenderOptions,
-    layout_generation: Option<u64>,
+    render_context: MessageRenderContext<'_>,
 ) -> MessageLayout {
     let mut layout = MessageLayout::new();
-    layout.push_wrapped_line(role_label_line(&msg.role), width);
+    layout.push_wrapped_line(role_label_line(&msg.role), render_context.width);
 
     match msg.role {
-        MessageRole::Welcome => append_welcome_blocks(msg, width, &mut layout),
-        MessageRole::User => append_user_blocks(msg, width, &mut layout),
-        MessageRole::Assistant => append_assistant_blocks(
-            msg,
-            spinner,
-            width,
-            options.tools_collapsed,
-            layout_generation,
-            &mut layout,
-        ),
-        MessageRole::System(_) => append_system_blocks(msg, width, &mut layout),
+        MessageRole::Welcome => append_welcome_blocks(msg, render_context.width, &mut layout),
+        MessageRole::User => append_user_blocks(msg, render_context.width, &mut layout),
+        MessageRole::Assistant => {
+            append_assistant_blocks(msg, spinner, render_context, &mut layout);
+        }
+        MessageRole::System(_) => append_system_blocks(msg, render_context.width, &mut layout),
     }
 
-    if options.include_trailing_separator {
+    if render_context.options.include_trailing_separator {
         layout.push_blank();
     }
 
@@ -287,17 +312,15 @@ struct AssistantLayoutState {
 fn append_assistant_blocks(
     msg: &mut ChatMessage,
     spinner: &SpinnerState,
-    width: u16,
-    tools_collapsed: bool,
-    layout_generation: Option<u64>,
+    render_context: MessageRenderContext<'_>,
     layout: &mut MessageLayout,
 ) {
     if msg.blocks.is_empty() && spinner.show_compacting {
-        layout.push_wrapped_line(compacting_line(spinner.frame), width);
+        layout.push_wrapped_line(compacting_line(spinner.frame), render_context.width);
         return;
     }
     if msg.blocks.is_empty() && spinner.show_empty_thinking {
-        layout.push_wrapped_line(thinking_line(spinner.frame), width);
+        layout.push_wrapped_line(thinking_line(spinner.frame), render_context.width);
         return;
     }
 
@@ -309,15 +332,7 @@ fn append_assistant_blocks(
             continue;
         }
 
-        append_assistant_block(
-            &mut msg.blocks[idx],
-            spinner,
-            width,
-            tools_collapsed,
-            layout_generation,
-            layout,
-            &mut state,
-        );
+        append_assistant_block(&mut msg.blocks[idx], spinner, render_context, layout, &mut state);
 
         if let Some((deferred_idx, render_after_idx)) = deferred_interaction
             && render_after_idx == idx
@@ -325,9 +340,7 @@ fn append_assistant_blocks(
             append_assistant_block(
                 &mut msg.blocks[deferred_idx],
                 spinner,
-                width,
-                tools_collapsed,
-                layout_generation,
+                render_context,
                 layout,
                 &mut state,
             );
@@ -338,13 +351,13 @@ fn append_assistant_blocks(
         if state.has_body_content {
             layout.push_blank();
         }
-        layout.push_wrapped_line(compacting_line(spinner.frame), width);
+        layout.push_wrapped_line(compacting_line(spinner.frame), render_context.width);
     }
     if spinner.show_thinking && !show_compacting {
         if state.has_body_content {
             layout.push_blank();
         }
-        layout.push_wrapped_line(thinking_line(spinner.frame), width);
+        layout.push_wrapped_line(thinking_line(spinner.frame), render_context.width);
     }
 }
 
@@ -367,28 +380,20 @@ fn deferred_hidden_interaction_render_after(blocks: &[MessageBlock]) -> Option<(
 fn append_assistant_block(
     block: &mut MessageBlock,
     spinner: &SpinnerState,
-    width: u16,
-    tools_collapsed: bool,
-    layout_generation: Option<u64>,
+    render_context: MessageRenderContext<'_>,
     layout: &mut MessageLayout,
     state: &mut AssistantLayoutState,
 ) {
     match block {
         MessageBlock::Text(block) => {
-            append_assistant_text_block(block, width, layout, state);
+            append_assistant_text_block(block, render_context.width, layout, state);
         }
         MessageBlock::Notice(notice) => {
-            append_assistant_notice_block(notice, width, layout, state);
+            append_assistant_notice_block(notice, render_context.width, layout, state);
         }
-        MessageBlock::ToolCall(tc) => append_assistant_tool_block(
-            tc.as_mut(),
-            spinner,
-            width,
-            tools_collapsed,
-            layout_generation,
-            layout,
-            state,
-        ),
+        MessageBlock::ToolCall(tc) => {
+            append_assistant_tool_block(tc.as_mut(), spinner, render_context, layout, state);
+        }
         MessageBlock::Welcome(_) | MessageBlock::ImageAttachment(_) => {}
     }
 }
@@ -448,9 +453,7 @@ fn append_assistant_notice_block(
 fn append_assistant_tool_block(
     tc: &mut crate::app::ToolCallInfo,
     spinner: &SpinnerState,
-    width: u16,
-    tools_collapsed: bool,
-    layout_generation: Option<u64>,
+    render_context: MessageRenderContext<'_>,
     layout: &mut MessageLayout,
     state: &mut AssistantLayoutState,
 ) {
@@ -463,22 +466,20 @@ fn append_assistant_tool_block(
     let mut lines = Vec::new();
     tool_call::render_tool_call_cached_with_tools_collapsed(
         tc,
-        width,
+        render_context.tool_render_context,
+        render_context.width,
         spinner.frame,
-        tools_collapsed,
+        render_context.options.tools_collapsed,
         &mut lines,
     );
-    let (height, wrapped_lines) = if let Some(layout_generation) = layout_generation {
-        tool_call::measure_tool_call_height_cached_with_tools_collapsed(
-            tc,
-            width,
-            spinner.frame,
-            layout_generation,
-            tools_collapsed,
-        )
-    } else {
-        (rendered_lines_height(&lines, width), 0)
-    };
+    let (height, wrapped_lines) = tool_call::measure_tool_call_height_cached_with_tools_collapsed(
+        tc,
+        render_context.tool_render_context,
+        render_context.width,
+        spinner.frame,
+        render_context.layout_generation,
+        render_context.options.tools_collapsed,
+    );
     layout.push_lines(lines, height, wrapped_lines);
     if height > 0 {
         state.has_body_content = true;
@@ -583,13 +584,33 @@ pub fn measure_message_height_cached_with_tools_collapsed_and_separator(
     tools_collapsed: bool,
     include_trailing_separator: bool,
 ) -> (usize, usize) {
-    let cache = get_or_build_message_render_cache(
+    measure_message_height_cached_with_tools_collapsed_and_separator_and_mode(
         msg,
         spinner,
+        None,
+        width,
+        layout_generation,
+        tools_collapsed,
+        include_trailing_separator,
+    )
+}
+
+pub fn measure_message_height_cached_with_tools_collapsed_and_separator_and_mode(
+    msg: &mut ChatMessage,
+    spinner: &SpinnerState,
+    current_mode_id: Option<&str>,
+    width: u16,
+    layout_generation: u64,
+    tools_collapsed: bool,
+    include_trailing_separator: bool,
+) -> (usize, usize) {
+    let render_context = MessageRenderContext::new(
+        current_mode_id,
         width,
         layout_generation,
         MessageRenderOptions { tools_collapsed, include_trailing_separator },
     );
+    let cache = get_or_build_message_render_cache(msg, spinner, render_context);
     (cache.height(), cache.wrapped_lines())
 }
 
@@ -640,6 +661,7 @@ pub(crate) fn render_message_from_offset_with_tools_collapsed(
     )
 }
 
+#[cfg(test)]
 pub(crate) fn render_message_from_offset_internal(
     msg: &mut ChatMessage,
     spinner: &SpinnerState,
@@ -649,12 +671,23 @@ pub(crate) fn render_message_from_offset_internal(
     skip_rows: usize,
     out: &mut Vec<Line<'static>>,
 ) -> usize {
+    let render_context = MessageRenderContext::new(None, width, layout_generation, options);
+    render_message_from_offset_internal_with_mode(msg, spinner, render_context, skip_rows, out)
+}
+
+pub(crate) fn render_message_from_offset_internal_with_mode(
+    msg: &mut ChatMessage,
+    spinner: &SpinnerState,
+    render_context: MessageRenderContext<'_>,
+    skip_rows: usize,
+    out: &mut Vec<Line<'static>>,
+) -> usize {
     let mut remaining_skip = skip_rows;
-    let cache = get_or_build_message_render_cache(msg, spinner, width, layout_generation, options);
+    let cache = get_or_build_message_render_cache(msg, spinner, render_context);
     let mut can_consume_skip = true;
     render_cached_message_from_offset(
         cache.segments(),
-        width,
+        render_context.width,
         out,
         &mut remaining_skip,
         &mut can_consume_skip,
@@ -742,13 +775,11 @@ pub(crate) struct MessageRenderOptions {
 fn get_or_build_message_render_cache<'a>(
     msg: &'a mut ChatMessage,
     spinner: &SpinnerState,
-    width: u16,
-    layout_generation: u64,
-    options: MessageRenderOptions,
+    render_context: MessageRenderContext<'_>,
 ) -> &'a MessageRenderCache {
-    let key = build_message_render_cache_key(msg, spinner, width, layout_generation, options);
+    let key = build_message_render_cache_key(msg, spinner, render_context);
     if !msg.render_cache.matches(&key) {
-        let layout = build_message_layout(msg, spinner, width, options, Some(layout_generation));
+        let layout = build_message_layout(msg, spinner, render_context);
         let height = layout.height;
         let wrapped_lines = layout.wrapped_lines;
         let segments =
@@ -761,22 +792,25 @@ fn get_or_build_message_render_cache<'a>(
 fn build_message_render_cache_key(
     msg: &ChatMessage,
     spinner: &SpinnerState,
-    width: u16,
-    layout_generation: u64,
-    options: MessageRenderOptions,
+    render_context: MessageRenderContext<'_>,
 ) -> MessageRenderCacheKey {
     MessageRenderCacheKey {
-        width,
-        layout_generation,
-        tools_collapsed: options.tools_collapsed,
-        include_trailing_separator: options.include_trailing_separator,
-        render_signature: build_message_render_signature(msg, spinner),
+        width: render_context.width,
+        layout_generation: render_context.layout_generation,
+        tools_collapsed: render_context.options.tools_collapsed,
+        include_trailing_separator: render_context.options.include_trailing_separator,
+        render_signature: build_message_render_signature(
+            msg,
+            spinner,
+            render_context.tool_render_context,
+        ),
     }
 }
 
 fn build_message_render_signature(
     msg: &ChatMessage,
     spinner: &SpinnerState,
+    tool_render_context: tool_call::ToolCallRenderContext<'_>,
 ) -> MessageRenderSignature {
     let assistant_frame = if message_has_frame_dependent_assistant_lines(msg, spinner) {
         Some(spinner.frame)
@@ -786,7 +820,7 @@ fn build_message_render_signature(
     let blocks = msg
         .blocks
         .iter()
-        .map(|block| build_message_block_render_signature(block, spinner))
+        .map(|block| build_message_block_render_signature(block, spinner, tool_render_context))
         .collect();
     MessageRenderSignature {
         role: msg.role.clone(),
@@ -801,6 +835,7 @@ fn build_message_render_signature(
 fn build_message_block_render_signature(
     block: &MessageBlock,
     spinner: &SpinnerState,
+    tool_render_context: tool_call::ToolCallRenderContext<'_>,
 ) -> MessageBlockRenderSignature {
     match block {
         MessageBlock::Text(block) => MessageBlockRenderSignature::Text {
@@ -818,6 +853,7 @@ fn build_message_block_render_signature(
             hidden: tc.hidden,
             status: tc.status,
             sdk_tool_name: tc.sdk_tool_name.clone(),
+            current_mode_id: tool_render_context.current_mode_id.map(str::to_owned),
             pending_permission: tc.pending_permission.is_some(),
             pending_question: tc.pending_question.is_some(),
             frame: tool_call_needs_spinner_frame(tc).then_some(spinner.frame),
@@ -2387,11 +2423,19 @@ mod tests {
         let mut msg = make_text_message(MessageRole::Assistant, "cached");
         let options = default_options();
 
-        let cache = get_or_build_message_render_cache(&mut msg, &spinner, 80, 1, options);
+        let cache = get_or_build_message_render_cache(
+            &mut msg,
+            &spinner,
+            MessageRenderContext::new(None, 80, 1, options),
+        );
         let first_segments = cache.segments().to_vec();
         let first_height = cache.height();
 
-        let cache = get_or_build_message_render_cache(&mut msg, &spinner, 80, 1, options);
+        let cache = get_or_build_message_render_cache(
+            &mut msg,
+            &spinner,
+            MessageRenderContext::new(None, 80, 1, options),
+        );
         assert_eq!(cache.segments().len(), first_segments.len());
         assert_eq!(cache.height(), first_height);
         assert_eq!(cache.height(), rendered_segment_height(&first_segments));
@@ -2404,12 +2448,19 @@ mod tests {
         let thinking_spinner = SpinnerState { show_thinking: true, frame: 1, ..idle_spinner() };
         let options = default_options();
 
-        let base_cache = get_or_build_message_render_cache(&mut msg, &base_spinner, 80, 1, options);
+        let base_cache = get_or_build_message_render_cache(
+            &mut msg,
+            &base_spinner,
+            MessageRenderContext::new(None, 80, 1, options),
+        );
         let base_height = base_cache.height();
         let base_segments = base_cache.segments().to_vec();
 
-        let thinking_cache =
-            get_or_build_message_render_cache(&mut msg, &thinking_spinner, 80, 1, options);
+        let thinking_cache = get_or_build_message_render_cache(
+            &mut msg,
+            &thinking_spinner,
+            MessageRenderContext::new(None, 80, 1, options),
+        );
         assert!(thinking_cache.height() >= base_height);
         assert!(
             thinking_cache.height() != base_height
@@ -2426,18 +2477,78 @@ mod tests {
         let without_separator =
             MessageRenderOptions { include_trailing_separator: false, ..default_options() };
 
-        let with_cache =
-            get_or_build_message_render_cache(&mut msg, &spinner, 80, 1, with_separator);
+        let with_cache = get_or_build_message_render_cache(
+            &mut msg,
+            &spinner,
+            MessageRenderContext::new(None, 80, 1, with_separator),
+        );
         let with_height = with_cache.height();
         let with_segments = with_cache.segments().len();
 
-        let without_cache =
-            get_or_build_message_render_cache(&mut msg, &spinner, 80, 1, without_separator);
+        let without_cache = get_or_build_message_render_cache(
+            &mut msg,
+            &spinner,
+            MessageRenderContext::new(None, 80, 1, without_separator),
+        );
         assert!(without_cache.height() <= with_height);
         assert!(
             without_cache.height() != with_height
                 || without_cache.segments().len() != with_segments
         );
+    }
+
+    #[test]
+    fn message_render_cache_rebuilds_when_mode_changes_for_tool_calls() {
+        let spinner = idle_spinner();
+        let tool = make_tool_call_info(
+            "Write notes/plan.md",
+            "Write",
+            crate::agent::model::ToolCallStatus::Completed,
+            "created plan",
+        );
+        let mut msg = ChatMessage::new(
+            MessageRole::Assistant,
+            vec![MessageBlock::ToolCall(Box::new(tool))],
+            None,
+        );
+        let options = default_options();
+
+        let code_cache = get_or_build_message_render_cache(
+            &mut msg,
+            &spinner,
+            MessageRenderContext::new(Some("code"), 80, 1, options),
+        );
+        let code_lines: Vec<String> = code_cache
+            .segments()
+            .iter()
+            .flat_map(|segment| match segment {
+                CachedMessageSegment::Blank => vec![String::new()],
+                CachedMessageSegment::Lines { lines, .. } => lines
+                    .iter()
+                    .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
+                    .collect(),
+            })
+            .collect();
+        assert!(code_lines.iter().any(|line| line.contains("Write notes/plan.md")));
+
+        let plan_cache = get_or_build_message_render_cache(
+            &mut msg,
+            &spinner,
+            MessageRenderContext::new(Some("plan"), 80, 1, options),
+        );
+        let plan_lines: Vec<String> = plan_cache
+            .segments()
+            .iter()
+            .flat_map(|segment| match segment {
+                CachedMessageSegment::Blank => vec![String::new()],
+                CachedMessageSegment::Lines { lines, .. } => lines
+                    .iter()
+                    .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
+                    .collect(),
+            })
+            .collect();
+        assert!(plan_lines.iter().any(|line| line.contains("Create Plan")));
+        assert!(!plan_lines.iter().any(|line| line.contains("Write notes/plan.md")));
     }
 
     fn rendered_segment_height(segments: &[CachedMessageSegment]) -> usize {

--- a/src/ui/tool_call/execute.rs
+++ b/src/ui/tool_call/execute.rs
@@ -14,8 +14,8 @@ use ratatui::text::{Line, Span};
 use super::errors::failed_execute_first_line;
 use super::interactions::{render_permission_lines, render_question_lines};
 use super::{
-    markdown_inline_spans, spans_width, status_icon, tool_output_badge_spans,
-    truncate_spans_to_width,
+    ToolCallRenderContext, markdown_inline_spans, spans_width, status_icon, tool_display_title,
+    tool_output_badge_spans, truncate_spans_to_width,
 };
 
 /// Max visible output lines for Execute/Bash tool calls.
@@ -91,6 +91,7 @@ pub(super) fn render_execute_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
 /// fill the terminal correctly even after resize.
 pub(super) fn render_execute_with_borders(
     tc: &ToolCallInfo,
+    render_context: ToolCallRenderContext<'_>,
     content: &[Line<'static>],
     width: u16,
     spinner_frame: usize,
@@ -117,7 +118,9 @@ pub(super) fn render_execute_with_borders(
     let right_border_w = 1; // "right-corner"
     // Reserve at least one fill char so the border looks continuous.
     let title_max_w = line_budget.saturating_sub(prefix_w + badges_w + right_border_w + 1);
-    let title_spans = truncate_spans_to_width(markdown_inline_spans(&tc.title), title_max_w);
+    let display_title = tool_display_title(tc, render_context);
+    let title_spans =
+        truncate_spans_to_width(markdown_inline_spans(display_title.as_ref()), title_max_w);
     let title_w = spans_width(&title_spans);
     let fill_w = line_budget.saturating_sub(prefix_w + title_w + badges_w + right_border_w);
     let top_fill: String = "\u{2500}".repeat(fill_w);

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -122,16 +122,26 @@ pub fn render_tool_call_cached_with_tools_collapsed(
         return;
     }
 
+    let body_depends_on_width = standard::tool_call_body_depends_on_width(tc);
+
     // Expanded body: use cache if valid, otherwise render and cache.
-    if let Some(cached_body) = tc.cache.get() {
+    let cached_body =
+        if body_depends_on_width { tc.cache.get_for_width(width) } else { tc.cache.get() };
+    if let Some(cached_body) = cached_body {
         crate::perf::mark_with("tc::cache_hit_body", "lines", cached_body.len());
         out.extend_from_slice(cached_body);
     } else {
         crate::perf::mark("tc::cache_miss_body");
         let _t = crate::perf::start("tc::render_body");
-        let body = standard::render_tool_call_body(tc);
-        tc.cache.store(body);
-        if let Some(stored) = tc.cache.get() {
+        let body = standard::render_tool_call_body(tc, width);
+        if body_depends_on_width {
+            tc.cache.store_for_width(body, width);
+        } else {
+            tc.cache.store(body);
+        }
+        let stored =
+            if body_depends_on_width { tc.cache.get_for_width(width) } else { tc.cache.get() };
+        if let Some(stored) = stored {
             out.extend_from_slice(stored);
         }
     }
@@ -201,25 +211,44 @@ pub fn measure_tool_call_height_cached_with_tools_collapsed(
         return (total, 1 + summary.len());
     }
 
-    if let Some(body_h) = tc.cache.height_at(width) {
-        let total = title_h + body_h;
-        tc.record_measured_height(width, total, layout_generation);
-        return (total, 1);
-    }
-    if let Some(body_h) = tc.cache.measure_and_set_height(width) {
-        let total = title_h + body_h;
-        tc.record_measured_height(width, total, layout_generation);
-        return (total, tc.cache.get().map_or(1, |b| b.len() + 1));
+    let body_depends_on_width = standard::tool_call_body_depends_on_width(tc);
+    let cached_body =
+        if body_depends_on_width { tc.cache.get_for_width(width) } else { tc.cache.get() };
+    if cached_body.is_some() {
+        if let Some(body_h) = tc.cache.height_at(width) {
+            let total = title_h + body_h;
+            tc.record_measured_height(width, total, layout_generation);
+            return (total, 1);
+        }
+        if let Some(body_h) = tc.cache.measure_and_set_height(width) {
+            let total = title_h + body_h;
+            tc.record_measured_height(width, total, layout_generation);
+            let cached_len = if body_depends_on_width {
+                tc.cache.get_for_width(width).map_or(1, |body| body.len() + 1)
+            } else {
+                tc.cache.get().map_or(1, |body| body.len() + 1)
+            };
+            return (total, cached_len);
+        }
     }
 
-    let body = standard::render_tool_call_body(tc);
+    let body = standard::render_tool_call_body(tc, width);
     let body_h =
         Paragraph::new(Text::from(body.clone())).wrap(Wrap { trim: false }).line_count(width);
-    tc.cache.store(body);
+    if body_depends_on_width {
+        tc.cache.store_for_width(body, width);
+    } else {
+        tc.cache.store(body);
+    }
     tc.cache.set_height(body_h, width);
     let total = title_h + body_h;
     tc.record_measured_height(width, total, layout_generation);
-    (total, tc.cache.get().map_or(1, |b| b.len() + 1))
+    let cached_len = if body_depends_on_width {
+        tc.cache.get_for_width(width).map_or(1, |body| body.len() + 1)
+    } else {
+        tc.cache.get().map_or(1, |body| body.len() + 1)
+    };
+    (total, cached_len)
 }
 
 // ---------------------------------------------------------------------------
@@ -679,7 +708,7 @@ mod tests {
                 .blob_saved_to(Some("C:\\tmp\\manual.pdf".to_owned())),
         )];
 
-        let body = standard::render_tool_call_body(&tc);
+        let body = standard::render_tool_call_body(&tc, 80);
         let rendered: Vec<String> = body
             .iter()
             .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
@@ -708,7 +737,7 @@ mod tests {
                 .blob_saved_to(Some("C:\\tmp\\manual.pdf".to_owned())),
         )];
 
-        let body = standard::render_tool_call_body(&tc);
+        let body = standard::render_tool_call_body(&tc, 80);
         let rendered: Vec<String> = body
             .iter()
             .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
@@ -808,7 +837,8 @@ mod tests {
             .collect();
 
         assert!(!text.iter().any(|line| line.contains("expand")));
-        assert!(text.iter().any(|line| line.contains("main.rs")));
+        assert!(text.iter().any(|line| line.contains("lines ")));
+        assert!(text.iter().any(|line| line.contains("+  new")));
         assert!(text.len() > 2);
     }
 
@@ -827,7 +857,7 @@ mod tests {
             .old_text(Some("# Old Plan\n".to_owned())),
         )];
 
-        let body = standard::render_tool_call_body(&tc);
+        let body = standard::render_tool_call_body(&tc, 80);
         let rendered: Vec<String> = body
             .iter()
             .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -14,6 +14,8 @@ mod execute;
 mod interactions;
 mod standard;
 
+use std::borrow::Cow;
+
 use crate::agent::model;
 use crate::app::ToolCallInfo;
 use crate::ui::markdown;
@@ -38,6 +40,11 @@ const SPINNER_STRS: &[&str] = &[
     "\u{280B}", "\u{2819}", "\u{2839}", "\u{2838}", "\u{283C}", "\u{2834}", "\u{2826}", "\u{2827}",
     "\u{2807}", "\u{280F}",
 ];
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ToolCallRenderContext<'a> {
+    pub current_mode_id: Option<&'a str>,
+}
 
 pub fn status_icon(status: model::ToolCallStatus, spinner_frame: usize) -> (&'static str, Color) {
     match status {
@@ -69,6 +76,7 @@ pub fn status_icon(status: model::ToolCallStatus, spinner_frame: usize) -> (&'st
 /// every completed tool-call cache.
 pub fn render_tool_call_cached_with_tools_collapsed(
     tc: &mut ToolCallInfo,
+    render_context: ToolCallRenderContext<'_>,
     width: u16,
     spinner_frame: usize,
     tools_collapsed: bool,
@@ -87,13 +95,19 @@ pub fn render_tool_call_cached_with_tools_collapsed(
             crate::perf::mark("tc::cache_hit_execute");
         }
         if let Some(content) = tc.cache.get() {
-            let bordered = execute::render_execute_with_borders(tc, content, width, spinner_frame);
+            let bordered = execute::render_execute_with_borders(
+                tc,
+                render_context,
+                content,
+                width,
+                spinner_frame,
+            );
             out.extend(bordered);
         }
         return;
     }
 
-    let title = standard::render_tool_call_title(tc, width, spinner_frame);
+    let title = standard::render_tool_call_title(tc, render_context, width, spinner_frame);
     out.push(title);
 
     let has_body = !(tc.content.is_empty()
@@ -127,6 +141,7 @@ pub fn render_tool_call_cached_with_tools_collapsed(
 /// Returns `(height, lines_wrapped_for_measurement)`.
 pub fn measure_tool_call_height_cached_with_tools_collapsed(
     tc: &mut ToolCallInfo,
+    render_context: ToolCallRenderContext<'_>,
     width: u16,
     spinner_frame: usize,
     layout_generation: u64,
@@ -145,7 +160,13 @@ pub fn measure_tool_call_height_cached_with_tools_collapsed(
             tc.cache.store(content);
         }
         if let Some(content) = tc.cache.get() {
-            let bordered = execute::render_execute_with_borders(tc, content, width, spinner_frame);
+            let bordered = execute::render_execute_with_borders(
+                tc,
+                render_context,
+                content,
+                width,
+                spinner_frame,
+            );
             let h = Paragraph::new(Text::from(bordered.clone()))
                 .wrap(Wrap { trim: false })
                 .line_count(width);
@@ -157,7 +178,7 @@ pub fn measure_tool_call_height_cached_with_tools_collapsed(
         return (0, 0);
     }
 
-    let title = standard::render_tool_call_title(tc, width, spinner_frame);
+    let title = standard::render_tool_call_title(tc, render_context, width, spinner_frame);
     let title_h =
         Paragraph::new(Text::from(vec![title])).wrap(Wrap { trim: false }).line_count(width);
     let has_body = !(tc.content.is_empty()
@@ -273,6 +294,21 @@ fn tool_output_badge_spans(tc: &ToolCallInfo) -> Vec<Span<'static>> {
     }
 
     badges
+}
+
+fn tool_display_title<'a>(
+    tc: &'a ToolCallInfo,
+    render_context: ToolCallRenderContext<'_>,
+) -> Cow<'a, str> {
+    if render_context.current_mode_id == Some("plan") {
+        match tc.sdk_tool_name.as_str() {
+            "Write" => return Cow::Borrowed("Create Plan"),
+            "Edit" | "MultiEdit" => return Cow::Borrowed("Update Plan"),
+            _ => {}
+        }
+    }
+
+    Cow::Borrowed(&tc.title)
 }
 
 // ---------------------------------------------------------------------------
@@ -415,10 +451,38 @@ mod tests {
         let mut tc = test_tool_call("tc-bg", "Agent", model::ToolCallStatus::InProgress);
         tc.task_metadata = Some(model::TaskMetadata::new().backgrounded(Some(true)));
 
-        let line = standard::render_tool_call_title(&tc, 80, 0);
+        let line = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 80, 0);
         let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
 
         assert!(rendered.contains("[backgrounded]"));
+    }
+
+    #[test]
+    fn tool_display_title_uses_plan_aliases() {
+        let write = test_tool_call("tc-plan-write", "Write", model::ToolCallStatus::Completed);
+        let edit = test_tool_call("tc-plan-edit", "Edit", model::ToolCallStatus::Completed);
+        let read = test_tool_call("tc-plan-read", "Read", model::ToolCallStatus::Completed);
+        let plan = ToolCallRenderContext { current_mode_id: Some("plan") };
+
+        assert_eq!(tool_display_title(&write, plan), "Create Plan");
+        assert_eq!(tool_display_title(&edit, plan), "Update Plan");
+        assert_eq!(tool_display_title(&read, plan), "tc-plan-read");
+    }
+
+    #[test]
+    fn standard_title_uses_plan_alias_for_write() {
+        let tc = test_tool_call("Write notes/plan.md", "Write", model::ToolCallStatus::Completed);
+
+        let rendered = standard::render_tool_call_title(
+            &tc,
+            ToolCallRenderContext { current_mode_id: Some("plan") },
+            80,
+            0,
+        );
+        let text: String = rendered.spans.iter().map(|span| span.content.as_ref()).collect();
+
+        assert!(text.contains("Create Plan"));
+        assert!(!text.contains("Write notes/plan.md"));
     }
 
     #[test]
@@ -452,7 +516,8 @@ mod tests {
             pending_question: None,
         };
 
-        let rendered = execute::render_execute_with_borders(&tc, &[], 80, 0);
+        let rendered =
+            execute::render_execute_with_borders(&tc, ToolCallRenderContext::default(), &[], 80, 0);
         let top = rendered.first().expect("top border line");
         assert!(spans_width(&top.spans) <= 80);
     }
@@ -465,10 +530,35 @@ mod tests {
                 model::BashOutputMetadata::new().assistant_auto_backgrounded(Some(true)),
             )));
 
-        let rendered = execute::render_execute_with_borders(&tc, &[], 100, 0);
+        let rendered = execute::render_execute_with_borders(
+            &tc,
+            ToolCallRenderContext::default(),
+            &[],
+            100,
+            0,
+        );
         let top = rendered.first().expect("top border line");
         let text: String = top.spans.iter().map(|span| span.content.as_ref()).collect();
         assert!(text.contains("[assistant backgrounded]"));
+    }
+
+    #[test]
+    fn execute_title_preserves_bash_title_in_plan_mode() {
+        let mut tc = test_tool_call("echo hi", "Bash", model::ToolCallStatus::Completed);
+        tc.terminal_command = Some("echo hi".to_owned());
+
+        let rendered = execute::render_execute_with_borders(
+            &tc,
+            ToolCallRenderContext { current_mode_id: Some("plan") },
+            &[],
+            80,
+            0,
+        );
+        let top = rendered.first().expect("top border line");
+        let text: String = top.spans.iter().map(|span| span.content.as_ref()).collect();
+
+        assert!(text.contains("Bash"));
+        assert!(text.contains("echo hi"));
     }
 
     #[test]
@@ -477,13 +567,25 @@ mod tests {
         tc.terminal_command = Some("echo hi".to_owned());
         tc.terminal_output = Some("hello\nworld".to_owned());
 
-        let (h1, lines1) =
-            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 1, false);
+        let (h1, lines1) = measure_tool_call_height_cached_with_tools_collapsed(
+            &mut tc,
+            ToolCallRenderContext::default(),
+            80,
+            0,
+            1,
+            false,
+        );
         assert!(h1 > 0);
         assert!(lines1 > 0);
 
-        let (h2, lines2) =
-            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 4, 1, false);
+        let (h2, lines2) = measure_tool_call_height_cached_with_tools_collapsed(
+            &mut tc,
+            ToolCallRenderContext::default(),
+            80,
+            4,
+            1,
+            false,
+        );
         assert_eq!(h2, h1);
         assert!(lines2 <= lines1);
     }
@@ -494,11 +596,23 @@ mod tests {
         tc.terminal_command = Some("echo hi".to_owned());
         tc.terminal_output = Some("hello".to_owned());
 
-        let (_, first_lines) =
-            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 1, false);
+        let (_, first_lines) = measure_tool_call_height_cached_with_tools_collapsed(
+            &mut tc,
+            ToolCallRenderContext::default(),
+            80,
+            0,
+            1,
+            false,
+        );
         assert!(first_lines > 0);
-        let (_, second_lines) =
-            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 2, false);
+        let (_, second_lines) = measure_tool_call_height_cached_with_tools_collapsed(
+            &mut tc,
+            ToolCallRenderContext::default(),
+            80,
+            0,
+            2,
+            false,
+        );
         assert!(second_lines > 0);
     }
 
@@ -507,17 +621,36 @@ mod tests {
         let mut tc = test_tool_call("tc-dirty", "Read", model::ToolCallStatus::Completed);
         tc.content = vec![model::ToolCallContent::from("one line")];
 
-        let (first_height, first_lines) =
-            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 1, false);
+        let (first_height, first_lines) = measure_tool_call_height_cached_with_tools_collapsed(
+            &mut tc,
+            ToolCallRenderContext::default(),
+            80,
+            0,
+            1,
+            false,
+        );
         assert!(first_lines > 0);
-        let (cached_height, fast_lines) =
-            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 1, false);
+        let (cached_height, fast_lines) = measure_tool_call_height_cached_with_tools_collapsed(
+            &mut tc,
+            ToolCallRenderContext::default(),
+            80,
+            0,
+            1,
+            false,
+        );
         assert_eq!(cached_height, first_height);
         assert!(fast_lines <= first_lines);
 
         tc.mark_tool_call_layout_dirty();
         let (recomputed_height, recompute_lines) =
-            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 80, 0, 1, false);
+            measure_tool_call_height_cached_with_tools_collapsed(
+                &mut tc,
+                ToolCallRenderContext::default(),
+                80,
+                0,
+                1,
+                false,
+            );
         assert_eq!(recomputed_height, first_height);
         assert!(recompute_lines > 0);
     }
@@ -529,7 +662,8 @@ mod tests {
             model::TodoWriteOutputMetadata::new().verification_nudge_needed(Some(true)),
         )));
 
-        let rendered = standard::render_tool_call_title(&tc, 80, 0);
+        let rendered =
+            standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 80, 0);
         let text: String = rendered.spans.iter().map(|span| span.content.as_ref()).collect();
         assert!(text.contains("[verification needed]"));
     }
@@ -592,7 +726,14 @@ mod tests {
         tc.content = vec![model::ToolCallContent::from("alpha\nbeta".to_owned())];
 
         let mut expanded = Vec::new();
-        render_tool_call_cached_with_tools_collapsed(&mut tc, 80, 0, false, &mut expanded);
+        render_tool_call_cached_with_tools_collapsed(
+            &mut tc,
+            ToolCallRenderContext::default(),
+            80,
+            0,
+            false,
+            &mut expanded,
+        );
         let expanded_text: Vec<String> = expanded
             .iter()
             .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
@@ -601,7 +742,14 @@ mod tests {
         assert!(expanded_text.first().is_some_and(|line| line.contains("tc-collapse")));
 
         let mut collapsed = Vec::new();
-        render_tool_call_cached_with_tools_collapsed(&mut tc, 80, 0, true, &mut collapsed);
+        render_tool_call_cached_with_tools_collapsed(
+            &mut tc,
+            ToolCallRenderContext::default(),
+            80,
+            0,
+            true,
+            &mut collapsed,
+        );
         let collapsed_text: Vec<String> = collapsed
             .iter()
             .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
@@ -618,10 +766,22 @@ mod tests {
             test_tool_call("tc-measure-collapse", "Read", model::ToolCallStatus::Completed);
         tc.content = vec![model::ToolCallContent::from("alpha\nbeta\ngamma\ndelta".to_owned())];
 
-        let (expanded_h, _) =
-            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 24, 0, 1, false);
-        let (collapsed_h, _) =
-            measure_tool_call_height_cached_with_tools_collapsed(&mut tc, 24, 0, 2, true);
+        let (expanded_h, _) = measure_tool_call_height_cached_with_tools_collapsed(
+            &mut tc,
+            ToolCallRenderContext::default(),
+            24,
+            0,
+            1,
+            false,
+        );
+        let (collapsed_h, _) = measure_tool_call_height_cached_with_tools_collapsed(
+            &mut tc,
+            ToolCallRenderContext::default(),
+            24,
+            0,
+            2,
+            true,
+        );
 
         assert!(collapsed_h < expanded_h);
     }
@@ -634,7 +794,14 @@ mod tests {
         )];
 
         let mut rendered = Vec::new();
-        render_tool_call_cached_with_tools_collapsed(&mut tc, 80, 0, true, &mut rendered);
+        render_tool_call_cached_with_tools_collapsed(
+            &mut tc,
+            ToolCallRenderContext::default(),
+            80,
+            0,
+            true,
+            &mut rendered,
+        );
         let text: Vec<String> = rendered
             .iter()
             .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
@@ -643,6 +810,33 @@ mod tests {
         assert!(!text.iter().any(|line| line.contains("expand")));
         assert!(text.iter().any(|line| line.contains("main.rs")));
         assert!(text.len() > 2);
+    }
+
+    #[test]
+    fn plan_files_render_markdown_instead_of_diff() {
+        let mut tc = test_tool_call(
+            "Write .claude/plans/launch.md",
+            "Write",
+            model::ToolCallStatus::Completed,
+        );
+        tc.content = vec![model::ToolCallContent::Diff(
+            model::Diff::new(
+                ".claude/plans/launch.md",
+                "# Launch Plan\n\n- Ship aliases\n- Render plan markdown\n".to_owned(),
+            )
+            .old_text(Some("# Old Plan\n".to_owned())),
+        )];
+
+        let body = standard::render_tool_call_body(&tc);
+        let rendered: Vec<String> = body
+            .iter()
+            .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
+            .collect();
+
+        assert!(rendered.iter().any(|line| line.contains("Launch Plan")));
+        assert!(rendered.iter().any(|line| line.contains("Render plan markdown")));
+        assert!(!rendered.iter().any(|line| line.contains("@@")));
+        assert!(!rendered.iter().any(|line| line.starts_with("+ ")));
     }
 
     #[test]

--- a/src/ui/tool_call/standard.rs
+++ b/src/ui/tool_call/standard.rs
@@ -18,7 +18,10 @@ use super::errors::{
     looks_like_internal_error, render_internal_failure_content, render_tool_use_error_content,
 };
 use super::interactions::{render_permission_lines, render_question_lines};
-use super::{markdown_inline_spans, status_icon, tool_output_badge_spans};
+use super::{
+    ToolCallRenderContext, markdown_inline_spans, status_icon, tool_display_title,
+    tool_output_badge_spans,
+};
 
 pub(super) const WRITE_DIFF_MAX_LINES: usize = 50;
 pub(super) const WRITE_DIFF_HEAD_LINES: usize = 10;
@@ -30,6 +33,7 @@ const IN_PROGRESS_SUBAGENT_COLLAPSED_TEXT_SUMMARY_LIMIT: usize = 180;
 /// Execute tool calls are handled separately via `render_execute_with_borders`.
 pub(super) fn render_tool_call_title(
     tc: &ToolCallInfo,
+    render_context: ToolCallRenderContext<'_>,
     _width: u16,
     spinner_frame: usize,
 ) -> Line<'static> {
@@ -44,7 +48,8 @@ pub(super) fn render_tool_call_title(
         ),
     ];
 
-    title_spans.extend(markdown_inline_spans(&tc.title));
+    let display_title = tool_display_title(tc, render_context);
+    title_spans.extend(markdown_inline_spans(display_title.as_ref()));
     title_spans.extend(tool_output_badge_spans(tc));
 
     Line::from(title_spans)
@@ -236,11 +241,15 @@ fn render_tool_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
     for content in &tc.content {
         match content {
             model::ToolCallContent::Diff(diff) => {
-                let raw = render_diff(diff);
-                if tc.sdk_tool_name == "Write" && !is_plan_file_path(&diff.path) {
-                    lines.extend(cap_write_diff_lines(raw));
+                if is_plan_file_path(&diff.path) {
+                    lines.extend(render_plan_content(&diff.new_text));
                 } else {
-                    lines.extend(raw);
+                    let raw = render_diff(diff);
+                    if tc.sdk_tool_name == "Write" {
+                        lines.extend(cap_write_diff_lines(raw));
+                    } else {
+                        lines.extend(raw);
+                    }
                 }
             }
             model::ToolCallContent::McpResource(resource) => {
@@ -257,6 +266,21 @@ fn render_tool_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
 
     debug_failed_tool_render(tc);
     lines
+}
+
+fn render_plan_content(text: &str) -> Vec<Line<'static>> {
+    let md_source = strip_outer_code_fence(text);
+    markdown::render_markdown_safe(&md_source, None)
+        .into_iter()
+        .map(|line| {
+            let owned: Vec<Span<'static>> = line
+                .spans
+                .into_iter()
+                .map(|span| Span::styled(span.content.into_owned(), span.style))
+                .collect();
+            Line::from(owned)
+        })
+        .collect()
 }
 
 fn render_text_content(tc: &ToolCallInfo, text: &str, lines: &mut Vec<Line<'static>>) {
@@ -319,7 +343,7 @@ fn render_mcp_resource_content(
 }
 
 /// Returns `true` for paths inside `.claude/plans/` (cross-platform).
-/// Write diffs for these files are never capped so the full plan is always visible.
+/// These files render as markdown plan content instead of unified diffs.
 fn is_plan_file_path(path: &std::path::Path) -> bool {
     path.components()
         .zip(path.components().skip(1))

--- a/src/ui/tool_call/standard.rs
+++ b/src/ui/tool_call/standard.rs
@@ -58,10 +58,15 @@ pub(super) fn render_tool_call_title(
 /// Render the body lines (everything after the title) for a non-Execute tool call.
 /// Used for in-progress tool calls where the body is cached separately from the title.
 /// Execute tool calls are handled separately via `render_execute_with_borders`.
-pub(super) fn render_tool_call_body(tc: &ToolCallInfo) -> Vec<Line<'static>> {
+pub(super) fn render_tool_call_body(tc: &ToolCallInfo, width: u16) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
-    render_standard_body(tc, &mut lines);
+    render_standard_body(tc, width, &mut lines);
     lines
+}
+
+#[must_use]
+pub(super) fn tool_call_body_depends_on_width(tc: &ToolCallInfo) -> bool {
+    tc.content.iter().any(|content| matches!(content, model::ToolCallContent::Diff(_)))
 }
 
 #[must_use]
@@ -85,7 +90,7 @@ pub(super) fn render_collapsed_tool_call_summary(
 }
 
 /// Render the body (everything after the title line) of a standard (non-Execute) tool call.
-fn render_standard_body(tc: &ToolCallInfo, lines: &mut Vec<Line<'static>>) {
+fn render_standard_body(tc: &ToolCallInfo, width: u16, lines: &mut Vec<Line<'static>>) {
     let pipe_style = Style::default().fg(theme::DIM);
     let has_permission = tc.pending_permission.is_some();
     let has_question = tc.pending_question.is_some();
@@ -95,7 +100,7 @@ fn render_standard_body(tc: &ToolCallInfo, lines: &mut Vec<Line<'static>>) {
     }
 
     // Expanded: render full content with | prefix on each line
-    let mut content_lines = render_tool_content(tc);
+    let mut content_lines = render_tool_content(tc, width.saturating_sub(5));
 
     // Append inline permission controls if pending
     if let Some(ref perm) = tc.pending_permission {
@@ -213,7 +218,7 @@ fn truncate_summary_line(line: &str, max_chars: usize) -> String {
 }
 
 /// Render the full content of a tool call as lines.
-fn render_tool_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
+fn render_tool_content(tc: &ToolCallInfo, width: u16) -> Vec<Line<'static>> {
     let is_execute = tc.is_execute_tool();
     let mut lines: Vec<Line<'static>> = Vec::new();
 
@@ -244,7 +249,7 @@ fn render_tool_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
                 if is_plan_file_path(&diff.path) {
                     lines.extend(render_plan_content(&diff.new_text));
                 } else {
-                    let raw = render_diff(diff);
+                    let raw = render_diff(diff, width);
                     if tc.sdk_tool_name == "Write" {
                         lines.extend(cap_write_diff_lines(raw));
                     } else {


### PR DESCRIPTION
## Summary

- improve generic tool-call diff rendering with compact hunk headers, per-line numbers, and hanging-indent wrapping
- reserve a dedicated chat scrollbar column so chat content no longer renders underneath the scrollbar
- make tool-call body caching width-aware so wrapped diff bodies are cached and measured correctly
- keep plan-file rendering in markdown while leaving normal diff rendering generic

## Why

The current tool-call diff presentation was technically correct but hard to scan in practice: long wrapped additions lost structure, hunk headers were noisy, and the diff body repeated information already present in the tool title. Separately, chat text could be painted underneath the scrollbar because the scrollbar overlaid the content area instead of having its own lane.

This change makes diffs more legible without adding tool-specific summaries, and it fixes the chat layout bug by aligning measurement, rendering, selection, and mouse hit-testing around a reserved scrollbar column.

Closes #

## Validation

- Automated:
  - `cargo test --all-features`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo fmt --all -- --check`
  - `cargo +1.88.0 check --all-features`
  - `cargo fetch --locked`
  - `npm.cmd ci` in `agent-sdk/`
  - `npm.cmd run audit:raw` in `agent-sdk/` (informational; reported 1 moderate transitive vulnerability in `hono`)
  - `npm.cmd run audit` in `agent-sdk/`
  - `npm.cmd run lint` in `agent-sdk/`
  - `npm.cmd run knip` in `agent-sdk/`
- Manual:
  - Not run
- Screenshot/video (if UI changed): Pending

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- `agent-sdk` direct dependency audit passed; the raw audit still reports a moderate transitive advisory for `hono`, which is consistent with the workflow's non-blocking informational step
