### PR TITLE
fix(ui): move update notice into warning system messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - **Tool-call diff rendering and scrollbar lane** (#138, @srothgan): Tighten tool-call diff rendering and reserve a dedicated chat scrollbar column so transcript content no longer renders underneath it
 - **Versioned short model names** (#139, @srothgan): Include model version numbers in `display_name_short` so footer and status surfaces show the resolved runtime model version
 - **Bridge script resolution precedence** (#142, @srothgan): Prefer the bundled `agent-sdk/dist/bridge.js` near the installed executable and keep repo-local fallback debug-only
+- **Update notice warning message** (#143, @srothgan): Move the update hint from the footer into a persistent warning system message with current version, latest version, and inline upgrade command
 
 ### CI and Dependencies
 

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -205,7 +205,7 @@ pub fn create_app(cli: &Cli) -> App {
         pending_images: Vec::new(),
         cached_todo_compact: None,
         git_context: super::git_context::GitContextState::default(),
-        update_check_hint: None,
+        update_notice: None,
         session_usage: super::SessionUsageState::default(),
         usage: super::UsageState::default(),
         mcp: super::McpState::default(),

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -514,6 +514,12 @@ mod tests {
         }
     }
 
+    fn is_update_notice_message(msg: &ChatMessage) -> bool {
+        matches!(msg.role, MessageRole::System(Some(SystemSeverity::Warning)))
+            && first_block_text(msg)
+                .contains("Upgrade to latest version via npm install -g claude-code-rust.")
+    }
+
     // shorten_tool_title
 
     #[test]
@@ -1683,9 +1689,9 @@ mod tests {
     }
 
     #[test]
-    fn update_available_sets_footer_hint() {
+    fn update_available_pushes_warning_system_message_with_versions_and_install_command() {
         let mut app = make_test_app();
-        assert!(app.update_check_hint.is_none());
+        assert!(app.update_notice.is_none());
 
         handle_client_event(
             &mut app,
@@ -1695,10 +1701,18 @@ mod tests {
             },
         );
 
+        assert_eq!(app.messages.len(), 1);
+        assert!(matches!(app.messages[0].role, MessageRole::System(Some(SystemSeverity::Warning))));
         assert_eq!(
-            app.update_check_hint.as_deref(),
-            Some("Update available: v0.3.0 (current v0.2.0)  Ctrl+U to hide")
+            first_block_text(&app.messages[0]),
+            "Update available: current v0.2.0, latest v0.3.0. Upgrade to latest version via npm install -g claude-code-rust."
         );
+        let Some(update_notice) = app.update_notice.as_ref() else {
+            panic!("expected update notice state");
+        };
+        assert_eq!(update_notice.current_version, "0.2.0");
+        assert_eq!(update_notice.latest_version, "0.3.0");
+        assert_eq!(update_notice.emitted_session_scope_epoch, Some(app.session_scope_epoch));
     }
 
     #[test]
@@ -3669,24 +3683,116 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_u_hides_update_hint_globally() {
+    fn update_notice_is_not_duplicated_within_same_session_epoch() {
         let mut app = make_test_app();
-        app.update_check_hint = Some("Update available: v9.9.9 (current v0.2.0)".into());
-        app.todos.push(TodoItem {
-            content: "Task".into(),
-            status: TodoStatus::Pending,
-            active_form: String::new(),
+        app.update_notice = Some(crate::app::UpdateNoticeState {
+            current_version: "0.11.1".into(),
+            latest_version: "0.11.2".into(),
+            emitted_session_scope_epoch: None,
         });
-        app.show_todo_panel = true;
-        app.claim_focus_target(FocusTarget::TodoList);
-        assert_eq!(app.focus_owner(), FocusOwner::TodoList);
 
-        handle_terminal_event(
+        session::ensure_update_notice_message(&mut app);
+        session::ensure_update_notice_message(&mut app);
+
+        assert_eq!(app.messages.iter().filter(|msg| is_update_notice_message(msg)).count(), 1);
+        assert_eq!(
+            app.update_notice.as_ref().and_then(|notice| notice.emitted_session_scope_epoch),
+            Some(app.session_scope_epoch)
+        );
+    }
+
+    #[test]
+    fn update_notice_is_re_emitted_after_epoch_change() {
+        let mut app = make_test_app();
+        app.update_notice = Some(crate::app::UpdateNoticeState {
+            current_version: "0.11.1".into(),
+            latest_version: "0.11.2".into(),
+            emitted_session_scope_epoch: None,
+        });
+
+        session::ensure_update_notice_message(&mut app);
+        app.bump_session_scope_epoch();
+        session::ensure_update_notice_message(&mut app);
+
+        assert_eq!(app.messages.iter().filter(|msg| is_update_notice_message(msg)).count(), 2);
+        assert_eq!(
+            app.update_notice.as_ref().and_then(|notice| notice.emitted_session_scope_epoch),
+            Some(app.session_scope_epoch)
+        );
+    }
+
+    #[test]
+    fn update_available_persists_across_connected_session_reset() {
+        let mut app = make_test_app();
+
+        handle_client_event(
             &mut app,
-            Event::Key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL)),
+            ClientEvent::UpdateAvailable {
+                latest_version: "0.11.2".into(),
+                current_version: "0.11.1".into(),
+            },
+        );
+        handle_client_event(&mut app, connected_event("claude-updated"));
+
+        assert_eq!(app.messages.iter().filter(|msg| is_update_notice_message(msg)).count(), 1);
+        assert!(matches!(app.messages.first().map(|msg| &msg.role), Some(MessageRole::Welcome)));
+        let notice = app
+            .messages
+            .iter()
+            .find(|msg| is_update_notice_message(msg))
+            .expect("expected update notice message after connect");
+        assert_eq!(
+            first_block_text(notice),
+            "Update available: current v0.11.1, latest v0.11.2. Upgrade to latest version via npm install -g claude-code-rust."
+        );
+        assert_eq!(
+            app.update_notice
+                .as_ref()
+                .and_then(|update_notice| update_notice.emitted_session_scope_epoch),
+            Some(app.session_scope_epoch)
+        );
+    }
+
+    #[test]
+    fn update_available_persists_across_session_replaced_reset() {
+        let mut app = make_test_app();
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::UpdateAvailable {
+                latest_version: "0.11.2".into(),
+                current_version: "0.11.1".into(),
+            },
+        );
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionReplaced {
+                session_id: model::SessionId::new("replacement"),
+                cwd: "/replacement".into(),
+                current_model: test_current_model("new-model"),
+                available_models: Vec::new(),
+                mode: None,
+                history_updates: Vec::new(),
+            },
         );
 
-        assert!(app.update_check_hint.is_none());
+        assert_eq!(app.messages.iter().filter(|msg| is_update_notice_message(msg)).count(), 1);
+        assert!(matches!(app.messages.first().map(|msg| &msg.role), Some(MessageRole::Welcome)));
+        let notice = app
+            .messages
+            .iter()
+            .find(|msg| is_update_notice_message(msg))
+            .expect("expected update notice message after replacement");
+        assert_eq!(
+            first_block_text(notice),
+            "Update available: current v0.11.1, latest v0.11.2. Upgrade to latest version via npm install -g claude-code-rust."
+        );
+        assert_eq!(
+            app.update_notice
+                .as_ref()
+                .and_then(|update_notice| update_notice.emitted_session_scope_epoch),
+            Some(app.session_scope_epoch)
+        );
     }
 
     fn attach_pending_permission(

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -7,6 +7,7 @@ use super::super::state::RecentSessionInfo;
 use super::super::view::{self, ActiveView};
 use super::super::{
     App, AppStatus, ChatMessage, LoginHint, MessageBlock, MessageRole, SystemSeverity, TextBlock,
+    UpdateNoticeState,
 };
 use super::push_system_message_with_severity;
 use super::session_reset::{load_resume_history, reset_for_new_session};
@@ -18,6 +19,7 @@ use std::rc::Rc;
 
 const TURN_ERROR_INPUT_LOCK_HINT: &str =
     "Input disabled after an error. Press Ctrl+Q to quit and try again.";
+const UPDATE_INSTALL_COMMAND: &str = "npm install -g claude-code-rust";
 
 pub(super) fn handle_connected_client_event(
     app: &mut App,
@@ -41,6 +43,7 @@ pub(super) fn handle_connected_client_event(
     if !history_updates.is_empty() {
         load_resume_history(app, history_updates);
     }
+    ensure_update_notice_message(app);
     clear_pending_command(app);
     app.resuming_session_id = None;
     crate::app::file_index::restart(app);
@@ -309,6 +312,7 @@ pub(super) fn handle_session_replaced_event(
     if !history_updates.is_empty() {
         load_resume_history(app, history_updates);
     }
+    ensure_update_notice_message(app);
     clear_pending_command(app);
     app.resuming_session_id = None;
     crate::app::file_index::restart(app);
@@ -331,9 +335,12 @@ pub(super) fn handle_update_available_event(
     latest_version: &str,
     current_version: &str,
 ) {
-    app.update_check_hint = Some(format!(
-        "Update available: v{latest_version} (current v{current_version})  Ctrl+U to hide"
-    ));
+    app.update_notice = Some(UpdateNoticeState {
+        current_version: current_version.to_owned(),
+        latest_version: latest_version.to_owned(),
+        emitted_session_scope_epoch: None,
+    });
+    ensure_update_notice_message(app);
     tracing::info!(
         target: crate::logging::targets::APP_UPDATE,
         event_name = "update_available_applied",
@@ -342,6 +349,27 @@ pub(super) fn handle_update_available_event(
         latest_version = %latest_version,
         current_version = %current_version,
     );
+}
+
+pub(super) fn ensure_update_notice_message(app: &mut App) {
+    let Some(notice) = app.update_notice.as_ref() else {
+        return;
+    };
+    if notice.emitted_session_scope_epoch == Some(app.session_scope_epoch) {
+        return;
+    }
+
+    let message = format_update_available_message(&notice.latest_version, &notice.current_version);
+    push_system_message_with_severity(app, Some(SystemSeverity::Warning), &message);
+    if let Some(notice) = app.update_notice.as_mut() {
+        notice.emitted_session_scope_epoch = Some(app.session_scope_epoch);
+    }
+}
+
+fn format_update_available_message(latest_version: &str, current_version: &str) -> String {
+    format!(
+        "Update available: current v{current_version}, latest v{latest_version}. Upgrade to latest version via {UPDATE_INSTALL_COMMAND}."
+    )
 }
 
 pub(super) fn handle_service_status_event(

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -203,12 +203,6 @@ pub(super) fn dispatch_key_by_focus(app: &mut App, key: KeyEvent) -> bool {
 /// During blocked-input states (Connecting, `CommandPending`, Error), keep input disabled and only allow
 /// navigation/help shortcuts.
 fn handle_blocked_input_shortcuts(app: &mut App, key: KeyEvent) -> bool {
-    if is_ctrl_char_shortcut(key, 'u') && app.update_check_hint.is_some() {
-        app.update_check_hint = None;
-        sync_help_focus(app);
-        return true;
-    }
-
     if is_ctrl_char_shortcut(key, 'l') {
         app.force_redraw = true;
         sync_help_focus(app);
@@ -251,12 +245,6 @@ fn handle_blocked_input_shortcuts(app: &mut App, key: KeyEvent) -> bool {
 
 /// Handle shortcuts that should work regardless of current focus owner.
 fn handle_global_shortcuts(app: &mut App, key: KeyEvent) -> bool {
-    // Session-only dismiss for update hint.
-    if is_ctrl_char_shortcut(key, 'u') && app.update_check_hint.is_some() {
-        app.update_check_hint = None;
-        return true;
-    }
-
     // Permission quick shortcuts are global when permissions are pending.
     if !app.pending_interaction_ids.is_empty() && is_permission_ctrl_shortcut(key) {
         return handle_inline_interaction_key(app, key);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -61,9 +61,9 @@ pub use state::{
     RecentSessionInfo, ScrollbarGeometry, SelectionKind, SelectionPoint, SelectionState,
     SessionPickerState, SessionUsageState, SystemSeverity, TerminalSnapshotMode, TextBlock,
     TextBlockSpacing, TodoItem, TodoStatus, ToolCallInfo, ToolCallScope, TurnNoticeLocation,
-    TurnNoticeRef, UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow,
-    WelcomeBlock, compute_scrollbar_geometry, hash_text_block_content, hash_welcome_block_content,
-    is_execute_tool_name,
+    TurnNoticeRef, UpdateNoticeState, UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState,
+    UsageWindow, WelcomeBlock, compute_scrollbar_geometry, hash_text_block_content,
+    hash_welcome_block_content, is_execute_tool_name,
 };
 pub use trust::TrustSelection;
 pub use update_check::start_update_check;

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -28,7 +28,7 @@ pub use types::{
     LoginHint, McpState, MessageUsage, ModeInfo, ModeState, PasteSessionState, PendingCommandAck,
     RecentSessionInfo, RenderCacheBudget, ScrollbarDragState, SelectionKind, SelectionPoint,
     SelectionState, SessionPickerState, SessionUsageState, TodoItem, TodoStatus, ToolCallScope,
-    UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow,
+    UpdateNoticeState, UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow,
 };
 pub use viewport::{
     ChatViewport, LayoutInvalidation, LayoutInvalidation as InvalidationLevel,
@@ -278,8 +278,8 @@ pub struct App {
     pub cached_todo_compact: Option<ratatui::text::Line<'static>>,
     /// Git repo context used by footer/status rendering and live branch tracking.
     pub(crate) git_context: GitContextState,
-    /// Optional startup update-check hint rendered at the footer's right edge.
-    pub update_check_hint: Option<String>,
+    /// Update availability state for the current app lifetime.
+    pub update_notice: Option<UpdateNoticeState>,
     /// Session-wide usage and cost telemetry from the bridge.
     pub session_usage: SessionUsageState,
     /// Config > Usage snapshot and refresh lifecycle.
@@ -891,7 +891,7 @@ impl App {
             pending_images: Vec::new(),
             cached_todo_compact: None,
             git_context: GitContextState::default(),
-            update_check_hint: None,
+            update_notice: None,
             session_usage: SessionUsageState::default(),
             usage: UsageState::default(),
             mcp: McpState::default(),

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -38,6 +38,13 @@ pub enum PendingCommandAck {
     ConfigOption { option_id: String },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateNoticeState {
+    pub current_version: String,
+    pub latest_version: String,
+    pub emitted_session_scope_epoch: Option<u64>,
+}
+
 /// A single todo item from Claude's `TodoWrite` tool call.
 #[derive(Debug, Clone)]
 pub struct TodoItem {

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -41,7 +41,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         frame,
         first_row,
         first_line,
-        footer_update_hint(app),
+        footer_primary_hint(app),
         PRIMARY_ROW_LEFT_MIN_WIDTH,
     );
 
@@ -60,12 +60,12 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     }
 }
 
-fn footer_update_hint(app: &App) -> FooterItem {
+fn footer_primary_hint(app: &App) -> FooterItem {
     let permission_count = pending_permission_request_count(app);
     if permission_count > 0 {
         return Some((format!("{permission_count} PEND. PERM."), Color::Yellow));
     }
-    app.update_check_hint.as_ref().map(|hint| (hint.clone(), theme::RUST_ORANGE))
+    None
 }
 
 fn footer_mcp_auth_hint(app: &App) -> FooterItem {
@@ -475,25 +475,14 @@ mod tests {
     }
 
     #[test]
-    fn footer_update_hint_none_without_hint() {
+    fn footer_primary_hint_none_without_pending_permission() {
         let app = App::test_default();
-        assert_eq!(footer_update_hint(&app), None);
+        assert_eq!(footer_primary_hint(&app), None);
     }
 
     #[test]
-    fn footer_update_hint_returns_text_when_present() {
+    fn footer_primary_hint_shows_pending_permission_count() {
         let mut app = App::test_default();
-        app.update_check_hint = Some("Update available".to_owned());
-        assert_eq!(
-            footer_update_hint(&app),
-            Some(("Update available".to_owned(), theme::RUST_ORANGE))
-        );
-    }
-
-    #[test]
-    fn footer_update_hint_prefers_pending_permission_count() {
-        let mut app = App::test_default();
-        app.update_check_hint = Some("Update available".to_owned());
         let (response_tx, _response_rx) = oneshot::channel();
         app.messages.push(ChatMessage::new(
             MessageRole::Assistant,
@@ -535,7 +524,7 @@ mod tests {
         app.index_tool_call("perm-1".into(), 0, 0);
         app.pending_interaction_ids.push("perm-1".into());
 
-        assert_eq!(footer_update_hint(&app), Some(("1 PEND. PERM.".to_owned(), Color::Yellow)));
+        assert_eq!(footer_primary_hint(&app), Some(("1 PEND. PERM.".to_owned(), Color::Yellow)));
     }
 
     #[test]

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -202,28 +202,16 @@ fn build_help_items(app: &App) -> Vec<(String, String)> {
 
 fn build_key_help_items(app: &App) -> Vec<(String, String)> {
     if app.status == AppStatus::Connecting {
-        let mut items = blocked_input_help_items("Unavailable while connecting");
-        if app.update_check_hint.is_some() {
-            items.push(("Ctrl+u".to_owned(), "Hide update hint".to_owned()));
-        }
-        return items;
+        return blocked_input_help_items("Unavailable while connecting");
     }
     if app.status == AppStatus::CommandPending {
-        let mut items = blocked_input_help_items(&format!(
+        return blocked_input_help_items(&format!(
             "Unavailable while command runs ({})",
             pending_command_help_label(app)
         ));
-        if app.update_check_hint.is_some() {
-            items.push(("Ctrl+u".to_owned(), "Hide update hint".to_owned()));
-        }
-        return items;
     }
     if app.status == AppStatus::Error {
-        let mut items = blocked_input_help_items("Unavailable after error");
-        if app.update_check_hint.is_some() {
-            items.push(("Ctrl+u".to_owned(), "Hide update hint".to_owned()));
-        }
-        return items;
+        return blocked_input_help_items("Unavailable after error");
     }
 
     let mut items: Vec<(String, String)> = vec![
@@ -238,9 +226,6 @@ fn build_key_help_items(app: &App) -> Vec<(String, String)> {
         ("Ctrl+Up/Down".to_owned(), "Scroll chat".to_owned()),
         ("Mouse wheel".to_owned(), "Scroll chat".to_owned()),
     ];
-    if app.update_check_hint.is_some() {
-        items.push(("Ctrl+u".to_owned(), "Hide update hint".to_owned()));
-    }
     if app.is_compacting {
         items.push(("Status".to_owned(), "Compacting context".to_owned()));
     }
@@ -625,14 +610,18 @@ mod tests {
     }
 
     #[test]
-    fn key_tab_shows_ctrl_u_only_when_update_hint_visible() {
+    fn key_tab_never_shows_ctrl_u_for_update_hiding() {
         let mut app = App::test_default();
         let items = build_help_items(&app);
         assert!(!has_item(&items, "Ctrl+u", "Hide update hint"));
 
-        app.update_check_hint = Some("Update available".into());
+        app.update_notice = Some(crate::app::UpdateNoticeState {
+            current_version: "0.11.1".into(),
+            latest_version: "0.11.2".into(),
+            emitted_session_scope_epoch: None,
+        });
         let items = build_help_items(&app);
-        assert!(has_item(&items, "Ctrl+u", "Hide update hint"));
+        assert!(!has_item(&items, "Ctrl+u", "Hide update hint"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- move update availability from the footer into a warning system message in the chat transcript
- include the current version, latest version, and inline upgrade command in the warning copy
- persist the update notice across connect and session replacement transcript rebuilds without duplicating it within the same session epoch
- remove the footer update hint and the `Ctrl+U` hide behavior from key handling and help text

## Why

- the footer hint was easy to miss and did not survive transcript rebuilds in a structured way
- update availability fits better as session-visible warning state than as dismissible footer chrome
- the new behavior keeps the notice visible, explicit, and consistent after reconnect or resume flows

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `cargo check --offline`
- Manual:
  - verified the cached update check path by forcing a newer cached version and confirming the warning message rendered in chat
  - verified final copy uses a single line with the inline upgrade command
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A