### PR TITLE
feat(agent-sdk): upgrade to 0.2.112 and bump model fixtures to 4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### CI and Dependencies
+
+- Bump `@anthropic-ai/claude-agent-sdk` from `0.2.104` to `0.2.112` in both the published package and bundled bridge, update the bridge version gate (`EXPECTED_AGENT_SDK_VERSION`), and refresh Rust TUI and bridge test fixtures from `4.6` to `4.7`
+
 ## [0.11.1] - 2026-04-16 [Changes][v0.11.1]
 
 ### Features

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.104"
+        "@anthropic-ai/claude-agent-sdk": "0.2.112"
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "0.81.0",
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.104",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.104.tgz",
-      "integrity": "sha512-lVm+nS79r6WWlDnv5AgRzTtAlbP8O6M6kkWmDZAWE3nt9agmngxls9frJFvH55uzws2+6l0yyup/JYspfijkzw==",
+      "version": "0.2.112",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.112.tgz",
+      "integrity": "sha512-vMFoiDKlOive8p3tphpV1gQaaytOipwGJ+uw9mvvaLQUODSC2+fCdRDAY25i2Tsv+lOtxzXBKctmaDuWqZY7ig==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.81.0",

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -17,7 +17,7 @@
     "test": "npm run build && node --test dist/**/*.test.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.104"
+    "@anthropic-ai/claude-agent-sdk": "0.2.112"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "0.81.0",

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -127,9 +127,9 @@ test("refreshSupportedModesForSession uses resolved current model for auto-mode 
     },
   ];
   session.currentModel = {
-    resolved_id: "claude-sonnet-4-6[1m]",
-    display_name_short: "Sonnet 4.6 [1M]",
-    display_name_long: "Sonnet 4.6 [1M]",
+    resolved_id: "claude-sonnet-4-7[1m]",
+    display_name_short: "Sonnet 4.7 [1M]",
+    display_name_long: "Sonnet 4.7 [1M]",
     supports_effort: true,
     supported_effort_levels: ["low", "medium", "high"],
     supports_auto_mode: false,
@@ -644,7 +644,7 @@ test("buildQueryOptions trims startup model before passing sdk option", () => {
     cwd: "C:/work",
     launchSettings: {
       settings: {
-        model: "  claude-opus-4-6  ",
+        model: "  claude-opus-4-7  ",
         permissions: { defaultMode: "plan" },
       },
     },
@@ -656,7 +656,7 @@ test("buildQueryOptions trims startup model before passing sdk option", () => {
     sessionIdForLogs: () => "session-model",
   });
 
-  assert.equal(options.model, "claude-opus-4-6");
+  assert.equal(options.model, "claude-opus-4-7");
   assert.equal(options.permissionMode, "plan");
 });
 
@@ -2050,7 +2050,7 @@ test("looksLikeAuthRequired detects login hints", () => {
 });
 
 test("agent sdk version compatibility check matches pinned version", () => {
-  assert.equal(resolveInstalledAgentSdkVersion(), "0.2.104");
+  assert.equal(resolveInstalledAgentSdkVersion(), "0.2.112");
   assert.equal(agentSdkVersionCompatibilityError(), undefined);
 });
 
@@ -2433,27 +2433,27 @@ test("mapAvailableModels preserves optional fast and auto mode metadata", () => 
 
 test("resolveCurrentModel keeps 1M context suffix in short and long display names", () => {
   const session = makeSessionState();
-  session.resolvedRuntimeModelId = "claude-opus-4-6[1m]";
+  session.resolvedRuntimeModelId = "claude-opus-4-7[1m]";
 
   const currentModel = resolveCurrentModel(session);
 
-  assert.equal(currentModel.display_name_short, "Opus 4.6 [1M]");
-  assert.equal(currentModel.display_name_long, "Opus 4.6 [1M]");
+  assert.equal(currentModel.display_name_short, "Opus 4.7 [1M]");
+  assert.equal(currentModel.display_name_long, "Opus 4.7 [1M]");
 });
 
 test("resolveCurrentModel does not inherit standard Opus capabilities for 1M when sibling variants exist", () => {
   const session = makeSessionState();
-  session.requestedModelId = "claude-opus-4-6";
-  session.resolvedRuntimeModelId = "claude-opus-4-6[1m]";
+  session.requestedModelId = "claude-opus-4-7";
+  session.resolvedRuntimeModelId = "claude-opus-4-7[1m]";
   session.availableModels = [
     {
-      id: "claude-opus-4-6",
+      id: "claude-opus-4-7",
       display_name: "Claude Opus",
       supports_effort: true,
       supported_effort_levels: ["low", "medium", "high"],
     },
     {
-      id: "claude-opus-4-6[1m]",
+      id: "claude-opus-4-7[1m]",
       display_name: "Claude Opus 1M",
       supports_effort: false,
       supported_effort_levels: [],
@@ -2462,23 +2462,23 @@ test("resolveCurrentModel does not inherit standard Opus capabilities for 1M whe
 
   const currentModel = resolveCurrentModel(session);
 
-  assert.equal(currentModel.catalog_id, "claude-opus-4-6[1m]");
+  assert.equal(currentModel.catalog_id, "claude-opus-4-7[1m]");
   assert.equal(currentModel.supports_effort, false);
 });
 
 test("resolveCurrentModel avoids suffix-insensitive fallback when sibling variants make it ambiguous", () => {
   const session = makeSessionState();
-  session.requestedModelId = "claude-opus-4-6";
-  session.resolvedRuntimeModelId = "claude-opus-4-6[1m]";
+  session.requestedModelId = "claude-opus-4-7";
+  session.resolvedRuntimeModelId = "claude-opus-4-7[1m]";
   session.availableModels = [
     {
-      id: "claude-opus-4-6",
+      id: "claude-opus-4-7",
       display_name: "Claude Opus",
       supports_effort: true,
       supported_effort_levels: ["low", "medium", "high"],
     },
     {
-      id: "claude-opus-4-6-alt[1m]",
+      id: "claude-opus-4-7-alt[1m]",
       display_name: "Claude Opus Alt 1M",
       supports_effort: false,
       supported_effort_levels: [],
@@ -2495,7 +2495,7 @@ test("emitCurrentModelUpdate can acknowledge a successful no-op set_model", () =
   const session = makeSessionState();
   session.model = "default";
   session.requestedModelId = "default";
-  session.resolvedRuntimeModelId = "claude-opus-4-6[1m]";
+  session.resolvedRuntimeModelId = "claude-opus-4-7[1m]";
   refreshCurrentModel(session);
 
   const events = captureBridgeEvents(() => {
@@ -2512,9 +2512,9 @@ test("emitCurrentModelUpdate can acknowledge a successful no-op set_model", () =
     type: "current_model_update",
     current_model: {
       requested_id: "default",
-      resolved_id: "claude-opus-4-6[1m]",
-      display_name_short: "Opus 4.6 [1M]",
-      display_name_long: "Opus 4.6 [1M]",
+      resolved_id: "claude-opus-4-7[1m]",
+      display_name_short: "Opus 4.7 [1M]",
+      display_name_long: "Opus 4.7 [1M]",
       supports_effort: false,
       supported_effort_levels: [],
       is_authoritative: true,

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -136,7 +136,7 @@ export async function generatePersistedSessionTitle(
   return title;
 }
 
-const EXPECTED_AGENT_SDK_VERSION = "0.2.104";
+const EXPECTED_AGENT_SDK_VERSION = "0.2.112";
 const require = createRequire(import.meta.url);
 
 export function resolveInstalledAgentSdkVersion(): string | undefined {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.104"
+        "@anthropic-ai/claude-agent-sdk": "0.2.112"
       },
       "bin": {
         "claude-rs": "bin/claude-rs.js"
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.104",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.104.tgz",
-      "integrity": "sha512-lVm+nS79r6WWlDnv5AgRzTtAlbP8O6M6kkWmDZAWE3nt9agmngxls9frJFvH55uzws2+6l0yyup/JYspfijkzw==",
+      "version": "0.2.112",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.112.tgz",
+      "integrity": "sha512-vMFoiDKlOive8p3tphpV1gQaaytOipwGJ+uw9mvvaLQUODSC2+fCdRDAY25i2Tsv+lOtxzXBKctmaDuWqZY7ig==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.81.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.104"
+    "@anthropic-ai/claude-agent-sdk": "0.2.112"
   },
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -1558,7 +1558,7 @@ mod tests {
         handle_client_event(
             &mut app,
             ClientEvent::SessionUpdate(model::SessionUpdate::CurrentModelUpdate(
-                model::CurrentModelUpdate::new(test_current_model("claude-opus-4-6")),
+                model::CurrentModelUpdate::new(test_current_model("claude-opus-4-7")),
             )),
         );
 
@@ -1632,7 +1632,7 @@ mod tests {
         handle_client_event(
             &mut app,
             ClientEvent::SessionUpdate(model::SessionUpdate::CurrentModelUpdate(
-                model::CurrentModelUpdate::new(test_current_model("claude-opus-4-6")),
+                model::CurrentModelUpdate::new(test_current_model("claude-opus-4-7")),
             )),
         );
 

--- a/src/app/usage/cli.rs
+++ b/src/app/usage/cli.rs
@@ -279,7 +279,7 @@ mod tests {
     fn ignores_status_bar_percentage_noise() {
         let sample = r"
         Claude Code v2.1.32
-        01:07 |  | Opus 4.6 | default | 0% left
+        01:07 |  | Opus 4.7 | default | 0% left
         Current session
         10% used
         Current week (all models)

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -964,7 +964,7 @@ mod tests {
         let mut app = App::test_default();
         app.available_models = vec![
             AvailableModel::new("default", "Default")
-                .description("Opus 4.6")
+                .description("Opus 4.7")
                 .supports_effort(true)
                 .supported_effort_levels(vec![
                     EffortLevel::Low,

--- a/src/ui/config/status.rs
+++ b/src/ui/config/status.rs
@@ -242,11 +242,11 @@ mod tests {
     fn status_lines_shows_model() {
         let mut app = App::test_default();
         app.current_model = Some(
-            crate::agent::model::CurrentModel::new("claude-sonnet-4-6", "Sonnet", "Sonnet 4.6")
+            crate::agent::model::CurrentModel::new("claude-sonnet-4-7", "Sonnet", "Sonnet 4.7")
                 .authoritative(true),
         );
         let text = lines_to_string(&status_lines(&app));
-        assert!(text.contains("Sonnet 4.6"));
+        assert!(text.contains("Sonnet 4.7"));
     }
 
     #[test]

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -553,7 +553,7 @@ mod tests {
     fn footer_model_badge_uses_resolved_model_and_effort() {
         let mut app = App::test_default();
         app.current_model = Some(
-            model::CurrentModel::new("claude-sonnet-4-6", "Sonnet 4.6", "Sonnet 4.6")
+            model::CurrentModel::new("claude-sonnet-4-7", "Sonnet 4.7", "Sonnet 4.7")
                 .supports_effort(true)
                 .supported_effort_levels(vec![
                     model::EffortLevel::Low,
@@ -563,7 +563,7 @@ mod tests {
                 .authoritative(true),
         );
 
-        assert_eq!(footer_model_badge(&app), Some("Sonnet 4.6/Med".to_owned()));
+        assert_eq!(footer_model_badge(&app), Some("Sonnet 4.7/Med".to_owned()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bump `@anthropic-ai/claude-agent-sdk` from `0.2.104` to `0.2.112` in both the published package and the bundled bridge, and update the bridge version gate (`EXPECTED_AGENT_SDK_VERSION`) and its test assertion.
- Rotate Rust TUI and TypeScript bridge test fixtures from `4.6` to `4.7` (covers `claude-opus-4-6` / `claude-sonnet-4-6` IDs and the corresponding display strings, including the `[1M]` variants).
- Record the bump under a new `[Unreleased]` section in `CHANGELOG.md`.

No bridge runtime code changed — the SDK jump spans patch releases only, and no consumed API surface drifted in `0.2.105`–`0.2.112`.

## Test plan

- [ ] `cd agent-sdk && npm test` (bridge unit tests, including the version-gate assertion and all rotated `4.7` / `[1M]` fixtures)
- [ ] `cargo test` (Rust TUI fixtures for footer, config, status, usage CLI, and events)
- [ ] `cargo clippy --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)