### PR TITLE
chore(release): prepare 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.0] - 2026-05-21 [Changes][v0.12.0]
+
+### Features
+
+- **Inline terminal chat runtime** (#165, @srothgan): Replace the full-screen chat surface with inline terminal-owned rendering.
+- **Resolved action-based keymap** (#166, @srothgan): Route shortcuts through semantic actions and generate help from the resolved keymap.
+- **macOS modifier key support** (#159, @TomasWeisss): Support Command-key shortcuts in terminal modes.
+
+### Fixes
+
+- **Inline rendering stability** (#165, @srothgan): Stabilize resume, resize, fullscreen return, slash notices, and active-turn state on the inline path.
+- **Tool-call and diff rendering** (#152, #165, #166, @srothgan): Preserve diff indentation, show compact change counts, uncap plan markdown, and keep concrete tool output.
+- **Agent SDK bridge events** (#165, @srothgan): Suppress `ToolSearch` events, protect the packaged bridge runtime, and accept fractional API retry delays.
+
+### UI
+
+- **Composer hints and Help tab** (#165, #166, @srothgan): Move autocomplete into compact composer rows and Help into fullscreen config.
+- **Compact inline tools and todos** (#165, @srothgan): Render todos inline and tighten standard tool body caps.
+
+### Documentation
+
+- **README billing and commands cleanup** (#165, @srothgan): Document Agent SDK billing changes, custom slash commands, and remove the outdated Architecture section.
+
+### CI and Dependencies
+
+- **Agent SDK 0.3.146 refresh** (#165, @srothgan): Update the Agent SDK bridge dependencies and package locks.
+- **Rust dependency updates** (#151, #154, #155, #156, #157, #158, #160, #161, #162, #163, #164): Bump Rust dependencies and clarify the `rand` audit ignore.
+- **rustls-webpki advisory fix** (#153): Bump `rustls-webpki` to `0.103.13` for `RUSTSEC-2026-0104`.
+
 ## [0.11.3] - 2026-04-19 [Changes][v0.11.3]
 
 ### Fixes
@@ -517,6 +546,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.12.0]: https://github.com/srothgan/claude-code-rust/compare/v0.11.3...v0.12.0
 [v0.11.3]: https://github.com/srothgan/claude-code-rust/compare/v0.11.2...v0.11.3
 [v0.11.2]: https://github.com/srothgan/claude-code-rust/compare/v0.11.1...v0.11.2
 [v0.11.1]: https://github.com/srothgan/claude-code-rust/compare/v0.11.0...v0.11.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -2969,9 +2969,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -12,13 +12,6 @@ A native Rust terminal interface for Claude Code. Drop-in replacement for Anthro
 
 Claude Code Rust replaces the stock Claude Code terminal interface with a native Rust binary built on [Ratatui](https://ratatui.rs/). It connects to the same Claude API through a local Agent SDK bridge. Core Claude Code functionality - tool calls, file editing, terminal commands, and permissions - works unchanged.
 
-> [!WARNING]
-> **Agent SDK billing changes on June 15, 2026.** Anthropic says Agent SDK usage, `claude -p`, Claude Code GitHub Actions, and third-party Agent SDK apps will use a separate monthly Agent SDK credit instead of normal interactive Claude or Claude Code subscription limits. Because Claude Code Rust wraps the Agent SDK, treat usage through this project as Agent SDK usage. If that credit is exhausted, continued use may require enabling extra usage billed at standard API rates, or requests may pause until the credit refreshes.
->
-> Sources:
-> - [Anthropic support: Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
-> - [ClaudeDevs announcement](https://x.com/ClaudeDevs/status/2054610152817619388)
-
 ## Requisites
 
 - Node.js 18+ (for the Agent SDK bridge)
@@ -41,6 +34,13 @@ If `claude-rs` resolves to an older global shim, ensure your npm global bin dire
 ```bash
 claude-rs
 ```
+
+> [!WARNING]
+> **Agent SDK billing changes on June 15, 2026.** Anthropic says Agent SDK usage, `claude -p`, Claude Code GitHub Actions, and third-party Agent SDK apps will use a separate monthly Agent SDK credit instead of normal interactive Claude or Claude Code subscription limits. Because Claude Code Rust wraps the Agent SDK, treat usage through this project as Agent SDK usage. If that credit is exhausted, continued use may require enabling extra usage billed at standard API rates, or requests may pause until the credit refreshes.
+>
+> Sources:
+> - [Anthropic support: Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
+> - [ClaudeDevs announcement](https://x.com/ClaudeDevs/status/2054610152817619388)
 
 ## Why
 


### PR DESCRIPTION
## Summary

- Prepare the `0.12.0` release by bumping the crate version and lockfile metadata.
- Add concise `0.12.0` changelog notes for the inline rendering runtime, resolved keymap, README updates, dependency refreshes, and the `rustls-webpki` advisory fix.
- Move the Agent SDK billing warning below README usage and keep the outdated Architecture section removed.

## Why

This branch packages the rendering and keymap work already merged to `main` into the `0.12.0` release, while also resolving the open `rustls-webpki` advisory before publishing.

Closes #153

## Validation

- Automated:
  - `cargo audit`
  - `cargo check --offline`
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `git diff --check`
- Manual:
  - Verified `rustls-webpki` resolves to `0.103.13`.
  - Verified the README warning is below Usage and no README Architecture section remains.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: Yes
