### PR TITLE
fix(agent-sdk): include model versions in short model names

### DIFF
--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -128,7 +128,7 @@ test("refreshSupportedModesForSession uses resolved current model for auto-mode 
   ];
   session.currentModel = {
     resolved_id: "claude-sonnet-4-6[1m]",
-    display_name_short: "Sonnet [1M]",
+    display_name_short: "Sonnet 4.6 [1M]",
     display_name_long: "Sonnet 4.6 [1M]",
     supports_effort: true,
     supported_effort_levels: ["low", "medium", "high"],
@@ -2437,7 +2437,7 @@ test("resolveCurrentModel keeps 1M context suffix in short and long display name
 
   const currentModel = resolveCurrentModel(session);
 
-  assert.equal(currentModel.display_name_short, "Opus [1M]");
+  assert.equal(currentModel.display_name_short, "Opus 4.6 [1M]");
   assert.equal(currentModel.display_name_long, "Opus 4.6 [1M]");
 });
 
@@ -2513,7 +2513,7 @@ test("emitCurrentModelUpdate can acknowledge a successful no-op set_model", () =
     current_model: {
       requested_id: "default",
       resolved_id: "claude-opus-4-6[1m]",
-      display_name_short: "Opus [1M]",
+      display_name_short: "Opus 4.6 [1M]",
       display_name_long: "Opus 4.6 [1M]",
       supports_effort: false,
       supported_effort_levels: [],

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -1415,13 +1415,15 @@ function shortDisplayNameForModelId(id: string): string {
     : normalized.family === "sonnet"
       ? "Sonnet"
       : "Haiku";
+  const versionLabel =
+    normalized.versionParts.length > 0 ? ` ${normalized.versionParts.join(".")}` : "";
   const contextLabel =
     normalized.contextSuffix?.toLowerCase() === "1m"
       ? " [1M]"
       : normalized.contextSuffix
         ? ` [${normalized.contextSuffix}]`
         : "";
-  return `${familyLabel}${contextLabel}`;
+  return `${familyLabel}${versionLabel}${contextLabel}`;
 }
 
 function currentModelIsAuthoritative(

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -553,7 +553,7 @@ mod tests {
     fn footer_model_badge_uses_resolved_model_and_effort() {
         let mut app = App::test_default();
         app.current_model = Some(
-            model::CurrentModel::new("claude-sonnet-4-6", "Sonnet", "Sonnet 4.6")
+            model::CurrentModel::new("claude-sonnet-4-6", "Sonnet 4.6", "Sonnet 4.6")
                 .supports_effort(true)
                 .supported_effort_levels(vec![
                     model::EffortLevel::Low,
@@ -563,17 +563,18 @@ mod tests {
                 .authoritative(true),
         );
 
-        assert_eq!(footer_model_badge(&app), Some("Sonnet/Med".to_owned()));
+        assert_eq!(footer_model_badge(&app), Some("Sonnet 4.6/Med".to_owned()));
     }
 
     #[test]
     fn footer_model_badge_hides_effort_for_models_without_support() {
         let mut app = App::test_default();
         app.current_model = Some(
-            model::CurrentModel::new("claude-haiku-4-5", "Haiku", "Haiku 4.5").authoritative(true),
+            model::CurrentModel::new("claude-haiku-4-5", "Haiku 4.5", "Haiku 4.5")
+                .authoritative(true),
         );
 
-        assert_eq!(footer_model_badge(&app), Some("Haiku".to_owned()));
+        assert_eq!(footer_model_badge(&app), Some("Haiku 4.5".to_owned()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- include model version numbers in `display_name_short` when resolving the current model in `agent-sdk`
- keep the footer badge sourced from the central current-model metadata while updating tests to expect versioned short names

## Why

- the footer currently hides version information for the active model, which makes it harder to tell when runtime model versions change
- short and long model display names should stay aligned so the UI reflects the actual resolved model version

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test --all-features`
  - `cargo +1.88.0 check --all-features`
  - `cargo fetch --locked`
  - `cd agent-sdk && npm.cmd ci`
  - `cd agent-sdk && npm.cmd run audit`
  - `cd agent-sdk && npm.cmd run lint`
  - `cd agent-sdk && npm.cmd run knip`
- Manual:
  - Not run
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- `cd agent-sdk && npm.cmd run audit:raw` still reports one moderate transitive `hono` advisory and remains non-blocking, matching the workflow configuration
