### PR TITLE
chore(release): prepare 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.11.2] - 2026-04-19 [Changes][v0.11.2]
 
 ### Features
 
@@ -511,6 +511,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.11.2]: https://github.com/srothgan/claude-code-rust/compare/v0.11.1...v0.11.2
 [v0.11.1]: https://github.com/srothgan/claude-code-rust/compare/v0.11.0...v0.11.1
 [v0.11.0]: https://github.com/srothgan/claude-code-rust/compare/v0.10.0...v0.11.0
 [v0.10.0]: https://github.com/srothgan/claude-code-rust/compare/v0.9.0...v0.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- bump the crate version from `0.11.1` to `0.11.2` in `Cargo.toml` and `Cargo.lock`
- promote the current unreleased changelog section to the `0.11.2` release dated 2026-04-19
- add the `v0.11.2` compare link in `CHANGELOG.md`

## Why

- prepare the repository metadata and changelog for the `0.11.2` release cut

Closes #

## Validation

- Automated: Not run in this session
- Manual: Verified the branch diff against `main` contains only the release version and changelog updates
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: Yes, `CHANGELOG.md`
