### PR TITLE
feat(model): add project-local opus pinning and clean bridge model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **Project-local Opus version controls** (#146, @srothgan): Add `/opus-version` to pin the Opus alias per project.
+
 ### Fixes
 
+- **Model alias cleanup and Opus naming** (#146, @srothgan): Replace `Default` with the explicit `opus` alias and normalize dated Opus labels.
+- **Dev versus installed bridge resolution** (#146, @srothgan): Make `cargo run` use the repo bridge and installed builds use the bundled bridge.
 - **Tool-call diff rendering and scrollbar lane** (#138, @srothgan): Reserve a dedicated scrollbar column and keep diff content out of it.
 - **Versioned short model names** (#139, @srothgan): Show resolved model versions in short model names.
 - **Bridge script resolution precedence** (#142, @srothgan): Prefer the bundled bridge script and keep repo-local fallback debug-only.

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -2493,8 +2493,8 @@ test("resolveCurrentModel avoids suffix-insensitive fallback when sibling varian
 
 test("emitCurrentModelUpdate can acknowledge a successful no-op set_model", () => {
   const session = makeSessionState();
-  session.model = "default";
-  session.requestedModelId = "default";
+  session.model = "opus";
+  session.requestedModelId = "opus";
   session.resolvedRuntimeModelId = "claude-opus-4-7[1m]";
   refreshCurrentModel(session);
 
@@ -2511,7 +2511,7 @@ test("emitCurrentModelUpdate can acknowledge a successful no-op set_model", () =
   assert.deepEqual(lastEvent.update, {
     type: "current_model_update",
     current_model: {
-      requested_id: "default",
+      requested_id: "opus",
       resolved_id: "claude-opus-4-7[1m]",
       display_name_short: "Opus 4.7 [1M]",
       display_name_long: "Opus 4.7 [1M]",
@@ -2562,7 +2562,7 @@ test("emitCurrentModelUpdate can publish catalog-enriched current model metadata
 
 test("shouldInvalidateResolvedRuntimeModel invalidates stale runtime identity only when the request changes", () => {
   assert.equal(
-    shouldInvalidateResolvedRuntimeModel("default", "default", "sonnet"),
+    shouldInvalidateResolvedRuntimeModel("opus", "opus", "sonnet"),
     true,
   );
   assert.equal(
@@ -2570,9 +2570,21 @@ test("shouldInvalidateResolvedRuntimeModel invalidates stale runtime identity on
     true,
   );
   assert.equal(
-    shouldInvalidateResolvedRuntimeModel("default", "default", "default"),
+    shouldInvalidateResolvedRuntimeModel("opus", "opus", "opus"),
     false,
   );
+});
+
+test("resolveCurrentModel strips release date suffix from dated model ids", () => {
+  const session = makeSessionState();
+  session.model = "claude-opus-4-5-20251101";
+  session.requestedModelId = "claude-opus-4-5-20251101";
+  session.resolvedRuntimeModelId = "claude-opus-4-5-20251101";
+
+  const currentModel = resolveCurrentModel(session);
+
+  assert.equal(currentModel.display_name_short, "Opus 4.5");
+  assert.equal(currentModel.display_name_long, "Opus 4.5");
 });
 
 test("resolveCurrentModel falls back to the requested model immediately after stale runtime identity is cleared", () => {

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -154,7 +154,7 @@ export function shouldEmitStartupAuthRequiredForAccount(account: AccountInfo): b
   return !nonEmptyString(account.email) && !nonEmptyString(account.apiKeySource);
 }
 const DEFAULT_SETTING_SOURCES: SettingSource[] = ["user", "project", "local"];
-const DEFAULT_MODEL_NAME = "default";
+const OPUS_MODEL_ALIAS = "opus";
 const DEFAULT_PERMISSION_MODE: PermissionMode = "default";
 
 function isSdkElicitationContentValue(value: Json): value is string | number | boolean | string[] {
@@ -774,7 +774,7 @@ function permissionModeFromSettingsValue(rawMode: unknown): PermissionMode | und
 function initialSessionModel(launchSettings: SessionLaunchSettings): string {
   const settings = settingsObjectFromLaunchSettings(launchSettings);
   const model = typeof settings?.model === "string" ? settings.model.trim() : "";
-  return model || DEFAULT_MODEL_NAME;
+  return model || OPUS_MODEL_ALIAS;
 }
 
 function startupModelOption(
@@ -1256,16 +1256,20 @@ export function handleElicitationResponse(
 }
 type NormalizedModelKey = {
   original: string;
-  family: "opus" | "sonnet" | "haiku" | "unknown" | "default";
+  family: "opus" | "sonnet" | "haiku" | "unknown";
   versionParts: number[];
   variantParts: string[];
+  buildParts: string[];
   contextSuffix?: string;
 };
 
+const MAX_MODEL_VERSION_PARTS = 2;
+const RELEASE_BUILD_TOKEN = /^20\d{6}$/;
+
 function normalizeModelKey(id: string): NormalizedModelKey {
   const original = id.trim();
-  if (!original || original === DEFAULT_MODEL_NAME) {
-    return { original, family: "default", versionParts: [], variantParts: [] };
+  if (!original) {
+    return { original, family: "unknown", versionParts: [], variantParts: [], buildParts: [] };
   }
 
   const lower = original.toLowerCase();
@@ -1281,26 +1285,35 @@ function normalizeModelKey(id: string): NormalizedModelKey {
     familyPart === "opus" || familyPart === "sonnet" || familyPart === "haiku"
       ? familyPart
       : "unknown";
-  const versionParts =
-    family === "unknown"
-      ? []
-      : parts
-          .slice(1)
-          .filter((part) => /^\d+$/.test(part))
-          .map((part) => Number.parseInt(part, 10))
-          .filter((part) => Number.isFinite(part));
-  const variantParts =
-    family === "unknown"
-      ? []
-      : parts
-          .slice(1)
-          .filter((part) => !/^\d+$/.test(part));
+  const versionParts: number[] = [];
+  const variantParts: string[] = [];
+  const buildParts: string[] = [];
+
+  if (family !== "unknown") {
+    for (const part of parts.slice(1)) {
+      if (/^\d+$/.test(part)) {
+        if (versionParts.length < MAX_MODEL_VERSION_PARTS) {
+          const parsed = Number.parseInt(part, 10);
+          if (Number.isFinite(parsed)) {
+            versionParts.push(parsed);
+          }
+          continue;
+        }
+        if (RELEASE_BUILD_TOKEN.test(part)) {
+          buildParts.push(part);
+          continue;
+        }
+      }
+      variantParts.push(part);
+    }
+  }
 
   return {
     original,
     family,
     versionParts,
     variantParts,
+    buildParts,
     ...(contextSuffix ? { contextSuffix } : {}),
   };
 }
@@ -1308,9 +1321,6 @@ function normalizeModelKey(id: string): NormalizedModelKey {
 function modelKeysAreCompatible(leftId: string, rightId: string): boolean {
   const left = normalizeModelKey(leftId);
   const right = normalizeModelKey(rightId);
-  if (left.family === "default" || right.family === "default") {
-    return false;
-  }
   if (left.family === "unknown" || right.family === "unknown") {
     return left.original.toLowerCase() === right.original.toLowerCase();
   }
@@ -1335,9 +1345,6 @@ function sameContextSuffix(leftId: string, rightId: string): boolean {
 function sameFamilyAndVersion(leftId: string, rightId: string): boolean {
   const left = normalizeModelKey(leftId);
   const right = normalizeModelKey(rightId);
-  if (left.family === "default" || right.family === "default") {
-    return false;
-  }
   if (left.family === "unknown" || right.family === "unknown") {
     return left.original.toLowerCase() === right.original.toLowerCase();
   }
@@ -1378,9 +1385,6 @@ function hasVariantSiblingConflict(
 
 function humanizeModelId(id: string): string {
   const normalized = normalizeModelKey(id);
-  if (normalized.family === "default") {
-    return "Default";
-  }
   if (normalized.family === "unknown") {
     return id;
   }
@@ -1404,9 +1408,6 @@ function humanizeModelId(id: string): string {
 
 function shortDisplayNameForModelId(id: string): string {
   const normalized = normalizeModelKey(id);
-  if (normalized.family === "default") {
-    return "Default";
-  }
   if (normalized.family === "unknown") {
     return id;
   }
@@ -1431,8 +1432,8 @@ function currentModelIsAuthoritative(
   requestedId: string | undefined,
 ): boolean {
   const resolved = resolvedId.trim();
-  if (!resolved || resolved === DEFAULT_MODEL_NAME || resolved === "Connecting...") {
-    return Boolean(requestedId?.trim() && requestedId.trim() !== DEFAULT_MODEL_NAME);
+  if (!resolved || resolved === "Connecting...") {
+    return Boolean(requestedId?.trim());
   }
   return true;
 }
@@ -1472,9 +1473,9 @@ export function resolveCurrentModel(session: SessionState): CurrentModel {
     session.resolvedRuntimeModelId?.trim() ||
     session.model.trim() ||
     requestedId ||
-    DEFAULT_MODEL_NAME;
+    OPUS_MODEL_ALIAS;
   const catalogModel = resolveCatalogModel(session.availableModels, resolvedId, requestedId);
-  const runtimeDisplayId = resolvedId || requestedId || DEFAULT_MODEL_NAME;
+  const runtimeDisplayId = resolvedId || requestedId || OPUS_MODEL_ALIAS;
   const displayNameShort = shortDisplayNameForModelId(runtimeDisplayId);
   const displayNameLong = humanizeModelId(runtimeDisplayId);
   const currentModel: CurrentModel = {

--- a/src/agent/bridge.rs
+++ b/src/agent/bridge.rs
@@ -77,6 +77,43 @@ struct BridgeScriptResolver<'a> {
     manifest_script: PathBuf,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AutomaticLookupMode {
+    CargoDevTarget,
+    ExecutableRelativePreferred,
+    DevFallbackOnly,
+    ExecutableRelativeOnly,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AutomaticCandidateSource {
+    ExecutableRelative,
+    WorkingDirectory,
+    ManifestProject,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AutomaticCandidate {
+    source: AutomaticCandidateSource,
+    path: PathBuf,
+}
+
+impl AutomaticCandidate {
+    fn describe(&self) -> String {
+        format!("{}: {}", self.source.label(), self.path.display())
+    }
+}
+
+impl AutomaticCandidateSource {
+    fn label(self) -> &'static str {
+        match self {
+            Self::ExecutableRelative => "executable-relative",
+            Self::WorkingDirectory => "working-directory",
+            Self::ManifestProject => "manifest-project",
+        }
+    }
+}
+
 impl<'a> BridgeScriptResolver<'a> {
     fn from_process(explicit_script: Option<&'a Path>) -> Self {
         Self {
@@ -99,30 +136,110 @@ impl<'a> BridgeScriptResolver<'a> {
             return validate_script_path(path);
         }
 
-        for candidate in self.automatic_candidates() {
-            if is_automatic_script_candidate(&candidate) {
-                return Ok(candidate);
+        let candidates = self.automatic_candidates();
+        for candidate in &candidates {
+            if is_automatic_script_candidate(&candidate.path) {
+                return Ok(candidate.path.clone());
             }
         }
 
+        let checked =
+            candidates.iter().map(AutomaticCandidate::describe).collect::<Vec<_>>().join(", ");
+
         Err(anyhow::anyhow!(
-            "bridge script not found near the installed executable. expected bundled `agent-sdk/dist/bridge.js`; debug builds also check repo-local fallbacks. set CLAUDE_RS_AGENT_BRIDGE to override."
+            "bridge script not found near the installed executable. lookup mode {:?} checked: {}. expected bundled `agent-sdk/dist/bridge.js`; debug builds also check repo-local fallbacks. set CLAUDE_RS_AGENT_BRIDGE to override.",
+            self.lookup_mode(),
+            if checked.is_empty() { "<none>" } else { checked.as_str() }
         ))
     }
 
-    fn automatic_candidates(&self) -> Vec<PathBuf> {
+    fn automatic_candidates(&self) -> Vec<AutomaticCandidate> {
         let mut candidates = Vec::new();
 
-        if let Some(current_exe) = self.current_exe.as_deref() {
-            candidates.extend(exe_relative_bridge_candidates(current_exe));
-        }
-
-        if self.allow_dev_fallbacks {
-            candidates.push(self.cwd_script.clone());
-            candidates.push(self.manifest_script.clone());
+        match self.lookup_mode() {
+            AutomaticLookupMode::CargoDevTarget => {
+                Self::push_candidate(
+                    &mut candidates,
+                    AutomaticCandidateSource::ManifestProject,
+                    self.manifest_script.clone(),
+                );
+                Self::push_candidate(
+                    &mut candidates,
+                    AutomaticCandidateSource::WorkingDirectory,
+                    self.cwd_script.clone(),
+                );
+                self.push_executable_relative_candidates(&mut candidates);
+            }
+            AutomaticLookupMode::ExecutableRelativePreferred => {
+                self.push_executable_relative_candidates(&mut candidates);
+                Self::push_candidate(
+                    &mut candidates,
+                    AutomaticCandidateSource::WorkingDirectory,
+                    self.cwd_script.clone(),
+                );
+                Self::push_candidate(
+                    &mut candidates,
+                    AutomaticCandidateSource::ManifestProject,
+                    self.manifest_script.clone(),
+                );
+            }
+            AutomaticLookupMode::DevFallbackOnly => {
+                Self::push_candidate(
+                    &mut candidates,
+                    AutomaticCandidateSource::WorkingDirectory,
+                    self.cwd_script.clone(),
+                );
+                Self::push_candidate(
+                    &mut candidates,
+                    AutomaticCandidateSource::ManifestProject,
+                    self.manifest_script.clone(),
+                );
+            }
+            AutomaticLookupMode::ExecutableRelativeOnly => {
+                self.push_executable_relative_candidates(&mut candidates);
+            }
         }
 
         candidates
+    }
+
+    fn lookup_mode(&self) -> AutomaticLookupMode {
+        match (self.allow_dev_fallbacks, self.current_exe.as_deref()) {
+            (true, Some(current_exe)) if self.is_cargo_dev_target_executable(current_exe) => {
+                AutomaticLookupMode::CargoDevTarget
+            }
+            (true, Some(_)) => AutomaticLookupMode::ExecutableRelativePreferred,
+            (true, None) => AutomaticLookupMode::DevFallbackOnly,
+            (false, Some(_) | None) => AutomaticLookupMode::ExecutableRelativeOnly,
+        }
+    }
+
+    fn is_cargo_dev_target_executable(&self, current_exe: &Path) -> bool {
+        let Some(manifest_root) = manifest_root_from_script(&self.manifest_script) else {
+            return false;
+        };
+        current_exe.starts_with(manifest_root.join("target"))
+    }
+
+    fn push_executable_relative_candidates(&self, candidates: &mut Vec<AutomaticCandidate>) {
+        let Some(current_exe) = self.current_exe.as_deref() else {
+            return;
+        };
+        for path in exe_relative_bridge_candidates(current_exe) {
+            Self::push_candidate(candidates, AutomaticCandidateSource::ExecutableRelative, path);
+        }
+    }
+
+    fn push_candidate(
+        candidates: &mut Vec<AutomaticCandidate>,
+        source: AutomaticCandidateSource,
+        path: PathBuf,
+    ) {
+        if path.as_os_str().is_empty() || candidates.iter().any(|candidate| candidate.path == path)
+        {
+            return;
+        }
+        candidates.push(AutomaticCandidate { source, path });
     }
 }
 
@@ -135,6 +252,10 @@ fn exe_relative_bridge_candidates(current_exe: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
+fn manifest_root_from_script(manifest_script: &Path) -> Option<&Path> {
+    manifest_script.parent()?.parent()?.parent()
+}
+
 fn is_automatic_script_candidate(path: &Path) -> bool {
     !path.as_os_str().is_empty() && path.is_file()
 }
@@ -142,8 +263,8 @@ fn is_automatic_script_candidate(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        BRIDGE_SCRIPT_RELATIVE_PATH, BridgeLauncher, BridgeScriptResolver,
-        exe_relative_bridge_candidates, resolve_bridge_launcher,
+        AutomaticCandidateSource, BRIDGE_SCRIPT_RELATIVE_PATH, BridgeLauncher,
+        BridgeScriptResolver, exe_relative_bridge_candidates, resolve_bridge_launcher,
         resolve_bridge_launcher_with_runtime,
     };
     use std::fs;
@@ -316,6 +437,66 @@ mod tests {
     }
 
     #[test]
+    fn cargo_run_prefers_manifest_bridge_over_target_bundle() {
+        let fixture = resolver_fixture();
+
+        let resolved = BridgeScriptResolver {
+            explicit_script: None,
+            env_script: None,
+            current_exe: Some(fixture.cargo_target_exe.clone()),
+            allow_dev_fallbacks: true,
+            cwd_script: fixture.cwd_script.clone(),
+            manifest_script: fixture.manifest_script.clone(),
+        }
+        .resolve()
+        .expect("cargo-run resolver should prefer manifest bridge");
+
+        assert_eq!(resolved, fixture.manifest_script);
+        assert_ne!(resolved, fixture.cargo_target_bridge);
+    }
+
+    #[test]
+    fn cargo_run_candidate_order_prefers_manifest_then_cwd_before_executable_relative() {
+        let fixture = resolver_fixture();
+
+        let candidates = BridgeScriptResolver {
+            explicit_script: None,
+            env_script: None,
+            current_exe: Some(fixture.cargo_target_exe.clone()),
+            allow_dev_fallbacks: true,
+            cwd_script: fixture.cwd_script.clone(),
+            manifest_script: fixture.manifest_script.clone(),
+        }
+        .automatic_candidates();
+
+        assert_eq!(candidates[0].source, AutomaticCandidateSource::ManifestProject);
+        assert_eq!(candidates[0].path, fixture.manifest_script);
+        assert_eq!(candidates[1].source, AutomaticCandidateSource::WorkingDirectory);
+        assert_eq!(candidates[1].path, fixture.cwd_script);
+    }
+
+    #[test]
+    fn installed_candidate_order_prefers_executable_relative_before_dev_fallbacks() {
+        let fixture = resolver_fixture();
+
+        let candidates = BridgeScriptResolver {
+            explicit_script: None,
+            env_script: None,
+            current_exe: Some(fixture.installed_exe.clone()),
+            allow_dev_fallbacks: true,
+            cwd_script: fixture.cwd_script.clone(),
+            manifest_script: fixture.manifest_script.clone(),
+        }
+        .automatic_candidates();
+
+        assert_eq!(candidates[0].source, AutomaticCandidateSource::ExecutableRelative);
+        assert_eq!(
+            candidates[0].path,
+            fixture.installed_exe.parent().expect("exe parent").join(BRIDGE_SCRIPT_RELATIVE_PATH)
+        );
+    }
+
+    #[test]
     fn release_mode_does_not_use_dev_fallbacks() {
         let fixture = resolver_fixture();
 
@@ -397,7 +578,9 @@ mod tests {
         dir: TempDir,
         installed_exe: PathBuf,
         unbundled_exe: PathBuf,
+        cargo_target_exe: PathBuf,
         packaged_bridge: PathBuf,
+        cargo_target_bridge: PathBuf,
         cwd_script: PathBuf,
         manifest_script: PathBuf,
         env_script: PathBuf,
@@ -420,14 +603,20 @@ mod tests {
             dir.path().join("package").join("vendor").join("x86_64").join("claude-rs");
         let unbundled_exe =
             dir.path().join("other").join("vendor").join("x86_64").join("claude-rs");
+        let cargo_target_exe =
+            dir.path().join("manifest").join("target").join("debug").join("claude-rs");
         let packaged_bridge = dir.path().join("package").join(BRIDGE_SCRIPT_RELATIVE_PATH);
+        let cargo_target_bridge =
+            dir.path().join("manifest").join("target").join(BRIDGE_SCRIPT_RELATIVE_PATH);
         let cwd_script = dir.path().join("repo").join(BRIDGE_SCRIPT_RELATIVE_PATH);
         let manifest_script = dir.path().join("manifest").join(BRIDGE_SCRIPT_RELATIVE_PATH);
         let env_script = dir.path().join("env").join("bridge.js");
 
         write_test_file(&installed_exe);
         write_test_file(&unbundled_exe);
+        write_test_file(&cargo_target_exe);
         write_test_file(&packaged_bridge);
+        write_test_file(&cargo_target_bridge);
         write_test_file(&cwd_script);
         write_test_file(&manifest_script);
         write_test_file(&env_script);
@@ -436,7 +625,9 @@ mod tests {
             dir,
             installed_exe,
             unbundled_exe,
+            cargo_target_exe,
             packaged_bridge,
+            cargo_target_bridge,
             cwd_script,
             manifest_script,
             env_script,

--- a/src/app/config/edit.rs
+++ b/src/app/config/edit.rs
@@ -1,8 +1,8 @@
 use super::resolve::{language_input_validation_message, normalized_language_value};
 use super::{
-    AddMarketplaceOverlayState, ConfigOverlayState, DEFAULT_EFFORT_LEVELS, DEFAULT_MODEL_ID,
-    DEFAULT_MODEL_LABEL, DefaultPermissionMode, LanguageOverlayState, ModelAndEffortOverlayState,
-    OutputStyle, OutputStyleOverlayState, OverlayFocus, PendingSessionTitleChangeKind,
+    AddMarketplaceOverlayState, ConfigOverlayState, DEFAULT_EFFORT_LEVELS, DefaultPermissionMode,
+    LanguageOverlayState, ModelAndEffortOverlayState, OPUS_MODEL_ALIAS_ID, OutputStyle,
+    OutputStyleOverlayState, OverlayFocus, PendingSessionTitleChangeKind,
     PendingSessionTitleChangeState, PreferredNotifChannel, ResolvedChoice, ResolvedSettingValue,
     SessionRenameOverlayState, SettingFile, SettingId, SettingOptions, SettingSpec,
     resolved_setting, setting_display_value, setting_spec, store,
@@ -207,10 +207,6 @@ pub(super) fn handle_overlay_paste(app: &mut App, text: &str) -> bool {
 }
 
 pub(crate) fn model_supports_effort(app: &App, model_id: &str) -> bool {
-    if model_id == DEFAULT_MODEL_ID {
-        return true;
-    }
-
     model_overlay_options(app)
         .into_iter()
         .find(|option| option.id == model_id)
@@ -259,18 +255,6 @@ pub(crate) fn model_overlay_options(app: &App) -> Vec<OverlayModelOption> {
             supports_auto_mode: model.supports_auto_mode,
         })
         .collect::<Vec<_>>();
-    if !options.iter().any(|option| option.id == DEFAULT_MODEL_ID) {
-        options.push(OverlayModelOption {
-            id: DEFAULT_MODEL_ID.to_owned(),
-            display_name: DEFAULT_MODEL_LABEL.to_owned(),
-            description: Some("Uses Claude's default model selection.".to_owned()),
-            supports_effort: true,
-            supported_effort_levels: DEFAULT_EFFORT_LEVELS.to_vec(),
-            supports_adaptive_thinking: None,
-            supports_fast_mode: None,
-            supports_auto_mode: None,
-        });
-    }
     options.sort_by(|left, right| {
         let left_key = left.display_name.to_ascii_lowercase();
         let right_key = right.display_name.to_ascii_lowercase();
@@ -381,7 +365,7 @@ fn open_model_and_effort_overlay(app: &mut App, focus: OverlayFocus) {
         .config
         .model_effective()
         .filter(|value| options.iter().any(|option| option.id == *value))
-        .unwrap_or_else(|| DEFAULT_MODEL_ID.to_owned());
+        .unwrap_or_else(|| OPUS_MODEL_ALIAS_ID.to_owned());
     let current_effort = app.config.thinking_effort_effective();
     let selected_effort = overlay_effort_for_model(app, &current_model, current_effort);
     app.config.overlay = Some(ConfigOverlayState::ModelAndEffort(ModelAndEffortOverlayState {

--- a/src/app/config/mod.rs
+++ b/src/app/config/mod.rs
@@ -378,8 +378,8 @@ const EDITOR_MODE_OPTIONS: &[SettingOption] = &[
     SettingOption { stored: "default", label: "Default" },
     SettingOption { stored: "vim", label: "Vim" },
 ];
-const DEFAULT_MODEL_ID: &str = "default";
-const DEFAULT_MODEL_LABEL: &str = "Default";
+const OPUS_MODEL_ALIAS_ID: &str = "opus";
+const OPUS_MODEL_ALIAS_LABEL: &str = "Opus";
 const DEFAULT_EFFORT_LEVELS: [EffortLevel; 3] =
     [EffortLevel::Low, EffortLevel::Medium, EffortLevel::High];
 const LANGUAGE_MIN_CHARS: usize = 2;
@@ -409,8 +409,8 @@ const CONFIG_SETTINGS: [SettingSpec; 14] = [
     SettingSpec {
         id: SettingId::Model,
         entry_id: "A19",
-        label: "Default model",
-        description: "Sets the default model for new sessions and opens the combined model and thinking effort picker.",
+        label: "Model",
+        description: "Sets the model for new sessions and opens the combined model and thinking effort picker.",
         file: SettingFile::Settings,
         json_path: &["model"],
         kind: SettingKind::DynamicEnum,
@@ -851,7 +851,7 @@ impl ConfigState {
             .value
         {
             ResolvedSettingValue::Choice(ResolvedChoice::Automatic) => {
-                Some(DEFAULT_MODEL_ID.to_owned())
+                Some(OPUS_MODEL_ALIAS_ID.to_owned())
             }
             ResolvedSettingValue::Choice(ResolvedChoice::Stored(value)) => Some(value),
             ResolvedSettingValue::Bool(_) | ResolvedSettingValue::Text(_) => None,
@@ -1326,7 +1326,7 @@ pub fn setting_display_value(app: &App, spec: &SettingSpec, resolved: &ResolvedS
             }
         }
         (ResolvedSettingValue::Choice(ResolvedChoice::Automatic), SettingId::Model) => {
-            DEFAULT_MODEL_LABEL.to_owned()
+            OPUS_MODEL_ALIAS_LABEL.to_owned()
         }
         (ResolvedSettingValue::Choice(ResolvedChoice::Stored(value)), SettingId::Model) => {
             model_status_label(Some(value), app)
@@ -1371,7 +1371,7 @@ pub fn setting_detail_options(app: &App, spec: &SettingSpec) -> Vec<String> {
             SettingOptions::RuntimeCatalog(RuntimeCatalogKind::Models) => {
                 if app.available_models.is_empty() {
                     vec![
-                        DEFAULT_MODEL_LABEL.to_owned(),
+                        OPUS_MODEL_ALIAS_LABEL.to_owned(),
                         "Connect to load available models".to_owned(),
                     ]
                 } else {
@@ -1576,14 +1576,14 @@ pub fn request_status_snapshot_if_needed(app: &App) {
 
 pub(crate) fn model_status_label(model: Option<&str>, app: &App) -> String {
     match model {
-        None => DEFAULT_MODEL_LABEL.to_owned(),
+        None => OPUS_MODEL_ALIAS_LABEL.to_owned(),
         Some(model_id) => model_overlay_options(app)
             .into_iter()
             .find(|candidate| candidate.id == model_id)
             .map_or_else(
                 || {
-                    if model_id == DEFAULT_MODEL_ID {
-                        DEFAULT_MODEL_LABEL.to_owned()
+                    if model_id == OPUS_MODEL_ALIAS_ID {
+                        OPUS_MODEL_ALIAS_LABEL.to_owned()
                     } else {
                         model_id.to_owned()
                     }

--- a/src/app/config/resolve.rs
+++ b/src/app/config/resolve.rs
@@ -1,6 +1,6 @@
 use super::{
-    DEFAULT_MODEL_ID, DEFAULT_PERMISSION_OPTIONS, DefaultPermissionMode, LANGUAGE_MAX_CHARS,
-    LANGUAGE_MIN_CHARS, OutputStyle, PreferredNotifChannel, ResolvedChoice, ResolvedSetting,
+    DEFAULT_PERMISSION_OPTIONS, DefaultPermissionMode, LANGUAGE_MAX_CHARS, LANGUAGE_MIN_CHARS,
+    OPUS_MODEL_ALIAS_ID, OutputStyle, PreferredNotifChannel, ResolvedChoice, ResolvedSetting,
     ResolvedSettingValue, RuntimeCatalogKind, SettingId, SettingOptions, SettingSpec,
     SettingValidation, store,
 };
@@ -115,7 +115,7 @@ fn resolve_model_setting(
         },
         Ok(store::PersistedSettingValue::String(value))
             if available_models.is_empty()
-                || value == DEFAULT_MODEL_ID
+                || value == OPUS_MODEL_ALIAS_ID
                 || available_models.iter().any(|model| model.id == value) =>
         {
             ResolvedSetting {
@@ -140,7 +140,7 @@ fn option_exists(spec: &SettingSpec, value: &str) -> bool {
         SettingOptions::RuntimeCatalog(RuntimeCatalogKind::PermissionModes) => {
             DEFAULT_PERMISSION_OPTIONS.iter().any(|option| option.stored == value)
         }
-        SettingOptions::RuntimeCatalog(RuntimeCatalogKind::Models) => value == DEFAULT_MODEL_ID,
+        SettingOptions::RuntimeCatalog(RuntimeCatalogKind::Models) => value == OPUS_MODEL_ALIAS_ID,
         SettingOptions::None => false,
     }
 }

--- a/src/app/config/store.rs
+++ b/src/app/config/store.rs
@@ -18,6 +18,7 @@ const LOCAL_SETTINGS_FILENAME: &str = "settings.local.json";
 const PREFERENCES_FILENAME: &str = ".claude.json";
 const CLAUDE_DIR: &str = ".claude";
 const CLAUDE_CODE_DISABLE_1M_CONTEXT_ENV: &str = "CLAUDE_CODE_DISABLE_1M_CONTEXT";
+const ANTHROPIC_DEFAULT_OPUS_MODEL_ENV: &str = "ANTHROPIC_DEFAULT_OPUS_MODEL";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PersistedSettingValue {
@@ -236,19 +237,20 @@ pub fn set_output_style(document: &mut Value, style: OutputStyle) {
     );
 }
 
+pub fn set_model(document: &mut Value, model: Option<&str>) {
+    let value = model.map_or(PersistedSettingValue::Missing, |model| {
+        PersistedSettingValue::String(model.to_owned())
+    });
+    write_persisted_setting(document, setting_spec(SettingId::Model), value);
+}
+
+#[cfg(test)]
 pub fn model(document: &Value) -> Result<Option<String>, ()> {
     match read_persisted_setting(document, setting_spec(SettingId::Model))? {
         PersistedSettingValue::Missing => Ok(None),
         PersistedSettingValue::Bool(_) => Err(()),
         PersistedSettingValue::String(value) => Ok(Some(value)),
     }
-}
-
-pub fn set_model(document: &mut Value, model: Option<&str>) {
-    let value = model.map_or(PersistedSettingValue::Missing, |model| {
-        PersistedSettingValue::String(model.to_owned())
-    });
-    write_persisted_setting(document, setting_spec(SettingId::Model), value);
 }
 
 #[cfg(test)]
@@ -305,6 +307,26 @@ pub fn set_disable_1m_context(document: &mut Value, disabled: bool) {
         );
     } else {
         remove_json_path(document, &["env", CLAUDE_CODE_DISABLE_1M_CONTEXT_ENV]);
+    }
+}
+
+pub fn opus_version_pin(document: &Value) -> Result<Option<String>, ()> {
+    match read_json_path(document, &["env", ANTHROPIC_DEFAULT_OPUS_MODEL_ENV]) {
+        None => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(()),
+    }
+}
+
+pub fn set_opus_version_pin(document: &mut Value, model: Option<&str>) {
+    if let Some(model) = model {
+        set_json_path(
+            document,
+            &["env", ANTHROPIC_DEFAULT_OPUS_MODEL_ENV],
+            Value::String(model.to_owned()),
+        );
+    } else {
+        remove_json_path(document, &["env", ANTHROPIC_DEFAULT_OPUS_MODEL_ENV]);
     }
 }
 
@@ -675,6 +697,68 @@ mod tests {
         set_disable_1m_context(&mut document, false);
 
         assert_eq!(disable_1m_context(&document), Ok(false));
+        assert!(document.get("env").is_none());
+    }
+
+    #[test]
+    fn opus_version_pin_returns_none_when_unset() {
+        let document = Value::Object(Map::new());
+
+        assert_eq!(opus_version_pin(&document), Ok(None));
+    }
+
+    #[test]
+    fn opus_version_pin_returns_string_when_set() {
+        let document = serde_json::json!({
+            "env": {
+                "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-7"
+            }
+        });
+
+        assert_eq!(opus_version_pin(&document), Ok(Some("claude-opus-4-7".to_owned())));
+    }
+
+    #[test]
+    fn opus_version_pin_errors_on_non_string_value() {
+        let document = serde_json::json!({
+            "env": {
+                "ANTHROPIC_DEFAULT_OPUS_MODEL": true
+            }
+        });
+
+        assert_eq!(opus_version_pin(&document), Err(()));
+    }
+
+    #[test]
+    fn set_opus_version_pin_preserves_neighboring_env_keys() {
+        let mut document = serde_json::json!({
+            "env": {
+                "KEEP_ME": "yes"
+            },
+            "other": true
+        });
+
+        set_opus_version_pin(&mut document, Some("claude-opus-4-6"));
+        assert_eq!(opus_version_pin(&document), Ok(Some("claude-opus-4-6".to_owned())));
+        assert_eq!(document["env"]["KEEP_ME"], Value::String("yes".to_owned()));
+
+        set_opus_version_pin(&mut document, None);
+        assert_eq!(opus_version_pin(&document), Ok(None));
+        assert_eq!(document["env"]["KEEP_ME"], Value::String("yes".to_owned()));
+        assert_eq!(document["other"], Value::Bool(true));
+    }
+
+    #[test]
+    fn set_opus_version_pin_removes_empty_env_object() {
+        let mut document = serde_json::json!({
+            "env": {
+                "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-7"
+            }
+        });
+
+        set_opus_version_pin(&mut document, None);
+
+        assert_eq!(opus_version_pin(&document), Ok(None));
         assert!(document.get("env").is_none());
     }
 

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -857,7 +857,7 @@ fn resolved_model_uses_runtime_fallback_when_catalog_rejects_value() {
     let resolved = resolved_setting(&app, setting_spec(SettingId::Model));
 
     assert_eq!(resolved.validation, SettingValidation::UnavailableOption);
-    assert_eq!(setting_display_value(&app, setting_spec(SettingId::Model), &resolved), "Default");
+    assert_eq!(setting_display_value(&app, setting_spec(SettingId::Model), &resolved), "Opus");
 }
 
 #[test]
@@ -874,7 +874,7 @@ fn model_overlay_options_are_sorted_alphabetically() {
         .map(|option| option.display_name)
         .collect::<Vec<_>>();
 
-    assert_eq!(labels, vec!["Default", "Haiku", "Opus", "Sonnet"]);
+    assert_eq!(labels, vec!["Haiku", "Opus", "Sonnet"]);
 }
 
 #[test]

--- a/src/app/connect/session_start.rs
+++ b/src/app/connect/session_start.rs
@@ -69,7 +69,7 @@ fn build_session_settings_object(app: &App) -> Value {
         Value::Bool(app.config.always_thinking_effective()),
     );
 
-    if let Some(model) = store::model(&app.config.committed_settings_document).ok().flatten() {
+    if let Some(model) = app.config.model_effective() {
         settings.insert("model".to_owned(), Value::String(model));
     }
 
@@ -301,7 +301,7 @@ mod tests {
             session_launch_settings_for_reason(&app, SessionStartReason::NewSession);
 
         assert_eq!(launch_settings.language, None);
-        assert_setting_absent(&launch_settings, "model");
+        assert_setting_value(&launch_settings, "model", &Value::String("opus".to_owned()));
         assert_setting_value(&launch_settings, "alwaysThinkingEnabled", &Value::Bool(false));
         assert_permission_mode(&launch_settings, "default");
         assert_setting_value(&launch_settings, "fastMode", &Value::Bool(false));
@@ -313,7 +313,7 @@ mod tests {
     }
 
     #[test]
-    fn persisted_launch_settings_include_supported_settings_json_without_model_when_unset() {
+    fn persisted_launch_settings_include_supported_settings_json_with_explicit_opus_when_unset() {
         let mut app = App::test_default();
         store::set_always_thinking_enabled(&mut app.config.committed_settings_document, true);
         store::set_thinking_effort_level(
@@ -334,7 +334,7 @@ mod tests {
         let launch_settings = session_launch_settings_for_reason(&app, SessionStartReason::Startup);
 
         assert_eq!(launch_settings.language, None);
-        assert_setting_absent(&launch_settings, "model");
+        assert_setting_value(&launch_settings, "model", &Value::String("opus".to_owned()));
         assert_setting_value(&launch_settings, "alwaysThinkingEnabled", &Value::Bool(true));
         assert_permission_mode(&launch_settings, "default");
         assert_setting_value(&launch_settings, "fastMode", &Value::Bool(true));
@@ -390,13 +390,6 @@ mod tests {
 
     fn assert_setting_value(launch_settings: &SessionLaunchSettings, key: &str, expected: &Value) {
         assert_eq!(settings_object(launch_settings).get(key), Some(expected));
-    }
-
-    fn assert_setting_absent(launch_settings: &SessionLaunchSettings, key: &str) {
-        assert!(
-            !settings_object(launch_settings).contains_key(key),
-            "expected `{key}` to be absent"
-        );
     }
 
     fn assert_permission_mode(launch_settings: &SessionLaunchSettings, expected: &str) {

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -850,9 +850,7 @@ mod tests {
     }
 
     fn test_current_model(model_name: &str) -> model::CurrentModel {
-        let (short, long) =
-            if model_name == "default" { ("Default", "Default") } else { (model_name, model_name) };
-        model::CurrentModel::new(model_name, short, long).authoritative(model_name != "default")
+        model::CurrentModel::new(model_name, model_name, model_name).authoritative(true)
     }
 
     fn connected_event(model_name: &str) -> ClientEvent {
@@ -1438,7 +1436,7 @@ mod tests {
         let mut app = make_test_app();
         app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "old", "/test", "old"));
 
-        handle_client_event(&mut app, connected_event("default"));
+        handle_client_event(&mut app, connected_event("opus"));
 
         let Some(first) = app.messages.first() else {
             panic!("missing welcome message");
@@ -1559,12 +1557,12 @@ mod tests {
     fn current_model_update_does_not_mutate_welcome_snapshot_after_settings_reconcile() {
         let mut app = make_test_app();
         app.session_id = Some(model::SessionId::new("session-1"));
-        app.current_model = Some(test_current_model("default"));
+        app.current_model = Some(test_current_model("opus"));
         app.messages =
             vec![ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "session-1")];
         crate::app::config::store::set_model(
             &mut app.config.committed_settings_document,
-            Some("default"),
+            Some("opus"),
         );
 
         crate::app::config::store::set_model(
@@ -1643,7 +1641,7 @@ mod tests {
     #[test]
     fn current_model_update_leaves_existing_welcome_snapshot_unchanged() {
         let mut app = make_test_app();
-        app.current_model = Some(test_current_model("default"));
+        app.current_model = Some(test_current_model("opus"));
         app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
         app.messages.push(user_msg("hello"));
 

--- a/src/app/slash/candidates.rs
+++ b/src/app/slash/candidates.rs
@@ -49,9 +49,7 @@ fn model_candidate_secondary(
     let Some(version) = opus_version_label_for_model_id(&pinned_model_id) else {
         return base;
     };
-    let Some(description) = base else {
-        return None;
-    };
+    let description = base?;
 
     Some(
         description

--- a/src/app/slash/candidates.rs
+++ b/src/app/slash/candidates.rs
@@ -7,8 +7,59 @@ use super::{
     MAX_CANDIDATES, SlashCandidate, SlashContext, SlashDetection, SlashState, normalize_slash_name,
 };
 use crate::app::App;
+use crate::app::config::store;
 use crate::app::dialog::DialogState;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+const OPUS_4_5_MODEL_ID: &str = "claude-opus-4-5-20251101";
+const OPUS_4_6_MODEL_ID: &str = "claude-opus-4-6";
+const OPUS_4_7_MODEL_ID: &str = "claude-opus-4-7";
+
+fn opus_version_label_for_model_id(model_id: &str) -> Option<&'static str> {
+    match model_id {
+        OPUS_4_5_MODEL_ID => Some("4.5"),
+        OPUS_4_6_MODEL_ID => Some("4.6"),
+        OPUS_4_7_MODEL_ID => Some("4.7"),
+        _ => None,
+    }
+}
+
+fn is_sdk_default_model_option(model: &crate::agent::model::AvailableModel) -> bool {
+    model.id.eq_ignore_ascii_case("default") || model.display_name.eq_ignore_ascii_case("default")
+}
+
+fn model_candidate_secondary(
+    app: &App,
+    model: &crate::agent::model::AvailableModel,
+) -> Option<String> {
+    let base = model
+        .description
+        .clone()
+        .or_else(|| (model.display_name != model.id).then(|| model.id.clone()));
+
+    if !model.id.eq_ignore_ascii_case("opus") && !model.id.eq_ignore_ascii_case("opus[1m]") {
+        return base;
+    }
+
+    let Some(pinned_model_id) =
+        store::opus_version_pin(&app.config.committed_local_settings_document).ok().flatten()
+    else {
+        return base;
+    };
+    let Some(version) = opus_version_label_for_model_id(&pinned_model_id) else {
+        return base;
+    };
+    let Some(description) = base else {
+        return None;
+    };
+
+    Some(
+        description
+            .replace("Opus 4.7", &format!("Opus {version}"))
+            .replace("Opus 4.6", &format!("Opus {version}"))
+            .replace("Opus 4.5", &format!("Opus {version}")),
+    )
+}
 
 pub(super) fn detect_argument_at_cursor(
     chars: &[char],
@@ -109,12 +160,18 @@ pub(super) fn find_advertised_command<'a>(
 }
 
 fn is_builtin_variable_input_command(command_name: &str) -> bool {
-    matches!(command_name, "/1m-context" | "/docs" | "/mode" | "/model" | "/resume")
+    matches!(
+        command_name,
+        "/1m-context" | "/docs" | "/mode" | "/model" | "/opus-version" | "/resume"
+    )
 }
 
 pub(super) fn builtin_argument_confirmation_closes(command_name: &str, arg_index: usize) -> bool {
     arg_index == 0
-        && matches!(command_name, "/1m-context" | "/docs" | "/mode" | "/model" | "/resume")
+        && matches!(
+            command_name,
+            "/1m-context" | "/docs" | "/mode" | "/model" | "/opus-version" | "/resume"
+        )
 }
 
 pub(super) fn is_variable_input_command(app: &App, command_name: &str) -> bool {
@@ -142,6 +199,7 @@ pub(super) fn supported_command_candidates(app: &App) -> Vec<SlashCandidate> {
     by_name.insert("/mode".into(), "Set session mode".into());
     by_name.insert("/model".into(), "Set session model".into());
     by_name.insert("/new-session".into(), "Start a fresh session".into());
+    by_name.insert("/opus-version".into(), "Pin the Opus alias version for this folder".into());
     by_name.insert("/resume".into(), "Resume a session by ID".into());
     by_name.insert("/plugins".into(), "Open plugins".into());
     by_name.insert("/status".into(), "Show session status".into());
@@ -280,6 +338,30 @@ pub(super) fn argument_candidates(
                 secondary: Some((*description).to_owned()),
             })
             .collect(),
+        "/opus-version" => [
+            ("4.5", "Claude Opus 4.5", OPUS_4_5_MODEL_ID),
+            ("4.6", "Claude Opus 4.6", OPUS_4_6_MODEL_ID),
+            ("4.7", "Claude Opus 4.7", OPUS_4_7_MODEL_ID),
+        ]
+        .into_iter()
+        .map(|(value, label, _model_id)| SlashCandidate {
+            insert_value: value.to_owned(),
+            primary: value.to_owned(),
+            secondary: Some(label.to_owned()),
+        })
+        .chain([
+            SlashCandidate {
+                insert_value: "default".to_owned(),
+                primary: "default".to_owned(),
+                secondary: Some("Use Claude default Opus alias".to_owned()),
+            },
+            SlashCandidate {
+                insert_value: "status".to_owned(),
+                primary: "status".to_owned(),
+                secondary: Some("Show current project-local Opus pin".to_owned()),
+            },
+        ])
+        .collect(),
         "/resume" => app
             .recent_sessions
             .iter()
@@ -311,13 +393,11 @@ pub(super) fn argument_candidates(
         "/model" => app
             .available_models
             .iter()
+            .filter(|model| !is_sdk_default_model_option(model))
             .map(|model| SlashCandidate {
                 insert_value: model.id.clone(),
                 primary: model.display_name.clone(),
-                secondary: model
-                    .description
-                    .clone()
-                    .or_else(|| (model.display_name != model.id).then(|| model.id.clone())),
+                secondary: model_candidate_secondary(app, model),
             })
             .collect(),
         _ => Vec::new(),
@@ -367,6 +447,7 @@ pub fn is_supported_command(app: &App, command_name: &str) -> bool {
             | "/mode"
             | "/model"
             | "/new-session"
+            | "/opus-version"
             | "/resume"
             | "/plugins"
             | "/status"

--- a/src/app/slash/executors.rs
+++ b/src/app/slash/executors.rs
@@ -15,6 +15,10 @@ use crate::app::{App, AppStatus, CancelOrigin, SystemSeverity};
 use std::fmt::Write as _;
 
 const ONE_M_CONTEXT_USAGE: &str = "Usage: /1m-context <enable|disable|status>";
+const OPUS_VERSION_USAGE: &str = "Usage: /opus-version <4.5|4.6|4.7|default|status>";
+const OPUS_4_5_MODEL_ID: &str = "claude-opus-4-5-20251101";
+const OPUS_4_6_MODEL_ID: &str = "claude-opus-4-6";
+const OPUS_4_7_MODEL_ID: &str = "claude-opus-4-7";
 
 /// Handle slash command submission.
 ///
@@ -33,6 +37,7 @@ pub fn try_handle_submit(app: &mut App, text: &str) -> bool {
         "/docs" => handle_docs_submit(app, &parsed.args),
         "/mcp" => handle_mcp_submit(app, &parsed.args),
         "/plugins" => handle_plugins_submit(app, &parsed.args),
+        "/opus-version" => handle_opus_version_submit(app, &parsed.args),
         "/status" => handle_status_submit(app, &parsed.args),
         "/usage" => handle_usage_submit(app, &parsed.args),
         "/login" => handle_login_submit(app, &parsed.args),
@@ -42,6 +47,84 @@ pub fn try_handle_submit(app: &mut App, text: &str) -> bool {
         "/new-session" => handle_new_session_submit(app, &parsed.args),
         "/resume" => handle_resume_submit(app, &parsed.args),
         _ => handle_unknown_submit(app, parsed.name),
+    }
+}
+
+fn opus_model_id_for_version(version: &str) -> Option<&'static str> {
+    match version {
+        "4.5" => Some(OPUS_4_5_MODEL_ID),
+        "4.6" => Some(OPUS_4_6_MODEL_ID),
+        "4.7" => Some(OPUS_4_7_MODEL_ID),
+        _ => None,
+    }
+}
+
+fn opus_version_label_for_model_id(model_id: &str) -> Option<&'static str> {
+    match model_id {
+        OPUS_4_5_MODEL_ID => Some("4.5"),
+        OPUS_4_6_MODEL_ID => Some("4.6"),
+        OPUS_4_7_MODEL_ID => Some("4.7"),
+        _ => None,
+    }
+}
+
+fn handle_opus_version_submit(app: &mut App, args: &[&str]) -> bool {
+    let [subcommand] = args else {
+        push_system_message(app, OPUS_VERSION_USAGE);
+        return true;
+    };
+    let subcommand = subcommand.trim();
+    if subcommand.is_empty() || args.len() != 1 {
+        push_system_message(app, OPUS_VERSION_USAGE);
+        return true;
+    }
+
+    match subcommand {
+        "status" => {
+            match current_opus_version_pin(app) {
+                Ok(Some(model_id)) => {
+                    let message = if let Some(version) = opus_version_label_for_model_id(&model_id)
+                    {
+                        format!(
+                            "Opus is pinned to {version} in this folder via `.claude/settings.local.json`."
+                        )
+                    } else {
+                        format!(
+                            "Opus is pinned to {model_id} in this folder via `.claude/settings.local.json`."
+                        )
+                    };
+                    push_system_message_with_severity(app, Some(SystemSeverity::Info), &message);
+                }
+                Ok(None) => push_system_message_with_severity(
+                    app,
+                    Some(SystemSeverity::Info),
+                    "Opus is using the default alias resolution in this folder.",
+                ),
+                Err(err) => {
+                    push_system_message(app, format!("Failed to read /opus-version status: {err}"));
+                }
+            }
+            true
+        }
+        "default" => {
+            if let Err(err) = set_opus_version_pin(app, None) {
+                push_system_message(app, format!("Failed to run /opus-version default: {err}"));
+            }
+            true
+        }
+        _ => {
+            let Some(model_id) = opus_model_id_for_version(subcommand) else {
+                push_system_message(app, OPUS_VERSION_USAGE);
+                return true;
+            };
+            if let Err(err) = set_opus_version_pin(app, Some(model_id)) {
+                push_system_message(
+                    app,
+                    format!("Failed to run /opus-version {subcommand}: {err}"),
+                );
+            }
+            true
+        }
     }
 }
 
@@ -143,6 +226,62 @@ fn set_1m_context_disabled(app: &mut App, disabled: bool) -> Result<(), String> 
         }
     };
     push_system_message_with_severity(app, Some(SystemSeverity::Info), message);
+    Ok(())
+}
+
+fn current_opus_version_pin(app: &mut App) -> Result<Option<String>, String> {
+    config::initialize_shared_state(app)?;
+    store::opus_version_pin(&app.config.committed_local_settings_document).map_err(|()| {
+        "Expected `.claude/settings.local.json` env.ANTHROPIC_DEFAULT_OPUS_MODEL to be a string"
+            .to_owned()
+    })
+}
+
+fn set_opus_version_pin(app: &mut App, model: Option<&str>) -> Result<(), String> {
+    if !app.is_project_trusted() {
+        return Err(
+            "Project trust must be accepted before editing folder-local Opus version settings"
+                .to_owned(),
+        );
+    }
+
+    config::initialize_shared_state(app)?;
+    let Some(path) = app.config.path_for(SettingFile::LocalSettings).cloned() else {
+        return Err("Local settings path is not available".to_owned());
+    };
+
+    let current =
+        store::opus_version_pin(&app.config.committed_local_settings_document).map_err(|()| {
+            "Expected `.claude/settings.local.json` env.ANTHROPIC_DEFAULT_OPUS_MODEL to be a string"
+                .to_owned()
+        })?;
+
+    let mut next_document = app.config.committed_local_settings_document.clone();
+    store::set_opus_version_pin(&mut next_document, model);
+    store::save(&path, &next_document)?;
+    app.config.committed_local_settings_document = next_document;
+    app.reconcile_runtime_from_persisted_settings_change();
+    app.config.last_error = None;
+
+    let message = match (model, current.as_deref()) {
+        (Some(next_model), Some(current_model)) if current_model == next_model => {
+            let version = opus_version_label_for_model_id(next_model).unwrap_or(next_model);
+            format!(
+                "Opus is already pinned to {version} for future sessions in this folder. Run /new-session to apply it."
+            )
+        }
+        (Some(next_model), _) => {
+            let version = opus_version_label_for_model_id(next_model).unwrap_or(next_model);
+            format!(
+                "Pinned Opus to {version} for future sessions in this folder. Run /new-session to apply it."
+            )
+        }
+        (None, None) => "Opus is already using the default alias in this folder.".to_owned(),
+        (None, Some(_)) => {
+            "Cleared the project-local Opus version pin for future sessions in this folder. Run /new-session to apply it.".to_owned()
+        }
+    };
+    push_system_message_with_severity(app, Some(SystemSeverity::Info), &message);
     Ok(())
 }
 

--- a/src/app/slash/mod.rs
+++ b/src/app/slash/mod.rs
@@ -151,6 +151,7 @@ fn set_command_pending(app: &mut App, label: &str, ack: Option<super::PendingCom
 mod tests {
     use super::*;
     use crate::app::App;
+    use serde_json::json;
 
     // Re-import submodule items needed by tests
     use super::candidates::{
@@ -199,6 +200,7 @@ mod tests {
         assert!(names.iter().any(|n| n == "/login"), "missing /login");
         assert!(names.iter().any(|n| n == "/logout"), "missing /logout");
         assert!(names.iter().any(|n| n == "/mcp"), "missing /mcp");
+        assert!(names.iter().any(|n| n == "/opus-version"), "missing /opus-version");
         assert!(names.iter().any(|n| n == "/plugins"), "missing /plugins");
         assert!(names.iter().any(|n| n == "/usage"), "missing /usage");
     }
@@ -311,6 +313,223 @@ mod tests {
         };
         assert!(block.text.contains("1M context is disabled"));
         assert!(block.text.contains(".claude/settings.local.json"));
+    }
+
+    #[test]
+    fn opus_version_argument_candidates_are_static() {
+        let app = App::test_default();
+        let candidates = argument_candidates(&app, "/opus-version", 0);
+        assert!(candidates.iter().any(|c| c.insert_value == "4.5"));
+        assert!(candidates.iter().any(|c| {
+            c.insert_value == "4.5"
+                && c.primary == "4.5"
+                && c.secondary.as_deref() == Some("Claude Opus 4.5")
+        }));
+        assert!(candidates.iter().any(|c| c.insert_value == "4.6"));
+        assert!(candidates.iter().any(|c| c.insert_value == "4.7"));
+        assert!(candidates.iter().any(|c| {
+            c.insert_value == "default"
+                && c.primary == "default"
+                && c.secondary.as_deref() == Some("Use Claude default Opus alias")
+        }));
+        assert!(candidates.iter().any(|c| {
+            c.insert_value == "status"
+                && c.primary == "status"
+                && c.secondary.as_deref() == Some("Show current project-local Opus pin")
+        }));
+    }
+
+    #[test]
+    fn opus_version_45_persists_folder_local_override_and_hints_new_session() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = App::test_default();
+        app.settings_home_override = Some(dir.path().to_path_buf());
+        app.cwd_raw = dir.path().to_string_lossy().to_string();
+
+        let consumed = try_handle_submit(&mut app, "/opus-version 4.5");
+
+        assert!(consumed);
+        let settings_path = dir.path().join(".claude").join("settings.local.json");
+        let raw = std::fs::read_to_string(settings_path).expect("read settings.local.json");
+        assert!(raw.contains("\"ANTHROPIC_DEFAULT_OPUS_MODEL\": \"claude-opus-4-5-20251101\""));
+        let Some(last) = app.messages.last() else {
+            panic!("expected success message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert!(block.text.contains("Pinned Opus to 4.5"));
+        assert!(block.text.contains("/new-session"));
+    }
+
+    #[test]
+    fn opus_version_46_persists_folder_local_override() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = App::test_default();
+        app.settings_home_override = Some(dir.path().to_path_buf());
+        app.cwd_raw = dir.path().to_string_lossy().to_string();
+
+        let consumed = try_handle_submit(&mut app, "/opus-version 4.6");
+
+        assert!(consumed);
+        let settings_path = dir.path().join(".claude").join("settings.local.json");
+        let raw = std::fs::read_to_string(settings_path).expect("read settings.local.json");
+        assert!(raw.contains("\"ANTHROPIC_DEFAULT_OPUS_MODEL\": \"claude-opus-4-6\""));
+    }
+
+    #[test]
+    fn opus_version_47_persists_folder_local_override() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = App::test_default();
+        app.settings_home_override = Some(dir.path().to_path_buf());
+        app.cwd_raw = dir.path().to_string_lossy().to_string();
+
+        let consumed = try_handle_submit(&mut app, "/opus-version 4.7");
+
+        assert!(consumed);
+        let settings_path = dir.path().join(".claude").join("settings.local.json");
+        let raw = std::fs::read_to_string(settings_path).expect("read settings.local.json");
+        assert!(raw.contains("\"ANTHROPIC_DEFAULT_OPUS_MODEL\": \"claude-opus-4-7\""));
+    }
+
+    #[test]
+    fn opus_version_default_removes_folder_local_override_and_preserves_neighbor_keys() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_settings = dir.path().join(".claude").join("settings.local.json");
+        std::fs::create_dir_all(local_settings.parent().expect("settings parent"))
+            .expect("create dir");
+        std::fs::write(
+            &local_settings,
+            "{\n  \"env\": {\n    \"ANTHROPIC_DEFAULT_OPUS_MODEL\": \"claude-opus-4-7\",\n    \"KEEP_ME\": \"yes\"\n  }\n}\n",
+        )
+        .expect("write settings");
+        let mut app = App::test_default();
+        app.settings_home_override = Some(dir.path().to_path_buf());
+        app.cwd_raw = dir.path().to_string_lossy().to_string();
+
+        let consumed = try_handle_submit(&mut app, "/opus-version default");
+
+        assert!(consumed);
+        let raw = std::fs::read_to_string(local_settings).expect("read settings.local.json");
+        assert!(!raw.contains("ANTHROPIC_DEFAULT_OPUS_MODEL"));
+        assert!(raw.contains("\"KEEP_ME\": \"yes\""));
+        let Some(last) = app.messages.last() else {
+            panic!("expected success message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert!(block.text.contains("Cleared the project-local Opus version pin"));
+        assert!(block.text.contains("/new-session"));
+    }
+
+    #[test]
+    fn opus_version_status_reports_known_folder_local_override() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_settings = dir.path().join(".claude").join("settings.local.json");
+        std::fs::create_dir_all(local_settings.parent().expect("settings parent"))
+            .expect("create dir");
+        std::fs::write(
+            &local_settings,
+            "{\n  \"env\": {\n    \"ANTHROPIC_DEFAULT_OPUS_MODEL\": \"claude-opus-4-6\"\n  }\n}\n",
+        )
+        .expect("write settings");
+        let mut app = App::test_default();
+        app.settings_home_override = Some(dir.path().to_path_buf());
+        app.cwd_raw = dir.path().to_string_lossy().to_string();
+
+        let consumed = try_handle_submit(&mut app, "/opus-version status");
+
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected status message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert!(block.text.contains("Opus is pinned to 4.6"));
+        assert!(block.text.contains(".claude/settings.local.json"));
+    }
+
+    #[test]
+    fn opus_version_status_reports_default_when_unset() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = App::test_default();
+        app.settings_home_override = Some(dir.path().to_path_buf());
+        app.cwd_raw = dir.path().to_string_lossy().to_string();
+
+        let consumed = try_handle_submit(&mut app, "/opus-version status");
+
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected status message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert!(block.text.contains("Opus is using the default alias resolution"));
+    }
+
+    #[test]
+    fn opus_version_with_missing_arg_returns_usage_message() {
+        let mut app = App::test_default();
+
+        let consumed = try_handle_submit(&mut app, "/opus-version");
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected system usage message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "Usage: /opus-version <4.5|4.6|4.7|default|status>");
+    }
+
+    #[test]
+    fn opus_version_with_extra_args_returns_usage_message() {
+        let mut app = App::test_default();
+
+        let consumed = try_handle_submit(&mut app, "/opus-version 4.7 extra");
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected system usage message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "Usage: /opus-version <4.5|4.6|4.7|default|status>");
+    }
+
+    #[test]
+    fn opus_version_with_unknown_arg_returns_usage_message() {
+        let mut app = App::test_default();
+
+        let consumed = try_handle_submit(&mut app, "/opus-version 9.9");
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected system usage message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "Usage: /opus-version <4.5|4.6|4.7|default|status>");
+    }
+
+    #[test]
+    fn opus_version_requires_trusted_project_for_mutation() {
+        let mut app = App::test_default();
+        app.trust.status = crate::app::trust::TrustStatus::Untrusted;
+
+        let consumed = try_handle_submit(&mut app, "/opus-version 4.7");
+
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected error message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert!(block.text.contains("Project trust must be accepted"));
     }
 
     #[test]
@@ -459,6 +678,65 @@ mod tests {
         assert!(candidates.iter().any(|c| c.primary == "Claude Sonnet"));
         assert!(candidates.iter().any(|c| c.secondary.as_deref() == Some("Balanced coding model")));
         assert!(candidates.iter().any(|c| c.insert_value == "opus"));
+    }
+
+    #[test]
+    fn model_argument_candidates_hide_sdk_default_option() {
+        let mut app = App::test_default();
+        app.available_models = vec![
+            crate::agent::model::AvailableModel::new("default", "Default")
+                .description("Default (recommended)"),
+            crate::agent::model::AvailableModel::new("sonnet", "Claude Sonnet"),
+            crate::agent::model::AvailableModel::new("opus", "Claude Opus"),
+        ];
+
+        let candidates = argument_candidates(&app, "/model", 0);
+
+        assert!(!candidates.iter().any(|c| c.insert_value == "default"));
+        assert!(!candidates.iter().any(|c| c.primary == "Default"));
+        assert!(candidates.iter().any(|c| c.insert_value == "sonnet"));
+        assert!(candidates.iter().any(|c| c.insert_value == "opus"));
+    }
+
+    #[test]
+    fn model_argument_candidates_rewrite_opus_secondary_from_project_pin() {
+        let mut app = App::test_default();
+        app.config.committed_local_settings_document = json!({
+            "env": {
+                "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-5-20251101"
+            }
+        });
+        app.available_models = vec![
+            crate::agent::model::AvailableModel::new("opus", "Opus")
+                .description("Opus 4.7 · Most capable for complex work"),
+        ];
+
+        let candidates = argument_candidates(&app, "/model", 0);
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].insert_value, "opus");
+        assert_eq!(
+            candidates[0].secondary.as_deref(),
+            Some("Opus 4.5 · Most capable for complex work")
+        );
+    }
+
+    #[test]
+    fn model_argument_candidates_keep_sdk_opus_description_when_unpinned() {
+        let mut app = App::test_default();
+        app.available_models = vec![
+            crate::agent::model::AvailableModel::new("opus", "Opus")
+                .description("Opus 4.7 · Most capable for complex work"),
+        ];
+
+        let candidates = argument_candidates(&app, "/model", 0);
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].insert_value, "opus");
+        assert_eq!(
+            candidates[0].secondary.as_deref(),
+            Some("Opus 4.7 · Most capable for complex work")
+        );
     }
 
     #[test]
@@ -980,6 +1258,7 @@ mod tests {
             ("/docs", "commands"),
             ("/mode", "plan"),
             ("/model", "sonnet"),
+            ("/opus-version", "4.7"),
             ("/resume", "session-1"),
         ] {
             let mut app = App::test_default();

--- a/src/app/usage/cli.rs
+++ b/src/app/usage/cli.rs
@@ -167,7 +167,7 @@ fn is_likely_status_context_line(line: &str) -> bool {
         return false;
     }
     let lower = line.to_ascii_lowercase();
-    ["opus", "sonnet", "haiku", "default"].iter().any(|token| lower.contains(token))
+    ["opus", "sonnet", "haiku"].iter().any(|token| lower.contains(token))
 }
 
 fn extract_usage_error(text: &str) -> Option<String> {

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -963,7 +963,7 @@ mod tests {
     fn model_overlay_scroll_keeps_selected_multiline_model_visible() {
         let mut app = App::test_default();
         app.available_models = vec![
-            AvailableModel::new("default", "Default")
+            AvailableModel::new("opus", "Opus")
                 .description("Opus 4.7")
                 .supports_effort(true)
                 .supported_effort_levels(vec![
@@ -1003,7 +1003,7 @@ mod tests {
     fn model_overlay_scroll_accounts_for_wrapped_lines() {
         let mut app = App::test_default();
         app.available_models = vec![
-            AvailableModel::new("default", "Default")
+            AvailableModel::new("opus", "Opus")
                 .description("1234567890")
                 .supports_effort(true)
                 .supported_effort_levels(vec![
@@ -1028,6 +1028,13 @@ mod tests {
     fn model_overlay_scroll_accounts_for_badge_padding_width() {
         let mut app = App::test_default();
         app.available_models = vec![
+            AvailableModel::new("opus", "Opus")
+                .description("Frontier")
+                .supports_effort(true)
+                .supported_effort_levels(vec![EffortLevel::Low, EffortLevel::Medium])
+                .supports_adaptive_thinking(Some(true))
+                .supports_fast_mode(Some(true))
+                .supports_auto_mode(Some(true)),
             AvailableModel::new("sonnet", "Sonnet")
                 .description("Everyday tasks")
                 .supports_effort(true)
@@ -1046,8 +1053,8 @@ mod tests {
             selected_effort: EffortLevel::Medium,
         }));
 
-        let narrow_scroll = assert_selected_model_visible(&app, 4, 18);
-        let wide_scroll = assert_selected_model_visible(&app, 4, 40);
+        let narrow_scroll = assert_selected_model_visible(&app, 3, 12);
+        let wide_scroll = assert_selected_model_visible(&app, 3, 40);
         assert!(narrow_scroll > 0);
         assert!(narrow_scroll >= wide_scroll);
     }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -20,12 +20,13 @@ const SUBAGENT_NAME_MAX_WIDTH: usize = 28;
 const SUBAGENT_NAME_MAX_SHARE_NUM: usize = 2;
 const SUBAGENT_NAME_MAX_SHARE_DEN: usize = 5;
 const HELP_PANEL_HEIGHT: u16 = 14;
-const HELP_BUILTIN_SLASH_COMMANDS: [(&str, &str); 8] = [
+const HELP_BUILTIN_SLASH_COMMANDS: [(&str, &str); 9] = [
     ("/config", "Open settings"),
     ("/docs", "Show in-chat help topics"),
     ("/login", "Authenticate with Claude"),
     ("/logout", "Sign out of Claude"),
     ("/mcp", "Open MCP"),
+    ("/opus-version", "Pin the Opus alias version for this folder"),
     ("/plugins", "Open plugins"),
     ("/status", "Show session status"),
     ("/usage", "Open usage"),


### PR DESCRIPTION
## Summary

- add `/opus-version` to pin `ANTHROPIC_DEFAULT_OPUS_MODEL` in `.claude/settings.local.json`
- remove the synthetic `Default` model path in favor of the explicit `opus` alias
- strip dated Opus release suffixes from model names and hide the SDK `default` entry from `/model`
- rework bridge script resolution so `cargo run` uses the local repo bridge while installed builds prefer the bundled bridge

## Why

- the previous `Default` model behavior was misleading because the supported aliases are `opus`, `sonnet`, and `haiku`
- project-scoped Opus version pinning is needed alongside the existing `.claude` env-driven workflow
- local development was resolving the wrong bridge, which made `cargo run` diverge from the intended dev path

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `cargo check --offline`
- Manual:
  - verified `/opus-version` autocomplete and local settings persistence
  - verified `/model` suggestions hide `Default` and reflect the local Opus pin in the secondary description
  - verified bridge resolution chooses the repo bridge for `cargo run` and the bundled bridge for installed builds
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: `default` and `Default` are no longer app-visible model options; `opus` is now the explicit fallback alias
- Docs updated: in-app slash help updated for `/opus-version`
