### PR TITLE
chore(security): bump rustls-webpki to 0.103.12 and clarify rand ignore

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -11,6 +11,9 @@ ignore = [
     "RUSTSEC-2024-0320",
 
     # rand unsoundness with custom logger + ThreadRng reseeding
-    # rand is only a transitive dev-dep of upstream crates, not in our build
+    # Resolved in Cargo.lock via unselected optional deps (phf_generator,
+    # quinn-proto behind reqwest's disabled HTTP/3 feature); never compiled
+    # into our binary. Verified: `cargo tree -i rand` returns nothing across
+    # all targets/features/edges.
     "RUSTSEC-2026-0097",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,9 +2949,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- Bumped `rustls-webpki` 0.103.11 → 0.103.12 via `cargo update -p rustls-webpki` (transitive dep; in-range update, no `Cargo.toml` change needed).
- Clarified the `RUSTSEC-2026-0097` ignore comment in `.cargo/audit.toml` to accurately describe why `rand` is flagged but not a real risk.

## Why

Two RustSec advisories fired against `rustls-webpki` 0.103.11:

- **RUSTSEC-2026-0099** (#150) — wildcard name constraint bypass
- **RUSTSEC-2026-0098** (#149) — URI name constraints incorrectly accepted

Both are patched in `>=0.103.12`. `rustls-webpki` is transitive (via `reqwest` → `rustls`), so a lockfile bump resolves it without touching `Cargo.toml`.

While reviewing `.cargo/audit.toml`, the `rand` ignore comment claimed "transitive dev-dep of upstream crates" which is technically incorrect. Verified via `cargo tree -i rand` (across all targets/features/edges) that neither `rand 0.8.5` nor `rand 0.9.2` is compiled — they're resolved in `Cargo.lock` only via **unselected optional deps** (`phf_generator`, `quinn-proto` behind reqwest's disabled HTTP/3 feature). Updated wording reflects this.

The other two ignores (`RUSTSEC-2025-0141` bincode, `RUSTSEC-2024-0320` yaml-rust) were also reviewed and remain valid — both come via `syntect 5.3.0`, still the latest release on crates.io; upstream fixes are pending a new release.

Closes #149
Closes #150

## Validation

- Automated: `cargo update -p rustls-webpki` reported clean in-range upgrade; weekly `cargo audit` workflow will re-run.
- Manual: `cargo tree -i rand@0.8.5 --target all --all-features` and same for `0.9.2` both return "nothing to print", confirming the rand comment claim.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A