### PR TITLE
docs(site): add mdBook manual and Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,72 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "CHANGELOG.md"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "CHANGELOG.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install mdBook
+        run: cargo install mdbook --version 0.5.3 --locked
+
+      - name: Build mdBook
+        run: mdbook build docs
+
+      - name: Configure GitHub Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/book
+
+  deploy:
+    name: Deploy docs
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ node_modules/
 .npm-cache/
 /vendor/
 /agent-sdk/dist/
+/docs/book/
 
 # Local Claude Code config
 .claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.1] - 2026-05-28 [Changes][v0.12.1]
+
+### Documentation
+
+- **mdBook manual and GitHub Pages workflow** (@srothgan): Add a repo-native manual and Pages deployment workflow.
+
+### Fixes
+
+- **CLI help examples** (@srothgan): Remove the invalid installed-binary `--features perf` example.
+
 ## [0.12.0] - 2026-05-21 [Changes][v0.12.0]
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A native Rust terminal interface for Claude Code. Drop-in replacement for Anthro
 [![npm version](https://img.shields.io/npm/v/claude-code-rust)](https://www.npmjs.com/package/claude-code-rust)
 [![npm downloads](https://img.shields.io/npm/dm/claude-code-rust)](https://www.npmjs.com/package/claude-code-rust)
 [![CI](https://github.com/srothgan/claude-code-rust/actions/workflows/ci.yml/badge.svg)](https://github.com/srothgan/claude-code-rust/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://srothgan.github.io/claude-code-rust/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D18-green.svg)](https://nodejs.org/)
 
@@ -35,6 +36,8 @@ If `claude-rs` resolves to an older global shim, ensure your npm global bin dire
 claude-rs
 ```
 
+Full documentation is available at [srothgan.github.io/claude-code-rust](https://srothgan.github.io/claude-code-rust/).
+
 > [!WARNING]
 > **Agent SDK billing changes on June 15, 2026.** Anthropic says Agent SDK usage, `claude -p`, Claude Code GitHub Actions, and third-party Agent SDK apps will use a separate monthly Agent SDK credit instead of normal interactive Claude or Claude Code subscription limits. Because Claude Code Rust wraps the Agent SDK, treat usage through this project as Agent SDK usage. If that credit is exhausted, continued use may require enabling extra usage billed at standard API rates, or requests may pause until the credit refreshes.
 >
@@ -54,14 +57,15 @@ The stock Claude Code TUI runs on Node.js with React Ink. This causes real probl
 
 Claude Code Rust fixes all of these by compiling to a single native binary with direct terminal control via Crossterm.
 
-## Custom Commands
+## Documentation
 
-Claude Code Rust adds project-local slash commands that set environment variables via `.claude/settings.local.json` without leaving the TUI. Changes apply on the next session.
+The manual covers installation from npm and source, help, slash commands, keyboard shortcuts, settings, diagnostics, architecture, and the changelog:
 
-| Command | Usage | Description |
-|---------|-------|-------------|
-| `/1m-context` | `/1m-context <enable\|disable\|status>` | Disable the 1 million token context window to improve model performance and prevent quality degradation on large context windows. |
-| `/opus-version` | `/opus-version <4.5\|4.6\|4.7\|default\|status>` | Pin the Opus model version for the current folder. Useful for switching to 4.6 or 4.5 to avoid 4.7's tokenization issues. Use `default` to clear the pin. |
+- [Installation](https://srothgan.github.io/claude-code-rust/installation.html)
+- [Usage](https://srothgan.github.io/claude-code-rust/usage.html)
+- [Help](https://srothgan.github.io/claude-code-rust/help.html)
+- [Slash commands](https://srothgan.github.io/claude-code-rust/commands.html)
+- [Settings](https://srothgan.github.io/claude-code-rust/settings.html)
 
 ## Status
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,18 @@
+[book]
+title = "Claude Code Rust"
+authors = ["Simon Peter Rothgang"]
+description = "User and contributor documentation for Claude Code Rust."
+language = "en"
+src = "src"
+
+[build]
+build-dir = "book"
+create-missing = false
+
+[output.html]
+git-repository-url = "https://github.com/srothgan/claude-code-rust"
+edit-url-template = "https://github.com/srothgan/claude-code-rust/edit/main/docs/{path}"
+site-url = "/claude-code-rust/"
+default-theme = "rust"
+preferred-dark-theme = "ayu"
+no-section-label = true

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,12 @@
+# Summary
+
+- [About](about.md)
+- [Installation](installation.md)
+- [Usage](usage.md)
+  - [Slash Commands](commands.md)
+  - [Keyboard Shortcuts](shortcuts.md)
+  - [Settings](settings.md)
+  - [Diagnostics](diagnostics.md)
+  - [Help](help.md)
+- [Architecture](architecture.md)
+- [Changelog](changelog.md)

--- a/docs/src/about.md
+++ b/docs/src/about.md
@@ -1,0 +1,28 @@
+# About
+
+Claude Code Rust is a native Rust terminal interface for Claude Code. It replaces the stock Node.js and React Ink terminal UI with a Ratatui-based binary while keeping Claude Code functionality routed through Anthropic's Agent SDK.
+
+The goal is a faster, lower-memory terminal experience with reliable scrollback, direct terminal rendering, native input handling, and a project-local configuration surface.
+
+## Project Status
+
+The project is pre-1.0. The current release line is `0.12.x`, and the crate version is tracked in the root `Cargo.toml`.
+
+The project is useful today, but the runtime still depends on the upstream Claude Agent SDK bridge. Startup readiness, authentication behavior, billing, model availability, and service limits are controlled by Anthropic.
+
+## Relationship To Anthropic
+
+This project is not affiliated with, endorsed by, or supported by Anthropic. It is a third-party terminal UI that talks to the official Agent SDK through a local TypeScript bridge. It is not a fork, copy, or port of Anthropic's Claude Code source.
+
+For official Claude documentation, use the Claude documentation:
+
+- [Claude Docs](https://claude.ai/docs)
+- [Claude Code Agent SDK overview](https://code.claude.com/docs/en/agent-sdk/overview)
+
+## Billing Note
+
+Because Claude Code Rust uses the Agent SDK, usage should be treated as Agent SDK usage. Anthropic's support article says that starting June 15, 2026, Agent SDK and `claude -p` usage on eligible Claude plans move to a separate monthly Agent SDK credit instead of normal interactive Claude plan usage limits.
+
+Check Anthropic's current support article before relying on billing assumptions:
+
+- [Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,0 +1,54 @@
+# Architecture
+
+Claude Code Rust is split into a native Rust terminal app and a TypeScript Agent SDK bridge.
+
+## Runtime Shape
+
+The Rust binary owns the terminal UI and process lifecycle. It parses CLI options with Clap, starts a Tokio runtime, and runs the app inside a `LocalSet` because parts of the terminal and child-process runtime are not `Send`.
+
+The app then starts or resumes a bridge session and renders the chat view directly in the terminal.
+
+## Rust Terminal App
+
+Important Rust areas:
+
+| Area | Responsibility |
+| --- | --- |
+| `src/main.rs` | Process entrypoint, runtime setup, logging/perf setup, and exit behavior. |
+| `src/lib.rs` | CLI arguments, subcommands, and diagnostics presets. |
+| `src/agent/` | Bridge process resolution, NDJSON client, wire types, and bridge error handling. |
+| `src/app/` | App state, lifecycle, sessions, config, permissions, input, slash commands, plugins, MCP, usage, and trust. |
+| `src/ui/` | Ratatui rendering for messages, markdown, diffs, tool calls, config tabs, help, autocomplete, and input. |
+
+The current runtime uses inline terminal-owned rendering rather than an older fullscreen-only model. Fullscreen views are still used for config, help, status, usage, MCP, and plugin surfaces.
+
+## Agent SDK Bridge
+
+The Rust process spawns a local Node runtime that runs:
+
+```text
+agent-sdk/dist/bridge.js
+```
+
+The TypeScript bridge wraps `@anthropic-ai/claude-agent-sdk`. Rust and TypeScript communicate over stdin/stdout using newline-delimited JSON command and event envelopes.
+
+Rust sends commands such as session creation, session resume, prompt submission, permission responses, MCP actions, and runtime refresh requests. The bridge sends events such as assistant messages, tool updates, permission requests, question requests, available commands, modes, models, usage, and errors.
+
+## Packaging
+
+The npm package exposes a `claude-rs` JavaScript launcher. That launcher finds the platform-specific Rust binary downloaded during npm `postinstall` and forwards CLI arguments to it.
+
+Release packaging includes:
+
+- Prebuilt Rust binaries attached to GitHub Releases.
+- `agent-sdk/dist/bridge.js` in the npm package.
+- A copied Node runtime next to the Rust binary when postinstall can validate it.
+- Fallback to `node` on `PATH` when the copied runtime is unavailable.
+
+Source builds are different: `cargo build` or `cargo install --path .` produce only the Rust binary. They do not build or install the JavaScript bridge. Build the bridge with npm and provide it through the checkout fallback, `--bridge-script`, or `CLAUDE_RS_AGENT_BRIDGE`.
+
+## Boundaries
+
+Claude Code Rust owns the terminal UI, local settings surface, bridge process management, and event rendering. Anthropic owns the Agent SDK, authentication, service behavior, billing, models, and upstream Claude Code semantics.
+
+The project does not depend on Agent SDK package subpath exports such as `/browser`, `/bridge`, or `/assistant` as the runtime path. The runtime path is the local TypeScript bridge in this repository.

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+The changelog below is included from the repository root `CHANGELOG.md`.
+
+{{#include ../../CHANGELOG.md}}

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -1,0 +1,47 @@
+# Slash Commands
+
+Claude Code Rust has app-owned slash commands and can also show slash commands advertised by the active Agent SDK session. App-owned commands are available from the Rust TUI itself; SDK-advertised commands depend on the current session and what the bridge reports.
+
+Use `/docs commands` in the app to render the live merged command list into chat. That is the source to use when you want to know exactly which app-owned and SDK-advertised commands are available in the current session.
+
+## App-Owned Commands
+
+| Command | Usage | Purpose |
+| --- | --- | --- |
+| `/1m-context` | `/1m-context <enable|disable|status>` | Enable, disable, or inspect project-local 1M context settings for future sessions. |
+| `/cancel` | `/cancel` | Cancel the active assistant turn. |
+| `/compact` | `/compact` | Ask the active session to compact conversation context. |
+| `/config` | `/config` | Open fullscreen settings. |
+| `/docs` | `/docs <mode|models|shortcuts|commands|agents>` | Render command, shortcut, model, mode, or subagent help into chat. |
+| `/help` | `/help` | Open the fullscreen Help tab. |
+| `/mcp` | `/mcp` | Open MCP status and authorization. |
+| `/plugins` | `/plugins` | Open plugin management. |
+| `/opus-version` | `/opus-version <4.5|4.6|4.7|default|status>` | Set, clear, or inspect the project-local Opus alias pin for future sessions. |
+| `/status` | `/status` | Open session and account status. |
+| `/usage` | `/usage` | Open quota and usage information. |
+| `/login` | `/login` | Run Claude CLI authentication and reconnect the session. |
+| `/logout` | `/logout` | Run Claude CLI logout and clear the active authenticated session. |
+| `/mode` | `/mode <id>` | Switch to a mode advertised by the active session. |
+| `/model` | `/model <id>` | Switch to a model advertised by the active session. |
+| `/new-session` | `/new-session` | Start a fresh bridge session in the current folder. |
+| `/resume` | `/resume <session_id>` | Resume a recent or manually supplied session id. |
+
+## SDK-Advertised Commands
+
+The active SDK session can advertise additional slash commands. These are not documented as a fixed table here because they can change with SDK behavior, session capabilities, account state, and future upstream changes.
+
+Use:
+
+```text
+/docs commands
+```
+
+to inspect the current session's full command list. The output includes app-owned commands and SDK-advertised commands, with descriptions when the SDK provides them.
+
+## Project-Local Commands
+
+`/1m-context` and `/opus-version` persist folder-local settings under `./.claude/settings.local.json`. The current session is not restarted automatically, so run `/new-session` after changing either setting.
+
+`/1m-context disable` writes the environment setting used to disable the 1M context window for future sessions in that folder. `enable` clears that override.
+
+`/opus-version <version>` pins the folder-local Opus alias. `default` clears the pin.

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -1,0 +1,98 @@
+# Diagnostics
+
+Diagnostics are off by default. Enable them only when debugging or preparing a useful issue report because verbose logs can grow quickly.
+
+## Logging
+
+Enable runtime diagnostics with a named preset:
+
+```bash
+claude-rs --enable-logs --diagnostics-preset session
+claude-rs --enable-logs --diagnostics-preset render
+```
+
+Available presets:
+
+| Preset | Use when |
+| --- | --- |
+| `runtime` | Debugging general app, bridge, session, tool, permission, network, and update flow. |
+| `session` | Debugging session startup, permission, and command flow. |
+| `render` | Debugging rendering, cache, input, paste, and perf-adjacent UI behavior. |
+| `bridge` | Debugging Agent SDK bridge lifecycle, protocol, SDK, permission, and MCP behavior. |
+| `full` | Capturing the broadest diagnostic trace. |
+
+Use an explicit log path when you want the file somewhere predictable:
+
+```bash
+claude-rs --enable-logs --diagnostics-preset bridge --log-file claude-rs.log
+```
+
+Use an explicit tracing filter for targeted debugging:
+
+```bash
+claude-rs --log-filter "info,app.render=trace,bridge.protocol=debug"
+```
+
+`--log-filter` overrides `--diagnostics-preset`. If `--log-file` is omitted but logging is enabled through `--enable-logs`, `--diagnostics-preset`, `--log-filter`, `--log-append`, or `RUST_LOG`, the app writes to the default diagnostics path.
+
+The default path is under the platform local data directory:
+
+- Windows: `%LOCALAPPDATA%\claude-code-rust\logs\claude-rs.log`
+- Linux: usually `$XDG_DATA_HOME/claude-code-rust/logs/claude-rs.log` or `~/.local/share/claude-code-rust/logs/claude-rs.log`
+- macOS: the platform data directory reported by the `dirs` crate, under `claude-code-rust/logs/claude-rs.log`
+
+Logs rotate at 10 MB and keep up to five rotated files.
+
+## Bridge Diagnostics
+
+When runtime logging is active, bridge diagnostics are enabled and bridge stderr is captured into the structured log. This is useful for Agent SDK startup, authentication, MCP, permission, and protocol issues.
+
+The bridge script can be overridden with:
+
+```bash
+claude-rs --bridge-script /path/to/agent-sdk/dist/bridge.js
+```
+
+or:
+
+```bash
+CLAUDE_RS_AGENT_BRIDGE=/path/to/agent-sdk/dist/bridge.js
+```
+
+The bridge Node runtime can be overridden with:
+
+```bash
+CLAUDE_RS_AGENT_BRIDGE_NODE=/path/to/node
+```
+
+## Perf Telemetry
+
+Perf telemetry is a separate JSON-lines sidecar intended for high-frequency render and layout samples. It requires a binary built with the `perf` feature.
+
+From source:
+
+```bash
+cargo run --features perf -- --enable-perf
+cargo run --features perf -- --perf-log claude-rs-perf.log
+```
+
+For an already-built perf-enabled binary:
+
+```bash
+claude-rs --enable-perf
+claude-rs --perf-log claude-rs-perf.log
+```
+
+If the binary was not built with `--features perf`, perf flags are rejected at startup.
+
+## Useful Issue Reports
+
+Include:
+
+- `claude-rs --version`
+- OS and terminal.
+- Install method: npm package, source build, fork build, or manual binary.
+- The exact command used to launch the app.
+- Whether a custom bridge script or Node runtime was used.
+- A short reproduction.
+- Relevant log snippets, not full secrets or private conversation content.

--- a/docs/src/help.md
+++ b/docs/src/help.md
@@ -1,0 +1,42 @@
+# Help
+
+Claude Code Rust has two built-in help paths:
+
+```text
+/help
+/docs <topic>
+```
+
+`/help` opens the fullscreen Help tab. Use it when you want navigable in-app help without adding a message to the chat transcript.
+
+`/docs` renders live help into the chat. Use it when you want the current commands, shortcuts, modes, models, or subagents copied into the conversation as reference material.
+
+## Fullscreen Help
+
+The fullscreen Help tab has three sections:
+
+| Section | Shows |
+| --- | --- |
+| Shortcuts | Keyboard shortcuts for the current app state and focused UI context. |
+| Commands | App-owned slash commands plus slash commands advertised by the active SDK session. |
+| Subagents | Subagents advertised by the active SDK session, including model labels when provided. |
+
+Use `Left` and `Right` to switch Help sections. Use `Up` and `Down` to move through the visible rows in the active section.
+
+The Shortcuts section is state-sensitive. It changes depending on whether focus is in chat input, autocomplete, an inline permission prompt, an inline question, or a blocked state such as connecting or command-pending.
+
+The Commands and Subagents sections are also session-sensitive. While the app is connecting, they show loading rows. If the active session does not advertise SDK commands or subagents, the Help tab shows an empty-state row instead of inventing unavailable entries.
+
+## In-Chat Docs
+
+| Command | Shows |
+| --- | --- |
+| `/docs mode` | Current and available session modes. |
+| `/docs models` | Models advertised by the active session. |
+| `/docs shortcuts` | Keyboard shortcuts for the current app state. |
+| `/docs commands` | App-owned and SDK-advertised slash commands. |
+| `/docs agents` | Subagents advertised by the active session. |
+
+`/docs` covers two topics that are not sections in the fullscreen Help tab: `mode` and `models`. Those topics are based on the active session's advertised modes and models.
+
+The `/docs` output is based on the running app state. It can differ from this manual when the active session advertises different models, modes, commands, or agents.

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,0 +1,176 @@
+# Installation
+
+## Prerequisites
+
+Claude Code Rust needs:
+
+- Node.js 18 or newer for the Agent SDK bridge runtime.
+- Existing Claude Code authentication, currently read from `~/.claude/config.json`.
+- Rust 1.88.0 or newer only when building from source.
+
+## Install From npm
+
+The recommended install path is the published npm package:
+
+```bash
+npm install -g claude-code-rust
+claude-rs --version
+claude-rs
+```
+
+The package installs a `claude-rs` launcher. During `postinstall`, it downloads the matching prebuilt Rust binary from GitHub Releases into the package `vendor/` directory.
+
+Supported published binary targets:
+
+| Platform | Target |
+| --- | --- |
+| Linux x64 | `x86_64-unknown-linux-gnu` |
+| Windows x64 | `x86_64-pc-windows-msvc` |
+| macOS x64 | `x86_64-apple-darwin` |
+| macOS arm64 | `aarch64-apple-darwin` |
+
+The installer also tries to copy the current Node.js executable next to the Rust binary as `claude-rs-bridge-node` or `claude-rs-bridge-node.exe`. If that copy fails, the Rust binary falls back to `node` on `PATH`.
+
+## Build From Source
+
+Use this path when developing the project or testing a fork without installing a global `claude-rs` command:
+
+```bash
+git clone https://github.com/srothgan/claude-code-rust.git
+cd claude-code-rust
+npm ci --prefix agent-sdk
+npm run build --prefix agent-sdk
+cargo run 
+```
+
+## Install A Source Or Fork Build Globally
+
+Use this path when you want a fully local build that can be launched as `claude-rs` from any directory. It installs through npm's global package location under the package name `claude-code-rust`, the same package name used by the published npm install. That means a later `npm install -g claude-code-rust` replaces the same global package and shim instead of competing with a separate `cargo install` binary on `PATH`.
+
+Do not use `cargo install --path .` for the global command if you want this behavior. `cargo install` writes to Cargo's bin directory and can create a separate `claude-rs` earlier or later on `PATH`.
+
+### Windows x64
+
+```powershell
+git clone https://github.com/<you>/claude-code-rust.git
+cd claude-code-rust
+
+npm ci --prefix agent-sdk
+npm run build --prefix agent-sdk
+
+cargo build --release --locked --target x86_64-pc-windows-msvc --bin claude-rs
+
+$target = "x86_64-pc-windows-msvc"
+New-Item -ItemType Directory -Force "vendor\$target" | Out-Null
+Copy-Item "target\$target\release\claude-rs.exe" "vendor\$target\claude-rs.exe" -Force
+Copy-Item (Get-Command node).Source "vendor\$target\claude-rs-bridge-node.exe" -Force
+
+npm install -g . --ignore-scripts
+claude-rs --version
+```
+
+### Linux x64
+
+```bash
+git clone https://github.com/<you>/claude-code-rust.git
+cd claude-code-rust
+
+npm ci --prefix agent-sdk
+npm run build --prefix agent-sdk
+
+target=x86_64-unknown-linux-gnu
+cargo build --release --locked --target "$target" --bin claude-rs
+
+mkdir -p "vendor/$target"
+cp "target/$target/release/claude-rs" "vendor/$target/claude-rs"
+chmod +x "vendor/$target/claude-rs"
+cp "$(command -v node)" "vendor/$target/claude-rs-bridge-node"
+chmod +x "vendor/$target/claude-rs-bridge-node"
+
+npm install -g . --ignore-scripts
+claude-rs --version
+```
+
+### macOS
+
+For Apple Silicon:
+
+```bash
+target=aarch64-apple-darwin
+```
+
+For Intel macOS:
+
+```bash
+target=x86_64-apple-darwin
+```
+
+Then run:
+
+```bash
+git clone https://github.com/<you>/claude-code-rust.git
+cd claude-code-rust
+
+npm ci --prefix agent-sdk
+npm run build --prefix agent-sdk
+
+cargo build --release --locked --target "$target" --bin claude-rs
+
+mkdir -p "vendor/$target"
+cp "target/$target/release/claude-rs" "vendor/$target/claude-rs"
+chmod +x "vendor/$target/claude-rs"
+cp "$(command -v node)" "vendor/$target/claude-rs-bridge-node"
+chmod +x "vendor/$target/claude-rs-bridge-node"
+
+npm install -g . --ignore-scripts
+claude-rs --version
+```
+
+The local global install relies on the same launcher shape as the published npm package:
+
+- `bin/claude-rs.js` is installed as the global `claude-rs` shim.
+- `vendor/<target>/claude-rs` or `vendor/<target>/claude-rs.exe` is the Rust binary the shim launches.
+- `agent-sdk/dist/bridge.js` is included from the source checkout after `npm run build --prefix agent-sdk`.
+- `claude-rs-bridge-node` is a copied Node runtime, matching the published installer behavior. If that file is missing, the Rust binary falls back to `node` on `PATH`.
+
+To go back to the published package later:
+
+```bash
+npm install -g claude-code-rust
+```
+
+That overwrites the same global npm package and command shim.
+
+## Manual Bridge Overrides
+
+If you need to run a manually built binary outside the npm package layout, pass the bridge explicitly:
+
+```bash
+claude-rs --bridge-script /path/to/claude-code-rust/agent-sdk/dist/bridge.js
+```
+
+You can also set:
+
+```bash
+CLAUDE_RS_AGENT_BRIDGE=/path/to/agent-sdk/dist/bridge.js
+```
+
+If the bundled or system Node runtime needs an explicit override, set:
+
+```bash
+CLAUDE_RS_AGENT_BRIDGE_NODE=/path/to/node
+```
+
+## Troubleshooting
+
+If `claude-rs` does not launch after npm install:
+
+- Confirm the npm global bin directory is first on `PATH`.
+- Remove stale global shims from older installs.
+- Reinstall with `npm install -g claude-code-rust`.
+- Confirm your platform is one of the published targets above.
+- Confirm Node.js 18 or newer is available.
+- Confirm Claude Code authentication exists at `~/.claude/config.json`.
+- If running from source, confirm `agent-sdk/dist/bridge.js` exists.
+
+When reporting install problems, include the install method, OS, terminal, `node --version`, `claude-rs --version`, the command you ran, and the exact error output.

--- a/docs/src/settings.md
+++ b/docs/src/settings.md
@@ -1,0 +1,105 @@
+# Settings
+
+Claude Code Rust has a fullscreen settings surface with multiple tabs. These slash commands open that surface directly:
+
+| Command | Tab | Purpose |
+| --- | --- | --- |
+| `/config` | Settings | Edit supported Claude-compatible settings. |
+| `/mcp` | MCP | Inspect live MCP server status and complete MCP authorization flows. |
+| `/plugins` | Plugins | Manage installed plugins, marketplace plugins, and marketplaces. |
+| `/status` | Status | Inspect session, account, authentication, and runtime status. |
+| `/usage` | Usage | Inspect quota and usage information reported by the active session. |
+| `/help` | Help | Open fullscreen in-app help. |
+
+The settings surface is session-aware. Some tabs need an active bridge session before they can show live SDK-backed state.
+
+## Usage
+
+Open the settings surface with any command in the table above. Each command opens the same fullscreen surface but targets a different starting tab.
+
+The tab order is:
+
+```text
+Settings -> Plugins -> Status -> Usage -> MCP -> Help
+```
+
+Use `Tab` to move to the next tab and `Shift+Tab` to move to the previous tab. The active tab can also have its own navigation and action keys. For example, the Settings tab edits persisted settings, the Plugins tab navigates plugin lists and overlays, the MCP tab opens server actions and authorization flows, and the Usage and Status tabs refresh live session-backed data.
+
+The surface is not only for editing JSON settings. It is the shared fullscreen control area for settings, plugins, MCP, account/session status, usage, and in-app help.
+
+## Help
+
+Use `/help` when you want fullscreen help inside the same tabbed surface. The Help tab has three sections:
+
+| Section | Shows |
+| --- | --- |
+| Shortcuts | Keyboard shortcuts for the current app state and focused UI context. |
+| Commands | App-owned slash commands plus slash commands advertised by the active SDK session. |
+| Subagents | Subagents advertised by the active SDK session, including model labels when provided. |
+
+Use `Left` and `Right` inside the Help tab to switch sections. Use `Up` and `Down` to move through rows in the active section.
+
+The Help tab is live UI, not a static manual page. Its Shortcuts section changes with focus and state, and its Commands and Subagents sections depend on what the active SDK session advertises.
+
+## Settings Files
+
+Settings are loaded from Claude-compatible JSON files. The app can edit supported settings and display unsupported settings that exist for compatibility or future work.
+
+| File | Scope |
+| --- | --- |
+| `~/.claude/settings.json` | User-level Claude settings. |
+| `./.claude/settings.local.json` | Project-local settings for the current working directory. |
+| `~/.claude.json` | User preferences. |
+
+Malformed JSON files are backed up with a timestamped `.bak` extension and replaced in memory with an empty object so the app can keep running.
+
+## Supported Settings
+
+| Setting | File | JSON path | Notes |
+| --- | --- | --- | --- |
+| Always Thinking | `~/.claude/settings.json` | `alwaysThinkingEnabled` | Enables adaptive thinking for new sessions. |
+| Model | `~/.claude/settings.json` | `model` | Uses the model catalog advertised by the active session. |
+| Default permission mode | `~/.claude/settings.json` | `permissions.defaultMode` | Uses permission modes advertised by the active session. |
+| Fast mode | `~/.claude/settings.json` | `fastMode` | Persists the fast-mode preference for future sessions. |
+| Language | `~/.claude/settings.json` | `language` | Free-text instruction, 2 to 30 characters. Does not localize the UI. |
+| Notifications | `~/.claude.json` | `preferredNotifChannel` | Controls how attention-needed notifications are delivered. |
+| Output style | `./.claude/settings.local.json` | `outputStyle` | Changes how Claude communicates in sessions. |
+| Reduce motion | `./.claude/settings.local.json` | `prefersReducedMotion` | Slows spinners and disables smooth chat scrolling. |
+| Respect .gitignore | `~/.claude.json` | `respectGitignore` | Controls whether file mentions hide ignored entries. |
+| Thinking effort | `~/.claude/settings.json` | `effortLevel` | Applies when Always Thinking is on and the selected model supports effort. |
+
+## Currently Unsupported Settings
+
+These settings are represented in the settings UI but are not currently supported by the app runtime:
+
+| Setting | File | JSON path |
+| --- | --- | --- |
+| Editor mode | `~/.claude.json` | `editorMode` |
+| Show Tips | `./.claude/settings.local.json` | `spinnerTipsEnabled` |
+| Terminal progress bar | `~/.claude.json` | `terminalProgressBarEnabled` |
+| Theme | `~/.claude.json` | `theme` |
+
+## MCP
+
+The MCP tab shows live session-backed MCP state. Use `/mcp` to inspect servers, refresh status, complete authorization, reconnect servers, and handle SDK-provided MCP prompts when available.
+
+If no session is active, the tab asks you to open or resume a session first. If the active session reports no MCP servers, the tab shows an empty state rather than editing raw config files.
+
+## Plugins
+
+The Plugins tab is available through `/plugins`. It shows installed plugins, marketplace plugins, and configured marketplaces.
+
+Supported actions include enabling, disabling, updating, uninstalling, and installing plugins into user, project, or local scopes when those actions are available for the selected plugin.
+
+After plugin changes, the app requests a session runtime plugin reload when an active session is available.
+
+## Project-Local Overrides
+
+Two slash commands write project-local environment overrides into `./.claude/settings.local.json`:
+
+```text
+/1m-context <enable|disable|status>
+/opus-version <4.5|4.6|4.7|default|status>
+```
+
+These settings apply to future sessions. Run `/new-session` after changing them.

--- a/docs/src/shortcuts.md
+++ b/docs/src/shortcuts.md
@@ -1,0 +1,88 @@
+# Keyboard Shortcuts
+
+Keyboard shortcuts are context-sensitive. Use `/docs shortcuts` in the app to show the live shortcuts for the current state.
+
+## Global
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl+Q` | Quit. |
+| `Ctrl+L` | Redraw. |
+| `Ctrl+Z` on Unix | Suspend the process. |
+
+When the app is blocked before a usable session is available, `Ctrl+C` quits.
+
+## Chat Input
+
+| Shortcut | Action |
+| --- | --- |
+| `Enter` | Submit. |
+| `Shift+Enter`, `Ctrl+Enter` | Insert newline. |
+| `Esc` | Cancel the active assistant turn. |
+| `Ctrl+C` | Clear the local draft, or quit when the draft is empty. |
+| `Tab` | Focus prompts or accept suggestions. |
+| `Shift+Tab` | Cycle mode. |
+| Arrow keys | Move through text. |
+| `Home`, `End` | Move to line start or line end. |
+| `Ctrl+Left`, `Ctrl+Right` | Move by word. |
+| `Alt+Left`, `Alt+Right` | Move by word. |
+| `Ctrl+Backspace`, `Ctrl+Delete` | Delete by word. |
+| `Alt+Backspace`, `Alt+Delete` | Delete by word. |
+
+Readline-style bindings are also supported:
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl+A`, `Ctrl+E` | Move to line start or line end. |
+| `Ctrl+B`, `Ctrl+F` | Move one character. |
+| `Ctrl+D` | Delete after cursor. |
+| `Ctrl+H` | Delete before cursor. |
+| `Ctrl+K` | Kill to line end. |
+| `Ctrl+U` | Kill to line start. |
+| `Ctrl+W` | Delete previous word. |
+| `Ctrl+Y` | Yank. |
+| `Alt+B`, `Alt+F` | Move by word. |
+| `Alt+D` | Delete next word. |
+
+## Undo And Redo
+
+| Platform | Undo | Redo |
+| --- | --- | --- |
+| macOS | `Cmd+Z` | `Cmd+Shift+Z`, `Cmd+Y` |
+| Windows | `Ctrl+Z` | `Ctrl+Shift+Z` |
+| Unix except macOS | `Ctrl+_`, `Ctrl+/` | `Ctrl+Shift+Z` |
+
+On Unix except macOS, `Ctrl+Z` is reserved for process suspend.
+
+## Autocomplete
+
+| Shortcut | Action |
+| --- | --- |
+| `Up`, `Down` | Move through candidates. |
+| `Enter`, `Tab` | Accept the selected candidate. |
+| `Esc` | Cancel autocomplete. |
+
+## Inline Permissions
+
+| Shortcut | Action |
+| --- | --- |
+| `Left`, `Up` | Move to the previous option. |
+| `Right`, `Down` | Move to the next option. |
+| `Enter` | Confirm the focused option. |
+| `Esc` | Cancel. |
+| `Tab` | Move focus. |
+
+Letter shortcuts such as `Ctrl+A`, `Ctrl+Y`, or `Ctrl+N` are not permission shortcuts.
+
+## Inline Questions
+
+| Shortcut | Action |
+| --- | --- |
+| `Left`, `Up` | Move to the previous option. |
+| `Right`, `Down` | Move to the next option. |
+| `Home`, `End` | Move to first or last option. |
+| `Space` | Toggle/select where applicable. |
+| `Enter` | Submit. |
+| `Esc` | Cancel. |
+| `Tab` | Toggle notes or move focus. |
+| `Shift+Tab` | Move focus backward. |

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -1,0 +1,70 @@
+# Usage
+
+Start a new session in the current directory:
+
+```bash
+claude-rs
+```
+
+Start in a specific working directory:
+
+```bash
+claude-rs -C path/to/project
+```
+
+Resume a previous session:
+
+```bash
+claude-rs resume
+```
+
+Resume by session id:
+
+```bash
+claude-rs resume <session_id>
+```
+
+The app prints a resume hint on clean exit when the active session has an id.
+
+## CLI Options
+
+The installed `claude-rs --help` command exposes these options:
+
+| Option | Purpose |
+| --- | --- |
+| `--no-update-check` | Disable startup update checks. |
+| `-C, --dir <DIR>` | Run in a specific working directory. |
+| `--bridge-script <PATH>` | Use a specific Agent SDK bridge script. |
+| `--enable-logs` | Enable diagnostics using the default log path when no `--log-file` is set. |
+| `--diagnostics-preset <runtime|session|render|bridge|full>` | Use a named diagnostics filter. |
+| `--log-file <PATH>` | Write tracing diagnostics to a specific file. |
+| `--log-filter <FILTER>` | Use explicit tracing filter directives. |
+| `--log-append` | Append to the active log file instead of resetting it on startup. |
+| `--enable-perf` | Enable perf telemetry when the binary was built with the `perf` feature. |
+| `--perf-log <PATH>` | Write high-frequency perf telemetry to a specific JSON-lines file. |
+| `--perf-append` | Append to the perf log instead of truncating it. |
+
+See [Diagnostics](diagnostics.md) before enabling verbose logs or perf telemetry.
+
+## Core UI
+
+The main screen is a terminal-owned chat view. The app renders messages, tool calls, diffs, permissions, questions, autocomplete, and status directly through Crossterm and Ratatui.
+
+Common surfaces:
+
+- Chat input for prompts and multiline text.
+- File, slash-command, and subagent autocomplete.
+- Inline permission prompts for tool decisions.
+- Inline questions for agent-requested choices or text.
+- Fullscreen settings, status, usage, MCP, plugins, and help tabs.
+- Session picker when running `claude-rs resume` without a session id.
+
+Use `/help` for the fullscreen help tab, `/config` for settings, and `/docs <topic>` for live in-chat help generated from the running app state.
+
+## More Usage Topics
+
+- [Slash Commands](commands.md)
+- [Keyboard Shortcuts](shortcuts.md)
+- [Settings](settings.md)
+- [Diagnostics](diagnostics.md)
+- [Help](help.md)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ impl DiagnosticsPreset {
     about = "Native Rust terminal for Claude Code"
 )]
 #[command(
-    after_help = "Examples:\n  claude-rs --enable-logs --diagnostics-preset session\n  claude-rs --enable-logs --diagnostics-preset render\n  claude-rs --features perf --enable-logs --enable-perf --diagnostics-preset full"
+    after_help = "Examples:\n  claude-rs --enable-logs --diagnostics-preset session\n  claude-rs --enable-logs --diagnostics-preset render"
 )]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Cli {


### PR DESCRIPTION
## Summary

- Add an mdBook manual under `docs/` with installation, usage, slash commands, shortcuts, settings, diagnostics, help, architecture, and changelog pages.
- Add a GitHub Pages workflow that builds the manual on PRs and deploys it from `main`.
- Link the manual from `README.md`, clean up the CLI help examples, and prepare the `0.12.1` release metadata.

## Why

This gives users a maintained documentation site instead of keeping detailed command, configuration, shortcut, and source-install instructions only in the README or issue threads.

Closes #25
Closes #107

## Validation

- Automated: `mdbook build docs`; `cargo fmt --all -- --check`; `cargo check --offline`
- Manual: Reviewed the docs structure and GitHub Pages workflow against the repository layout.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: Added the mdBook manual and README links.
- GitHub Pages should use the Actions workflow source; the Pages site will be created on the first successful deployment from `main`.
