### PR TITLE
fix(ui): preserve ANSI colors in terminal tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - **Versioned short model names** (#139, @srothgan): Include model version numbers in `display_name_short` so footer and status surfaces show the resolved runtime model version
 - **Bridge script resolution precedence** (#142, @srothgan): Prefer the bundled `agent-sdk/dist/bridge.js` near the installed executable and keep repo-local fallback debug-only
 - **Update notice warning message** (#143, @srothgan): Move the update hint from the footer into a persistent warning system message with current version, latest version, and inline upgrade command
+- **Terminal ANSI output rendering** (#144, @srothgan): Preserve command-emitted ANSI colors in terminal tool output while keeping unified diff rendering on stripped text
 
 ### CI and Dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 name = "claude-code-rust"
 version = "0.11.1"
 dependencies = [
+ "ansi-to-tui",
  "anyhow",
  "arboard",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.101"
+ansi-to-tui = "8.0.1"
 arboard = { version = "3.6.1", features = ["image-data"] }
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/src/ui/highlight.rs
+++ b/src/ui/highlight.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::diff;
+use ansi_to_tui::IntoText as _;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use std::sync::LazyLock;
@@ -71,7 +72,7 @@ pub(crate) fn render_terminal_output(text: &str) -> Vec<Line<'static>> {
     if diff::looks_like_unified_diff(&stripped) {
         return diff::render_raw_unified_diff(&stripped);
     }
-    plain_text_lines(&stripped)
+    ansi_text_lines(text).unwrap_or_else(|| plain_text_lines(&stripped))
 }
 
 pub(crate) fn highlight_code(text: &str, language: Option<&str>) -> Vec<Line<'static>> {
@@ -156,6 +157,11 @@ fn plain_text_lines(text: &str) -> Vec<Line<'static>> {
     lines
 }
 
+fn ansi_text_lines(text: &str) -> Option<Vec<Line<'static>>> {
+    let rendered = text.as_bytes().into_text().ok()?.clone();
+    Some(rendered.lines)
+}
+
 fn find_syntax(language: &str) -> Option<&'static SyntaxReference> {
     let token = language.trim();
     if token.is_empty() {
@@ -220,5 +226,15 @@ mod tests {
         let spans = highlight_shell_command("git diff --stat");
         let text: String = spans.iter().map(|span| span.content.as_ref()).collect();
         assert_eq!(text, "git diff --stat");
+    }
+
+    #[test]
+    fn render_terminal_output_preserves_ansi_color() {
+        let rendered = render_terminal_output("\u{1b}[31mred\u{1b}[0m plain");
+        assert_eq!(rendered.len(), 1);
+        assert_eq!(rendered[0].spans.len(), 2);
+        assert_eq!(rendered[0].spans[0].content.as_ref(), "red");
+        assert_eq!(rendered[0].spans[0].style.fg, Some(Color::Red));
+        assert_eq!(rendered[0].spans[1].content.as_ref(), " plain");
     }
 }

--- a/src/ui/tool_call/execute.rs
+++ b/src/ui/tool_call/execute.rs
@@ -55,7 +55,7 @@ pub(super) fn render_execute_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
                 Style::default().fg(theme::STATUS_ERROR),
             )));
         } else {
-            let raw_lines = highlight::render_terminal_output(&stripped_output);
+            let raw_lines = highlight::render_terminal_output(output);
 
             let total = raw_lines.len();
             if total > TERMINAL_MAX_LINES {

--- a/src/ui/tool_call/standard.rs
+++ b/src/ui/tool_call/standard.rs
@@ -234,7 +234,7 @@ fn render_tool_content(tc: &ToolCallInfo, width: u16) -> Vec<Line<'static>> {
                     Style::default().fg(theme::STATUS_ERROR),
                 )));
             } else {
-                lines.extend(highlight::render_terminal_output(&stripped_output));
+                lines.extend(highlight::render_terminal_output(output));
             }
         } else if matches!(tc.status, model::ToolCallStatus::InProgress) {
             lines.push(Line::from(Span::styled("running...", Style::default().fg(theme::DIM))));


### PR DESCRIPTION
## Summary

- preserve ANSI styling for terminal tool output instead of normalizing it to plain text
- keep unified diff rendering on stripped text while rendering normal terminal output through `ansi-to-tui`
- add a regression test for ANSI-colored terminal output and declare `ansi-to-tui` directly

## Why

Terminal Bash output in the TUI was being stripped to plain text before rendering, so color emitted by commands like `ls`, `grep`, and `git` could never survive into the UI. This change fixes the rendering path instead of layering on custom heuristic coloring.

Closes #

## Validation

- Automated: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, `cargo check --offline`
- Manual: Not run
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A