### PR TITLE
fix(input): bind plan approvals to ctrl y and ctrl n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.3] - 2026-04-19 [Changes][v0.11.3]
+
+### Fixes
+
+- **Plan approval Ctrl shortcuts** (@srothgan): Replace plain `y`/`n` exit-plan approvals with `Ctrl+y`/`Ctrl+n`.
+
 ## [0.11.2] - 2026-04-19 [Changes][v0.11.2]
 
 ### Features
@@ -511,6 +517,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.11.3]: https://github.com/srothgan/claude-code-rust/compare/v0.11.2...v0.11.3
 [v0.11.2]: https://github.com/srothgan/claude-code-rust/compare/v0.11.1...v0.11.2
 [v0.11.1]: https://github.com/srothgan/claude-code-rust/compare/v0.11.0...v0.11.1
 [v0.11.0]: https://github.com/srothgan/claude-code-rust/compare/v0.10.0...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -4272,6 +4272,42 @@ mod tests {
     }
 
     #[test]
+    fn plan_approval_raw_ctrl_y_resolves_without_editing_input() {
+        let mut app = make_test_app();
+        app.input.set_text("seed");
+        let mut response_rx = attach_pending_permission(
+            &mut app,
+            "perm-1",
+            vec![
+                model::PermissionOption::new(
+                    "plan-approve",
+                    "Approve",
+                    model::PermissionOptionKind::PlanApprove,
+                ),
+                model::PermissionOption::new(
+                    "plan-reject",
+                    "Reject",
+                    model::PermissionOptionKind::PlanReject,
+                ),
+            ],
+            true,
+        );
+
+        handle_terminal_event(
+            &mut app,
+            Event::Key(KeyEvent::new(KeyCode::Char('\u{19}'), KeyModifiers::NONE)),
+        );
+
+        let resp = response_rx.try_recv().expect("raw ctrl+y should resolve plan approval");
+        let model::RequestPermissionOutcome::Selected(selected) = resp.outcome else {
+            panic!("expected selected permission response");
+        };
+        assert_eq!(selected.option_id.clone(), "plan-approve");
+        assert_eq!(app.input.text(), "seed");
+        assert!(app.pending_interaction_ids.is_empty());
+    }
+
+    #[test]
     fn connecting_state_ctrl_c_with_non_empty_selection_does_not_quit() {
         let mut app = make_test_app();
         let _clipboard =

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -36,7 +36,7 @@ fn ctrl_char(expected: char) -> Option<char> {
     Some(char::from((upper as u8) & 0x1f))
 }
 
-fn is_ctrl_char_shortcut(key: KeyEvent, expected: char) -> bool {
+pub(super) fn is_ctrl_char_shortcut(key: KeyEvent, expected: char) -> bool {
     match key.code {
         KeyCode::Char(c) if c.eq_ignore_ascii_case(&expected) => is_ctrl_shortcut(key.modifiers),
         KeyCode::Char(c) if Some(c) == ctrl_char(expected) => {

--- a/src/app/permissions.rs
+++ b/src/app/permissions.rs
@@ -5,10 +5,11 @@ use super::inline_interactions::{
     focus_next_inline_interaction, focused_interaction, focused_interaction_dirty_idx,
     get_focused_interaction_tc, invalidate_if_changed, pop_next_valid_interaction_id,
 };
+use super::keys::is_ctrl_char_shortcut;
 use super::{App, InvalidationLevel, MessageBlock};
 use crate::agent::model;
 use crate::agent::model::PermissionOptionKind;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent};
 
 fn focused_permission(app: &App) -> Option<&crate::app::InlinePermission> {
     focused_interaction(app)?.pending_permission.as_ref()
@@ -23,15 +24,6 @@ where
     F: FnMut(&model::PermissionOption) -> bool,
 {
     focused_permission(app)?.options.iter().position(&mut predicate)
-}
-
-fn is_ctrl_shortcut(modifiers: KeyModifiers) -> bool {
-    modifiers.contains(KeyModifiers::CONTROL) && !modifiers.contains(KeyModifiers::ALT)
-}
-
-fn is_ctrl_char_shortcut(key: KeyEvent, expected: char) -> bool {
-    is_ctrl_shortcut(key.modifiers)
-        && matches!(key.code, KeyCode::Char(c) if c.eq_ignore_ascii_case(&expected))
 }
 
 fn normalized_option_tokens(option: &model::PermissionOption) -> String {
@@ -176,27 +168,23 @@ fn handle_permission_quick_shortcuts(app: &mut App, key: KeyEvent) -> Option<boo
         return None;
     }
     if focused_permission_is_plan_approval(app) {
-        if is_ctrl_char_shortcut(key, 'y')
-            || is_ctrl_char_shortcut(key, 'a')
-            || is_ctrl_char_shortcut(key, 'n')
-        {
+        if is_ctrl_char_shortcut(key, 'y') {
+            if let Some(idx) = focused_option_index_by_kind(app, PermissionOptionKind::PlanApprove)
+            {
+                respond_permission(app, Some(idx));
+                return Some(true);
+            }
             return Some(false);
         }
-        if !is_ctrl_shortcut(key.modifiers) {
-            if matches!(key.code, KeyCode::Char('y' | 'Y'))
-                && let Some(idx) =
-                    focused_option_index_by_kind(app, PermissionOptionKind::PlanApprove)
-            {
+        if is_ctrl_char_shortcut(key, 'n') {
+            if let Some(idx) = focused_option_index_by_kind(app, PermissionOptionKind::PlanReject) {
                 respond_permission(app, Some(idx));
                 return Some(true);
             }
-            if matches!(key.code, KeyCode::Char('n' | 'N'))
-                && let Some(idx) =
-                    focused_option_index_by_kind(app, PermissionOptionKind::PlanReject)
-            {
-                respond_permission(app, Some(idx));
-                return Some(true);
-            }
+            return Some(false);
+        }
+        if is_ctrl_char_shortcut(key, 'a') {
+            return Some(false);
         }
         return None;
     }
@@ -346,6 +334,7 @@ mod tests {
         App, AppStatus, BlockCache, ChatMessage, IncrementalMarkdown, InlinePermission,
         MessageBlock, MessageRole, ToolCallInfo,
     };
+    use crossterm::event::KeyModifiers;
     use pretty_assertions::assert_eq;
     use tokio::sync::oneshot;
 
@@ -537,6 +526,149 @@ mod tests {
     fn plain_y_and_n_are_not_consumed() {
         let mut app = App::test_default();
         let mut rx = add_permission(&mut app, "perm-1", allow_options(), true);
+
+        let consumed_y = handle_permission_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE),
+            true,
+        );
+        let consumed_n = handle_permission_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE),
+            true,
+        );
+
+        assert!(!consumed_y);
+        assert!(!consumed_n);
+        assert_eq!(app.pending_interaction_ids, vec!["perm-1"]);
+        assert!(matches!(rx.try_recv(), Err(tokio::sync::oneshot::error::TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn ctrl_y_approves_plan_permission() {
+        let mut app = App::test_default();
+        let mut rx = add_permission(
+            &mut app,
+            "perm-1",
+            vec![
+                model::PermissionOption::new(
+                    "plan-approve",
+                    "Approve",
+                    PermissionOptionKind::PlanApprove,
+                ),
+                model::PermissionOption::new(
+                    "plan-reject",
+                    "Reject",
+                    PermissionOptionKind::PlanReject,
+                ),
+            ],
+            true,
+        );
+
+        let consumed = handle_permission_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('y'), KeyModifiers::CONTROL),
+            true,
+        );
+        assert!(consumed);
+
+        let resp = rx.try_recv().expect("plan permission should be answered by ctrl+y");
+        let model::RequestPermissionOutcome::Selected(sel) = resp.outcome else {
+            panic!("expected selected permission response");
+        };
+        assert_eq!(sel.option_id.clone(), "plan-approve");
+    }
+
+    #[test]
+    fn raw_ctrl_y_approves_plan_permission() {
+        let mut app = App::test_default();
+        let mut rx = add_permission(
+            &mut app,
+            "perm-1",
+            vec![
+                model::PermissionOption::new(
+                    "plan-approve",
+                    "Approve",
+                    PermissionOptionKind::PlanApprove,
+                ),
+                model::PermissionOption::new(
+                    "plan-reject",
+                    "Reject",
+                    PermissionOptionKind::PlanReject,
+                ),
+            ],
+            true,
+        );
+
+        let consumed = handle_permission_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('\u{19}'), KeyModifiers::NONE),
+            true,
+        );
+        assert!(consumed);
+
+        let resp = rx.try_recv().expect("plan permission should be answered by raw ctrl+y");
+        let model::RequestPermissionOutcome::Selected(sel) = resp.outcome else {
+            panic!("expected selected permission response");
+        };
+        assert_eq!(sel.option_id.clone(), "plan-approve");
+    }
+
+    #[test]
+    fn ctrl_n_rejects_plan_permission() {
+        let mut app = App::test_default();
+        let mut rx = add_permission(
+            &mut app,
+            "perm-1",
+            vec![
+                model::PermissionOption::new(
+                    "plan-approve",
+                    "Approve",
+                    PermissionOptionKind::PlanApprove,
+                ),
+                model::PermissionOption::new(
+                    "plan-reject",
+                    "Reject",
+                    PermissionOptionKind::PlanReject,
+                ),
+            ],
+            true,
+        );
+
+        let consumed = handle_permission_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('n'), KeyModifiers::CONTROL),
+            true,
+        );
+        assert!(consumed);
+
+        let resp = rx.try_recv().expect("plan permission should be answered by ctrl+n");
+        let model::RequestPermissionOutcome::Selected(sel) = resp.outcome else {
+            panic!("expected selected permission response");
+        };
+        assert_eq!(sel.option_id.clone(), "plan-reject");
+    }
+
+    #[test]
+    fn plain_y_and_n_are_not_consumed_for_plan_approval() {
+        let mut app = App::test_default();
+        let mut rx = add_permission(
+            &mut app,
+            "perm-1",
+            vec![
+                model::PermissionOption::new(
+                    "plan-approve",
+                    "Approve",
+                    PermissionOptionKind::PlanApprove,
+                ),
+                model::PermissionOption::new(
+                    "plan-reject",
+                    "Reject",
+                    PermissionOptionKind::PlanReject,
+                ),
+            ],
+            true,
+        );
 
         let consumed_y = handle_permission_key(
             &mut app,

--- a/src/ui/tool_call/interactions.rs
+++ b/src/ui/tool_call/interactions.rs
@@ -211,8 +211,8 @@ fn render_plan_approval_lines(tc: &ToolCallInfo, perm: &InlinePermission) -> Vec
     for (i, opt) in perm.options.iter().enumerate() {
         let is_selected = i == perm.selected_index;
         let (icon, icon_color, shortcut) = match opt.kind {
-            PermissionOptionKind::PlanApprove => ("\u{2713}", Color::Green, " [y]"),
-            PermissionOptionKind::PlanReject => ("\u{2717}", Color::Red, " [n]"),
+            PermissionOptionKind::PlanApprove => ("\u{2713}", Color::Green, " [Ctrl+y]"),
+            PermissionOptionKind::PlanReject => ("\u{2717}", Color::Red, " [Ctrl+n]"),
             _ => ("\u{00b7}", Color::Gray, ""),
         };
 
@@ -238,7 +238,7 @@ fn render_plan_approval_lines(tc: &ToolCallInfo, perm: &InlinePermission) -> Vec
     }
 
     lines.push(Line::from(Span::styled(
-        "  \u{2191}\u{2193} select  enter confirm  y approve  n/esc reject",
+        "  \u{2191}\u{2193} select  enter confirm  Ctrl+y approve  Ctrl+n/esc reject",
         Style::default().fg(theme::DIM),
     )));
 
@@ -470,10 +470,17 @@ mod tests {
 
     fn test_permission(kind: PermissionOptionKind) -> InlinePermission {
         let (response_tx, _response_rx) = tokio::sync::oneshot::channel();
+        let reject_kind =
+            if matches!(kind, PermissionOptionKind::PlanApprove | PermissionOptionKind::PlanReject)
+            {
+                PermissionOptionKind::PlanReject
+            } else {
+                PermissionOptionKind::RejectOnce
+            };
         InlinePermission {
             options: vec![
                 PermissionOption::new("allow", "Allow", kind),
-                PermissionOption::new("deny", "Deny", PermissionOptionKind::RejectOnce),
+                PermissionOption::new("deny", "Deny", reject_kind),
             ],
             display: None,
             response_tx,
@@ -580,5 +587,26 @@ mod tests {
             .expect("selected plan label");
 
         assert_eq!(selected_label.style.fg, Some(theme::RUST_ORANGE));
+    }
+
+    #[test]
+    fn plan_approval_hints_use_ctrl_shortcuts_only() {
+        let tc = test_tool_call("ExitPlanMode");
+        let perm = test_permission(PermissionOptionKind::PlanApprove);
+
+        let rendered = render_plan_approval_lines(&tc, &perm)
+            .into_iter()
+            .map(|line| {
+                line.spans.into_iter().map(|span| span.content.into_owned()).collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("[Ctrl+y]"));
+        assert!(rendered.contains("[Ctrl+n]"));
+        assert!(rendered.contains("Ctrl+y approve"));
+        assert!(rendered.contains("Ctrl+n/esc reject"));
+        assert!(!rendered.contains(" [y]"));
+        assert!(!rendered.contains(" [n]"));
     }
 }


### PR DESCRIPTION
## Summary

- replace plain `y`/`n` exit-plan approvals with `Ctrl+y`/`Ctrl+n` only
- reuse the shared control-key decoding path and add regressions for raw terminal control-key encodings
- bump the crate to `0.11.3` and add the matching changelog entry

## Why

- plain `y`/`n` plan approvals leaked into the draft input and made plan mode unreliable
- this keeps the fallout narrow by shipping the binding fix with a small `0.11.3` release prep update

Closes #

## Validation

- Automated: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, `cargo check --offline`
- Manual: Verified plan approvals now require `Ctrl+y`/`Ctrl+n` and raw `Ctrl+y` terminal encoding resolves without editing the draft
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: Plan-mode exit approvals no longer accept plain `y`/`n`; they now require `Ctrl+y`/`Ctrl+n`
- Docs updated: `CHANGELOG.md`