### PR TITLE
fix(input): keep draft focus when inline prompts arrive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
-- **Tool-call diff rendering and scrollbar lane** (#138, @srothgan): Tighten tool-call diff rendering and reserve a dedicated chat scrollbar column so transcript content no longer renders underneath it
-- **Versioned short model names** (#139, @srothgan): Include model version numbers in `display_name_short` so footer and status surfaces show the resolved runtime model version
-- **Bridge script resolution precedence** (#142, @srothgan): Prefer the bundled `agent-sdk/dist/bridge.js` near the installed executable and keep repo-local fallback debug-only
-- **Update notice warning message** (#143, @srothgan): Move the update hint from the footer into a persistent warning system message with current version, latest version, and inline upgrade command
-- **Terminal ANSI output rendering** (#144, @srothgan): Preserve command-emitted ANSI colors in terminal tool output while keeping unified diff rendering on stripped text
+- **Tool-call diff rendering and scrollbar lane** (#138, @srothgan): Reserve a dedicated scrollbar column and keep diff content out of it.
+- **Versioned short model names** (#139, @srothgan): Show resolved model versions in short model names.
+- **Bridge script resolution precedence** (#142, @srothgan): Prefer the bundled bridge script and keep repo-local fallback debug-only.
+- **Update notice warning message** (#143, @srothgan): Move upgrade hints from the footer into a warning system message.
+- **Terminal ANSI output rendering** (#144, @srothgan): Preserve command-emitted ANSI colors in terminal tool output.
+- **Draft-focused inline prompts** (#145, @srothgan): Keep pending prompts from stealing draft focus and move prompt handoff to `Tab`.
 
 ### CI and Dependencies
 
-- Bump `@anthropic-ai/claude-agent-sdk` from `0.2.104` to `0.2.112` in both the published package and bundled bridge, update the bridge version gate (`EXPECTED_AGENT_SDK_VERSION`), and refresh Rust TUI and bridge test fixtures from `4.6` to `4.7`
+- **Agent SDK 0.2.112 refresh** (#141, @shyal): Bump `@anthropic-ai/claude-agent-sdk` to `0.2.112`, update `EXPECTED_AGENT_SDK_VERSION`, and refresh `4.7` fixtures.
 
 ## [0.11.1] - 2026-04-16 [Changes][v0.11.1]
 

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -18,6 +18,7 @@ use super::{
     PendingCommandAck, SystemSeverity, TextBlock,
 };
 use crate::agent::model;
+use crate::app::keys::reclaim_input_from_inline_prompt_if_needed;
 use crate::app::todos::apply_plan_todos;
 #[cfg(test)]
 use crossterm::event::KeyEvent;
@@ -120,6 +121,7 @@ fn dispatch_paste_by_view(app: &mut App, text: &str) -> bool {
                 AppStatus::Connecting | AppStatus::CommandPending | AppStatus::Error
             ) && !app.is_compacting
             {
+                reclaim_input_from_inline_prompt_if_needed(app);
                 app.queue_paste_text(text);
                 return true;
             }
@@ -446,8 +448,8 @@ mod tests {
     use crate::app::slash::{SlashCandidate, SlashContext, SlashState};
     use crate::app::{
         ActiveView, BlockCache, CancelOrigin, FocusOwner, FocusTarget, HelpView, InlinePermission,
-        SelectionKind, SelectionPoint, SelectionState, TextBlockSpacing, TodoItem, TodoStatus,
-        ToolCallInfo, ToolCallScope, UsageSnapshot, UsageSourceKind, mention,
+        InlineQuestion, SelectionKind, SelectionPoint, SelectionState, TextBlockSpacing, TodoItem,
+        TodoStatus, ToolCallInfo, ToolCallScope, UsageSnapshot, UsageSourceKind, mention,
     };
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
     use pretty_assertions::assert_eq;
@@ -491,6 +493,16 @@ mod tests {
 
     fn assistant_msg(blocks: Vec<MessageBlock>) -> ChatMessage {
         ChatMessage::new(MessageRole::Assistant, blocks, None)
+    }
+
+    fn append_tool_call_block(app: &mut App, tool_id: &str) -> (usize, usize) {
+        app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+            tool_id,
+            model::ToolCallStatus::InProgress,
+        )))]));
+        let msg_idx = app.messages.len().saturating_sub(1);
+        app.index_tool_call(tool_id.into(), msg_idx, 0);
+        (msg_idx, 0)
     }
 
     fn user_msg(text: &str) -> ChatMessage {
@@ -3559,6 +3571,266 @@ mod tests {
         );
 
         assert_eq!(app.input.text(), "h");
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
+    }
+
+    #[test]
+    fn permission_request_with_existing_draft_does_not_claim_focus() {
+        let mut app = make_test_app();
+        let tool_id = "perm-draft";
+        append_tool_call_block(&mut app, tool_id);
+        app.input.set_text("draft in progress");
+
+        let (response_tx, _response_rx) = oneshot::channel();
+        turn::handle_permission_request_event(
+            &mut app,
+            model::RequestPermissionRequest::new(
+                "session-1",
+                model::ToolCallUpdate::new(tool_id, model::ToolCallUpdateFields::new()),
+                vec![
+                    model::PermissionOption::new(
+                        "allow",
+                        "Allow",
+                        model::PermissionOptionKind::AllowOnce,
+                    ),
+                    model::PermissionOption::new(
+                        "deny",
+                        "Deny",
+                        model::PermissionOptionKind::RejectOnce,
+                    ),
+                ],
+                None,
+            ),
+            response_tx,
+        );
+
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
+        assert_eq!(app.pending_interaction_ids, vec![tool_id]);
+        assert_eq!(permission_focus_state(&app, tool_id), Some(false));
+    }
+
+    #[test]
+    fn question_request_with_existing_draft_does_not_claim_focus() {
+        let mut app = make_test_app();
+        let tool_id = "question-draft";
+        append_tool_call_block(&mut app, tool_id);
+        app.input.set_text("draft in progress");
+
+        let (response_tx, _response_rx) = oneshot::channel();
+        turn::handle_question_request_event(
+            &mut app,
+            model::RequestQuestionRequest::new(
+                "session-1",
+                model::ToolCallUpdate::new(tool_id, model::ToolCallUpdateFields::new()),
+                model::QuestionPrompt::new(
+                    "Choose one",
+                    "Question",
+                    false,
+                    vec![
+                        model::QuestionOption::new("yes", "Yes"),
+                        model::QuestionOption::new("no", "No"),
+                    ],
+                ),
+                0,
+                1,
+            ),
+            response_tx,
+        );
+
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
+        assert_eq!(app.pending_interaction_ids, vec![tool_id]);
+        assert_eq!(question_focus_state(&app, tool_id), Some(false));
+    }
+
+    #[test]
+    fn enter_submits_draft_when_permission_arrives_mid_compose() {
+        let (mut app, mut bridge_rx) = app_with_bridge_connection();
+        let tool_id = "perm-submit";
+        append_tool_call_block(&mut app, tool_id);
+        app.session_id = Some(model::SessionId::new("session-1"));
+        app.input.set_text("ship the fix");
+
+        let (response_tx, mut response_rx) = oneshot::channel();
+        turn::handle_permission_request_event(
+            &mut app,
+            model::RequestPermissionRequest::new(
+                "session-1",
+                model::ToolCallUpdate::new(tool_id, model::ToolCallUpdateFields::new()),
+                vec![
+                    model::PermissionOption::new(
+                        "allow",
+                        "Allow",
+                        model::PermissionOptionKind::AllowOnce,
+                    ),
+                    model::PermissionOption::new(
+                        "deny",
+                        "Deny",
+                        model::PermissionOptionKind::RejectOnce,
+                    ),
+                ],
+                None,
+            ),
+            response_tx,
+        );
+
+        handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+
+        assert!(app.pending_submit.is_some());
+        assert!(matches!(
+            response_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+
+        super::super::finalize_deferred_submit(&mut app);
+
+        assert!(app.pending_submit.is_none());
+        assert!(app.pending_interaction_ids.is_empty());
+        assert!(bridge_rx.try_recv().is_ok());
+        assert!(response_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn tab_toggles_focus_between_input_and_pending_permission() {
+        let mut app = make_test_app();
+        let _response_rx = attach_pending_permission(
+            &mut app,
+            "perm-tab",
+            vec![
+                model::PermissionOption::new(
+                    "allow",
+                    "Allow",
+                    model::PermissionOptionKind::AllowOnce,
+                ),
+                model::PermissionOption::new(
+                    "deny",
+                    "Deny",
+                    model::PermissionOptionKind::RejectOnce,
+                ),
+            ],
+            false,
+        );
+        app.input.set_text("keep drafting");
+        app.release_focus_target(FocusTarget::Permission);
+
+        handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+        );
+        assert_eq!(app.focus_owner(), FocusOwner::Permission);
+        assert_eq!(permission_focus_state(&app, "perm-tab"), Some(true));
+
+        handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+        );
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
+        assert_eq!(permission_focus_state(&app, "perm-tab"), Some(false));
+    }
+
+    #[test]
+    fn typing_reclaims_input_from_auto_focused_permission() {
+        let mut app = make_test_app();
+        let _response_rx = attach_pending_permission(
+            &mut app,
+            "perm-auto",
+            vec![
+                model::PermissionOption::new(
+                    "allow",
+                    "Allow",
+                    model::PermissionOptionKind::AllowOnce,
+                ),
+                model::PermissionOption::new(
+                    "deny",
+                    "Deny",
+                    model::PermissionOptionKind::RejectOnce,
+                ),
+            ],
+            true,
+        );
+
+        handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE)),
+        );
+
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
+        assert_eq!(app.input.text(), "h");
+        assert_eq!(permission_focus_state(&app, "perm-auto"), Some(false));
+    }
+
+    #[test]
+    fn tab_focuses_question_and_enter_confirms_only_after_explicit_handoff() {
+        let (mut app, _bridge_rx) = app_with_bridge_connection();
+        let mut response_rx = attach_pending_question(
+            &mut app,
+            "question-tab",
+            model::QuestionPrompt::new(
+                "Choose one",
+                "Question",
+                false,
+                vec![
+                    model::QuestionOption::new("yes", "Yes"),
+                    model::QuestionOption::new("no", "No"),
+                ],
+            ),
+            false,
+        );
+        app.input.set_text("draft answer");
+
+        handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+        assert!(app.pending_submit.is_some());
+        assert!(matches!(
+            response_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+
+        handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+        );
+        assert_eq!(app.focus_owner(), FocusOwner::Permission);
+        assert_eq!(question_focus_state(&app, "question-tab"), Some(true));
+
+        handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        );
+        let response = response_rx.try_recv().expect("question should be answered after Tab focus");
+        assert!(matches!(response.outcome, model::RequestQuestionOutcome::Answered(_)));
+    }
+
+    #[test]
+    fn typing_reclaims_input_from_auto_focused_question() {
+        let mut app = make_test_app();
+        let _response_rx = attach_pending_question(
+            &mut app,
+            "question-auto",
+            model::QuestionPrompt::new(
+                "Choose one",
+                "Question",
+                false,
+                vec![
+                    model::QuestionOption::new("yes", "Yes"),
+                    model::QuestionOption::new("no", "No"),
+                ],
+            ),
+            true,
+        );
+
+        handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)),
+        );
+
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
+        assert_eq!(app.input.text(), "n");
+        assert_eq!(question_focus_state(&app, "question-auto"), Some(false));
     }
 
     #[test]
@@ -3648,7 +3920,7 @@ mod tests {
     }
 
     #[test]
-    fn permission_focus_tab_moves_focus_to_todo_list() {
+    fn permission_focus_tab_returns_focus_to_input_before_todos() {
         let mut app = make_test_app();
         let _response_rx = attach_pending_permission(
             &mut app,
@@ -3679,7 +3951,7 @@ mod tests {
             Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
         );
 
-        assert_eq!(app.focus_owner(), FocusOwner::TodoList);
+        assert_eq!(app.focus_owner(), FocusOwner::Input);
     }
 
     #[test]
@@ -3816,6 +4088,52 @@ mod tests {
         app.pending_interaction_ids.push(tool_id.into());
         app.claim_focus_target(FocusTarget::Permission);
         response_rx
+    }
+
+    fn attach_pending_question(
+        app: &mut App,
+        tool_id: &str,
+        prompt: model::QuestionPrompt,
+        focused: bool,
+    ) -> oneshot::Receiver<model::RequestQuestionResponse> {
+        let (response_tx, response_rx) = oneshot::channel();
+        let mut tc = tool_call(tool_id, model::ToolCallStatus::InProgress);
+        tc.pending_question = Some(InlineQuestion {
+            prompt,
+            response_tx,
+            focused_option_index: 0,
+            selected_option_indices: std::collections::BTreeSet::new(),
+            notes: String::new(),
+            notes_cursor: 0,
+            editing_notes: false,
+            focused,
+            question_index: 0,
+            total_questions: 1,
+        });
+        app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tc))]));
+        let msg_idx = app.messages.len().saturating_sub(1);
+        app.index_tool_call(tool_id.into(), msg_idx, 0);
+        app.pending_interaction_ids.push(tool_id.into());
+        if focused {
+            app.claim_focus_target(FocusTarget::Permission);
+        }
+        response_rx
+    }
+
+    fn permission_focus_state(app: &App, tool_id: &str) -> Option<bool> {
+        let (mi, bi) = app.lookup_tool_call(tool_id)?;
+        let MessageBlock::ToolCall(tc) = app.messages.get(mi)?.blocks.get(bi)? else {
+            return None;
+        };
+        tc.pending_permission.as_ref().map(|permission| permission.focused)
+    }
+
+    fn question_focus_state(app: &App, tool_id: &str) -> Option<bool> {
+        let (mi, bi) = app.lookup_tool_call(tool_id)?;
+        let MessageBlock::ToolCall(tc) = app.messages.get(mi)?.blocks.get(bi)? else {
+            return None;
+        };
+        tc.pending_question.as_ref().map(|question| question.focused)
     }
 
     fn push_todo_and_focus(app: &mut App) {

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -67,22 +67,24 @@ pub(super) fn handle_permission_request_event(
     }
 
     let mut layout_dirty = false;
+    let auto_focus = app.pending_interaction_ids.is_empty() && !app.has_draft_input_for_focus();
     if let Some(MessageBlock::ToolCall(tc)) =
         app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     {
         let tc = tc.as_mut();
-        let is_first = app.pending_interaction_ids.is_empty();
         tc.pending_permission = Some(InlinePermission {
             options: request.options,
             display: request.display,
             response_tx,
             selected_index: 0,
-            focused: is_first,
+            focused: auto_focus,
         });
         tc.mark_tool_call_layout_dirty();
         layout_dirty = true;
         app.pending_interaction_ids.push(tool_id.clone());
-        app.claim_focus_target(FocusTarget::Permission);
+        if auto_focus {
+            app.claim_focus_target(FocusTarget::Permission);
+        }
         app.viewport.engage_auto_scroll();
         app.notifications.notify(
             app.config.preferred_notification_channel_effective(),
@@ -96,7 +98,7 @@ pub(super) fn handle_permission_request_event(
             session_id = %session_id,
             tool_call_id = %tool_id,
             option_count = options.len(),
-            focused = is_first,
+            focused = auto_focus,
         );
     } else {
         tracing::warn!(
@@ -160,11 +162,11 @@ pub(super) fn handle_question_request_event(
     }
 
     let mut layout_dirty = false;
+    let auto_focus = app.pending_interaction_ids.is_empty() && !app.has_draft_input_for_focus();
     if let Some(MessageBlock::ToolCall(tc)) =
         app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     {
         let tc = tc.as_mut();
-        let is_first = app.pending_interaction_ids.is_empty();
         tc.pending_question = Some(InlineQuestion {
             prompt: request.prompt,
             response_tx,
@@ -173,14 +175,16 @@ pub(super) fn handle_question_request_event(
             notes: String::new(),
             notes_cursor: 0,
             editing_notes: false,
-            focused: is_first,
+            focused: auto_focus,
             question_index: request.question_index,
             total_questions: request.total_questions,
         });
         tc.mark_tool_call_layout_dirty();
         layout_dirty = true;
         app.pending_interaction_ids.push(tool_id.clone());
-        app.claim_focus_target(FocusTarget::Permission);
+        if auto_focus {
+            app.claim_focus_target(FocusTarget::Permission);
+        }
         app.viewport.engage_auto_scroll();
         app.notifications.notify(
             app.config.preferred_notification_channel_effective(),
@@ -196,7 +200,7 @@ pub(super) fn handle_question_request_event(
             question_index,
             total_questions,
             option_count,
-            focused = is_first,
+            focused = auto_focus,
         );
     } else {
         tracing::warn!(

--- a/src/app/inline_interactions.rs
+++ b/src/app/inline_interactions.rs
@@ -99,8 +99,51 @@ pub(super) fn focused_interaction_is_active(app: &App) -> bool {
     })
 }
 
+pub(super) fn clear_inline_interaction_focus(app: &mut App) {
+    let mut changed = false;
+    for idx in 0..app.pending_interaction_ids.len() {
+        let Some(tool_id) = app.pending_interaction_ids.get(idx) else {
+            continue;
+        };
+        let Some((mi, bi)) = app.tool_call_index.get(tool_id).copied() else {
+            continue;
+        };
+        if let Some(msg) = app.messages.get_mut(mi)
+            && let Some(MessageBlock::ToolCall(tc)) = msg.blocks.get_mut(bi)
+        {
+            let tc = tc.as_mut();
+            let mut interaction_changed = false;
+            if let Some(ref mut perm) = tc.pending_permission
+                && perm.focused
+            {
+                perm.focused = false;
+                interaction_changed = true;
+            }
+            if let Some(ref mut question) = tc.pending_question
+                && question.focused
+            {
+                question.focused = false;
+                interaction_changed = true;
+            }
+            if interaction_changed {
+                tc.mark_tool_call_layout_dirty();
+                app.sync_render_cache_slot(mi, bi);
+                app.recompute_message_retained_bytes(mi);
+                app.invalidate_layout(InvalidationLevel::MessageChanged(mi));
+                changed = true;
+            }
+        }
+    }
+
+    if changed || matches!(app.focus_owner(), super::FocusOwner::Permission) {
+        app.release_focus_target(FocusTarget::Permission);
+        app.normalize_focus_stack();
+    }
+}
+
 pub(super) fn focus_next_inline_interaction(app: &mut App) {
     normalize_pending_interaction_queue(app);
+    clear_inline_interaction_focus(app);
     set_interaction_focused(app, 0, true);
     if app.pending_interaction_ids.is_empty() {
         app.release_focus_target(FocusTarget::Permission);
@@ -122,18 +165,20 @@ pub(super) fn normalize_pending_interaction_queue(app: &mut App) {
     app.pending_interaction_ids = queue;
 
     if app.pending_interaction_ids.is_empty() {
-        app.release_focus_target(FocusTarget::Permission);
-        app.normalize_focus_stack();
+        clear_inline_interaction_focus(app);
         return;
     }
 
     if changed {
+        let permission_has_focus = matches!(app.focus_owner(), super::FocusOwner::Permission);
         for idx in 0..app.pending_interaction_ids.len() {
-            set_interaction_focused(app, idx, idx == 0);
+            set_interaction_focused(app, idx, permission_has_focus && idx == 0);
         }
     }
-    app.claim_focus_target(FocusTarget::Permission);
-    app.normalize_focus_stack();
+    if matches!(app.focus_owner(), super::FocusOwner::Permission) {
+        app.claim_focus_target(FocusTarget::Permission);
+        app.normalize_focus_stack();
+    }
 }
 
 pub(super) fn pop_next_valid_interaction_id(app: &mut App) -> Option<String> {

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -9,10 +9,12 @@ use super::{
 };
 #[cfg(not(test))]
 use crate::app::SystemSeverity;
-use crate::app::inline_interactions::handle_inline_interaction_key;
+use crate::app::inline_interactions::{
+    clear_inline_interaction_focus, focus_next_inline_interaction, handle_inline_interaction_key,
+};
 use crate::app::selection::{clear_selection, selection_text_from_rendered_lines};
 use crate::app::state::AutocompleteKind;
-use crate::app::{mention, slash, subagent};
+use crate::app::{mention, questions, slash, subagent};
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 #[cfg(test)]
 use std::cell::Cell;
@@ -190,7 +192,10 @@ pub(super) fn dispatch_key_by_focus(app: &mut App, key: KeyEvent) -> bool {
         FocusOwner::Mention => handle_autocomplete_key(app, key),
         FocusOwner::Help => handle_help_key(app, key),
         FocusOwner::Permission => {
-            if handle_inline_interaction_key(app, key) {
+            if should_reclaim_input_focus_before_inline_interaction(app, key) {
+                reclaim_input_from_inline_prompt_if_needed(app);
+                handle_normal_key(app, key)
+            } else if handle_inline_interaction_key(app, key) {
                 true
             } else {
                 handle_normal_key(app, key)
@@ -318,6 +323,15 @@ fn is_editing_like_key(key: KeyEvent) -> bool {
         key.code,
         KeyCode::Char(_) | KeyCode::Enter | KeyCode::Tab | KeyCode::Backspace | KeyCode::Delete
     )
+}
+
+fn should_reclaim_input_focus_before_inline_interaction(app: &App, key: KeyEvent) -> bool {
+    let question_notes_editing = questions::focused_question_is_editing_notes(app);
+    match key.code {
+        KeyCode::Backspace | KeyCode::Delete => !question_notes_editing,
+        KeyCode::Char(_) if is_printable_text_modifiers(key.modifiers) => !question_notes_editing,
+        _ => false,
+    }
 }
 
 fn handle_normal_key_actions(app: &mut App, key: KeyEvent) -> bool {
@@ -488,16 +502,30 @@ fn handle_focus_toggle_key(app: &mut App, key: KeyEvent) -> bool {
         (KeyCode::Tab, m)
             if !m.contains(KeyModifiers::SHIFT)
                 && !m.contains(KeyModifiers::CONTROL)
-                && !m.contains(KeyModifiers::ALT)
-                && app.show_todo_panel
-                && !app.todos.is_empty() =>
+                && !m.contains(KeyModifiers::ALT) =>
         {
-            if app.focus_owner() == FocusOwner::TodoList {
-                app.release_focus_target(FocusTarget::TodoList);
+            if !app.pending_interaction_ids.is_empty() {
+                match app.focus_owner() {
+                    FocusOwner::Permission => {
+                        clear_inline_interaction_focus(app);
+                        true
+                    }
+                    FocusOwner::Input => {
+                        focus_next_inline_interaction(app);
+                        true
+                    }
+                    _ => false,
+                }
+            } else if app.show_todo_panel && !app.todos.is_empty() {
+                if app.focus_owner() == FocusOwner::TodoList {
+                    app.release_focus_target(FocusTarget::TodoList);
+                } else {
+                    app.claim_focus_target(FocusTarget::TodoList);
+                }
+                true
             } else {
-                app.claim_focus_target(FocusTarget::TodoList);
+                false
             }
-            true
         }
         _ => false,
     }
@@ -639,6 +667,12 @@ pub(super) fn is_clipboard_paste_shortcut(key: KeyEvent) -> bool {
     is_ctrl_char_shortcut(key, 'v')
 }
 
+pub(super) fn reclaim_input_from_inline_prompt_if_needed(app: &mut App) {
+    if app.focus_owner() == FocusOwner::Permission {
+        clear_inline_interaction_focus(app);
+    }
+}
+
 fn handle_editing_key(app: &mut App, key: KeyEvent) -> bool {
     match (key.code, key.modifiers) {
         (KeyCode::Backspace, m)
@@ -646,6 +680,7 @@ fn handle_editing_key(app: &mut App, key: KeyEvent) -> bool {
                 && m.contains(KeyModifiers::CONTROL)
                 && !m.contains(KeyModifiers::ALT) =>
         {
+            reclaim_input_from_inline_prompt_if_needed(app);
             if try_delete_image_badge(app, "before") {
                 return true;
             }
@@ -656,18 +691,21 @@ fn handle_editing_key(app: &mut App, key: KeyEvent) -> bool {
                 && m.contains(KeyModifiers::CONTROL)
                 && !m.contains(KeyModifiers::ALT) =>
         {
+            reclaim_input_from_inline_prompt_if_needed(app);
             if try_delete_image_badge(app, "after") {
                 return true;
             }
             app.input.textarea_delete_word_after()
         }
         (KeyCode::Backspace, _) if app.focus_owner() != FocusOwner::TodoList => {
+            reclaim_input_from_inline_prompt_if_needed(app);
             if try_delete_image_badge(app, "before") {
                 return true;
             }
             app.input.textarea_delete_char_before()
         }
         (KeyCode::Delete, _) if app.focus_owner() != FocusOwner::TodoList => {
+            reclaim_input_from_inline_prompt_if_needed(app);
             if try_delete_image_badge(app, "after") {
                 return true;
             }
@@ -705,6 +743,7 @@ fn handle_printable_key(app: &mut App, key: KeyEvent) -> bool {
     if app.focus_owner() == FocusOwner::TodoList {
         app.release_focus_target(FocusTarget::TodoList);
     }
+    reclaim_input_from_inline_prompt_if_needed(app);
 
     let now = Instant::now();
     match app.paste_burst.on_char(c, now) {

--- a/src/app/questions.rs
+++ b/src/app/questions.rs
@@ -17,7 +17,7 @@ pub(super) fn has_focused_question(app: &App) -> bool {
     focused_question(app).is_some()
 }
 
-fn focused_question_is_editing_notes(app: &App) -> bool {
+pub(super) fn focused_question_is_editing_notes(app: &App) -> bool {
     focused_question(app).is_some_and(|question| question.editing_notes)
 }
 

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -49,6 +49,7 @@ use super::dialog;
 use super::file_index;
 use super::focus::{FocusContext, FocusManager, FocusOwner, FocusTarget};
 use super::git_context::GitContextState;
+use super::inline_interactions::{clear_inline_interaction_focus, focus_next_inline_interaction};
 use super::input::{InputSnapshot, InputState, parse_paste_placeholder_before_cursor};
 use super::mention;
 use super::plugins::PluginsState;
@@ -1116,6 +1117,11 @@ impl App {
             || self.subagent.is_some()
     }
 
+    #[must_use]
+    pub fn has_draft_input_for_focus(&self) -> bool {
+        !self.input.is_empty()
+    }
+
     pub fn rebuild_chat_focus_from_state(&mut self) {
         if self.active_view != ActiveView::Chat {
             return;
@@ -1124,9 +1130,12 @@ impl App {
         self.normalize_focus_stack();
 
         if self.pending_interaction_ids.is_empty() {
-            self.release_focus_target(FocusTarget::Permission);
+            clear_inline_interaction_focus(self);
+        } else if self.focus_owner() == FocusOwner::Permission || !self.has_draft_input_for_focus()
+        {
+            focus_next_inline_interaction(self);
         } else {
-            self.claim_focus_target(FocusTarget::Permission);
+            clear_inline_interaction_focus(self);
         }
 
         if self.autocomplete_focus_available() {

--- a/src/app/view/tests.rs
+++ b/src/app/view/tests.rs
@@ -107,7 +107,7 @@ fn set_active_view_same_view_is_noop() {
 }
 
 #[test]
-fn set_active_view_restores_permission_focus_when_returning_to_chat() {
+fn set_active_view_keeps_permission_unfocused_when_returning_to_chat_with_draft() {
     let mut app = busy_view_test_app();
 
     set_active_view(&mut app, ActiveView::Trusted);
@@ -116,7 +116,7 @@ fn set_active_view_restores_permission_focus_when_returning_to_chat() {
     set_active_view(&mut app, ActiveView::Chat);
 
     assert_eq!(app.active_view, ActiveView::Chat);
-    assert_eq!(app.focus_owner(), crate::app::FocusOwner::Permission);
+    assert_eq!(app.focus_owner(), crate::app::FocusOwner::TodoList);
 }
 
 #[test]

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -231,14 +231,27 @@ fn build_key_help_items(app: &App) -> Vec<(String, String)> {
     }
     let focus_owner = app.focus_owner();
 
-    if app.show_todo_panel && !app.todos.is_empty() {
+    if app.show_todo_panel && !app.todos.is_empty() && app.pending_interaction_ids.is_empty() {
         items.push(("Tab".to_owned(), "Toggle todo focus".to_owned()));
+    }
+
+    if !app.pending_interaction_ids.is_empty() {
+        match focus_owner {
+            FocusOwner::Input => {
+                items.push(("Tab".to_owned(), "Focus pending prompt".to_owned()));
+            }
+            FocusOwner::Permission => {
+                items.push(("Tab".to_owned(), "Return to draft".to_owned()));
+            }
+            _ => {}
+        }
     }
 
     // Input + navigation (active outside todo-list and mention focus)
     if focus_owner != FocusOwner::TodoList
         && focus_owner != FocusOwner::Mention
         && focus_owner != FocusOwner::Help
+        && focus_owner != FocusOwner::Permission
     {
         items.push(("Enter".to_owned(), "Send message".to_owned()));
         items.push(("Shift+Enter".to_owned(), "Insert newline".to_owned()));
@@ -631,11 +644,16 @@ mod tests {
 
         // Without permission focus claim, do not show permission-only arrows.
         let items = build_help_items(&app);
+        assert!(has_item(&items, "Tab", "Focus pending prompt"));
+        assert!(has_item(&items, "Enter", "Send message"));
         assert!(!has_item(&items, "Left/Right", "Select option"));
         assert!(!has_item(&items, "Up/Down", "Switch prompt focus"));
 
         app.claim_focus_target(FocusTarget::Permission);
         let items = build_help_items(&app);
+        assert!(has_item(&items, "Tab", "Return to draft"));
+        assert!(!has_item(&items, "Enter", "Send message"));
+        assert!(has_item(&items, "Enter", "Confirm option"));
         assert!(has_item(&items, "Left/Right", "Select option"));
         assert!(has_item(&items, "Up/Down", "Switch prompt focus"));
     }

--- a/src/ui/tool_call/interactions.rs
+++ b/src/ui/tool_call/interactions.rs
@@ -27,7 +27,7 @@ pub(super) fn render_permission_lines(
         return vec![
             Line::default(),
             Line::from(Span::styled(
-                "  \u{25cb} Waiting for input\u{2026} (\u{2191}\u{2193} to focus)",
+                "  \u{25cb} Waiting for input... (Tab to focus)",
                 Style::default().fg(theme::DIM),
             )),
         ];
@@ -183,7 +183,7 @@ fn render_plan_approval_lines(tc: &ToolCallInfo, perm: &InlinePermission) -> Vec
         return vec![
             Line::default(),
             Line::from(Span::styled(
-                "  \u{25cb} Waiting for input\u{2026} (\u{2191}\u{2193} to focus)",
+                "  \u{25cb} Waiting for input... (Tab to focus)",
                 Style::default().fg(theme::DIM),
             )),
         ];
@@ -276,7 +276,7 @@ pub(super) fn render_question_lines(question: &InlineQuestion) -> Vec<Line<'stat
 
     if !question.focused {
         lines.push(Line::from(Span::styled(
-            "  waiting for input... (Up/Down to focus)",
+            "  waiting for input... (Tab to focus)",
             Style::default().fg(theme::DIM),
         )));
         return lines;
@@ -504,7 +504,7 @@ mod tests {
         question.focused = false;
         let lines = render_question_lines(&question);
         let footer = lines.last().expect("question footer line");
-        assert_eq!(footer.spans[0].content.as_ref(), "  waiting for input... (Up/Down to focus)");
+        assert_eq!(footer.spans[0].content.as_ref(), "  waiting for input... (Tab to focus)");
         assert_eq!(lines[2].spans[0].style.fg, Some(Color::Gray));
     }
 


### PR DESCRIPTION
## Summary

- keep pending permission and question prompts from auto-claiming keyboard focus while a draft is already being composed
- add explicit `Tab` handoff between draft input and pending inline prompts, and reclaim input focus on typing, editing, and paste
- update help and inline prompt copy to match the new focus behavior and add regression coverage for the handoff flows

## Why

- the current focus model allows normal typing to continue in the draft while `Enter` and some navigation keys are still consumed by pending inline prompts
- this leads to bad UX where pressing `Enter` while composing can answer the modal instead of sending the draft

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `cargo check --offline`
- Manual:
  - verified that pending prompts stay visible but do not steal focus while draft text exists
  - verified that `Tab` toggles between draft input and the pending prompt
  - verified that typing, editing, and paste reclaim input focus so `Enter` submits the draft unless prompt focus was explicitly chosen
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A