### PR TITLE
feat(agent-sdk): migrate Claude Agent SDK to 0.3.177

### DIFF
--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.161",
+        "@anthropic-ai/claude-agent-sdk": "0.3.177",
         "@anthropic-ai/sdk": "0.97.1",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "4.4.3"
@@ -28,7 +28,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.161",
+        "@anthropic-ai/claude-agent-sdk": "0.3.177",
         "@anthropic-ai/sdk": "0.97.1",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "4.4.3"
@@ -41,22 +41,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.161.tgz",
-      "integrity": "sha512-TWVFmPsGePXPNnNuWAAuKagQai9kNj99tuu2KLo8FN3oWF5r82OnWTNpQ3IubpWYPyO1vC0+kQu2GfqoEme/hA==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.177.tgz",
+      "integrity": "sha512-CBzXnzR661q3AlfZzBjmIFQx0cxr36iJV3PExTYmPyGQX32qxtiFQgnxTcF8wB4hcSVf2hnoy/gprVJdkNx7cw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.161"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.177"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.161.tgz",
-      "integrity": "sha512-KwDpi1O2P++uAskFt454K/sShPmhHSYhSbBxaap2KLFoVFti1pttDcEqDPfmKCk2XzKTwlpnVSI1IwTiawPJTw==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.177.tgz",
+      "integrity": "sha512-u9Ty+KPllm2nw0RatdPF0zcPRquNZjVptmyLG0DqduGbgZDLQpfPFMF5hffFIRnVaXhx7+jkUmEdw0jrda0UcA==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.161.tgz",
-      "integrity": "sha512-VoLz1BfKDc6UOYL+UhRKNSFA1k4l6kvOUrWqkHJ34V5zI5/7VzQilaGl7hU5JECE1TleXMzrWpDrLZO7akApJA==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.177.tgz",
+      "integrity": "sha512-ona6Jv54XFwBTqOj3MzLWfKtc2m7Rdh58wOAX9Hnue/6FcWfyeuz/UDcidVTXQ7Xytz//Tb0JJgFtiQjO7FbIA==",
       "cpu": [
         "x64"
       ],
@@ -91,9 +91,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.161.tgz",
-      "integrity": "sha512-QQbGTJ+2AFeP6+vsZQtafqeGZGX72jaHOjOyrhEcMk1T2DSrJV05J0xnkZT4yIOsByGosntTcY6963EfkuwuTg==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.177.tgz",
+      "integrity": "sha512-wBCbklkaDb483Ab4DUFfmJjZJKXz58YXPv+CiGsyjq1St19mbKEma5KKz3Ya9mlV8aLyh4zmLK2mEHPnF//Ipg==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.161.tgz",
-      "integrity": "sha512-y+RPkQ6ZFje6LP0WyGvM4yHp7IQAaxAbcKSP9QVzKtT9yWiDeqWSnPzdP2Rp3B+6Kd12MuhwIMAbiKS4onAusA==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.177.tgz",
+      "integrity": "sha512-v6PMDD3h2erLuTK5S2ZvExqdL3v44OyC70XpKhyqIUnyPaGR9YAMjh//EKdWC+mNvt6mIbRZpaDcHtbASVW8Rw==",
       "cpu": [
         "arm64"
       ],
@@ -117,9 +117,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.161.tgz",
-      "integrity": "sha512-gq4tvNRRcfSf8o35mLWKN351I6FowQa2n28YiZJBvZU1glQ3HKQM4srrXzjwLwv1VcndyWBfLxoaDB1I9BS++w==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.177.tgz",
+      "integrity": "sha512-WDP6puwPHscggNAfvIxyUSHSAjfUEkGRfnMXEPBHOqO+qjX2KGxeE13/ih3EVioeBVOUIqPui6VB05vXLa6T9Q==",
       "cpu": [
         "x64"
       ],
@@ -130,9 +130,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.161.tgz",
-      "integrity": "sha512-ev0eJhypbyatvSL+Cl2LqOos5+XZbgBMV6MJk7jIh/9dirMLwDj2JFlLlOnHdmIpFcznESZ/Z2wgMtqmOMUCHQ==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.177.tgz",
+      "integrity": "sha512-1cdEO06WoEsl1JnnLCPIlg/8x37GtBsTuj65gIpSjdrImNBjgIuMWVyceP4qaXhFjtQgYK1nx3TpaxEFVDOrDg==",
       "cpu": [
         "x64"
       ],
@@ -143,9 +143,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.161.tgz",
-      "integrity": "sha512-toJhVo/7RKyPc/IEGvgIcN/mPmGs38gnuDOrdtdxXoPR7WRkHcHfwprD5S9zV/pZAhuLhj/cznhno3G7b4Pnkg==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.177.tgz",
+      "integrity": "sha512-xLgDWnZaYohtFrkgEIkGZdP+rp4sXxAMbbpEvEp0LK1vAYmJam/ztT2yoK6gfI58IbToJq1WGUEX2HVnE65yOg==",
       "cpu": [
         "arm64"
       ],
@@ -156,9 +156,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.161.tgz",
-      "integrity": "sha512-QmYFeX/P7bt4diCZhXgazkmzLxL+uK1zwPaCSL2sIQyYGWAXiUulZ41TVLQbHglCBlKzUzVP9kwEXaAZye7LPA==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.177.tgz",
+      "integrity": "sha512-SIdQLbtF//rYK4KDBNpUPyjyui7NwCFPZ2/3vyW3TR8R8xynkNq3cLis90FnPSgxaSshi38vkJYWh+9kGDB7zg==",
       "cpu": [
         "x64"
       ],

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -17,7 +17,7 @@
     "test": "npm run build && node --test dist/**/*.test.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.161",
+    "@anthropic-ai/claude-agent-sdk": "0.3.177",
     "@anthropic-ai/sdk": "0.97.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "zod": "4.4.3"

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -1286,6 +1286,197 @@ test("handleSdkMessage suppresses ToolSearch bridge events without denying SDK u
   assert.equal(session.toolCalls.has("tool-search-1"), false);
 });
 
+test("handleSdkMessage emits transcript retraction for model_refusal_fallback", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "model_refusal_fallback",
+      trigger: "refusal",
+      direction: "retry",
+      original_model: "claude-opus-4-1",
+      fallback_model: "claude-sonnet-4-5",
+      request_id: "req-1",
+      api_refusal_category: "cyber",
+      api_refusal_explanation: "policy text",
+      retracted_message_uuids: ["assistant-old", "assistant-old", "", 7],
+      content: "Retried with fallback model",
+      uuid: "fallback-notice",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    {
+      type: "transcript_retraction",
+      message_uuids: ["assistant-old"],
+      reason: "model_refusal_fallback",
+      request_id: "req-1",
+      trigger: "refusal",
+      direction: "retry",
+      original_model: "claude-opus-4-1",
+      fallback_model: "claude-sonnet-4-5",
+      api_refusal_category: "cyber",
+      api_refusal_explanation: "policy text",
+      content: "Retried with fallback model",
+    },
+  ]);
+  assert.equal(
+    events.some(
+      (event) =>
+        (event.update as Record<string, unknown> | undefined)?.type === "system_notice_update",
+    ),
+    false,
+  );
+});
+
+test("handleSdkMessage emits tolerant transcript retraction for model_fallback", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "model_fallback",
+      original_model: "claude-opus-4-1",
+      fallback_model: "claude-sonnet-4-5",
+      retracted_message_uuids: ["old-1", "old-2"],
+      uuid: "fallback-notice",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    {
+      type: "transcript_retraction",
+      message_uuids: ["old-1", "old-2"],
+      reason: "model_fallback",
+      original_model: "claude-opus-4-1",
+      fallback_model: "claude-sonnet-4-5",
+    },
+  ]);
+});
+
+test("handleSdkMessage emits assistant supersedes before replacement content", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "assistant",
+      uuid: "assistant-new",
+      supersedes: ["assistant-old"],
+      session_id: "session-1",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "echo ok" } },
+        ],
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    {
+      type: "transcript_retraction",
+      message_uuids: ["assistant-old"],
+      reason: "assistant_supersedes",
+    },
+    {
+      type: "tool_call",
+      tool_call: {
+        tool_call_id: "tool-1",
+        title: "echo ok",
+        kind: "execute",
+        status: "in_progress",
+        source_message_uuid: "assistant-new",
+        content: [],
+        raw_input: { command: "echo ok" },
+        locations: [],
+        meta: { claudeCode: { toolName: "Bash", parentToolUseId: null } },
+      },
+    },
+  ]);
+});
+
+test("handleSdkMessage propagates source UUIDs for stream text and tool results", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "stream_event",
+      uuid: "assistant-stream",
+      session_id: "session-1",
+      event: {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "partial" },
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "stream_event",
+      uuid: "assistant-tool",
+      session_id: "session-1",
+      event: {
+        type: "content_block_start",
+        content_block: {
+          type: "tool_use",
+          id: "tool-1",
+          name: "Bash",
+          input: { command: "echo ok" },
+        },
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "user",
+      uuid: "user-result",
+      session_id: "session-1",
+      parent_tool_use_id: "tool-1",
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tool-1", content: "ok", is_error: false },
+        ],
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "agent_message_chunk",
+        content: { type: "text", text: "partial" },
+        source_message_uuid: "assistant-stream",
+      },
+      {
+        type: "tool_call",
+        tool_call: {
+          tool_call_id: "tool-1",
+          title: "echo ok",
+          kind: "execute",
+          status: "in_progress",
+          source_message_uuid: "assistant-tool",
+          content: [],
+          raw_input: { command: "echo ok" },
+          locations: [],
+          meta: { claudeCode: { toolName: "Bash", parentToolUseId: null } },
+        },
+      },
+      {
+        type: "tool_call_update",
+        tool_call_update: {
+          tool_call_id: "tool-1",
+          source_message_uuid: "user-result",
+          fields: {
+            status: "completed",
+            raw_output: "ok",
+            content: [{ type: "content", content: { type: "text", text: "ok" } }],
+          },
+        },
+      },
+    ],
+  );
+});
+
 test("handleTaskSystemMessage applies task_updated description patches to the linked task", () => {
   const session = makeSessionState();
 
@@ -3074,6 +3265,7 @@ test("handleSdkMessage preserves assistant correlation metadata on tool calls", 
         title: "npm test",
         kind: "execute",
         status: "in_progress",
+        source_message_uuid: "message-assistant",
         content: [],
         raw_input: { command: "npm test" },
         locations: [],
@@ -4131,6 +4323,35 @@ test("mapSessionMessagesToUpdates maps message content blocks", () => {
   assert.equal(variantCounts.get("agent_message_chunk"), 1);
   assert.equal(variantCounts.get("tool_call"), 1);
   assert.equal(variantCounts.get("tool_call_update"), 1);
+  const userChunk = updates.find(
+    (
+      update,
+    ): update is Extract<import("./types.js").SessionUpdate, { type: "user_message_chunk" }> =>
+      update.type === "user_message_chunk",
+  );
+  const agentChunk = updates.find(
+    (
+      update,
+    ): update is Extract<import("./types.js").SessionUpdate, { type: "agent_message_chunk" }> =>
+      update.type === "agent_message_chunk",
+  );
+  const toolCall = updates.find(
+    (update): update is Extract<import("./types.js").SessionUpdate, { type: "tool_call" }> =>
+      update.type === "tool_call",
+  );
+  const toolCallUpdate = updates.find(
+    (
+      update,
+    ): update is Extract<import("./types.js").SessionUpdate, { type: "tool_call_update" }> =>
+      update.type === "tool_call_update",
+  );
+  assert.equal(userChunk?.source_message_uuid, "u1");
+  assert.equal(agentChunk?.source_message_uuid, "a1");
+  assert.equal(toolCall?.tool_call.source_message_uuid, "a1");
+  assert.equal(
+    toolCallUpdate?.tool_call_update.source_message_uuid,
+    "u2",
+  );
 });
 
 test("mapSessionMessagesToUpdates suppresses ToolSearch history blocks", () => {

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -4067,7 +4067,7 @@ test("looksLikeAuthRequired detects login hints", () => {
 });
 
 test("agent sdk version compatibility check matches pinned version", () => {
-  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.161");
+  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.177");
   assert.equal(agentSdkVersionCompatibilityError(), undefined);
 });
 

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -6377,6 +6377,45 @@ test("mapAvailableModels preserves optional fast and auto mode metadata", () => 
   ]);
 });
 
+test("mapAvailableModels filters unavailable Fable models while preserving unknown ids", () => {
+  const mapped = mapAvailableModels([
+    {
+      value: "fable",
+      displayName: "Claude Fable",
+      description: "Unavailable model alias",
+      supportsEffort: true,
+    },
+    {
+      value: "claude-fable-5",
+      displayName: "Claude Fable 5",
+      description: "Unavailable model",
+      supportsEffort: true,
+    },
+    {
+      value: "claude-fable-5-20260612",
+      displayName: "Claude Fable 5 dated",
+      description: "Unavailable dated model",
+      supportsEffort: true,
+    },
+    {
+      value: "claude-unknown-1",
+      displayName: "Claude Unknown",
+      description: "Unrecognized but available model",
+      supportsEffort: false,
+    },
+  ]);
+
+  assert.deepEqual(mapped, [
+    {
+      id: "claude-unknown-1",
+      display_name: "Claude Unknown",
+      description: "Unrecognized but available model",
+      supports_effort: false,
+      supported_effort_levels: [],
+    },
+  ]);
+});
+
 test("resolveCurrentModel keeps 1M context suffix in short and long display names", () => {
   const session = makeSessionState();
   session.resolvedRuntimeModelId = "claude-opus-4-7[1m]";

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -52,6 +52,7 @@ import {
   permissionModeFailureLooksUnsupported,
   refreshSupportedModesForSession,
 } from "./bridge/commands.js";
+import { handleMcpSetServersCommand } from "./bridge/mcp.js";
 import {
   emitCurrentModelUpdate,
   handleUserDialogResponse,
@@ -564,6 +565,98 @@ test("parseCommandEnvelope rejects invalid latest MCP config fields", () => {
       ),
     /tools is only supported for http and sse MCP servers/,
   );
+});
+
+test("handleMcpSetServersCommand emits SDK result", async () => {
+  const session = makeSessionState();
+  let receivedServers: unknown;
+  session.query = {
+    setMcpServers: async (servers: unknown) => {
+      receivedServers = servers;
+      return {
+        added: ["docs"],
+        removed: ["plugin:Notion:notion"],
+        errors: { docs: "connection failed" },
+      };
+    },
+  } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
+
+  const events = await captureBridgeEventsAsync(async () => {
+    await handleMcpSetServersCommand(
+      session,
+      {
+        command: "mcp_set_servers",
+        session_id: "session-1",
+        servers: {
+          docs: {
+            type: "http",
+            url: "https://example.test/mcp",
+            always_load: true,
+          },
+        },
+      },
+      "req-mcp-set",
+    );
+  });
+
+  assert.deepEqual(receivedServers, {
+    docs: {
+      type: "http",
+      url: "https://example.test/mcp",
+      alwaysLoad: true,
+    },
+  });
+  assert.deepEqual(events, [
+    {
+      request_id: "req-mcp-set",
+      event: "mcp_set_servers_result",
+      session_id: "session-1",
+      result: {
+        added: ["docs"],
+        removed: ["plugin:Notion:notion"],
+        errors: { docs: "connection failed" },
+      },
+    },
+  ]);
+});
+
+test("handleMcpSetServersCommand emits MCP operation error on failure", async () => {
+  const session = makeSessionState();
+  session.query = {
+    setMcpServers: async () => {
+      throw new Error("dynamic update failed");
+    },
+  } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
+
+  const events = await captureBridgeEventsAsync(async () => {
+    await handleMcpSetServersCommand(
+      session,
+      {
+        command: "mcp_set_servers",
+        session_id: "session-1",
+        servers: {},
+      },
+      "req-mcp-set",
+    );
+  });
+
+  assert.deepEqual(events, [
+    {
+      request_id: "req-mcp-set",
+      event: "mcp_operation_error",
+      session_id: "session-1",
+      error: {
+        operation: "set-servers",
+        message: "dynamic update failed",
+      },
+    },
+    {
+      request_id: "req-mcp-set",
+      event: "slash_error",
+      session_id: "session-1",
+      message: "failed to set MCP servers: dynamic update failed",
+    },
+  ]);
 });
 
 test("bridgeMcpConfigToSdk maps latest MCP fields to SDK casing", () => {

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -1479,6 +1479,75 @@ test("handleSdkMessage propagates source UUIDs for stream text and tool results"
   );
 });
 
+test("handleSdkMessage refreshes Grep title when final assistant snapshot carries input", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "stream_event",
+      uuid: "assistant-stream",
+      session_id: "session-1",
+      event: {
+        type: "content_block_start",
+        content_block: {
+          type: "tool_use",
+          id: "tool-grep",
+          name: "Grep",
+          input: {},
+        },
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "assistant",
+      uuid: "assistant-final",
+      session_id: "session-1",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "tool-grep",
+            name: "Grep",
+            input: { pattern: "<rare string>", output_mode: "content", "-n": true },
+          },
+        ],
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    {
+      type: "tool_call",
+      tool_call: {
+        tool_call_id: "tool-grep",
+        title: "Grep",
+        kind: "search",
+        status: "in_progress",
+        source_message_uuid: "assistant-stream",
+        content: [],
+        raw_input: {},
+        locations: [],
+        meta: { claudeCode: { toolName: "Grep", parentToolUseId: null } },
+      },
+    },
+    {
+      type: "tool_call_update",
+      tool_call_update: {
+        tool_call_id: "tool-grep",
+        source_message_uuid: "assistant-final",
+        fields: {
+          title: "Grep <rare string> (content)",
+          kind: "search",
+          status: "in_progress",
+          raw_input: { pattern: "<rare string>", output_mode: "content", "-n": true },
+          locations: [],
+          meta: { claudeCode: { toolName: "Grep", parentToolUseId: null } },
+        },
+      },
+    },
+  ]);
+});
+
 test("handleTaskSystemMessage applies task_updated description patches to the linked task", () => {
   const session = makeSessionState();
 
@@ -3706,9 +3775,26 @@ test("createToolCall builds write preview diff content", () => {
   ]);
 });
 
-test("createToolCall includes glob and webfetch context in title", () => {
+test("createToolCall includes search and webfetch context in title", () => {
   const glob = createToolCall("tc-g", "Glob", { pattern: "**/*.md", path: "notes" });
   assert.equal(glob.title, "Glob **/*.md in notes");
+
+  const grep = createToolCall("tc-grep", "Grep", {
+    pattern: "TODO",
+    path: "src",
+    glob: "**/*.rs",
+    output_mode: "content",
+    "-i": true,
+    "-C": 2,
+    type: "rust",
+    head_limit: 10,
+    offset: 5,
+    multiline: true,
+  });
+  assert.equal(
+    grep.title,
+    "Grep TODO in src (glob **/*.rs, type rust, content, case-insensitive, context 2, limit 10, offset 5, multiline)",
+  );
 
   const fetch = createToolCall("tc-f", "WebFetch", { url: "https://example.com" });
   assert.equal(fetch.title, "WebFetch https://example.com");
@@ -3845,6 +3931,68 @@ test("buildToolResultFields extracts plain-text output", () => {
   assert.equal(fields.raw_output, "line 1\nline 2");
   assert.deepEqual(fields.content, [
     { type: "content", content: { type: "text", text: "line 1\nline 2" } },
+  ]);
+});
+
+test("buildToolResultFields renders structured Grep output", () => {
+  const base = createToolCall("tc-grep", "Grep", {
+    pattern: "TODO",
+    path: "src",
+    output_mode: "content",
+  });
+  const fields = buildToolResultFields(false, "raw SDK text", base, {
+    mode: "content",
+    numFiles: 2,
+    filenames: ["src/a.rs", "src/b.rs"],
+    content: "src/a.rs:1:TODO\nsrc/b.rs:2:TODO",
+    numLines: 2,
+    numMatches: 2,
+    appliedLimit: 250,
+  });
+
+  const expected =
+    "src/a.rs:1:TODO\nsrc/b.rs:2:TODO\nSummary: 2 files, 2 matches, 2 lines, mode content, limit 250";
+  assert.equal(fields.status, "completed");
+  assert.equal(fields.raw_output, expected);
+  assert.deepEqual(fields.content, [
+    { type: "content", content: { type: "text", text: expected } },
+  ]);
+});
+
+test("buildToolResultFields renders structured empty Grep output", () => {
+  const base = createToolCall("tc-grep-empty", "Grep", {
+    pattern: "<rare string>",
+    output_mode: "content",
+  });
+  const fields = buildToolResultFields(false, "No matches found", base, {
+    mode: "content",
+    numFiles: 0,
+    filenames: [],
+    content: "",
+    numLines: 0,
+  });
+
+  const expected = "No matches found\nSummary: 0 files, 0 lines, mode content";
+  assert.equal(fields.raw_output, expected);
+  assert.deepEqual(fields.content, [
+    { type: "content", content: { type: "text", text: expected } },
+  ]);
+});
+
+test("buildToolResultFields renders structured Glob output", () => {
+  const base = createToolCall("tc-glob", "Glob", { pattern: "**/*.rs", path: "src" });
+  const fields = buildToolResultFields(false, "", base, {
+    durationMs: 12,
+    numFiles: 2,
+    filenames: ["src/main.rs", "src/lib.rs"],
+    truncated: false,
+  });
+
+  const expected = "2 files found\nsrc/main.rs\nsrc/lib.rs\nDuration: 12ms";
+  assert.equal(fields.status, "completed");
+  assert.equal(fields.raw_output, expected);
+  assert.deepEqual(fields.content, [
+    { type: "content", content: { type: "text", text: expected } },
   ]);
 });
 

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -579,6 +579,23 @@ test("handleMcpSetServersCommand emits SDK result", async () => {
         errors: { docs: "connection failed" },
       };
     },
+    mcpServerStatus: async () => [
+      {
+        name: "docs",
+        status: "connected",
+        config: {
+          type: "http",
+          url: "https://example.test/mcp",
+          alwaysLoad: true,
+        },
+        tools: [
+          {
+            name: "read_resource",
+            description: "Read docs resources",
+          },
+        ],
+      },
+    ],
   } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
 
   const events = await captureBridgeEventsAsync(async () => {
@@ -616,6 +633,28 @@ test("handleMcpSetServersCommand emits SDK result", async () => {
         removed: ["plugin:Notion:notion"],
         errors: { docs: "connection failed" },
       },
+    },
+    {
+      request_id: "req-mcp-set",
+      event: "mcp_snapshot",
+      session_id: "session-1",
+      servers: [
+        {
+          name: "docs",
+          status: "connected",
+          config: {
+            type: "http",
+            url: "https://example.test/mcp",
+            always_load: true,
+          },
+          tools: [
+            {
+              name: "read_resource",
+              description: "Read docs resources",
+            },
+          ],
+        },
+      ],
     },
   ]);
 });
@@ -2342,6 +2381,32 @@ test("TaskStop renders structured output and marks the task terminal", () => {
     is_complete_snapshot: false,
   });
   assert.equal(session.taskToolUseIds.has("task-1"), false);
+});
+
+test("TaskStop result for an already-gone task does not create stale task state", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    emitToolCall(session, "tool-stop-missing", "TaskStop", {
+      task_id: "task-missing",
+    });
+    emitToolResultUpdate(session, "tool-stop-missing", false, {
+      message: "Task was already stopped",
+      task_id: "task-missing",
+      task_type: "bash",
+      command: "npm run watch",
+    });
+  });
+
+  const updates = events.map((event) => event.update as Record<string, unknown>);
+  const result = updates.find((update) => {
+    const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+    return toolCallUpdate?.tool_call_id === "tool-stop-missing";
+  })?.tool_call_update as Record<string, unknown> | undefined;
+  const fields = result?.fields as Record<string, unknown> | undefined;
+  assert.equal(fields?.status, "completed");
+  assert.equal(updates.some((update) => update.type === "task_state_update"), false);
+  assert.equal(session.tasksById.has("task-missing"), false);
 });
 
 test("TaskUpdate in-progress result leaves activity rendering to app task state", () => {
@@ -4840,6 +4905,154 @@ test("mapSessionMessagesToUpdates preserves parallel tool results", () => {
   );
 });
 
+test("mapSessionMessagesToUpdates maps task system records from resume history", () => {
+  const updates = mapSessionMessagesToUpdates([
+    {
+      type: "assistant",
+      uuid: "assistant-agent",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "tool-agent",
+            name: "Agent",
+            input: { prompt: "Inspect the migration smoke" },
+          },
+        ],
+      },
+    },
+    {
+      type: "system",
+      uuid: "system-bg-start",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      message: {
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-bg",
+        tool_use_id: "tool-agent",
+        description: "Inspect the migration smoke",
+        subagent_type: "general-purpose",
+      },
+    },
+    {
+      type: "system",
+      uuid: "system-bg-update",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      message: {
+        type: "system",
+        subtype: "task_updated",
+        task_id: "task-bg",
+        patch: {
+          status: "running",
+          description: "Checking runtime MCP resources",
+          is_backgrounded: true,
+        },
+      },
+    },
+    {
+      type: "system",
+      uuid: "system-remote-start",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      message: {
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-remote",
+        description: "Remote agent is still running",
+        task_type: "remote_agent",
+        task_description: "Remote agent smoke",
+        prompt: "Continue remotely",
+      },
+    },
+    {
+      type: "system",
+      uuid: "system-mcp-start",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      message: {
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-mcp",
+        description: "MCP task is still running",
+        task_type: "mcp",
+        workflow_name: "docs",
+        prompt: "Read resource",
+      },
+    },
+  ]);
+
+  const taskUpdates = updates.filter((update) => update.type === "task_state_update");
+  assert.equal(taskUpdates.length, 4);
+  assert.deepEqual(taskUpdates.at(1), {
+    type: "task_state_update",
+    source: "task_lifecycle",
+    tasks: [
+      {
+        task_id: "task-bg",
+        subject: "Inspect the migration smoke",
+        description: "Checking runtime MCP resources",
+        status: "in_progress",
+        blocks: [],
+        blocked_by: [],
+        metadata: {
+          subagent_type: "general-purpose",
+          is_backgrounded: true,
+        },
+        source_tool_call_id: "tool-agent",
+      },
+    ],
+    removed_task_ids: [],
+    is_complete_snapshot: false,
+  });
+  assert.deepEqual(taskUpdates.at(2), {
+    type: "task_state_update",
+    source: "task_lifecycle",
+    tasks: [
+      {
+        task_id: "task-remote",
+        subject: "Remote agent smoke",
+        description: "Remote agent is still running",
+        status: "in_progress",
+        blocks: [],
+        blocked_by: [],
+        metadata: {
+          task_description: "Remote agent smoke",
+          task_type: "remote_agent",
+          prompt: "Continue remotely",
+        },
+      },
+    ],
+    removed_task_ids: [],
+    is_complete_snapshot: false,
+  });
+  assert.deepEqual(taskUpdates.at(3), {
+    type: "task_state_update",
+    source: "task_lifecycle",
+    tasks: [
+      {
+        task_id: "task-mcp",
+        subject: "docs",
+        description: "MCP task is still running",
+        status: "in_progress",
+        blocks: [],
+        blocked_by: [],
+        metadata: {
+          task_type: "mcp",
+          workflow_name: "docs",
+          prompt: "Read resource",
+        },
+      },
+    ],
+    removed_task_ids: [],
+    is_complete_snapshot: false,
+  });
+});
+
 test("handleResultMessage emits terminal reason on successful turn completion", () => {
   const session = makeSessionState();
 
@@ -4877,6 +5090,52 @@ test("handleResultMessage ignores success result telemetry fields", () => {
     event: "turn_complete",
     session_id: "session-1",
   });
+});
+
+test("handleResultMessage emits repeated turn_complete while background work remains open", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    emitToolCall(session, "tool-monitor", "Monitor", {
+      description: "watch deploy logs",
+      timeout_ms: 30000,
+      persistent: false,
+      command: "tail -f deploy.log",
+    });
+    emitToolResultUpdate(session, "tool-monitor", false, {
+      taskId: "monitor-1",
+      timeoutMs: 30000,
+      persistent: false,
+    });
+    handleResultMessage(session, {
+      type: "result",
+      subtype: "success",
+      terminal_reason: "completed",
+    });
+    handleResultMessage(session, {
+      type: "result",
+      subtype: "success",
+      terminal_reason: "completed",
+    });
+  });
+
+  assert.deepEqual(
+    events.filter((event) => event.event === "turn_complete"),
+    [
+      {
+        event: "turn_complete",
+        session_id: "session-1",
+        terminal_reason: "completed",
+      },
+      {
+        event: "turn_complete",
+        session_id: "session-1",
+        terminal_reason: "completed",
+      },
+    ],
+  );
+  assert.equal(session.toolCalls.get("tool-monitor")?.status, "in_progress");
+  assert.equal(session.taskToolUseIds.get("monitor-1"), "tool-monitor");
 });
 
 test("handleResultMessage emits terminal reason on turn errors", () => {
@@ -4966,6 +5225,17 @@ test("mapSessionMessagesToUpdates ignores unsupported records", () => {
       message: {
         role: "assistant",
         content: [{ type: "thinking", thinking: "h" }],
+      },
+    },
+    {
+      type: "system",
+      uuid: "system-unsupported",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      message: {
+        type: "system",
+        subtype: "compact_boundary",
+        content: [{ type: "text", text: "internal system text" }],
       },
     },
   ]);

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -3087,6 +3087,27 @@ test("buildRateLimitUpdate maps SDK fields to wire shape", () => {
   });
 });
 
+test("buildRateLimitUpdate normalizes SDK overage boolean spellings", () => {
+  const cases = [
+    ["old spelling true", { isUsingOverage: true }, true],
+    ["old spelling false", { isUsingOverage: false }, false],
+    ["new spelling true", { overageInUse: true }, true],
+    ["new spelling false", { overageInUse: false }, false],
+    ["both spellings true", { isUsingOverage: true, overageInUse: true }, true],
+    ["both spellings false", { isUsingOverage: false, overageInUse: false }, false],
+    ["conflicting spellings prefer new true", { isUsingOverage: false, overageInUse: true }, true],
+    ["conflicting spellings prefer new false", { isUsingOverage: true, overageInUse: false }, false],
+  ] as const;
+
+  for (const [name, fields, expected] of cases) {
+    const update = buildRateLimitUpdate({
+      status: "allowed",
+      ...fields,
+    });
+    assert.equal(update?.is_using_overage, expected, name);
+  }
+});
+
 test("buildRateLimitUpdate rejects invalid payloads", () => {
   assert.equal(buildRateLimitUpdate(null), null);
   assert.equal(buildRateLimitUpdate({}), null);
@@ -4835,6 +4856,26 @@ test("handleResultMessage emits terminal reason on successful turn completion", 
     event: "turn_complete",
     session_id: "session-1",
     terminal_reason: "completed",
+  });
+});
+
+test("handleResultMessage ignores success result telemetry fields", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleResultMessage(session, {
+      type: "result",
+      subtype: "success",
+      ttft_stream_ms: 42,
+      time_to_request_ms: 12,
+      time_to_request_from_spawn_ms: 7,
+      warm_spare_claimed: true,
+    });
+  });
+
+  assert.deepEqual(events.at(-1), {
+    event: "turn_complete",
+    session_id: "session-1",
   });
 });
 

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -24,7 +24,6 @@ import {
   mapSessionMessagesToUpdates,
   mapSdkSessions,
   agentSdkVersionCompatibilityError,
-  attachRequestUserDialogInterceptor,
   looksLikeAuthRequired,
   normalizeToolResultText,
   parseFastModeState,
@@ -55,8 +54,10 @@ import {
 } from "./bridge/commands.js";
 import {
   emitCurrentModelUpdate,
+  handleUserDialogResponse,
   refreshCurrentModel,
   resolveCurrentModel,
+  sessions,
   shouldInvalidateResolvedRuntimeModel,
   shouldEmitStartupAuthRequiredForAccount,
 } from "./bridge/session_lifecycle.js";
@@ -98,6 +99,7 @@ function makeSessionState(): SessionState {
     taskIdsByToolUseId: new Map(),
     pendingPermissions: new Map(),
     pendingQuestions: new Map(),
+    pendingUserDialogs: new Map(),
     pendingElicitations: new Map(),
     mcpStatusRevalidatedAt: new Map(),
     hiddenToolUseIds: new Set(),
@@ -2592,6 +2594,67 @@ test("parseCommandEnvelope validates question_response command", () => {
       notes: "User note",
     },
   });
+});
+
+test("parseCommandEnvelope validates user_dialog_response selected command", () => {
+  const parsed = parseCommandEnvelope(
+    JSON.stringify({
+      command: "user_dialog_response",
+      session_id: "session-1",
+      request_id: "dialog-1",
+      outcome: {
+        outcome: "selected",
+        option_id: "retry_fallback",
+      },
+    }),
+  );
+
+  assert.equal(parsed.requestId, "dialog-1");
+  assert.equal(parsed.command.command, "user_dialog_response");
+  if (parsed.command.command !== "user_dialog_response") {
+    throw new Error("unexpected command variant");
+  }
+  assert.equal(parsed.command.session_id, "session-1");
+  assert.equal(parsed.command.request_id, "dialog-1");
+  assert.deepEqual(parsed.command.outcome, {
+    outcome: "selected",
+    option_id: "retry_fallback",
+  });
+});
+
+test("parseCommandEnvelope validates user_dialog_response cancelled command", () => {
+  const parsed = parseCommandEnvelope(
+    JSON.stringify({
+      command: "user_dialog_response",
+      session_id: "session-1",
+      request_id: "dialog-1",
+      outcome: { outcome: "cancelled" },
+    }),
+  );
+
+  assert.equal(parsed.command.command, "user_dialog_response");
+  if (parsed.command.command !== "user_dialog_response") {
+    throw new Error("unexpected command variant");
+  }
+  assert.deepEqual(parsed.command.outcome, { outcome: "cancelled" });
+});
+
+test("parseCommandEnvelope rejects unsupported user_dialog_response choices", () => {
+  assert.throws(
+    () =>
+      parseCommandEnvelope(
+        JSON.stringify({
+          command: "user_dialog_response",
+          session_id: "session-1",
+          request_id: "dialog-1",
+          outcome: {
+            outcome: "selected",
+            option_id: "future_choice",
+          },
+        }),
+      ),
+    /user_dialog_response\.outcome\.option_id must be 'retry_fallback' or 'edit_prompt'/,
+  );
 });
 
 test("requestAskUserQuestionAnswers preserves previews and annotations in updated input", async () => {
@@ -5590,131 +5653,185 @@ test("resolveCurrentModel keeps runtime version in short display while using cat
   assert.equal(currentModel.supports_effort, true);
 });
 
-test("attachRequestUserDialogInterceptor rejects request_user_dialog with a stable error", async () => {
-  const calls: Array<{ request_id: string; request: Record<string, unknown> }> = [];
-  const fakeQuery = {
-    async processControlRequest(
-      request: { request_id: string; request: Record<string, unknown> },
-      _signal: AbortSignal,
-    ): Promise<Record<string, unknown>> {
-      calls.push(request);
-      return { ok: true };
-    },
-  } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
+function userDialogHandlerForTest(): NonNullable<Options["onUserDialog"]> {
+  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const options = buildQueryOptions({
+    cwd: "C:/work",
+    launchSettings: { language: "English" },
+    provisionalSessionId: "session-dialog",
+    input,
+    canUseTool: async () => ({ behavior: "deny", message: "not used" }),
+    enableSdkDebug: false,
+    enableSpawnDebug: false,
+    sessionIdForLogs: () => "session-dialog",
+  });
+  assert.deepEqual(options.supportedDialogKinds, ["refusal_fallback_prompt"]);
+  const handler = options.onUserDialog;
+  assert.ok(handler, "expected buildQueryOptions to declare onUserDialog");
+  return handler;
+}
 
-  assert.equal(
-    attachRequestUserDialogInterceptor(fakeQuery, () => "session-test"),
-    true,
-  );
+function registerDialogSession(): SessionState {
+  const session = makeSessionState();
+  session.sessionId = "session-dialog";
+  sessions.set("session-dialog", session);
+  return session;
+}
 
-  await assert.rejects(
-    (fakeQuery as import("@anthropic-ai/claude-agent-sdk").Query & {
-      processControlRequest: (
-        request: { request_id: string; request: Record<string, unknown> },
-        signal: AbortSignal,
-      ) => Promise<Record<string, unknown> | undefined>;
-    }).processControlRequest(
-      {
-        request_id: "dialog-1",
-        request: {
-          subtype: "request_user_dialog",
-          dialog_kind: "computer_use_approval",
-          payload: { title: "Need approval", kind: "computer_use_approval" },
-          tool_use_id: "tool-1",
-        },
-      },
-      new AbortController().signal,
-    ),
-    /request_user_dialog is not supported by claude-rs yet \(dialog_kind: computer_use_approval\)/,
-  );
-  assert.equal(calls.length, 0);
-});
-
-test("attachRequestUserDialogInterceptor preserves non-dialog control requests", async () => {
-  const calls: Array<{ request_id: string; request: Record<string, unknown> }> = [];
-  const fakeQuery = {
-    async processControlRequest(
-      request: { request_id: string; request: Record<string, unknown> },
-      _signal: AbortSignal,
-    ): Promise<Record<string, unknown>> {
-      calls.push(request);
-      return { ok: true };
-    },
-  } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
-
-  attachRequestUserDialogInterceptor(fakeQuery, () => "session-test");
-  const result = await (
-    fakeQuery as import("@anthropic-ai/claude-agent-sdk").Query & {
-      processControlRequest: (
-        request: { request_id: string; request: Record<string, unknown> },
-        signal: AbortSignal,
-      ) => Promise<Record<string, unknown> | undefined>;
-    }
-  ).processControlRequest(
-    {
-      request_id: "permission-1",
-      request: {
-        subtype: "can_use_tool",
-        tool_name: "Bash",
-        input: { command: "dir" },
-        tool_use_id: "tool-1",
-      },
-    },
-    new AbortController().signal,
-  );
-
-  assert.deepEqual(result, { ok: true });
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0]?.request.subtype, "can_use_tool");
-});
-
-test("attachRequestUserDialogInterceptor delegates replayed pending permission requests", async () => {
-  const calls: Array<{ request_id: string; request: Record<string, unknown> }> = [];
-  const fakeQuery = {
-    async processControlRequest(
-      request: { request_id: string; request: Record<string, unknown> },
-      _signal: AbortSignal,
-    ): Promise<Record<string, unknown>> {
-      calls.push(request);
-      return { ok: true };
-    },
-  } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
-
-  const replayedPendingPermission = {
-    request_id: "pending-permission-1",
-    request: {
-      subtype: "can_use_tool",
-      tool_name: "Write",
-      input: {
-        file_path: "C:/work/file.txt",
-        content: "hello",
-      },
-      permission_suggestions: [
+test("onUserDialog round-trips a retry_fallback selection", async () => {
+  const handler = userDialogHandlerForTest();
+  const session = registerDialogSession();
+  try {
+    const events = await captureBridgeEventsAsync(async () => {
+      const resultPromise = handler(
         {
-          type: "addRules",
-          rules: [{ toolName: "Write" }],
-          behavior: "allow",
-          destination: "session",
+          dialogKind: "refusal_fallback_prompt",
+          payload: {
+            originalModel: "claude-opus-4-8",
+            fallbackModel: "claude-sonnet-4-6",
+            guidanceText: "This request was declined.",
+          },
         },
-      ],
-      blocked_path: "C:/work/file.txt",
-      title: "Write file",
-      display_name: "Write",
-      description: "Create or overwrite a file",
-      tool_use_id: "tool-pending-1",
-    },
-  };
+        { signal: new AbortController().signal },
+      );
 
-  attachRequestUserDialogInterceptor(fakeQuery, () => "session-test");
-  const result = await (
-    fakeQuery as import("@anthropic-ai/claude-agent-sdk").Query & {
-      processControlRequest: (
-        request: { request_id: string; request: Record<string, unknown> },
-        signal: AbortSignal,
-      ) => Promise<Record<string, unknown> | undefined>;
-    }
-  ).processControlRequest(replayedPendingPermission, new AbortController().signal);
+      const requestId = [...session.pendingUserDialogs.keys()][0];
+      assert.ok(requestId, "expected a pending user dialog resolver");
 
-  assert.deepEqual(result, { ok: true });
-  assert.deepEqual(calls, [replayedPendingPermission]);
+      handleUserDialogResponse({
+        command: "user_dialog_response",
+        session_id: "session-dialog",
+        request_id: requestId,
+        outcome: { outcome: "selected", option_id: "retry_fallback" },
+      });
+
+      assert.deepEqual(await resultPromise, {
+        behavior: "completed",
+        result: "retry_fallback",
+      });
+    });
+
+    const dialogEvent = events.find((event) => event.event === "user_dialog_request");
+    assert.ok(dialogEvent, "expected a user_dialog_request event");
+    const request = dialogEvent.request as {
+      dialog_kind: string;
+      payload: Record<string, unknown>;
+      options: Array<{ option_id: string; label: string }>;
+    };
+    assert.equal(request.dialog_kind, "refusal_fallback_prompt");
+    assert.equal(request.payload.original_model, "claude-opus-4-8");
+    assert.equal(request.payload.fallback_model, "claude-sonnet-4-6");
+    assert.equal(request.payload.guidance_text, "This request was declined.");
+    assert.deepEqual(
+      request.options.map((option) => option.option_id),
+      ["retry_fallback", "edit_prompt"],
+    );
+    assert.equal(request.options[0].label, "Switch to claude-sonnet-4-6");
+    assert.equal(request.options[1].label, "Edit prompt and retry with claude-opus-4-8");
+  } finally {
+    sessions.delete("session-dialog");
+  }
+});
+
+test("onUserDialog round-trips an edit_prompt selection", async () => {
+  const handler = userDialogHandlerForTest();
+  const session = registerDialogSession();
+  try {
+    const resultPromise = handler(
+      {
+        dialogKind: "refusal_fallback_prompt",
+        payload: { originalModel: "claude-opus-4-8", fallbackModel: "claude-sonnet-4-6" },
+      },
+      { signal: new AbortController().signal },
+    );
+
+    const requestId = [...session.pendingUserDialogs.keys()][0];
+    handleUserDialogResponse({
+      command: "user_dialog_response",
+      session_id: "session-dialog",
+      request_id: requestId,
+      outcome: { outcome: "selected", option_id: "edit_prompt" },
+    });
+
+    assert.deepEqual(await resultPromise, { behavior: "completed", result: "edit_prompt" });
+  } finally {
+    sessions.delete("session-dialog");
+  }
+});
+
+test("onUserDialog cancels when the dialog is aborted", async () => {
+  const handler = userDialogHandlerForTest();
+  const session = registerDialogSession();
+  const controller = new AbortController();
+  try {
+    const resultPromise = handler(
+      {
+        dialogKind: "refusal_fallback_prompt",
+        payload: { originalModel: "claude-opus-4-8", fallbackModel: "claude-sonnet-4-6" },
+      },
+      { signal: controller.signal },
+    );
+
+    assert.equal(session.pendingUserDialogs.size, 1);
+    controller.abort();
+
+    assert.deepEqual(await resultPromise, { behavior: "cancelled" });
+    assert.equal(session.pendingUserDialogs.size, 0);
+  } finally {
+    sessions.delete("session-dialog");
+  }
+});
+
+test("onUserDialog fails closed on an unknown dialog kind without emitting", async () => {
+  const handler = userDialogHandlerForTest();
+  const session = registerDialogSession();
+  try {
+    const events = await captureBridgeEventsAsync(async () => {
+      const result = await handler(
+        { dialogKind: "some_future_dialog_kind", payload: { anything: true } },
+        { signal: new AbortController().signal },
+      );
+      assert.deepEqual(result, { behavior: "cancelled" });
+    });
+
+    assert.equal(
+      events.find((event) => event.event === "user_dialog_request"),
+      undefined,
+    );
+    assert.equal(session.pendingUserDialogs.size, 0);
+  } finally {
+    sessions.delete("session-dialog");
+  }
+});
+
+test("handleUserDialogResponse ignores a duplicate response for a resolved request", async () => {
+  const handler = userDialogHandlerForTest();
+  const session = registerDialogSession();
+  try {
+    const resultPromise = handler(
+      {
+        dialogKind: "refusal_fallback_prompt",
+        payload: { originalModel: "claude-opus-4-8", fallbackModel: "claude-sonnet-4-6" },
+      },
+      { signal: new AbortController().signal },
+    );
+
+    const requestId = [...session.pendingUserDialogs.keys()][0];
+    const response = {
+      command: "user_dialog_response" as const,
+      session_id: "session-dialog",
+      request_id: requestId,
+      outcome: { outcome: "selected" as const, option_id: "retry_fallback" as const },
+    };
+
+    handleUserDialogResponse(response);
+    assert.deepEqual(await resultPromise, { behavior: "completed", result: "retry_fallback" });
+
+    // A replayed pending_user_dialog_requests entry with the same id must be a
+    // no-op now that the resolver is gone.
+    assert.equal(session.pendingUserDialogs.has(requestId), false);
+    assert.doesNotThrow(() => handleUserDialogResponse(response));
+  } finally {
+    sessions.delete("session-dialog");
+  }
 });

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -1247,7 +1247,7 @@ test("handleTaskSystemMessage falls back to description and last tool when progr
   });
 });
 
-test("handleTaskSystemMessage final summary replaces prior task content and finalizes status", () => {
+test("handleTaskSystemMessage keeps Agent completed notification provisional until tool result", () => {
   const session = makeSessionState();
 
   const events = captureBridgeEvents(() => {
@@ -1276,7 +1276,6 @@ test("handleTaskSystemMessage final summary replaces prior task content and fina
     tool_call_update: {
       tool_call_id: "tool-1",
       fields: {
-        status: "completed",
         raw_output: "Found the auth bug and prepared the fix",
         content: [
           {
@@ -1291,7 +1290,59 @@ test("handleTaskSystemMessage final summary replaces prior task content and fina
       },
     },
   });
+  assert.equal(session.toolCalls.get("tool-1")?.status, "in_progress");
+  assert.equal(session.taskToolUseIds.get("task-1"), "tool-1");
+  assert.equal(session.taskIdsByToolUseId.get("tool-1"), "task-1");
+});
+
+test("emitToolResultUpdate finalizes deferred Agent completion and unlinks lifecycle task", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleTaskSystemMessage(session, "task_started", {
+      task_id: "task-1",
+      tool_use_id: "tool-1",
+      description: "Initial task description",
+    });
+    handleTaskSystemMessage(session, "task_notification", {
+      task_id: "task-1",
+      status: "completed",
+      summary: "Found the auth bug and prepared the fix",
+    });
+    emitToolResultUpdate(session, "tool-1", false, {
+      agentId: "agent-1",
+      agentType: "general-purpose",
+      resolvedModel: "claude-opus-4-8",
+      content: [{ type: "text", text: "Done" }],
+      status: "completed",
+      prompt: "Review the branch",
+    });
+  });
+
+  const lastEvent = events.at(-1);
+  assert.ok(lastEvent);
+  assert.equal(lastEvent.event, "session_update");
+  const update = lastEvent.update as Record<string, unknown>;
+  assert.equal(update.type, "tool_call_update");
+  const toolCallUpdate = update.tool_call_update as Record<string, unknown>;
+  const fields = toolCallUpdate.fields as Record<string, unknown>;
+  assert.equal(toolCallUpdate.tool_call_id, "tool-1");
+  assert.equal(fields.status, "completed");
+  assert.deepEqual(fields.output_metadata, {
+    agent: {
+      resolved_model: "claude-opus-4-8",
+    },
+  });
+
+  const toolCall = session.toolCalls.get("tool-1");
+  assert.equal(toolCall?.status, "completed");
+  assert.deepEqual(toolCall?.output_metadata, {
+    agent: {
+      resolved_model: "claude-opus-4-8",
+    },
+  });
   assert.equal(session.taskToolUseIds.has("task-1"), false);
+  assert.equal(session.taskIdsByToolUseId.has("tool-1"), false);
 });
 
 test("handleTaskSystemMessage ignores lifecycle content for concrete output tools", () => {
@@ -1724,6 +1775,94 @@ test("handleSdkMessage refreshes Grep title when final assistant snapshot carrie
       },
     },
   ]);
+});
+
+test("handleSdkMessage refreshes Agent title when final assistant snapshot carries input", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "stream_event",
+      uuid: "assistant-stream",
+      session_id: "session-1",
+      event: {
+        type: "content_block_start",
+        content_block: {
+          type: "tool_use",
+          id: "tool-agent",
+          name: "Agent",
+          input: {},
+        },
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "assistant",
+      uuid: "assistant-final",
+      session_id: "session-1",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "tool-agent",
+            name: "Agent",
+            input: {
+              description: "review changes",
+              prompt: "Review the branch",
+              name: "review-worker",
+              subagent_type: "general-purpose",
+              model: "opus",
+            },
+          },
+        ],
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    {
+      type: "tool_call",
+      tool_call: {
+        tool_call_id: "tool-agent",
+        title: "Agent",
+        kind: "think",
+        status: "in_progress",
+        source_message_uuid: "assistant-stream",
+        content: [],
+        raw_input: {},
+        locations: [],
+        meta: { claudeCode: { toolName: "Agent", parentToolUseId: null } },
+      },
+    },
+    {
+      type: "tool_call_update",
+      tool_call_update: {
+        tool_call_id: "tool-agent",
+        source_message_uuid: "assistant-final",
+        fields: {
+          title: "Agent: review-worker",
+          kind: "think",
+          status: "in_progress",
+          raw_input: {
+            description: "review changes",
+            prompt: "Review the branch",
+            name: "review-worker",
+            subagent_type: "general-purpose",
+            model: "opus",
+          },
+          locations: [],
+          meta: { claudeCode: { toolName: "Agent", parentToolUseId: null } },
+        },
+      },
+    },
+  ]);
+  assert.deepEqual(session.toolCalls.get("tool-agent")?.raw_input, {
+    description: "review changes",
+    prompt: "Review the branch",
+    name: "review-worker",
+    subagent_type: "general-purpose",
+    model: "opus",
+  });
 });
 
 test("handleTaskSystemMessage applies task_updated description patches to the linked task", () => {
@@ -3092,6 +3231,9 @@ test("normalizeToolKind maps known tool names", () => {
   assert.equal(normalizeToolKind("REPL"), "other");
   assert.equal(normalizeToolKind("Monitor"), "other");
   assert.equal(normalizeToolKind("Workflow"), "other");
+  assert.equal(normalizeToolKind("Projects"), "other");
+  assert.equal(normalizeToolKind("Artifact"), "other");
+  assert.equal(normalizeToolKind("ShowOnboardingRolePicker"), "other");
   assert.equal(normalizeToolKind("TaskOutput"), "other");
   assert.equal(normalizeToolKind("TaskStop"), "other");
   assert.equal(normalizeToolKind("Task"), "think");
@@ -4025,6 +4167,30 @@ test("createToolCall includes search and webfetch context in title", () => {
   assert.equal(fetch.title, "WebFetch https://example.com");
 });
 
+test("createToolCall builds Agent title from name and type without description fallback", () => {
+  const named = createToolCall("tc-agent-name", "Agent", {
+    description: "review changes",
+    prompt: "Review the branch",
+    name: " review-worker ",
+    subagent_type: " general-purpose ",
+    model: " opus ",
+  });
+  const typed = createToolCall("tc-agent-type", "Agent", {
+    description: "inspect state",
+    prompt: "Inspect the runtime",
+    subagent_type: " general-purpose ",
+    model: " sonnet ",
+  });
+  const describedOnly = createToolCall("tc-agent-description", "Agent", {
+    description: "should not become title",
+    prompt: "Review",
+  });
+
+  assert.equal(named.title, "Agent: review-worker");
+  assert.equal(typed.title, "Agent: general-purpose");
+  assert.equal(describedOnly.title, "Agent");
+});
+
 test("createToolCall builds worktree titles from input rules", () => {
   const namedEnter = createToolCall("tc-enter-name", "EnterWorktree", { name: "feature-auth" });
   assert.equal(namedEnter.kind, "other");
@@ -4141,6 +4307,40 @@ test("createToolCall maps Workflow to other kind and name title", () => {
   assert.equal(namedWorkflow.title, "Workflow: spec");
   assert.equal(fallbackWorkflow.kind, "other");
   assert.equal(fallbackWorkflow.title, "Workflow");
+});
+
+test("createToolCall maps project and artifact tools to compact titles", () => {
+  const projectInfo = createToolCall("tc-project-info", "Projects", {
+    method: "project_info",
+  });
+  const projectRead = createToolCall("tc-project-read", "Projects", {
+    method: "project_read",
+    path: "claude/notes.md",
+  });
+  const projectSearch = createToolCall("tc-project-search", "Projects", {
+    method: "project_search",
+    query: "migration",
+  });
+  const artifactWithLabel = createToolCall("tc-artifact-label", "Artifact", {
+    file_path: "C:/work/report.html",
+    favicon: "R",
+    label: "report-v2",
+  });
+  const artifactFallback = createToolCall("tc-artifact-path", "Artifact", {
+    file_path: "C:/work/report.html",
+    favicon: "R",
+  });
+  const rolePicker = createToolCall("tc-role-picker", "ShowOnboardingRolePicker", {});
+
+  assert.equal(projectInfo.kind, "other");
+  assert.equal(projectInfo.title, "Projects: info");
+  assert.equal(projectRead.title, "Projects: read claude/notes.md");
+  assert.equal(projectSearch.title, "Projects: search migration");
+  assert.equal(artifactWithLabel.kind, "other");
+  assert.equal(artifactWithLabel.title, "Artifact: report-v2");
+  assert.equal(artifactFallback.title, "Artifact: C:/work/report.html");
+  assert.equal(rolePicker.kind, "other");
+  assert.equal(rolePicker.title, "ShowOnboardingRolePicker");
 });
 
 test("createToolCall maps EnterPlanMode to switch_mode kind with stable title", () => {
@@ -4503,6 +4703,130 @@ test("buildToolResultFields restores ReadMcpResource blob paths from transcript 
       blob_saved_to: "C:\\tmp\\manual.pdf",
     },
   ]);
+});
+
+test("buildToolResultFields marks ReadMcpResource error output as failed", () => {
+  const base = createToolCall("tc-mcp-error", "ReadMcpResource", {
+    server: "docs",
+    uri: "file://missing.md",
+  });
+  const fields = buildToolResultFields(
+    false,
+    {
+      contents: [],
+      error: "resource not found",
+    },
+    base,
+  );
+
+  assert.equal(fields.status, "failed");
+  assert.equal(fields.raw_output, "Error: resource not found");
+  assert.deepEqual(fields.content, [
+    {
+      type: "content",
+      content: { type: "text", text: "Error: resource not found" },
+    },
+  ]);
+});
+
+test("buildToolResultFields preserves WebFetch artifactRead only as metadata", () => {
+  const base = createToolCall("tc-web-fetch-artifact", "WebFetch", {
+    url: "https://artifact.local/dashboard",
+  });
+  const fields = buildToolResultFields(
+    false,
+    {
+      bytes: 128,
+      code: 200,
+      codeText: "OK",
+      durationMs: 42,
+      result: "Artifact content summary",
+      url: "https://artifact.local/dashboard",
+      artifactRead: {
+        slug: "dashboard",
+        ver: "v3",
+      },
+    },
+    base,
+  );
+
+  assert.equal(fields.raw_output, "Artifact content summary");
+  assert.equal(fields.raw_output?.includes("artifactRead"), false);
+  assert.deepEqual(fields.output_metadata, {
+    web_fetch: {
+      artifact_read: {
+        slug: "dashboard",
+        ver: "v3",
+      },
+    },
+  });
+});
+
+test("buildToolResultFields preserves Agent resolvedModel metadata", () => {
+  const base = createToolCall("tc-agent-model", "Agent", {
+    description: "review changes",
+    prompt: "Review the branch",
+  });
+  const fields = buildToolResultFields(
+    false,
+    {
+      agentId: "agent-1",
+      agentType: "reviewer",
+      resolvedModel: "claude-sonnet-4-7",
+      content: [{ type: "text", text: "Done" }],
+      totalToolUseCount: 1,
+      totalDurationMs: 100,
+      totalTokens: 25,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 15,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+        server_tool_use: null,
+        service_tier: null,
+        cache_creation: null,
+      },
+      status: "completed",
+      prompt: "Review the branch",
+    },
+    base,
+  );
+
+  assert.equal(fields.title, "Agent: reviewer");
+  assert.deepEqual(fields.output_metadata, {
+    agent: {
+      resolved_model: "claude-sonnet-4-7",
+    },
+  });
+});
+
+test("buildToolResultFields keeps Agent input name while preserving resolvedModel metadata", () => {
+  const base = createToolCall("tc-agent-named-model", "Agent", {
+    description: "review changes",
+    prompt: "Review the branch",
+    name: "review-worker",
+    subagent_type: "general-purpose",
+    model: "opus",
+  });
+  const fields = buildToolResultFields(
+    false,
+    {
+      agentId: "agent-1",
+      agentType: "general-purpose",
+      resolvedModel: "claude-opus-4-8",
+      content: [{ type: "text", text: "Done" }],
+      status: "completed",
+      prompt: "Review the branch",
+    },
+    base,
+  );
+
+  assert.equal(fields.title, undefined);
+  assert.deepEqual(fields.output_metadata, {
+    agent: {
+      resolved_model: "claude-opus-4-8",
+    },
+  });
 });
 
 test("unwrapToolUseResult extracts error/content payload", () => {
@@ -5353,7 +5677,7 @@ test("buildToolResultFields uses Agent output agentType as task title", () => {
     base,
   );
 
-  assert.equal(fields.title, "reviewer");
+  assert.equal(fields.title, "Agent: reviewer");
 });
 
 test("buildToolResultFields reads array-wrapped Agent output agentType", () => {
@@ -5374,7 +5698,7 @@ test("buildToolResultFields reads array-wrapped Agent output agentType", () => {
     },
   );
 
-  assert.equal(fields.title, "planner");
+  assert.equal(fields.title, "Agent: planner");
 });
 
 test("buildToolResultFields leaves worktree title unchanged on completed output", () => {
@@ -5903,6 +6227,8 @@ test("buildToolResultFields renders Workflow launch output as structured text", 
     {
       status: "async_launched",
       taskId: "workflow-1",
+      taskType: "local_workflow",
+      workflowName: "spec",
       runId: "run-1",
       summary: "Workflow started",
       transcriptDir: "C:/tmp/transcripts",
@@ -5915,7 +6241,7 @@ test("buildToolResultFields renders Workflow launch output as structured text", 
   assert.equal(fields.status, "in_progress");
   assert.equal(
     fields.raw_output,
-    "Status: async launched\nTask ID: workflow-1\nRun ID: run-1\nSummary: Workflow started\nTranscript dir: C:/tmp/transcripts\nScript path: C:/tmp/workflow.js\nWarning: branch diverged",
+    "Status: async launched\nTask ID: workflow-1\nTask type: local_workflow\nWorkflow name: spec\nRun ID: run-1\nSummary: Workflow started\nTranscript dir: C:/tmp/transcripts\nScript path: C:/tmp/workflow.js\nWarning: branch diverged",
   );
   assert.equal(fields.raw_output?.includes("{"), false);
   assert.equal(fields.raw_output?.includes('"status"'), false);

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -437,7 +437,15 @@ test("parseCommandEnvelope validates mcp_set_servers command", () => {
           tools: [
             {
               name: "search",
+            },
+            {
+              name: "read",
               permission_policy: "always_ask",
+            },
+            {
+              name: "write",
+              permission_policy: "always_deny",
+              org_max_permission: "ask",
             },
           ],
         },
@@ -463,7 +471,15 @@ test("parseCommandEnvelope validates mcp_set_servers command", () => {
       tools: [
         {
           name: "search",
+        },
+        {
+          name: "read",
           permission_policy: "always_ask",
+        },
+        {
+          name: "write",
+          permission_policy: "always_deny",
+          org_max_permission: "ask",
         },
       ],
     },
@@ -471,6 +487,24 @@ test("parseCommandEnvelope validates mcp_set_servers command", () => {
 });
 
 test("parseCommandEnvelope rejects invalid latest MCP config fields", () => {
+  assert.throws(
+    () =>
+      parseCommandEnvelope(
+        JSON.stringify({
+          command: "mcp_set_servers",
+          session_id: "session-123",
+          servers: {
+            bad: {
+              type: "http",
+              url: "https://mcp.example.com",
+              tools: [{ name: "read", org_max_permission: "deny" }],
+            },
+          },
+        }),
+      ),
+    /org_max_permission must be one of allow, ask, blocked/,
+  );
+
   assert.throws(
     () =>
       parseCommandEnvelope(
@@ -539,14 +573,20 @@ test("bridgeMcpConfigToSdk maps latest MCP fields to SDK casing", () => {
       url: "https://mcp.example.com/sse",
       timeout: 2500,
       always_load: true,
-      tools: [{ name: "search", permission_policy: "always_allow" }],
+      tools: [
+        { name: "search" },
+        { name: "write", permission_policy: "always_allow", org_max_permission: "blocked" },
+      ],
     }),
     {
       type: "sse",
       url: "https://mcp.example.com/sse",
       timeout: 2500,
       alwaysLoad: true,
-      tools: [{ name: "search", permission_policy: "always_allow" }],
+      tools: [
+        { name: "search" },
+        { name: "write", permission_policy: "always_allow", org_max_permission: "blocked" },
+      ],
     },
   );
 });
@@ -561,7 +601,10 @@ test("mapMcpServerStatus preserves latest MCP status config fields", () => {
       headers: { Authorization: "Bearer token" },
       timeout: 5000,
       alwaysLoad: true,
-      tools: [{ name: "search", permission_policy: "always_deny" }],
+      tools: [
+        { name: "search" },
+        { name: "write", permission_policy: "always_deny", org_max_permission: "ask" },
+      ],
     },
     tools: [],
   });
@@ -572,7 +615,10 @@ test("mapMcpServerStatus preserves latest MCP status config fields", () => {
     headers: { Authorization: "Bearer token" },
     timeout: 5000,
     always_load: true,
-    tools: [{ name: "search", permission_policy: "always_deny" }],
+    tools: [
+      { name: "search" },
+      { name: "write", permission_policy: "always_deny", org_max_permission: "ask" },
+    ],
   });
 });
 

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -42,6 +42,7 @@ import {
   resolveInstalledAgentSdkVersion,
   unwrapToolUseResult,
   updateAvailableCommands,
+  handleReloadPluginsCommand,
 } from "./bridge.js";
 import type { SessionState } from "./bridge.js";
 import type { Options } from "@anthropic-ai/claude-agent-sdk";
@@ -638,6 +639,7 @@ test("handleMcpSetServersCommand emits SDK result", async () => {
       request_id: "req-mcp-set",
       event: "mcp_snapshot",
       session_id: "session-1",
+      source: "mcp_set_servers",
       servers: [
         {
           name: "docs",
@@ -777,6 +779,139 @@ test("parseCommandEnvelope validates reload_plugins command", () => {
     command: "reload_plugins",
     session_id: "session-123",
   });
+});
+
+test("handleReloadPluginsCommand emits MCP snapshot from reload result", async () => {
+  const session = makeSessionState();
+  let mcpServerStatusCalls = 0;
+  session.query = {
+    reloadPlugins: async () => ({
+      commands: [],
+      agents: [],
+      plugins: [],
+      mcpServers: [
+        {
+          name: "docs",
+          status: "connected",
+          config: {
+            type: "http",
+            url: "https://example.test/mcp",
+          },
+          tools: [],
+        },
+      ],
+      error_count: 0,
+    }),
+    mcpServerStatus: async () => {
+      mcpServerStatusCalls += 1;
+      throw new Error("mcpServerStatus should not be called");
+    },
+  } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
+
+  const events = await captureBridgeEventsAsync(async () => {
+    await handleReloadPluginsCommand(session, "req-reload");
+  });
+
+  assert.equal(mcpServerStatusCalls, 0);
+  assert.deepEqual(
+    events.filter((event) => event.event === "mcp_snapshot"),
+    [
+      {
+        request_id: "req-reload",
+        event: "mcp_snapshot",
+        session_id: "session-1",
+        source: "reload_plugins",
+        servers: [
+          {
+            name: "docs",
+            status: "connected",
+            config: {
+              type: "http",
+              url: "https://example.test/mcp",
+            },
+            tools: [],
+          },
+        ],
+      },
+    ],
+  );
+  assert.deepEqual(
+    events.filter((event) => event.event === "runtime_reload_completed"),
+    [
+      {
+        request_id: "req-reload",
+        event: "runtime_reload_completed",
+        session_id: "session-1",
+      },
+    ],
+  );
+});
+
+test("handleReloadPluginsCommand revalidates stale MCP auth statuses", async () => {
+  const session = makeSessionState();
+  const serverName = "reload-auth-revalidation";
+  let reloadCalls = 0;
+  let mcpServerStatusCalls = 0;
+  const reconnectCalls: string[] = [];
+  const connectedServer = {
+    name: serverName,
+    status: "connected" as const,
+    config: {
+      type: "http" as const,
+      url: "https://example.test/mcp",
+    },
+    tools: [],
+  };
+
+  session.query = {
+    reloadPlugins: async () => {
+      reloadCalls += 1;
+      return {
+        commands: [],
+        agents: [],
+        plugins: [],
+        mcpServers:
+          reloadCalls === 1
+            ? [connectedServer]
+            : [
+                {
+                  ...connectedServer,
+                  status: "needs-auth" as const,
+                },
+              ],
+        error_count: 0,
+      };
+    },
+    reconnectMcpServer: async (name: string) => {
+      reconnectCalls.push(name);
+    },
+    mcpServerStatus: async () => {
+      mcpServerStatusCalls += 1;
+      return [connectedServer];
+    },
+  } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
+
+  await captureBridgeEventsAsync(async () => {
+    await handleReloadPluginsCommand(session, "req-reload-seed");
+  });
+  const events = await captureBridgeEventsAsync(async () => {
+    await handleReloadPluginsCommand(session, "req-reload");
+  });
+
+  assert.deepEqual(reconnectCalls, [serverName]);
+  assert.equal(mcpServerStatusCalls, 1);
+  assert.deepEqual(
+    events.filter((event) => event.event === "mcp_snapshot"),
+    [
+      {
+        request_id: "req-reload",
+        event: "mcp_snapshot",
+        session_id: "session-1",
+        source: "reload_plugins",
+        servers: [connectedServer],
+      },
+    ],
+  );
 });
 
 test("parseCommandEnvelope validates get_context_usage command", () => {
@@ -2909,6 +3044,7 @@ test("handleSdkMessage emits MCP snapshot from init status payload", () => {
   assert.deepEqual(snapshot, {
     event: "mcp_snapshot",
     session_id: "session-1",
+    source: "init",
     servers: [
       {
         name: "docs",

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -327,7 +327,9 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
         setSessionListingDir(matched.cwd ?? process.cwd());
         const historyMessages = await getSessionMessages(
           command.session_id,
-          matched.cwd ? { dir: matched.cwd } : undefined,
+          matched.cwd
+            ? { dir: matched.cwd, includeSystemMessages: true }
+            : { includeSystemMessages: true },
         );
         const resumeUpdates = mapSessionMessagesToUpdates(historyMessages);
         const staleSessions = Array.from(sessions.values());

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -42,6 +42,7 @@ import {
   emitCurrentModelUpdate,
   refreshCurrentModel,
   shouldInvalidateResolvedRuntimeModel,
+  type SessionState,
 } from "./bridge/session_lifecycle.js";
 import { mapSessionMessagesToUpdates } from "./bridge/history.js";
 import { emitAvailableAgentsIfChanged, mapAvailableAgents } from "./bridge/agents.js";
@@ -49,6 +50,7 @@ import { mapSdkSlashCommands, updateAvailableCommands } from "./bridge/available
 import { mapSdkAccountInfo } from "./bridge/account_metadata.js";
 import {
   MCP_STALE_STATUS_REVALIDATION_COOLDOWN_MS,
+  emitReconciledMcpSnapshotFromStatuses,
   handleMcpAuthenticateCommand,
   handleMcpClearAuthCommand,
   handleMcpOauthCallbackUrlCommand,
@@ -215,6 +217,36 @@ export function agentSdkVersionCompatibilityError(): string | undefined {
     `Unsupported @anthropic-ai/claude-agent-sdk version: expected ${EXPECTED_AGENT_SDK_VERSION}, ` +
     `found ${installed}.`
   );
+}
+
+export async function handleReloadPluginsCommand(
+  session: SessionState,
+  requestId?: string,
+): Promise<void> {
+  try {
+    const result = await session.query.reloadPlugins();
+    updateAvailableCommands(session, "reload_plugins", mapSdkSlashCommands(result.commands));
+    emitAvailableAgentsIfChanged(session, mapAvailableAgents(result.agents));
+    await emitReconciledMcpSnapshotFromStatuses(
+      session,
+      result.mcpServers,
+      "reload_plugins",
+      requestId,
+    );
+    emitRuntimeReloadCompleted(session.sessionId, requestId);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    bridgeLogger.warn({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "reload_plugins_failed",
+      message: "failed to reload session plugins",
+      outcome: "failure",
+      ...(requestId ? { requestId } : {}),
+      sessionId: session.sessionId,
+      fields: { error_message: message },
+    });
+    emitRuntimeReloadFailed(session.sessionId, message, requestId);
+  }
 }
 
 async function handleCommand(command: BridgeCommand, requestId?: string): Promise<void> {
@@ -731,25 +763,7 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
         slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
         return;
       }
-      try {
-        const result = await session.query.reloadPlugins();
-        updateAvailableCommands(session, "reload_plugins", mapSdkSlashCommands(result.commands));
-        emitAvailableAgentsIfChanged(session, mapAvailableAgents(result.agents));
-        await handleMcpStatusCommand(session, requestId);
-        emitRuntimeReloadCompleted(session.sessionId, requestId);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        bridgeLogger.warn({
-          target: LOG_TARGETS.APP_SESSION,
-          eventName: "reload_plugins_failed",
-          message: "failed to reload session plugins",
-          outcome: "failure",
-          ...(requestId ? { requestId } : {}),
-          sessionId: session.sessionId,
-          fields: { error_message: message },
-        });
-        emitRuntimeReloadFailed(session.sessionId, message, requestId);
-      }
+      await handleReloadPluginsCommand(session, requestId);
       return;
     }
 

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -188,7 +188,7 @@ export function emitAgentConfigOptionUpdate(sessionId: string, agent: string | n
   });
 }
 
-const EXPECTED_AGENT_SDK_VERSION = "0.3.161";
+const EXPECTED_AGENT_SDK_VERSION = "0.3.177";
 const require = createRequire(import.meta.url);
 
 export function resolveInstalledAgentSdkVersion(): string | undefined {

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -38,6 +38,7 @@ import {
   handleElicitationResponse,
   handlePermissionResponse,
   handleQuestionResponse,
+  handleUserDialogResponse,
   emitCurrentModelUpdate,
   refreshCurrentModel,
   shouldInvalidateResolvedRuntimeModel,
@@ -88,10 +89,7 @@ export {
 } from "./bridge/history.js";
 export { handleSdkMessage, handleTaskSystemMessage } from "./bridge/message_handlers.js";
 export { mapAvailableAgents } from "./bridge/agents.js";
-export {
-  attachRequestUserDialogInterceptor,
-  buildQueryOptions,
-} from "./bridge/session_lifecycle.js";
+export { buildQueryOptions } from "./bridge/session_lifecycle.js";
 export { mapAvailableModels } from "./bridge/model_metadata.js";
 export {
   bridgeMcpConfigToSdk,
@@ -829,6 +827,10 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
 
     case "question_response":
       handleQuestionResponse(command);
+      return;
+
+    case "user_dialog_response":
+      handleUserDialogResponse(command);
       return;
 
     case "elicitation_response":

--- a/agent-sdk/src/bridge/commands.ts
+++ b/agent-sdk/src/bridge/commands.ts
@@ -9,7 +9,9 @@ import type {
   ModeState,
   PermissionOutcome,
   QuestionOutcome,
+  RefusalFallbackPromptChoice,
   SessionLaunchSettings,
+  UserDialogOutcome,
 } from "../types.js";
 import { parseMcpServersRecord } from "./mcp_metadata.js";
 import type { SessionState } from "./session_lifecycle.js";
@@ -275,6 +277,18 @@ function expectBoolean(
   return value;
 }
 
+function expectRefusalFallbackPromptChoice(
+  record: Record<string, unknown>,
+  key: string,
+  context: string,
+): RefusalFallbackPromptChoice {
+  const value = expectString(record, key, context);
+  if (value !== "retry_fallback" && value !== "edit_prompt") {
+    throw new Error(`${context}.${key} must be 'retry_fallback' or 'edit_prompt'`);
+  }
+  return value;
+}
+
 export function parseCommandEnvelope(line: string): { requestId?: string; command: BridgeCommand } {
   const raw = asRecord(JSON.parse(line) as BridgeCommandEnvelope, "command envelope");
   const requestId = typeof raw.request_id === "string" ? raw.request_id : undefined;
@@ -440,6 +454,30 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
           command: "question_response",
           session_id: expectString(raw, "session_id", "question_response"),
           tool_call_id: expectString(raw, "tool_call_id", "question_response"),
+          outcome: parsedOutcome,
+        };
+      }
+      case "user_dialog_response": {
+        const outcome = asRecord(raw.outcome, "user_dialog_response.outcome");
+        const outcomeType = expectString(outcome, "outcome", "user_dialog_response.outcome");
+        if (outcomeType !== "selected" && outcomeType !== "cancelled") {
+          throw new Error("user_dialog_response.outcome.outcome must be 'selected' or 'cancelled'");
+        }
+        const parsedOutcome: UserDialogOutcome =
+          outcomeType === "selected"
+            ? {
+                outcome: "selected",
+                option_id: expectRefusalFallbackPromptChoice(
+                  outcome,
+                  "option_id",
+                  "user_dialog_response.outcome",
+                ),
+              }
+            : { outcome: "cancelled" };
+        return {
+          command: "user_dialog_response",
+          session_id: expectString(raw, "session_id", "user_dialog_response"),
+          request_id: expectString(raw, "request_id", "user_dialog_response"),
           outcome: parsedOutcome,
         };
       }

--- a/agent-sdk/src/bridge/events.ts
+++ b/agent-sdk/src/bridge/events.ts
@@ -107,6 +107,28 @@ export function emitQuestionRequestEvent(
   writeEvent({ event: "question_request", session_id: sessionId, request });
 }
 
+export function emitUserDialogRequestEvent(
+  sessionId: string,
+  request: Extract<BridgeEvent, { event: "user_dialog_request" }>["request"],
+): void {
+  bridgeLogger.info({
+    target: LOG_TARGETS.BRIDGE_PERMISSION,
+    eventName: "user_dialog_request_emitted",
+    message: "user dialog request emitted",
+    outcome: "success",
+    sessionId,
+    requestId: request.request_id,
+    count: request.options.length,
+    fields: {
+      dialog_kind: request.dialog_kind,
+      option_count: request.options.length,
+      original_model: request.payload.original_model,
+      fallback_model: request.payload.fallback_model,
+    },
+  });
+  writeEvent({ event: "user_dialog_request", session_id: sessionId, request });
+}
+
 export function emitElicitationRequestEvent(
   sessionId: string,
   request: Extract<BridgeEvent, { event: "elicitation_request" }>["request"],

--- a/agent-sdk/src/bridge/history.ts
+++ b/agent-sdk/src/bridge/history.ts
@@ -1,5 +1,5 @@
 import type { SDKSessionInfo, SessionMessage } from "@anthropic-ai/claude-agent-sdk";
-import type { SessionListEntry, SessionUpdate, ToolCall } from "../types.js";
+import type { Json, SessionListEntry, SessionUpdate, TaskItem, TaskStatus, ToolCall } from "../types.js";
 import { asRecordOrNull } from "./shared.js";
 import {
   TOOL_RESULT_TYPES,
@@ -29,6 +29,173 @@ function messageCandidates(raw: unknown): Record<string, unknown>[] {
     }
   }
   return candidates;
+}
+
+function jsonValue(value: unknown): Json | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  try {
+    const text = JSON.stringify(value);
+    if (text === undefined) {
+      return undefined;
+    }
+    return JSON.parse(text) as Json;
+  } catch {
+    return undefined;
+  }
+}
+
+function mergeTaskMetadata(
+  existing: Json | undefined,
+  patch: Record<string, Json> | undefined,
+): Json | undefined {
+  if (!patch) {
+    return existing;
+  }
+  const existingRecord =
+    existing && typeof existing === "object" && !Array.isArray(existing)
+      ? { ...(existing as Record<string, Json>) }
+      : {};
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete existingRecord[key];
+    } else {
+      existingRecord[key] = value;
+    }
+  }
+  return Object.keys(existingRecord).length > 0 ? existingRecord : null;
+}
+
+function normalizeLifecycleTaskStatus(value: unknown): TaskStatus | undefined {
+  switch (value) {
+    case "pending":
+      return "pending";
+    case "running":
+    case "in_progress":
+      return "in_progress";
+    case "completed":
+    case "failed":
+    case "killed":
+    case "stopped":
+      return "completed";
+    default:
+      return undefined;
+  }
+}
+
+function taskSystemMetadata(
+  msg: Record<string, unknown>,
+  patch: Record<string, unknown> | undefined,
+): Record<string, Json> | undefined {
+  const metadata: Record<string, Json> = {};
+  const copyValue = (from: Record<string, unknown> | undefined, key: string): void => {
+    if (!from || !Object.hasOwn(from, key)) {
+      return;
+    }
+    const value = jsonValue(from[key]);
+    if (value !== undefined) {
+      metadata[key] = value;
+    }
+  };
+
+  for (const key of [
+    "error",
+    "is_backgrounded",
+    "request_id",
+    "subagent_type",
+    "task_description",
+    "task_type",
+    "workflow_name",
+    "prompt",
+    "output_file",
+    "summary",
+    "end_time",
+    "total_paused_ms",
+  ]) {
+    copyValue(msg, key);
+    copyValue(patch, key);
+  }
+  const terminalStatus = nonEmptyTrimmed(msg.status) ?? nonEmptyTrimmed(patch?.status);
+  if (
+    terminalStatus === "completed" ||
+    terminalStatus === "failed" ||
+    terminalStatus === "killed" ||
+    terminalStatus === "stopped"
+  ) {
+    metadata.terminal_status = terminalStatus;
+  }
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+function pushResumeTaskSystemUpdate(
+  updates: SessionUpdate[],
+  tasksById: Map<string, TaskItem>,
+  taskToolUseIds: Map<string, string>,
+  msg: Record<string, unknown>,
+): boolean {
+  const subtype = nonEmptyTrimmed(msg.subtype);
+  if (
+    subtype !== "task_started" &&
+    subtype !== "task_progress" &&
+    subtype !== "task_updated" &&
+    subtype !== "task_notification"
+  ) {
+    return false;
+  }
+
+  const taskId = nonEmptyTrimmed(msg.task_id);
+  if (!taskId) {
+    return true;
+  }
+  const explicitToolUseId = nonEmptyTrimmed(msg.tool_use_id);
+  if (explicitToolUseId) {
+    taskToolUseIds.set(taskId, explicitToolUseId);
+  }
+
+  const existing = tasksById.get(taskId);
+  const patch = asRecordOrNull(msg.patch) ?? undefined;
+  const status =
+    normalizeLifecycleTaskStatus(msg.status) ??
+    normalizeLifecycleTaskStatus(patch?.status) ??
+    (subtype === "task_started" || subtype === "task_progress" ? "in_progress" : undefined);
+  const description =
+    nonEmptyTrimmed(patch?.description) ??
+    nonEmptyTrimmed(msg.description) ??
+    nonEmptyTrimmed(msg.summary);
+  const activeForm = nonEmptyTrimmed(patch?.activeForm) ?? nonEmptyTrimmed(patch?.active_form);
+  const subject =
+    nonEmptyTrimmed(patch?.subject) ??
+    nonEmptyTrimmed(msg.subject) ??
+    existing?.subject ??
+    nonEmptyTrimmed(msg.workflow_name) ??
+    nonEmptyTrimmed(msg.task_description) ??
+    description ??
+    taskId;
+  const metadata = mergeTaskMetadata(existing?.metadata, taskSystemMetadata(msg, patch));
+  const sourceToolCallId = taskToolUseIds.get(taskId) ?? existing?.source_tool_call_id;
+
+  const task: TaskItem = {
+    task_id: taskId,
+    subject,
+    ...(description !== undefined ? { description } : existing?.description !== undefined ? { description: existing.description } : {}),
+    ...(activeForm !== undefined ? { active_form: activeForm } : existing?.active_form !== undefined ? { active_form: existing.active_form } : {}),
+    status: status ?? existing?.status ?? "pending",
+    ...(existing?.owner !== undefined ? { owner: existing.owner } : {}),
+    blocks: existing ? [...existing.blocks] : [],
+    blocked_by: existing ? [...existing.blocked_by] : [],
+    ...(metadata !== undefined ? { metadata } : {}),
+    ...(sourceToolCallId !== undefined ? { source_tool_call_id: sourceToolCallId } : {}),
+  };
+  tasksById.set(taskId, task);
+  updates.push({
+    type: "task_state_update",
+    source: "task_lifecycle",
+    tasks: [task],
+    removed_task_ids: [],
+    is_complete_snapshot: false,
+  });
+  return true;
 }
 
 function pushResumeTextChunk(
@@ -170,11 +337,22 @@ export function mapSessionMessagesToUpdates(messages: SessionMessage[]): Session
   const updates: SessionUpdate[] = [];
   const toolCalls = new Map<string, ToolCall>();
   const hiddenToolUseIds = new Set<string>();
+  const tasksById = new Map<string, TaskItem>();
+  const taskToolUseIds = new Map<string, string>();
 
   for (const entry of messages) {
     const fallbackRole = entry.type === "assistant" ? "assistant" : "user";
     const entrySourceMessageUuid = typeof entry.uuid === "string" ? entry.uuid : undefined;
-    for (const message of messageCandidates(entry.message)) {
+    const candidates = messageCandidates(entry.message);
+    if (entry.type === "system") {
+      for (const message of candidates) {
+        if (pushResumeTaskSystemUpdate(updates, tasksById, taskToolUseIds, message)) {
+          break;
+        }
+      }
+      continue;
+    }
+    for (const message of candidates) {
       const sourceMessageUuid =
         typeof message.uuid === "string" ? message.uuid : entrySourceMessageUuid;
       const roleCandidate = message.role;

--- a/agent-sdk/src/bridge/history.ts
+++ b/agent-sdk/src/bridge/history.ts
@@ -31,15 +31,28 @@ function messageCandidates(raw: unknown): Record<string, unknown>[] {
   return candidates;
 }
 
-function pushResumeTextChunk(updates: SessionUpdate[], role: "user" | "assistant", text: string): void {
+function pushResumeTextChunk(
+  updates: SessionUpdate[],
+  role: "user" | "assistant",
+  text: string,
+  sourceMessageUuid?: string,
+): void {
   if (!text.trim()) {
     return;
   }
   if (role === "assistant") {
-    updates.push({ type: "agent_message_chunk", content: { type: "text", text } });
+    updates.push({
+      type: "agent_message_chunk",
+      content: { type: "text", text },
+      ...(sourceMessageUuid ? { source_message_uuid: sourceMessageUuid } : {}),
+    });
     return;
   }
-  updates.push({ type: "user_message_chunk", content: { type: "text", text } });
+  updates.push({
+    type: "user_message_chunk",
+    content: { type: "text", text },
+    ...(sourceMessageUuid ? { source_message_uuid: sourceMessageUuid } : {}),
+  });
 }
 
 function pushResumeToolUse(
@@ -48,6 +61,7 @@ function pushResumeToolUse(
   hiddenToolUseIds: Set<string>,
   block: Record<string, unknown>,
   parentToolUseId: string | null,
+  sourceMessageUuid?: string,
 ): void {
   const toolUseId = typeof block.id === "string" ? block.id : "";
   if (!toolUseId) {
@@ -63,6 +77,9 @@ function pushResumeToolUse(
 
   const toolCall = createToolCall(toolUseId, name, input, parentToolUseId);
   toolCall.status = "in_progress";
+  if (sourceMessageUuid) {
+    toolCall.source_message_uuid = sourceMessageUuid;
+  }
   toolCalls.set(toolUseId, toolCall);
   updates.push({ type: "tool_call", tool_call: toolCall });
 }
@@ -72,6 +89,7 @@ function pushResumeToolResult(
   toolCalls: Map<string, ToolCall>,
   hiddenToolUseIds: Set<string>,
   block: Record<string, unknown>,
+  sourceMessageUuid?: string,
 ): void {
   const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
   if (!toolUseId) {
@@ -85,7 +103,14 @@ function pushResumeToolResult(
   const isError = Boolean(block.is_error);
   const base = toolCalls.get(toolUseId);
   const fields = buildToolResultFields(isError, block.content, base, block);
-  updates.push({ type: "tool_call_update", tool_call_update: { tool_call_id: toolUseId, fields } });
+  updates.push({
+    type: "tool_call_update",
+    tool_call_update: {
+      tool_call_id: toolUseId,
+      ...(sourceMessageUuid ? { source_message_uuid: sourceMessageUuid } : {}),
+      fields,
+    },
+  });
 
   if (!base) {
     return;
@@ -148,7 +173,10 @@ export function mapSessionMessagesToUpdates(messages: SessionMessage[]): Session
 
   for (const entry of messages) {
     const fallbackRole = entry.type === "assistant" ? "assistant" : "user";
+    const entrySourceMessageUuid = typeof entry.uuid === "string" ? entry.uuid : undefined;
     for (const message of messageCandidates(entry.message)) {
+      const sourceMessageUuid =
+        typeof message.uuid === "string" ? message.uuid : entrySourceMessageUuid;
       const roleCandidate = message.role;
       const role = roleCandidate === "assistant" || roleCandidate === "user" ? roleCandidate : fallbackRole;
       const parentToolUseId =
@@ -169,19 +197,26 @@ export function mapSessionMessagesToUpdates(messages: SessionMessage[]): Session
           continue;
         }
         if (blockType === "text" && typeof block.text === "string") {
-          pushResumeTextChunk(updates, role, block.text);
+          pushResumeTextChunk(updates, role, block.text, sourceMessageUuid);
           continue;
         }
         if (isToolUseBlockType(blockType) && role === "assistant") {
-          pushResumeToolUse(updates, toolCalls, hiddenToolUseIds, block, parentToolUseId);
+          pushResumeToolUse(
+            updates,
+            toolCalls,
+            hiddenToolUseIds,
+            block,
+            parentToolUseId,
+            sourceMessageUuid,
+          );
           continue;
         }
         if (TOOL_RESULT_TYPES.has(blockType)) {
-          pushResumeToolResult(updates, toolCalls, hiddenToolUseIds, block);
+          pushResumeToolResult(updates, toolCalls, hiddenToolUseIds, block, sourceMessageUuid);
           continue;
         }
         if (blockType === "image") {
-          pushResumeTextChunk(updates, role, "[image]");
+          pushResumeTextChunk(updates, role, "[image]", sourceMessageUuid);
         }
       }
     }

--- a/agent-sdk/src/bridge/logger.ts
+++ b/agent-sdk/src/bridge/logger.ts
@@ -163,6 +163,7 @@ function eventToolCallId(event: BridgeEvent): string | undefined {
     case "elicitation_complete":
     case "mcp_auth_redirect":
     case "mcp_operation_error":
+    case "mcp_set_servers_result":
     case "turn_complete":
     case "turn_error":
     case "slash_error":
@@ -218,6 +219,7 @@ function protocolEventLevel(event: BridgeEvent): LogLevel {
     case "status_snapshot":
     case "context_usage":
     case "runtime_reload_completed":
+    case "mcp_set_servers_result":
     case "mcp_snapshot":
       return "debug";
   }

--- a/agent-sdk/src/bridge/logger.ts
+++ b/agent-sdk/src/bridge/logger.ts
@@ -208,6 +208,7 @@ function protocolEventLevel(event: BridgeEvent): LogLevel {
     case "session_update":
     case "permission_request":
     case "question_request":
+    case "user_dialog_request":
     case "elicitation_request":
     case "elicitation_complete":
     case "mcp_auth_redirect":

--- a/agent-sdk/src/bridge/mcp.ts
+++ b/agent-sdk/src/bridge/mcp.ts
@@ -1,4 +1,9 @@
-import type { BridgeCommand, McpSetServersResult, McpServerStatus } from "../types.js";
+import type {
+  BridgeCommand,
+  McpSetServersResult,
+  McpServerStatus,
+  McpSnapshotSource,
+} from "../types.js";
 import { emitMcpOperationError, slashError, writeEvent } from "./events.js";
 import { bridgeLogger, LOG_TARGETS } from "./logger.js";
 import {
@@ -18,6 +23,7 @@ type McpAuthMethodName =
   | "mcpAuthenticate"
   | "mcpClearAuth"
   | "mcpSubmitOAuthCallbackUrl";
+type SdkMcpServerStatus = import("@anthropic-ai/claude-agent-sdk").McpServerStatus;
 
 export const MCP_STALE_STATUS_REVALIDATION_COOLDOWN_MS = 30_000;
 const knownConnectedMcpServers = new Set<string>();
@@ -153,12 +159,48 @@ function emitMcpCommandError(
 export async function emitMcpSnapshotEvent(
   session: SessionState,
   requestId?: string,
+  source: McpSnapshotSource = "mcp_status",
 ): Promise<McpServerStatus[]> {
   const servers = await session.query.mcpServerStatus();
   let mapped = servers.map(mapMcpServerStatus);
   mapped = await reconcileSuspiciousMcpStatuses(session, mapped);
+  return emitMcpSnapshotFromMappedStatuses(session, mapped, source, requestId);
+}
+
+export function emitMcpSnapshotFromStatuses(
+  session: SessionState,
+  servers: readonly SdkMcpServerStatus[],
+  source: McpSnapshotSource,
+  requestId?: string,
+): McpServerStatus[] {
+  return emitMcpSnapshotFromMappedStatuses(
+    session,
+    servers.map(mapMcpServerStatus),
+    source,
+    requestId,
+  );
+}
+
+export async function emitReconciledMcpSnapshotFromStatuses(
+  session: SessionState,
+  servers: readonly SdkMcpServerStatus[],
+  source: McpSnapshotSource,
+  requestId?: string,
+): Promise<McpServerStatus[]> {
+  let mapped = servers.map(mapMcpServerStatus);
+  mapped = await reconcileSuspiciousMcpStatuses(session, mapped);
+  return emitMcpSnapshotFromMappedStatuses(session, mapped, source, requestId);
+}
+
+function emitMcpSnapshotFromMappedStatuses(
+  session: SessionState,
+  mapped: McpServerStatus[],
+  source: McpSnapshotSource,
+  requestId?: string,
+): McpServerStatus[] {
   rememberKnownConnectedMcpServers(mapped);
   logMcpSuccess("mcp_snapshot_emitted", "MCP snapshot emitted", session.sessionId, requestId, {
+    source,
     server_count: mapped.length,
     servers: summarizeMcpServersForDiagnostics(mapped),
   });
@@ -166,6 +208,7 @@ export async function emitMcpSnapshotEvent(
     {
       event: "mcp_snapshot",
       session_id: session.sessionId,
+      source,
       servers: mapped,
     },
     requestId,
@@ -300,9 +343,10 @@ async function monitorMcpAuthSnapshot(
 export async function handleMcpStatusCommand(
   session: SessionState,
   requestId?: string,
+  source: McpSnapshotSource = "mcp_status",
 ): Promise<void> {
   try {
-    await emitMcpSnapshotEvent(session, requestId);
+    await emitMcpSnapshotEvent(session, requestId, source);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logMcpFailure(
@@ -316,6 +360,7 @@ export async function handleMcpStatusCommand(
       {
         event: "mcp_snapshot",
         session_id: session.sessionId,
+        source,
         servers: [],
         error: message,
       },
@@ -411,7 +456,7 @@ export async function handleMcpSetServersCommand(
       },
       requestId,
     );
-    await handleMcpStatusCommand(session, requestId);
+    await handleMcpStatusCommand(session, requestId, "mcp_set_servers");
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logMcpFailure(

--- a/agent-sdk/src/bridge/mcp.ts
+++ b/agent-sdk/src/bridge/mcp.ts
@@ -1,4 +1,4 @@
-import type { BridgeCommand, McpServerStatus } from "../types.js";
+import type { BridgeCommand, McpSetServersResult, McpServerStatus } from "../types.js";
 import { emitMcpOperationError, slashError, writeEvent } from "./events.js";
 import { bridgeLogger, LOG_TARGETS } from "./logger.js";
 import {
@@ -64,6 +64,28 @@ function logMcpFailure(
 
 function queryWithMcpAuth(session: SessionState): QueryWithMcpAuth {
   return session.query as QueryWithMcpAuth;
+}
+
+function mapMcpSetServersResult(result: unknown): McpSetServersResult {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return { added: [], removed: [], errors: {} };
+  }
+  const record = result as Record<string, unknown>;
+  const added = Array.isArray(record.added)
+    ? record.added.filter((value): value is string => typeof value === "string")
+    : [];
+  const removed = Array.isArray(record.removed)
+    ? record.removed.filter((value): value is string => typeof value === "string")
+    : [];
+  const errors =
+    record.errors && typeof record.errors === "object" && !Array.isArray(record.errors)
+      ? Object.fromEntries(
+          Object.entries(record.errors as Record<string, unknown>).filter(
+            (entry): entry is [string, string] => typeof entry[1] === "string",
+          ),
+        )
+      : {};
+  return { added, removed, errors };
 }
 
 async function callMcpAuthMethod(
@@ -366,13 +388,28 @@ export async function handleMcpSetServersCommand(
   requestId?: string,
 ): Promise<void> {
   try {
-    await session.query.setMcpServers(bridgeMcpServersToSdk(command.servers));
+    const result = mapMcpSetServersResult(
+      await session.query.setMcpServers(bridgeMcpServersToSdk(command.servers)),
+    );
     logMcpSuccess(
       "mcp_servers_set_completed",
       "MCP server configuration updated",
       command.session_id,
       requestId,
-      { server_count: Object.keys(command.servers).length },
+      {
+        server_count: Object.keys(command.servers).length,
+        added_count: result.added.length,
+        removed_count: result.removed.length,
+        error_count: Object.keys(result.errors).length,
+      },
+    );
+    writeEvent(
+      {
+        event: "mcp_set_servers_result",
+        session_id: command.session_id,
+        result,
+      },
+      requestId,
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -383,6 +420,11 @@ export async function handleMcpSetServersCommand(
       message,
       requestId,
       { server_count: Object.keys(command.servers).length },
+    );
+    emitMcpOperationError(
+      command.session_id,
+      { operation: "set-servers", message },
+      requestId,
     );
     slashError(command.session_id, `failed to set MCP servers: ${message}`, requestId);
   }

--- a/agent-sdk/src/bridge/mcp.ts
+++ b/agent-sdk/src/bridge/mcp.ts
@@ -411,6 +411,7 @@ export async function handleMcpSetServersCommand(
       },
       requestId,
     );
+    await handleMcpStatusCommand(session, requestId);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logMcpFailure(

--- a/agent-sdk/src/bridge/mcp_metadata.ts
+++ b/agent-sdk/src/bridge/mcp_metadata.ts
@@ -1,5 +1,6 @@
 import type {
   McpServerConfig,
+  McpServerOrgMaxPermission,
   McpServerStatus,
   McpServerStatusConfig,
   McpServerToolPermissionPolicy,
@@ -28,6 +29,12 @@ const TOOL_PERMISSION_POLICIES = new Set<McpServerToolPermissionPolicy>([
   "always_allow",
   "always_ask",
   "always_deny",
+]);
+
+const ORG_MAX_PERMISSIONS = new Set<McpServerOrgMaxPermission>([
+  "allow",
+  "ask",
+  "blocked",
 ]);
 
 function asRecord(value: unknown, context: string): Record<string, unknown> {
@@ -115,14 +122,22 @@ function optionalToolPolicies(
     if (typeof name !== "string") {
       throw new Error(`${context}.tools[${index}].name must be a string`);
     }
+    const policy: McpServerToolPolicy = { name };
     const permissionPolicy = item.permission_policy;
-    if (typeof permissionPolicy !== "string" || !TOOL_PERMISSION_POLICIES.has(permissionPolicy as McpServerToolPermissionPolicy)) {
-      throw new Error(`${context}.tools[${index}].permission_policy must be one of always_allow, always_ask, always_deny`);
+    if (permissionPolicy !== undefined) {
+      if (typeof permissionPolicy !== "string" || !TOOL_PERMISSION_POLICIES.has(permissionPolicy as McpServerToolPermissionPolicy)) {
+        throw new Error(`${context}.tools[${index}].permission_policy must be one of always_allow, always_ask, always_deny`);
+      }
+      policy.permission_policy = permissionPolicy as McpServerToolPermissionPolicy;
     }
-    return {
-      name,
-      permission_policy: permissionPolicy as McpServerToolPermissionPolicy,
-    };
+    const orgMaxPermission = item.org_max_permission;
+    if (orgMaxPermission !== undefined) {
+      if (typeof orgMaxPermission !== "string" || !ORG_MAX_PERMISSIONS.has(orgMaxPermission as McpServerOrgMaxPermission)) {
+        throw new Error(`${context}.tools[${index}].org_max_permission must be one of allow, ask, blocked`);
+      }
+      policy.org_max_permission = orgMaxPermission as McpServerOrgMaxPermission;
+    }
+    return policy;
   });
 }
 
@@ -189,7 +204,8 @@ export function parseMcpServersRecord(
 function toSdkToolPolicies(tools?: McpServerToolPolicy[]): import("@anthropic-ai/claude-agent-sdk").McpServerToolPolicy[] | undefined {
   return tools?.map((tool) => ({
     name: tool.name,
-    permission_policy: tool.permission_policy,
+    ...(tool.permission_policy === undefined ? {} : { permission_policy: tool.permission_policy }),
+    ...(tool.org_max_permission === undefined ? {} : { org_max_permission: tool.org_max_permission }),
   }));
 }
 
@@ -239,17 +255,27 @@ function mapSdkToolPolicies(tools: unknown): McpServerToolPolicy[] | undefined {
   }
   return tools
     .map((tool) => {
+      if (!tool || typeof tool !== "object" || Array.isArray(tool)) {
+        return null;
+      }
       const raw = tool as Record<string, unknown>;
-      if (typeof raw.name !== "string" || typeof raw.permission_policy !== "string") {
+      if (typeof raw.name !== "string") {
         return null;
       }
-      if (!TOOL_PERMISSION_POLICIES.has(raw.permission_policy as McpServerToolPermissionPolicy)) {
-        return null;
+      const policy: McpServerToolPolicy = { name: raw.name };
+      if (raw.permission_policy !== undefined) {
+        if (typeof raw.permission_policy !== "string" || !TOOL_PERMISSION_POLICIES.has(raw.permission_policy as McpServerToolPermissionPolicy)) {
+          return null;
+        }
+        policy.permission_policy = raw.permission_policy as McpServerToolPermissionPolicy;
       }
-      return {
-        name: raw.name,
-        permission_policy: raw.permission_policy as McpServerToolPermissionPolicy,
-      };
+      if (raw.org_max_permission !== undefined) {
+        if (typeof raw.org_max_permission !== "string" || !ORG_MAX_PERMISSIONS.has(raw.org_max_permission as McpServerOrgMaxPermission)) {
+          return null;
+        }
+        policy.org_max_permission = raw.org_max_permission as McpServerOrgMaxPermission;
+      }
+      return policy;
     })
     .filter((tool): tool is McpServerToolPolicy => tool !== null);
 }

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -58,7 +58,7 @@ import { looksLikeAuthRequired } from "./auth.js";
 import type { SessionState } from "./session_lifecycle.js";
 import { emitCurrentModelUpdate, refreshCurrentModel, updateSessionId } from "./session_lifecycle.js";
 import { bridgeLogger, LOG_TARGETS } from "./logger.js";
-import { mapMcpServerStatus, summarizeMcpServersForDiagnostics } from "./mcp_metadata.js";
+import { emitMcpSnapshotFromStatuses } from "./mcp.js";
 
 export function textFromPrompt(command: Extract<BridgeCommand, { command: "prompt" }>): string {
   const chunks = command.chunks ?? [];
@@ -1009,27 +1009,11 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
       }
 
       if (Array.isArray(msg.mcp_servers)) {
-        const servers = msg.mcp_servers.map((server) =>
-          mapMcpServerStatus(
-            server as import("@anthropic-ai/claude-agent-sdk").McpServerStatus,
-          ),
+        emitMcpSnapshotFromStatuses(
+          session,
+          msg.mcp_servers as import("@anthropic-ai/claude-agent-sdk").McpServerStatus[],
+          "init",
         );
-        bridgeLogger.info({
-          target: LOG_TARGETS.BRIDGE_MCP,
-          eventName: "mcp_init_snapshot_emitted",
-          message: "MCP init snapshot emitted",
-          outcome: "success",
-          sessionId: session.sessionId,
-          fields: {
-            server_count: servers.length,
-            servers: summarizeMcpServersForDiagnostics(servers),
-          },
-        });
-        writeEvent({
-          event: "mcp_snapshot",
-          session_id: session.sessionId,
-          servers,
-        });
       }
 
       if (session.lastAvailableAgentsSignature === undefined && Array.isArray(msg.agents)) {

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -31,6 +31,7 @@ import {
   emitToolSummaryUpdate,
   ensureToolCallVisible,
   resolveTaskToolUseId,
+  defersTaskNotificationCompletion,
   toolAcceptsTaskLifecycle,
   taskProgressText,
   taskUpdatedFields,
@@ -382,7 +383,8 @@ export function handleTaskSystemMessage(
   const status = typeof msg.status === "string" ? msg.status : "";
   const summary = typeof msg.summary === "string" ? msg.summary : "";
   const finalStatus = status === "completed" ? "completed" : status === "stopped" ? "killed" : "failed";
-  const fields: ToolCallUpdateFields = { status: finalStatus };
+  const deferCompletion = finalStatus === "completed" && defersTaskNotificationCompletion(toolCall);
+  const fields: ToolCallUpdateFields = deferCompletion ? {} : { status: finalStatus };
   if (messageTaskMetadata) {
     fields.task_metadata = messageTaskMetadata;
   }
@@ -390,8 +392,10 @@ export function handleTaskSystemMessage(
     fields.raw_output = summary;
     fields.content = [{ type: "content", content: { type: "text", text: summary } }];
   }
-  emitToolCallUpdate(session, toolUseId, fields, "task_notification");
-  if (taskId) {
+  if (Object.keys(fields).length > 0) {
+    emitToolCallUpdate(session, toolUseId, fields, "task_notification");
+  }
+  if (taskId && !deferCompletion) {
     unlinkTaskToolUse(session, taskId);
   }
   return true;

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -5,6 +5,7 @@ import type {
   SystemNoticeSeverity,
   TaskMetadata,
   TerminalReason,
+  TranscriptRetractionReason,
   ToolCallUpdateFields,
 } from "../types.js";
 import { asRecordOrNull } from "./shared.js";
@@ -400,7 +401,111 @@ type ContentBlockLinkage = {
   source: "assistant" | "stream_event" | "user";
   parentToolUseId?: string;
   metadata?: ToolCorrelationMetadata;
+  sourceMessageUuid?: string;
 };
+
+function stringField(msg: Record<string, unknown>, field: string): string | undefined {
+  const value = msg[field];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function nullableStringField(msg: Record<string, unknown>, field: string): string | undefined {
+  const value = msg[field];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function sourceMessageUuid(msg: Record<string, unknown>): string | undefined {
+  return stringField(msg, "uuid");
+}
+
+function dedupeMessageUuids(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const uuids: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" || !entry) {
+      continue;
+    }
+    if (seen.has(entry)) {
+      continue;
+    }
+    seen.add(entry);
+    uuids.push(entry);
+  }
+  return uuids;
+}
+
+function emitTranscriptRetraction(
+  session: SessionState,
+  messageUuids: string[],
+  reason: TranscriptRetractionReason,
+  metadata: Record<string, string | undefined> = {},
+): boolean {
+  const deduped = dedupeMessageUuids(messageUuids);
+  if (deduped.length === 0) {
+    return false;
+  }
+  emitSessionUpdate(session.sessionId, {
+    type: "transcript_retraction",
+    message_uuids: deduped,
+    reason,
+    ...(metadata.requestId ? { request_id: metadata.requestId } : {}),
+    ...(metadata.trigger ? { trigger: metadata.trigger } : {}),
+    ...(metadata.direction ? { direction: metadata.direction } : {}),
+    ...(metadata.originalModel ? { original_model: metadata.originalModel } : {}),
+    ...(metadata.fallbackModel ? { fallback_model: metadata.fallbackModel } : {}),
+    ...(metadata.apiRefusalCategory ? { api_refusal_category: metadata.apiRefusalCategory } : {}),
+    ...(metadata.apiRefusalExplanation ? { api_refusal_explanation: metadata.apiRefusalExplanation } : {}),
+    ...(metadata.content ? { content: metadata.content } : {}),
+  });
+  return true;
+}
+
+function handleFallbackRetractionMessage(
+  session: SessionState,
+  subtype: string,
+  msg: Record<string, unknown>,
+): boolean {
+  if (subtype !== "model_refusal_fallback" && subtype !== "model_fallback") {
+    return false;
+  }
+  const reason: TranscriptRetractionReason =
+    subtype === "model_fallback" ? "model_fallback" : "model_refusal_fallback";
+  const messageUuids = dedupeMessageUuids(msg.retracted_message_uuids);
+  const metadata = {
+    requestId: nullableStringField(msg, "request_id"),
+    trigger: stringField(msg, "trigger"),
+    direction: stringField(msg, "direction"),
+    originalModel: stringField(msg, "original_model"),
+    fallbackModel: stringField(msg, "fallback_model"),
+    apiRefusalCategory: nullableStringField(msg, "api_refusal_category"),
+    apiRefusalExplanation: nullableStringField(msg, "api_refusal_explanation"),
+    content: stringField(msg, "content"),
+  };
+  const emitted = emitTranscriptRetraction(session, messageUuids, reason, metadata);
+  bridgeLogger.info({
+    target: LOG_TARGETS.APP_SESSION,
+    eventName: "sdk_model_fallback_received",
+    message: "SDK model fallback retraction received",
+    outcome: emitted ? "success" : "observed",
+    sessionId: session.sessionId,
+    requestId: metadata.requestId,
+    count: messageUuids.length,
+    fields: {
+      sdk_subtype: subtype,
+      trigger: metadata.trigger,
+      direction: metadata.direction,
+      original_model: metadata.originalModel,
+      fallback_model: metadata.fallbackModel,
+      api_refusal_category: metadata.apiRefusalCategory,
+      has_api_refusal_explanation: metadata.apiRefusalExplanation !== undefined,
+      has_content: metadata.content !== undefined,
+    },
+  });
+  return true;
+}
 
 function logContentBlockLinkage(
   session: SessionState,
@@ -467,7 +572,11 @@ export function handleContentBlock(
   if (blockType === "text") {
     const text = typeof block.text === "string" ? block.text : "";
     if (text) {
-      emitSessionUpdate(session.sessionId, { type: "agent_message_chunk", content: { type: "text", text } });
+      emitSessionUpdate(session.sessionId, {
+        type: "agent_message_chunk",
+        content: { type: "text", text },
+        ...(linkage?.sourceMessageUuid ? { source_message_uuid: linkage.sourceMessageUuid } : {}),
+      });
     }
     return;
   }
@@ -475,7 +584,11 @@ export function handleContentBlock(
   if (blockType === "thinking") {
     const text = typeof block.thinking === "string" ? block.thinking : "";
     if (text) {
-      emitSessionUpdate(session.sessionId, { type: "agent_thought_chunk", content: { type: "text", text } });
+      emitSessionUpdate(session.sessionId, {
+        type: "agent_thought_chunk",
+        content: { type: "text", text },
+        ...(linkage?.sourceMessageUuid ? { source_message_uuid: linkage.sourceMessageUuid } : {}),
+      });
     }
     return;
   }
@@ -492,7 +605,15 @@ export function handleContentBlock(
       return;
     }
     logContentBlockLinkage(session, blockType, toolUseId, name, linkage);
-    emitToolCall(session, toolUseId, name, input, linkage?.parentToolUseId ?? null, linkage?.metadata);
+    emitToolCall(
+      session,
+      toolUseId,
+      name,
+      input,
+      linkage?.parentToolUseId ?? null,
+      linkage?.metadata,
+      linkage?.sourceMessageUuid,
+    );
     return;
   }
 
@@ -506,7 +627,7 @@ export function handleContentBlock(
     }
     logContentBlockLinkage(session, blockType, toolUseId, undefined, linkage);
     const isError = Boolean(block.is_error);
-    emitToolResultUpdate(session, toolUseId, isError, block.content, block);
+    emitToolResultUpdate(session, toolUseId, isError, block.content, block, linkage?.sourceMessageUuid);
   }
 }
 
@@ -514,6 +635,7 @@ export function handleStreamEvent(
   session: SessionState,
   event: Record<string, unknown>,
   parentToolUseId?: string,
+  sourceMessageUuid?: string,
 ): void {
   const eventType = typeof event.type === "string" ? event.type : "";
 
@@ -522,6 +644,7 @@ export function handleStreamEvent(
       handleContentBlock(session, event.content_block as Record<string, unknown>, {
         source: "stream_event",
         parentToolUseId,
+        sourceMessageUuid,
       });
     }
     return;
@@ -536,18 +659,32 @@ export function handleStreamEvent(
     if (deltaType === "text_delta") {
       const text = typeof delta.text === "string" ? delta.text : "";
       if (text) {
-        emitSessionUpdate(session.sessionId, { type: "agent_message_chunk", content: { type: "text", text } });
+        emitSessionUpdate(session.sessionId, {
+          type: "agent_message_chunk",
+          content: { type: "text", text },
+          ...(sourceMessageUuid ? { source_message_uuid: sourceMessageUuid } : {}),
+        });
       }
     } else if (deltaType === "thinking_delta") {
       const text = typeof delta.thinking === "string" ? delta.thinking : "";
       if (text) {
-        emitSessionUpdate(session.sessionId, { type: "agent_thought_chunk", content: { type: "text", text } });
+        emitSessionUpdate(session.sessionId, {
+          type: "agent_thought_chunk",
+          content: { type: "text", text },
+          ...(sourceMessageUuid ? { source_message_uuid: sourceMessageUuid } : {}),
+        });
       }
     }
   }
 }
 
 export function handleAssistantMessage(session: SessionState, message: Record<string, unknown>): void {
+  const assistantMessageUuid = sourceMessageUuid(message);
+  emitTranscriptRetraction(
+    session,
+    dedupeMessageUuids(message.supersedes),
+    "assistant_supersedes",
+  );
   const assistantError = typeof message.error === "string" ? message.error : "";
   if (assistantError.length > 0) {
     session.lastAssistantError = parseApiRetryError(assistantError);
@@ -576,7 +713,12 @@ export function handleAssistantMessage(session: SessionState, message: Record<st
     ) {
       const parentToolUseId =
         typeof message.parent_tool_use_id === "string" ? message.parent_tool_use_id : undefined;
-      handleContentBlock(session, blockRecord, { source: "assistant", parentToolUseId, metadata });
+      handleContentBlock(session, blockRecord, {
+        source: "assistant",
+        parentToolUseId,
+        metadata,
+        sourceMessageUuid: assistantMessageUuid,
+      });
     }
   }
 }
@@ -621,6 +763,7 @@ export function handleUserToolResultBlocks(session: SessionState, message: Recor
       logContentBlockLinkage(session, blockType, toolUseId, undefined, {
         source: "user",
         parentToolUseId,
+        sourceMessageUuid: sourceMessageUuid(message),
       });
       emitToolResultUpdate(
         session,
@@ -628,6 +771,7 @@ export function handleUserToolResultBlocks(session: SessionState, message: Recor
         Boolean(blockRecord.is_error),
         blockRecord.content,
         messageToolUseResult(message) ?? blockRecord,
+        sourceMessageUuid(message),
       );
     }
   }
@@ -706,6 +850,10 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
 
   if (type === "system") {
     const subtype = typeof msg.subtype === "string" ? msg.subtype : "";
+    if (handleFallbackRetractionMessage(session, subtype, msg)) {
+      return;
+    }
+
     if (subtype === "commands_changed") {
       updateAvailableCommands(session, "commands_changed", mapSdkSlashCommands(msg.commands));
       return;
@@ -947,6 +1095,7 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         emitSessionUpdate(session.sessionId, {
           type: "agent_message_chunk",
           content: { type: "text", text: content },
+          ...(sourceMessageUuid(msg) ? { source_message_uuid: sourceMessageUuid(msg) } : {}),
         });
       }
       return;
@@ -1018,7 +1167,12 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
     if (msg.event && typeof msg.event === "object") {
       const parentToolUseId =
         typeof msg.parent_tool_use_id === "string" ? msg.parent_tool_use_id : undefined;
-      handleStreamEvent(session, msg.event as Record<string, unknown>, parentToolUseId);
+      handleStreamEvent(
+        session,
+        msg.event as Record<string, unknown>,
+        parentToolUseId,
+        sourceMessageUuid(msg),
+      );
     }
     return;
   }
@@ -1127,7 +1281,14 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         return;
       }
       const parsed = unwrapToolUseResult(rawToolUseResult);
-      emitToolResultUpdate(session, toolUseId, parsed.isError, parsed.content, rawToolUseResult);
+      emitToolResultUpdate(
+        session,
+        toolUseId,
+        parsed.isError,
+        parsed.content,
+        rawToolUseResult,
+        sourceMessageUuid(msg),
+      );
     }
     return;
   }

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -1227,6 +1227,27 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
   if (type === "rate_limit_event") {
     const rateLimitInfo = asRecordOrNull(msg.rate_limit_info);
     const update = buildRateLimitUpdate(msg.rate_limit_info);
+    const rawIsUsingOverage =
+      typeof rateLimitInfo?.isUsingOverage === "boolean" ? rateLimitInfo.isUsingOverage : undefined;
+    const rawOverageInUse =
+      typeof rateLimitInfo?.overageInUse === "boolean" ? rateLimitInfo.overageInUse : undefined;
+    if (
+      rawIsUsingOverage !== undefined &&
+      rawOverageInUse !== undefined &&
+      rawIsUsingOverage !== rawOverageInUse
+    ) {
+      bridgeLogger.warn({
+        target: LOG_TARGETS.APP_SESSION,
+        eventName: "sdk_rate_limit_overage_spelling_conflict",
+        message: "SDK rate limit overage booleans conflict",
+        outcome: "using_overageInUse",
+        sessionId: session.sessionId,
+        fields: {
+          raw_is_using_overage: rawIsUsingOverage,
+          raw_overage_in_use: rawOverageInUse,
+        },
+      });
+    }
     bridgeLogger.debug({
       target: LOG_TARGETS.APP_SESSION,
       eventName: "sdk_rate_limit_event_received",
@@ -1242,8 +1263,8 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         raw_overage_status:
           typeof rateLimitInfo?.overageStatus === "string" ? rateLimitInfo.overageStatus : undefined,
         raw_overage_resets_at: numberField(rateLimitInfo ?? {}, "overageResetsAt"),
-        raw_is_using_overage:
-          typeof rateLimitInfo?.isUsingOverage === "boolean" ? rateLimitInfo.isUsingOverage : undefined,
+        raw_is_using_overage: rawIsUsingOverage,
+        raw_overage_in_use: rawOverageInUse,
         raw_surpassed_threshold: numberField(rateLimitInfo ?? {}, "surpassedThreshold"),
         parsed_status: update?.status,
         parsed_rate_limit_type: update?.rate_limit_type,

--- a/agent-sdk/src/bridge/model_metadata.ts
+++ b/agent-sdk/src/bridge/model_metadata.ts
@@ -21,6 +21,12 @@ const OPUS_MODEL_ALIAS = "opus";
 const MAX_MODEL_VERSION_PARTS = 2;
 const RELEASE_BUILD_TOKEN = /^20\d{6}$/;
 
+function isUnavailableModelId(id: string): boolean {
+  const normalized = id.trim().toLowerCase();
+  // TODO: Revisit only after a product decision if Anthropic restores Fable 5 access.
+  return normalized === "fable" || normalized.startsWith("claude-fable-5");
+}
+
 function isEffortLevel(value: unknown): value is EffortLevel {
   return (
     value === "low" ||
@@ -225,6 +231,7 @@ export function mapAvailableModels(models: ModelInfo[] | undefined): AvailableMo
       return (
         typeof entry?.value === "string" &&
         entry.value.trim().length > 0 &&
+        !isUnavailableModelId(entry.value) &&
         typeof entry.displayName === "string" &&
         entry.displayName.trim().length > 0
       );

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -11,6 +11,8 @@ import {
   type Query,
   type SDKUserMessage,
   type SettingSource,
+  type UserDialogRequest,
+  type UserDialogResult,
 } from "@anthropic-ai/claude-agent-sdk";
 import type {
   CurrentModel,
@@ -25,10 +27,13 @@ import type {
   PermissionDisplay,
   PermissionRequest,
   QuestionOutcome,
+  RefusalFallbackPromptChoice,
+  RefusalFallbackPromptPayload,
   SessionLaunchSettings,
   SessionUpdate,
   TaskItem,
   ToolCall,
+  UserDialogOption,
 } from "../types.js";
 import { bridgeLogger, LOG_TARGETS, logSdkStderrLine } from "./logger.js";
 import { AsyncQueue } from "./shared.js";
@@ -42,6 +47,7 @@ import {
   emitConnectEvent,
   emitPermissionRequestEvent,
   emitElicitationRequestEvent,
+  emitUserDialogRequestEvent,
 } from "./events.js";
 import {
   ensureToolCallVisible,
@@ -110,6 +116,10 @@ export type PendingQuestion = {
   inputData: Record<string, unknown>;
 };
 
+export type PendingUserDialog = {
+  resolve: (choice: RefusalFallbackPromptChoice | "cancelled") => void;
+};
+
 export type PendingElicitation = {
   resolve: (result: {
     action: ElicitationAction;
@@ -144,6 +154,7 @@ export type SessionState = {
   taskIdsByToolUseId: Map<string, string>;
   pendingPermissions: Map<string, PendingPermission>;
   pendingQuestions: Map<string, PendingQuestion>;
+  pendingUserDialogs: Map<string, PendingUserDialog>;
   pendingElicitations: Map<string, PendingElicitation>;
   mcpStatusRevalidatedAt: Map<string, number>;
   hiddenToolUseIds: Set<string>;
@@ -154,19 +165,6 @@ export type SessionState = {
   sessionsToCloseAfterConnect?: SessionState[];
   resumeUpdates?: SessionUpdate[];
 };
-
-type QueryWithInternalControlHandling = Query & {
-  processControlRequest?: (
-    request: {
-      request_id: string;
-      request: Record<string, unknown>;
-    },
-    signal: AbortSignal,
-  ) => Promise<Record<string, unknown> | undefined>;
-  [requestUserDialogInterceptorInstalled]?: boolean;
-};
-
-const requestUserDialogInterceptorInstalled = Symbol("requestUserDialogInterceptorInstalled");
 
 export const sessions = new Map<string, SessionState>();
 
@@ -195,6 +193,55 @@ function normalizeSdkElicitationContent(
     }
   }
   return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+const REFUSAL_FALLBACK_DIALOG_KIND = "refusal_fallback_prompt";
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function optionalStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const entries = value.filter((entry): entry is string => typeof entry === "string");
+  return entries.length > 0 ? entries : undefined;
+}
+
+/**
+ * Normalize the camelCase `refusal_fallback_prompt` payload built by the CLI
+ * into the snake-case host wire shape. The dialog descriptor requires
+ * `originalModel`/`fallbackModel`; the rest are optional metadata.
+ */
+function normalizeRefusalFallbackPayload(
+  payload: Record<string, unknown>,
+): RefusalFallbackPromptPayload {
+  return {
+    original_model: typeof payload.originalModel === "string" ? payload.originalModel : "",
+    fallback_model: typeof payload.fallbackModel === "string" ? payload.fallbackModel : "",
+    ...(optionalString(payload.apiRefusalCategory) !== undefined
+      ? { api_refusal_category: optionalString(payload.apiRefusalCategory) }
+      : {}),
+    ...(optionalString(payload.guidanceText) !== undefined
+      ? { guidance_text: optionalString(payload.guidanceText) }
+      : {}),
+    ...(optionalStringArray(payload.retractedMessageUuids) !== undefined
+      ? { retracted_message_uuids: optionalStringArray(payload.retractedMessageUuids) }
+      : {}),
+  };
+}
+
+/**
+ * Build the selectable options the host renders, mirroring the labels the CLI
+ * itself produces (`function Wg$`). `cancelled` is the Esc/decline default and
+ * is not a listed option.
+ */
+function buildRefusalFallbackOptions(payload: RefusalFallbackPromptPayload): UserDialogOption[] {
+  return [
+    { option_id: "retry_fallback", label: `Switch to ${payload.fallback_model}` },
+    { option_id: "edit_prompt", label: `Edit prompt and retry with ${payload.original_model}` },
+  ];
 }
 
 type CloseSessionOptions = {
@@ -246,97 +293,6 @@ export function updateSessionId(session: SessionState, newSessionId: string): vo
   sessions.set(newSessionId, session);
 }
 
-function isRequestUserDialogControlRequest(
-  value: unknown,
-): value is {
-  request_id: string;
-  request: {
-    subtype: "request_user_dialog";
-    dialog_kind: string;
-    payload: Record<string, unknown>;
-    tool_use_id?: string;
-  };
-} {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const record = value as Record<string, unknown>;
-  const request = record.request;
-  if (!request || typeof request !== "object") {
-    return false;
-  }
-  const inner = request as Record<string, unknown>;
-  const payload = inner.payload;
-  return (
-    typeof record.request_id === "string" &&
-    inner.subtype === "request_user_dialog" &&
-    typeof inner.dialog_kind === "string" &&
-    Boolean(payload && typeof payload === "object" && !Array.isArray(payload))
-  );
-}
-
-export function attachRequestUserDialogInterceptor(
-  query: Query,
-  sessionIdForLogs: () => string,
-): boolean {
-  const internalQuery = query as QueryWithInternalControlHandling;
-  if (internalQuery[requestUserDialogInterceptorInstalled]) {
-    return true;
-  }
-  if (typeof internalQuery.processControlRequest !== "function") {
-    bridgeLogger.warn({
-      target: LOG_TARGETS.APP_SESSION,
-      eventName: "request_user_dialog_interceptor_unavailable",
-      message: "request_user_dialog interceptor could not be installed",
-      outcome: "failure",
-      sessionId: sessionIdForLogs(),
-    });
-    return false;
-  }
-
-  const originalProcessControlRequest = internalQuery.processControlRequest.bind(query);
-  internalQuery.processControlRequest = async (request, signal) => {
-    // SDK 0.2.104 also added cancel_async_message and seed_read_state control
-    // requests. Keep those delegated to the SDK internals: claude-rs does not
-    // own the SDK async-message queue or read-state cache, so TUI-level commands
-    // for them would add unsupported host behavior without user-visible value.
-    if (isRequestUserDialogControlRequest(request)) {
-      bridgeLogger.warn({
-        target: LOG_TARGETS.APP_SESSION,
-        eventName: "request_user_dialog_received",
-        message: "request_user_dialog control request received",
-        outcome: "failure",
-        sessionId: sessionIdForLogs(),
-        requestId: request.request_id,
-        ...(typeof request.request.tool_use_id === "string"
-          ? { toolCallId: request.request.tool_use_id }
-          : {}),
-        fields: {
-          dialog_kind: request.request.dialog_kind,
-          raw_payload: request.request.payload,
-          raw_request: request.request,
-        },
-      });
-      // TODO(request_user_dialog): Revisit this when a real claude-rs host flow needs it.
-      // For now we only log the full control request and reject it explicitly because
-      // normal TUI sessions do not appear to exercise these dialog kinds.
-      throw new Error(
-        `request_user_dialog is not supported by claude-rs yet (dialog_kind: ${request.request.dialog_kind})`,
-      );
-    }
-    return await originalProcessControlRequest(request, signal);
-  };
-  internalQuery[requestUserDialogInterceptorInstalled] = true;
-  bridgeLogger.info({
-    target: LOG_TARGETS.APP_SESSION,
-    eventName: "request_user_dialog_interceptor_installed",
-    message: "request_user_dialog interceptor installed",
-    outcome: "success",
-    sessionId: sessionIdForLogs(),
-  });
-  return true;
-}
-
 export async function closeSession(session: SessionState): Promise<void> {
   session.input.close();
   session.query.close();
@@ -349,6 +305,10 @@ export async function closeSession(session: SessionState): Promise<void> {
     pending.onOutcome({ outcome: "cancelled" });
   }
   session.pendingQuestions.clear();
+  for (const pending of session.pendingUserDialogs.values()) {
+    pending.resolve("cancelled");
+  }
+  session.pendingUserDialogs.clear();
   for (const pending of session.pendingElicitations.values()) {
     pending.resolve({ action: "cancel" });
   }
@@ -508,7 +468,6 @@ export async function createSession(params: {
         sessionIdForLogs,
       }),
     });
-    attachRequestUserDialogInterceptor(queryHandle, sessionIdForLogs);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     bridgeLogger.error({
@@ -554,6 +513,7 @@ export async function createSession(params: {
     taskIdsByToolUseId: new Map<string, string>(),
     pendingPermissions: new Map<string, PendingPermission>(),
     pendingQuestions: new Map<string, PendingQuestion>(),
+    pendingUserDialogs: new Map<string, PendingUserDialog>(),
     pendingElicitations: new Map<string, PendingElicitation>(),
     mcpStatusRevalidatedAt: new Map<string, number>(),
     hiddenToolUseIds: new Set<string>(),
@@ -1000,6 +960,96 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
         });
       });
     },
+    // The SDK "fails closed" and never emits a dialog kind unless it is declared
+    // here. We declare the one refusal-related kind we render: when the API
+    // returns a hard `stop_reason: "refusal"` and a fallback model is configured,
+    // the CLI emits `request_user_dialog` and the host renders the chooser below.
+    supportedDialogKinds: [REFUSAL_FALLBACK_DIALOG_KIND],
+    // Host policy for `request_user_dialog` control requests. Unknown kinds are
+    // logged and answered `{ behavior: "cancelled" }` (the spec-required answer
+    // for unrecognized kinds). For `refusal_fallback_prompt`, we surface an
+    // interactive chooser in the TUI and route the user's decision back to the
+    // CLI as `{ behavior: "completed", result: <choice> }` (or cancelled on
+    // decline/abort/teardown).
+    onUserDialog: async (
+      request: UserDialogRequest,
+      options: { signal: AbortSignal },
+    ): Promise<UserDialogResult> => {
+      if (request.dialogKind !== REFUSAL_FALLBACK_DIALOG_KIND) {
+        bridgeLogger.warn({
+          target: LOG_TARGETS.APP_SESSION,
+          eventName: "user_dialog_received",
+          message: "request_user_dialog received for unknown kind; cancelled",
+          outcome: "cancelled",
+          sessionId: params.sessionIdForLogs(),
+          ...(typeof request.toolUseID === "string" ? { toolCallId: request.toolUseID } : {}),
+          fields: { dialog_kind: request.dialogKind },
+        });
+        return { behavior: "cancelled" };
+      }
+
+      const payload = normalizeRefusalFallbackPayload(request.payload);
+      const requestId = randomUUID();
+      const dialogRequest = {
+        request_id: requestId,
+        dialog_kind: REFUSAL_FALLBACK_DIALOG_KIND as typeof REFUSAL_FALLBACK_DIALOG_KIND,
+        payload,
+        options: buildRefusalFallbackOptions(payload),
+      };
+      bridgeLogger.info({
+        target: LOG_TARGETS.APP_SESSION,
+        eventName: "user_dialog_received",
+        message: "request_user_dialog received; awaiting host decision",
+        outcome: "start",
+        sessionId: params.sessionIdForLogs(),
+        requestId,
+        ...(typeof request.toolUseID === "string" ? { toolCallId: request.toolUseID } : {}),
+        fields: {
+          dialog_kind: request.dialogKind,
+          original_model: payload.original_model,
+          fallback_model: payload.fallback_model,
+        },
+      });
+
+      const choice = await new Promise<RefusalFallbackPromptChoice | "cancelled">((resolve) => {
+        const currentSession = sessions.get(params.sessionIdForLogs());
+        if (!currentSession) {
+          bridgeLogger.warn({
+            target: LOG_TARGETS.APP_SESSION,
+            eventName: "user_dialog_request_dropped",
+            message: "user dialog request dropped without an active session",
+            outcome: "dropped",
+            sessionId: params.sessionIdForLogs(),
+            requestId,
+            fields: { reason: "unknown_session" },
+          });
+          resolve("cancelled");
+          return;
+        }
+        let settled = false;
+        const settle = (value: RefusalFallbackPromptChoice | "cancelled") => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          currentSession.pendingUserDialogs.delete(requestId);
+          options.signal.removeEventListener("abort", onAbort);
+          resolve(value);
+        };
+        const onAbort = () => settle("cancelled");
+        if (options.signal.aborted) {
+          settle("cancelled");
+          return;
+        }
+        options.signal.addEventListener("abort", onAbort);
+        currentSession.pendingUserDialogs.set(requestId, { resolve: settle });
+        emitUserDialogRequestEvent(params.sessionIdForLogs(), dialogRequest);
+      });
+
+      return choice === "cancelled"
+        ? { behavior: "cancelled" }
+        : { behavior: "completed", result: choice };
+    },
   };
 }
 
@@ -1167,6 +1217,64 @@ export function handleQuestionResponse(command: Extract<BridgeCommand, { command
     },
   });
   resolver.onOutcome(command.outcome);
+}
+
+export function handleUserDialogResponse(
+  command: Extract<BridgeCommand, { command: "user_dialog_response" }>,
+): void {
+  bridgeLogger.info({
+    target: LOG_TARGETS.BRIDGE_PERMISSION,
+    eventName: "user_dialog_response_received",
+    message: "user dialog response received",
+    outcome: "success",
+    sessionId: command.session_id,
+    requestId: command.request_id,
+    fields: {
+      response_kind: command.outcome.outcome,
+      selected_option:
+        command.outcome.outcome === "selected" ? command.outcome.option_id : "cancelled",
+    },
+  });
+  const session = sessionById(command.session_id);
+  if (!session) {
+    bridgeLogger.warn({
+      target: LOG_TARGETS.BRIDGE_PERMISSION,
+      eventName: "user_dialog_response_dropped",
+      message: "user dialog response dropped for unknown session",
+      outcome: "dropped",
+      sessionId: command.session_id,
+      requestId: command.request_id,
+      fields: { reason: "unknown_session" },
+    });
+    return;
+  }
+  const pending = session.pendingUserDialogs.get(command.request_id);
+  if (!pending) {
+    // Idempotent: a late or duplicate response for an already-resolved request
+    // (e.g. the dialog was cancelled on abort/teardown first) is a no-op.
+    bridgeLogger.warn({
+      target: LOG_TARGETS.BRIDGE_PERMISSION,
+      eventName: "user_dialog_response_dropped",
+      message: "user dialog response dropped without a pending request",
+      outcome: "dropped",
+      sessionId: command.session_id,
+      requestId: command.request_id,
+      fields: { reason: "missing_pending_request" },
+    });
+    return;
+  }
+  session.pendingUserDialogs.delete(command.request_id);
+  const choice = command.outcome.outcome === "selected" ? command.outcome.option_id : "cancelled";
+  bridgeLogger.info({
+    target: LOG_TARGETS.BRIDGE_PERMISSION,
+    eventName: "user_dialog_response_applied",
+    message: "user dialog response applied",
+    outcome: "success",
+    sessionId: command.session_id,
+    requestId: command.request_id,
+    fields: { choice },
+  });
+  pending.resolve(choice);
 }
 
 export function handleElicitationResponse(

--- a/agent-sdk/src/bridge/state_parsing.ts
+++ b/agent-sdk/src/bridge/state_parsing.ts
@@ -110,7 +110,9 @@ export function buildRateLimitUpdate(
     update.overage_disabled_reason = info.overageDisabledReason;
   }
 
-  if (typeof info.isUsingOverage === "boolean") {
+  if (typeof info.overageInUse === "boolean") {
+    update.is_using_overage = info.overageInUse;
+  } else if (typeof info.isUsingOverage === "boolean") {
     update.is_using_overage = info.isUsingOverage;
   }
 

--- a/agent-sdk/src/bridge/tasks.ts
+++ b/agent-sdk/src/bridge/tasks.ts
@@ -885,6 +885,9 @@ export function applyTaskToolResult(
     }
     const existing = session.tasksById.get(taskId);
     const sourceToolCallId = existing?.source_tool_call_id ?? session.taskToolUseIds.get(taskId);
+    if (!existing && !sourceToolCallId) {
+      return;
+    }
     const metadata = mergeMetadata(existing?.metadata, {
       terminal_status: "stopped",
       task_type: output.task_type as Json,

--- a/agent-sdk/src/bridge/tool_calls.ts
+++ b/agent-sdk/src/bridge/tool_calls.ts
@@ -4,7 +4,7 @@ import { bridgeLogger, LOG_TARGETS } from "./logger.js";
 import type { SessionState } from "./session_lifecycle.js";
 import { asRecordOrNull } from "./shared.js";
 import { applyTaskToolResult } from "./tasks.js";
-import { activeTaskIdForToolUse, linkTaskToolUse } from "./task_links.js";
+import { activeTaskIdForToolUse, linkTaskToolUse, unlinkTaskToolUse } from "./task_links.js";
 import {
   backgroundToolLaunchTaskIdFromResult,
   buildToolResultFields,
@@ -74,6 +74,11 @@ export function toolUsesSummaryOutput(base: ToolCall | undefined): boolean {
 export function toolAcceptsTaskLifecycle(base: ToolCall | undefined): boolean {
   const baseToolName = toolName(base);
   return Boolean(baseToolName && TASK_LIFECYCLE_TOOL_NAMES.has(baseToolName));
+}
+
+export function defersTaskNotificationCompletion(base: ToolCall | undefined): boolean {
+  const baseToolName = toolName(base);
+  return baseToolName === "Agent" || baseToolName === "Task";
 }
 
 function classifyFailureKind(rawOutput: string | undefined): "refused" | "timeout" | "failed" {
@@ -433,6 +438,12 @@ export function emitToolResultUpdate(
   }
   emitToolCallUpdate(session, toolUseId, fields, "result", sourceMessageUuid);
   applyTaskToolResult(session, toolUseId, isError, rawContent, rawResult);
+  if (baseToolName === "Agent" || baseToolName === "Task") {
+    const taskId = activeTaskIdForToolUse(session, toolUseId);
+    if (taskId) {
+      unlinkTaskToolUse(session, taskId);
+    }
+  }
 }
 
 export function finalizeOpenToolCalls(session: SessionState, status: "completed" | "failed"): void {

--- a/agent-sdk/src/bridge/tool_calls.ts
+++ b/agent-sdk/src/bridge/tool_calls.ts
@@ -311,14 +311,22 @@ export function emitToolCallUpdate(
   toolUseId: string,
   fields: ToolCallUpdateFields,
   updateKind: ToolUpdateKind,
+  sourceMessageUuid?: string,
 ): void {
   const base = session.toolCalls.get(toolUseId);
   logToolCallUpdateEmitted(session.sessionId, toolUseId, fields, base, updateKind);
   emitSessionUpdate(session.sessionId, {
     type: "tool_call_update",
-    tool_call_update: { tool_call_id: toolUseId, fields },
+    tool_call_update: {
+      tool_call_id: toolUseId,
+      ...(sourceMessageUuid ? { source_message_uuid: sourceMessageUuid } : {}),
+      fields,
+    },
   });
   if (base) {
+    if (sourceMessageUuid) {
+      base.source_message_uuid = sourceMessageUuid;
+    }
     applyFieldsToBase(base, fields);
   }
 }
@@ -330,6 +338,7 @@ export function emitToolCall(
   input: Record<string, unknown>,
   parentToolUseId: string | null = null,
   metadata?: ToolCorrelationMetadata,
+  sourceMessageUuid?: string,
 ): void {
   const existing = session.toolCalls.get(toolUseId);
   const resolvedParentToolUseId = parentToolUseId ?? parentToolUseIdFromMeta(existing?.meta);
@@ -341,6 +350,9 @@ export function emitToolCall(
     taskTitleContext(session, name, input),
   );
   applyToolCorrelationMetadata(toolCall, metadata);
+  if (sourceMessageUuid) {
+    toolCall.source_message_uuid = sourceMessageUuid;
+  }
   const status: ToolCall["status"] = "in_progress";
   toolCall.status = status;
 
@@ -360,7 +372,7 @@ export function emitToolCall(
   if (toolCall.content.length > 0) {
     fields.content = toolCall.content;
   }
-  emitToolCallUpdate(session, toolUseId, fields, "refresh");
+  emitToolCallUpdate(session, toolUseId, fields, "refresh", sourceMessageUuid);
 }
 
 export function ensureToolCallVisible(
@@ -402,6 +414,7 @@ export function emitToolResultUpdate(
   isError: boolean,
   rawContent: unknown,
   rawResult: unknown = rawContent,
+  sourceMessageUuid?: string,
 ): void {
   const base = session.toolCalls.get(toolUseId);
   const baseToolName = toolNameFromMeta(base?.meta) ?? "";
@@ -418,7 +431,7 @@ export function emitToolResultUpdate(
       linkTaskToolUse(session, taskId, toolUseId);
     }
   }
-  emitToolCallUpdate(session, toolUseId, fields, "result");
+  emitToolCallUpdate(session, toolUseId, fields, "result", sourceMessageUuid);
   applyTaskToolResult(session, toolUseId, isError, rawContent, rawResult);
 }
 

--- a/agent-sdk/src/bridge/tooling.ts
+++ b/agent-sdk/src/bridge/tooling.ts
@@ -29,6 +29,9 @@ const ENTER_PLAN_MODE_TOOL_NAME = "EnterPlanMode";
 const REPL_TOOL_NAME = "REPL";
 const MONITOR_TOOL_NAME = "Monitor";
 const WORKFLOW_TOOL_NAME = "Workflow";
+const PROJECTS_TOOL_NAME = "Projects";
+const ARTIFACT_TOOL_NAME = "Artifact";
+const SHOW_ONBOARDING_ROLE_PICKER_TOOL_NAME = "ShowOnboardingRolePicker";
 const SEARCH_OUTPUT_MODES = new Set(["content", "files_with_matches", "count"]);
 
 function isCronToolName(name: string): boolean {
@@ -59,6 +62,22 @@ function inputNumber(input: Record<string, unknown>, key: string): number | unde
 
 function inputBoolean(input: Record<string, unknown>, key: string): boolean | undefined {
   return typeof input[key] === "boolean" ? input[key] : undefined;
+}
+
+function isAgentLikeToolName(name: string): boolean {
+  return name === "Agent" || name === "Task";
+}
+
+function agentInputTitle(name: string, input: Record<string, unknown>): string | undefined {
+  if (!isAgentLikeToolName(name)) {
+    return undefined;
+  }
+  const agentName = nonEmptyString(input.name);
+  if (agentName) {
+    return `${name}: ${agentName}`;
+  }
+  const subagentType = nonEmptyString(input.subagent_type);
+  return subagentType ? `${name}: ${subagentType}` : undefined;
 }
 
 function searchModeLabel(value: unknown): string {
@@ -178,6 +197,9 @@ export function normalizeToolKind(name: string): string {
     case "REPL":
     case "Monitor":
     case "Workflow":
+    case "Projects":
+    case "Artifact":
+    case "ShowOnboardingRolePicker":
       return "other";
     case "Task":
     case "Agent":
@@ -195,6 +217,10 @@ export function toolTitle(
   input: Record<string, unknown>,
   context: TaskTitleContext = {},
 ): string {
+  const agentTitle = agentInputTitle(name, input);
+  if (agentTitle) {
+    return agentTitle;
+  }
   if (name === "Bash") {
     const command = typeof input.command === "string" ? input.command : "";
     return command || "Terminal";
@@ -249,6 +275,17 @@ export function toolTitle(
     const workflowName = nonEmptyString(input.name);
     return workflowName ? `${WORKFLOW_TOOL_NAME}: ${workflowName}` : WORKFLOW_TOOL_NAME;
   }
+  if (name === PROJECTS_TOOL_NAME) {
+    return formatProjectsTitle(input);
+  }
+  if (name === ARTIFACT_TOOL_NAME) {
+    const label = nonEmptyString(input.label) ?? nonEmptyString(input.file_path);
+    return label ? `${ARTIFACT_TOOL_NAME}: ${label}` : ARTIFACT_TOOL_NAME;
+  }
+  if (name === SHOW_ONBOARDING_ROLE_PICKER_TOOL_NAME) {
+    // TODO: The TUI accepts this SDK tool call but does not implement an onboarding role flow yet.
+    return SHOW_ONBOARDING_ROLE_PICKER_TOOL_NAME;
+  }
   if (name === "EnterWorktree") {
     const worktreeName = typeof input.name === "string" ? input.name.trim() : "";
     return worktreeName || "EnterWorktree";
@@ -270,6 +307,14 @@ export function toolTitle(
     }
   }
   return name;
+}
+
+function formatProjectsTitle(input: Record<string, unknown>): string {
+  const method = nonEmptyString(input.method);
+  const action = method?.startsWith("project_") ? method.slice("project_".length) : method;
+  const suffix = nonEmptyString(input.path) ?? nonEmptyString(input.query);
+  const base = action ? `${PROJECTS_TOOL_NAME}: ${action}` : PROJECTS_TOOL_NAME;
+  return suffix ? `${base} ${suffix}` : base;
 }
 
 function editDiffContent(name: string, input: Record<string, unknown>): ToolCall["content"] {
@@ -460,7 +505,8 @@ function extractToolOutputMetadata(
   rawResult: unknown,
   rawContent: unknown,
 ): import("../types.js").ToolOutputMetadata | undefined {
-  const candidates = resultRecordCandidates(rawResult, rawContent);
+  const candidates = collectResultCandidates(rawResult, rawContent);
+  const metadata: import("../types.js").ToolOutputMetadata = {};
 
   if (toolName === "Bash") {
     for (const candidate of candidates) {
@@ -468,15 +514,41 @@ function extractToolOutputMetadata(
       if (hasAssistantAutoBackgrounded) {
         const bashMetadata: import("../types.js").BashOutputMetadata = {};
         bashMetadata.assistant_auto_backgrounded = candidate.assistantAutoBackgrounded as boolean;
-        return {
-          bash: bashMetadata,
-        };
+        metadata.bash = bashMetadata;
+        break;
       }
     }
-    return undefined;
   }
 
-  return undefined;
+  if (toolName === "Agent" || toolName === "Task") {
+    for (const candidate of candidates) {
+      const resolvedModel = nonEmptyString(candidate.resolvedModel);
+      if (resolvedModel) {
+        const agentMetadata: import("../types.js").AgentOutputMetadata = {
+          resolved_model: resolvedModel,
+        };
+        metadata.agent = agentMetadata;
+        break;
+      }
+    }
+  }
+
+  if (toolName === "WebFetch") {
+    for (const candidate of candidates) {
+      const artifactRead = asRecordOrNull(candidate.artifactRead);
+      const slug = nonEmptyString(artifactRead?.slug);
+      const ver = nonEmptyString(artifactRead?.ver);
+      if (slug && ver) {
+        const webFetchMetadata: import("../types.js").WebFetchOutputMetadata = {
+          artifact_read: { slug, ver },
+        };
+        metadata.web_fetch = webFetchMetadata;
+        break;
+      }
+    }
+  }
+
+  return metadata.bash || metadata.agent || metadata.web_fetch ? metadata : undefined;
 }
 
 export function extractText(value: unknown): string {
@@ -780,11 +852,15 @@ function fileUnchangedResultText(rawResult: unknown, rawContent: unknown): strin
   return "";
 }
 
-function agentTitleFromAgentOutput(rawResult: unknown, rawContent: unknown): string {
+function agentTitleFromAgentOutput(rawResult: unknown, rawContent: unknown, base?: ToolCall): string {
+  const inputAgentName = nonEmptyString(asRecordOrNull(base?.raw_input)?.name);
+  if (inputAgentName) {
+    return "";
+  }
   for (const candidate of resultRecordCandidates(rawResult, rawContent)) {
     const agentType = typeof candidate.agentType === "string" ? candidate.agentType.trim() : "";
     if (agentType) {
-      return agentType;
+      return `Agent: ${agentType}`;
     }
   }
   return "";
@@ -1738,9 +1814,13 @@ function workflowResultFields(
     const taskId = nonEmptyString(candidate.taskId);
     const status = workflowStatusLabel(candidate.status);
     const error = nonEmptyString(candidate.error);
+    const taskType = nonEmptyString(candidate.taskType);
+    const workflowName = nonEmptyString(candidate.workflowName);
     const isStructuredWorkflowOutput =
       status !== undefined ||
       taskId !== undefined ||
+      taskType !== undefined ||
+      workflowName !== undefined ||
       "runId" in candidate ||
       "summary" in candidate ||
       "transcriptDir" in candidate ||
@@ -1758,6 +1838,12 @@ function workflowResultFields(
     }
     if (taskId) {
       lines.push(`Task ID: ${taskId}`);
+    }
+    if (taskType) {
+      lines.push(`Task type: ${taskType}`);
+    }
+    if (workflowName) {
+      lines.push(`Workflow name: ${workflowName}`);
     }
     const runId = nonEmptyString(candidate.runId);
     if (runId) {
@@ -1841,6 +1927,73 @@ function enterPlanModeStructuredOutputHandled(
   return false;
 }
 
+function readMcpResourceErrorText(
+  toolName: string,
+  rawResult: unknown,
+  rawContent: unknown,
+): string | undefined {
+  if (toolName !== "ReadMcpResource") {
+    return undefined;
+  }
+
+  for (const candidate of collectResultCandidates(rawResult, rawContent)) {
+    const error = nonEmptyString(candidate.error);
+    if (error) {
+      return `Error: ${error}`;
+    }
+  }
+
+  return undefined;
+}
+
+function webFetchResultText(
+  toolName: string,
+  rawResult: unknown,
+  rawContent: unknown,
+): string | undefined {
+  if (toolName !== "WebFetch") {
+    return undefined;
+  }
+
+  for (const candidate of collectResultCandidates(rawResult, rawContent)) {
+    const isStructuredWebFetchOutput =
+      "result" in candidate ||
+      "url" in candidate ||
+      "code" in candidate ||
+      "codeText" in candidate ||
+      "bytes" in candidate ||
+      "durationMs" in candidate ||
+      "artifactRead" in candidate;
+    if (!isStructuredWebFetchOutput) {
+      continue;
+    }
+
+    const result = nonEmptyString(candidate.result);
+    if (result) {
+      return result;
+    }
+
+    const lines: string[] = [];
+    const url = nonEmptyString(candidate.url);
+    if (url) {
+      lines.push(`URL: ${url}`);
+    }
+    if (typeof candidate.code === "number" && Number.isFinite(candidate.code)) {
+      const codeText = nonEmptyString(candidate.codeText);
+      lines.push(`Status: ${candidate.code}${codeText ? ` ${codeText}` : ""}`);
+    }
+    if (typeof candidate.bytes === "number" && Number.isFinite(candidate.bytes)) {
+      lines.push(`Bytes: ${Math.max(0, Math.trunc(candidate.bytes))}`);
+    }
+    if (typeof candidate.durationMs === "number" && Number.isFinite(candidate.durationMs)) {
+      lines.push(`Duration: ${Math.max(0, Math.trunc(candidate.durationMs))}ms`);
+    }
+    return lines.length > 0 ? lines.join("\n") : undefined;
+  }
+
+  return undefined;
+}
+
 export function buildToolResultFields(
   isError: boolean,
   rawContent: unknown,
@@ -1852,20 +2005,39 @@ export function buildToolResultFields(
   const fields: ToolCallUpdateFields = {
     status: isError ? "failed" : "completed",
   };
+  const outputMetadata = extractToolOutputMetadata(toolName, rawResult, rawContent);
+  if (outputMetadata) {
+    fields.output_metadata = outputMetadata;
+  }
   const fileUnchangedText = !isError && toolName === "Read" ? fileUnchangedResultText(rawResult, rawContent) : "";
   if (fileUnchangedText) {
     fields.raw_output = fileUnchangedText;
     fields.content = [{ type: "content", content: { type: "text", text: fileUnchangedText } }];
     return fields;
   }
-  const agentTitle = !isError && toolName === "Agent" ? agentTitleFromAgentOutput(rawResult, rawContent) : "";
+  const agentTitle = !isError && toolName === "Agent"
+    ? agentTitleFromAgentOutput(rawResult, rawContent, base)
+    : "";
   if (agentTitle) {
     fields.title = agentTitle;
+  }
+  const readMcpResourceError = readMcpResourceErrorText(toolName, rawResult, rawContent);
+  if (readMcpResourceError) {
+    fields.status = "failed";
+    fields.raw_output = readMcpResourceError;
+    fields.content = [{ type: "content", content: { type: "text", text: readMcpResourceError } }];
+    return fields;
   }
   const searchOutput = !isError ? searchResultText(toolName, rawResult, rawContent) : undefined;
   if (searchOutput !== undefined) {
     fields.raw_output = searchOutput;
     fields.content = [{ type: "content", content: { type: "text", text: searchOutput } }];
+    return fields;
+  }
+  const webFetchOutput = !isError ? webFetchResultText(toolName, rawResult, rawContent) : undefined;
+  if (webFetchOutput !== undefined) {
+    fields.raw_output = webFetchOutput;
+    fields.content = [{ type: "content", content: { type: "text", text: webFetchOutput } }];
     return fields;
   }
   const worktreeOutput = !isError
@@ -1965,11 +2137,6 @@ export function buildToolResultFields(
   if (rawOutput && !(isTaskToolName(toolName) && !isError)) {
     fields.raw_output = rawOutput;
   }
-  const outputMetadata = extractToolOutputMetadata(toolName, rawResult, rawContent);
-  if (outputMetadata) {
-    fields.output_metadata = outputMetadata;
-  }
-
   if (!isError && isTaskToolName(toolName)) {
     if (toolName === "TaskUpdate" && taskUpdateSucceeded(rawResult, rawContent) === false) {
       fields.status = "failed";

--- a/agent-sdk/src/bridge/tooling.ts
+++ b/agent-sdk/src/bridge/tooling.ts
@@ -29,6 +29,7 @@ const ENTER_PLAN_MODE_TOOL_NAME = "EnterPlanMode";
 const REPL_TOOL_NAME = "REPL";
 const MONITOR_TOOL_NAME = "Monitor";
 const WORKFLOW_TOOL_NAME = "Workflow";
+const SEARCH_OUTPUT_MODES = new Set(["content", "files_with_matches", "count"]);
 
 function isCronToolName(name: string): boolean {
   return CRON_TOOL_NAMES.has(name);
@@ -45,6 +46,100 @@ export function isToolSearchToolResultType(blockType: string): boolean {
 
 export function isToolUseBlockType(blockType: string): boolean {
   return blockType === "tool_use" || blockType === "server_tool_use" || blockType === "mcp_tool_use";
+}
+
+function inputString(input: Record<string, unknown>, key: string): string {
+  return typeof input[key] === "string" ? input[key].trim() : "";
+}
+
+function inputNumber(input: Record<string, unknown>, key: string): number | undefined {
+  const value = input[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function inputBoolean(input: Record<string, unknown>, key: string): boolean | undefined {
+  return typeof input[key] === "boolean" ? input[key] : undefined;
+}
+
+function searchModeLabel(value: unknown): string {
+  if (typeof value !== "string" || !SEARCH_OUTPUT_MODES.has(value)) {
+    return "";
+  }
+  switch (value) {
+    case "files_with_matches":
+      return "files";
+    case "content":
+      return "content";
+    case "count":
+      return "count";
+    default:
+      return "";
+  }
+}
+
+function grepContextValue(input: Record<string, unknown>): number | undefined {
+  return (
+    inputNumber(input, "context") ??
+    inputNumber(input, "-C") ??
+    inputNumber(input, "-A") ??
+    inputNumber(input, "-B")
+  );
+}
+
+function formatGlobTitle(input: Record<string, unknown>): string {
+  const pattern = inputString(input, "pattern");
+  const path = inputString(input, "path");
+  if (pattern && path) {
+    return `Glob ${pattern} in ${path}`;
+  }
+  if (pattern) {
+    return `Glob ${pattern}`;
+  }
+  if (path) {
+    return `Glob ${path}`;
+  }
+  return "Glob";
+}
+
+function formatGrepTitle(input: Record<string, unknown>): string {
+  const pattern = inputString(input, "pattern");
+  const path = inputString(input, "path");
+  const glob = inputString(input, "glob");
+  const fileType = inputString(input, "type");
+  const outputMode = searchModeLabel(input.output_mode);
+  const headLimit = inputNumber(input, "head_limit");
+  const offset = inputNumber(input, "offset");
+  const context = grepContextValue(input);
+  const flags: string[] = [];
+
+  if (glob) {
+    flags.push(`glob ${glob}`);
+  }
+  if (fileType) {
+    flags.push(`type ${fileType}`);
+  }
+  if (outputMode) {
+    flags.push(outputMode);
+  }
+  if (inputBoolean(input, "-i") === true) {
+    flags.push("case-insensitive");
+  }
+  if (context !== undefined) {
+    flags.push(`context ${context}`);
+  }
+  if (headLimit !== undefined) {
+    flags.push(`limit ${headLimit}`);
+  }
+  if (offset !== undefined && offset > 0) {
+    flags.push(`offset ${offset}`);
+  }
+  if (inputBoolean(input, "multiline") === true) {
+    flags.push("multiline");
+  }
+
+  const base = pattern ? `Grep ${pattern}` : "Grep";
+  const scoped = path ? `${base} in ${path}` : base;
+  return flags.length > 0 ? `${scoped} (${flags.join(", ")})` : scoped;
 }
 
 export function normalizeToolKind(name: string): string {
@@ -105,17 +200,10 @@ export function toolTitle(
     return command || "Terminal";
   }
   if (name === "Glob") {
-    const pattern = typeof input.pattern === "string" ? input.pattern : "";
-    const path = typeof input.path === "string" ? input.path : "";
-    if (pattern && path) {
-      return `Glob ${pattern} in ${path}`;
-    }
-    if (pattern) {
-      return `Glob ${pattern}`;
-    }
-    if (path) {
-      return `Glob ${path}`;
-    }
+    return formatGlobTitle(input);
+  }
+  if (name === "Grep") {
+    return formatGrepTitle(input);
   }
   if (name === "WebFetch") {
     const url = typeof input.url === "string" ? input.url : "";
@@ -700,6 +788,139 @@ function agentTitleFromAgentOutput(rawResult: unknown, rawContent: unknown): str
     }
   }
   return "";
+}
+
+function firstSearchRecord(toolName: string, rawResult: unknown, rawContent: unknown): Record<string, unknown> | undefined {
+  if (toolName !== "Glob" && toolName !== "Grep") {
+    return undefined;
+  }
+
+  const candidates = resultRecordCandidates(rawResult, rawContent);
+  for (const parsed of [parseJsonCandidate(rawResult), parseJsonCandidate(rawContent)]) {
+    candidates.push(...resultRecordCandidates(parsed, undefined));
+  }
+
+  return candidates.find((candidate) => {
+    if (toolName === "Glob") {
+      return Array.isArray(candidate.filenames) || "numFiles" in candidate || "truncated" in candidate;
+    }
+    return (
+      Array.isArray(candidate.filenames) ||
+      "numFiles" in candidate ||
+      "content" in candidate ||
+      "numLines" in candidate ||
+      "numMatches" in candidate
+    );
+  });
+}
+
+function recordNumber(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function recordString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function searchFilenames(record: Record<string, unknown>): string[] {
+  return Array.isArray(record.filenames)
+    ? record.filenames.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    : [];
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return count === 1 ? singular : plural;
+}
+
+function truncateList(values: string[], limit: number): { visible: string[]; hidden: number } {
+  if (values.length <= limit) {
+    return { visible: values, hidden: 0 };
+  }
+  return { visible: values.slice(0, limit), hidden: values.length - limit };
+}
+
+function globResultText(record: Record<string, unknown>): string | undefined {
+  const filenames = searchFilenames(record);
+  const numFiles = recordNumber(record, "numFiles") ?? filenames.length;
+  const truncated = record.truncated === true;
+  const lines: string[] = [];
+
+  if (numFiles === 0 && filenames.length === 0) {
+    lines.push("No files found");
+  } else {
+    lines.push(`${numFiles} ${pluralize(numFiles, "file")} found${truncated ? " (truncated)" : ""}`);
+  }
+
+  if (filenames.length > 0) {
+    const { visible, hidden } = truncateList(filenames, 20);
+    lines.push(...visible);
+    if (hidden > 0) {
+      lines.push(`... ${hidden} more ${pluralize(hidden, "file")} hidden`);
+    }
+  }
+
+  const durationMs = recordNumber(record, "durationMs");
+  if (durationMs !== undefined) {
+    lines.push(`Duration: ${durationMs}ms`);
+  }
+
+  return lines.join("\n");
+}
+
+function grepResultText(record: Record<string, unknown>): string | undefined {
+  const filenames = searchFilenames(record);
+  const content = recordString(record, "content") ?? "";
+  const numFiles = recordNumber(record, "numFiles") ?? filenames.length;
+  const numLines = recordNumber(record, "numLines");
+  const numMatches = recordNumber(record, "numMatches");
+  const appliedLimit = recordNumber(record, "appliedLimit");
+  const appliedOffset = recordNumber(record, "appliedOffset");
+  const mode = searchModeLabel(record.mode) || "files";
+  const lines: string[] = [];
+
+  if (content.trim().length > 0) {
+    lines.push(content);
+  } else if (filenames.length > 0) {
+    const { visible, hidden } = truncateList(filenames, 20);
+    lines.push(...visible);
+    if (hidden > 0) {
+      lines.push(`... ${hidden} more ${pluralize(hidden, "file")} hidden`);
+    }
+  } else {
+    lines.push("No matches found");
+  }
+
+  const summaryParts: string[] = [];
+  summaryParts.push(`${numFiles} ${pluralize(numFiles, "file")}`);
+  if (numMatches !== undefined) {
+    summaryParts.push(`${numMatches} ${pluralize(numMatches, "match", "matches")}`);
+  }
+  if (numLines !== undefined) {
+    summaryParts.push(`${numLines} ${pluralize(numLines, "line")}`);
+  }
+  summaryParts.push(`mode ${mode}`);
+  if (appliedLimit !== undefined) {
+    summaryParts.push(`limit ${appliedLimit}`);
+  }
+  if (appliedOffset !== undefined && appliedOffset > 0) {
+    summaryParts.push(`offset ${appliedOffset}`);
+  }
+
+  if (summaryParts.length > 0) {
+    lines.push(`Summary: ${summaryParts.join(", ")}`);
+  }
+
+  return lines.join("\n");
+}
+
+function searchResultText(toolName: string, rawResult: unknown, rawContent: unknown): string | undefined {
+  const record = firstSearchRecord(toolName, rawResult, rawContent);
+  if (!record) {
+    return undefined;
+  }
+  return toolName === "Glob" ? globResultText(record) : grepResultText(record);
 }
 
 function worktreeResultFields(
@@ -1640,6 +1861,12 @@ export function buildToolResultFields(
   const agentTitle = !isError && toolName === "Agent" ? agentTitleFromAgentOutput(rawResult, rawContent) : "";
   if (agentTitle) {
     fields.title = agentTitle;
+  }
+  const searchOutput = !isError ? searchResultText(toolName, rawResult, rawContent) : undefined;
+  if (searchOutput !== undefined) {
+    fields.raw_output = searchOutput;
+    fields.content = [{ type: "content", content: { type: "text", text: searchOutput } }];
+    return fields;
   }
   const worktreeOutput = !isError
     ? worktreeResultFields(toolName, rawResult, rawContent)

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -367,6 +367,46 @@ export type QuestionOutcome =
     }
   | { outcome: "cancelled" };
 
+/**
+ * The host-selectable choices of a `refusal_fallback_prompt` dialog. `cancelled`
+ * is the CLI default and is delivered via the Esc/decline path, not as a listed
+ * option, so it is excluded from this union (see {@link UserDialogOutcome}).
+ */
+export type RefusalFallbackPromptChoice = "retry_fallback" | "edit_prompt";
+
+/**
+ * Snake-case host wire shape of the `refusal_fallback_prompt` payload. The CLI
+ * builds it with camelCase keys (`originalModel`, …); the bridge normalizes the
+ * casing before emitting.
+ */
+export interface RefusalFallbackPromptPayload {
+  original_model: string;
+  fallback_model: string;
+  api_refusal_category?: string;
+  guidance_text?: string;
+  retracted_message_uuids?: string[];
+}
+
+export interface UserDialogOption {
+  option_id: RefusalFallbackPromptChoice;
+  label: string;
+}
+
+/**
+ * Host-facing shape of a `request_user_dialog` control request. The bridge owns
+ * `request_id` (generated per callback) and the rendered option labels.
+ */
+export interface UserDialogRequestPayload {
+  request_id: string;
+  dialog_kind: "refusal_fallback_prompt";
+  payload: RefusalFallbackPromptPayload;
+  options: UserDialogOption[];
+}
+
+export type UserDialogOutcome =
+  | { outcome: "selected"; option_id: RefusalFallbackPromptChoice }
+  | { outcome: "cancelled" };
+
 export interface SessionListEntry {
   session_id: string;
   summary: string;
@@ -568,6 +608,12 @@ export type BridgeCommand =
       outcome: QuestionOutcome;
     }
   | {
+      command: "user_dialog_response";
+      session_id: string;
+      request_id: string;
+      outcome: UserDialogOutcome;
+    }
+  | {
       command: "elicitation_response";
       session_id: string;
       elicitation_request_id: string;
@@ -668,6 +714,7 @@ export type BridgeEvent =
   | { event: "session_update"; session_id: string; update: SessionUpdate }
   | { event: "permission_request"; session_id: string; request: PermissionRequest }
   | { event: "question_request"; session_id: string; request: QuestionRequest }
+  | { event: "user_dialog_request"; session_id: string; request: UserDialogRequestPayload }
   | { event: "elicitation_request"; session_id: string; request: ElicitationRequest }
   | { event: "elicitation_complete"; session_id: string; completion: ElicitationComplete }
   | { event: "mcp_auth_redirect"; session_id: string; redirect: McpAuthRedirect }

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -538,6 +538,12 @@ export interface McpSetServersResult {
   errors: Record<string, string>;
 }
 
+export type McpSnapshotSource =
+  | "reload_plugins"
+  | "mcp_status"
+  | "mcp_set_servers"
+  | "init";
+
 export interface SessionLaunchSettings {
   language?: string;
   settings?: { [key: string]: Json };
@@ -773,5 +779,6 @@ export type BridgeEvent =
       event: "mcp_snapshot";
       session_id: string;
       servers: McpServerStatus[];
+      source?: McpSnapshotSource;
       error?: string;
     };

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -456,9 +456,12 @@ export type McpServerToolPermissionPolicy =
   | "always_ask"
   | "always_deny";
 
+export type McpServerOrgMaxPermission = "allow" | "ask" | "blocked";
+
 export interface McpServerToolPolicy {
   name: string;
-  permission_policy: McpServerToolPermissionPolicy;
+  permission_policy?: McpServerToolPermissionPolicy;
+  org_max_permission?: McpServerOrgMaxPermission;
 }
 
 export type McpServerConfig =

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -138,8 +138,23 @@ export interface BashOutputMetadata {
   assistant_auto_backgrounded?: boolean;
 }
 
+export interface AgentOutputMetadata {
+  resolved_model?: string;
+}
+
+export interface WebFetchArtifactReadMetadata {
+  slug: string;
+  ver: string;
+}
+
+export interface WebFetchOutputMetadata {
+  artifact_read?: WebFetchArtifactReadMetadata;
+}
+
 export interface ToolOutputMetadata {
   bash?: BashOutputMetadata;
+  agent?: AgentOutputMetadata;
+  web_fetch?: WebFetchOutputMetadata;
 }
 
 export interface TaskMetadata {

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -168,6 +168,7 @@ export interface ToolCall {
   title: string;
   kind: string;
   status: string;
+  source_message_uuid?: string;
   content: ToolCallContent[];
   raw_input?: Json;
   raw_output?: string;
@@ -192,7 +193,26 @@ export interface ToolCallUpdateFields {
 
 export interface ToolCallUpdate {
   tool_call_id: string;
+  source_message_uuid?: string;
   fields: ToolCallUpdateFields;
+}
+
+export type TranscriptRetractionReason =
+  | "model_refusal_fallback"
+  | "model_fallback"
+  | "assistant_supersedes";
+
+export interface TranscriptRetraction {
+  message_uuids: string[];
+  reason: TranscriptRetractionReason;
+  request_id?: string;
+  trigger?: string;
+  direction?: string;
+  original_model?: string;
+  fallback_model?: string;
+  api_refusal_category?: string;
+  api_refusal_explanation?: string;
+  content?: string;
 }
 
 export type TaskStatus = "pending" | "in_progress" | "completed";
@@ -224,11 +244,12 @@ export interface TaskStateUpdate {
 }
 
 export type SessionUpdate =
-  | { type: "agent_message_chunk"; content: ContentBlock }
-  | { type: "user_message_chunk"; content: ContentBlock }
-  | { type: "agent_thought_chunk"; content: ContentBlock }
+  | { type: "agent_message_chunk"; content: ContentBlock; source_message_uuid?: string }
+  | { type: "user_message_chunk"; content: ContentBlock; source_message_uuid?: string }
+  | { type: "agent_thought_chunk"; content: ContentBlock; source_message_uuid?: string }
   | { type: "tool_call"; tool_call: ToolCall }
   | { type: "tool_call_update"; tool_call_update: ToolCallUpdate }
+  | ({ type: "transcript_retraction" } & TranscriptRetraction)
   | ({ type: "task_state_update" } & TaskStateUpdate)
   | {
       type: "available_commands_update";

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -722,6 +722,7 @@ export type BridgeEvent =
   | { event: "elicitation_complete"; session_id: string; completion: ElicitationComplete }
   | { event: "mcp_auth_redirect"; session_id: string; redirect: McpAuthRedirect }
   | { event: "mcp_operation_error"; session_id: string; error: McpOperationError }
+  | { event: "mcp_set_servers_result"; session_id: string; result: McpSetServersResult }
   | { event: "turn_complete"; session_id: string; terminal_reason?: TerminalReason }
   | {
       event: "turn_error";

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.161",
+        "@anthropic-ai/claude-agent-sdk": "0.3.177",
         "@anthropic-ai/sdk": "0.97.1",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "4.4.3"
@@ -23,22 +23,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.161.tgz",
-      "integrity": "sha512-TWVFmPsGePXPNnNuWAAuKagQai9kNj99tuu2KLo8FN3oWF5r82OnWTNpQ3IubpWYPyO1vC0+kQu2GfqoEme/hA==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.177.tgz",
+      "integrity": "sha512-CBzXnzR661q3AlfZzBjmIFQx0cxr36iJV3PExTYmPyGQX32qxtiFQgnxTcF8wB4hcSVf2hnoy/gprVJdkNx7cw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.161",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.161"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.177"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.161.tgz",
-      "integrity": "sha512-KwDpi1O2P++uAskFt454K/sShPmhHSYhSbBxaap2KLFoVFti1pttDcEqDPfmKCk2XzKTwlpnVSI1IwTiawPJTw==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.177.tgz",
+      "integrity": "sha512-u9Ty+KPllm2nw0RatdPF0zcPRquNZjVptmyLG0DqduGbgZDLQpfPFMF5hffFIRnVaXhx7+jkUmEdw0jrda0UcA==",
       "cpu": [
         "arm64"
       ],
@@ -60,9 +60,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.161.tgz",
-      "integrity": "sha512-VoLz1BfKDc6UOYL+UhRKNSFA1k4l6kvOUrWqkHJ34V5zI5/7VzQilaGl7hU5JECE1TleXMzrWpDrLZO7akApJA==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.177.tgz",
+      "integrity": "sha512-ona6Jv54XFwBTqOj3MzLWfKtc2m7Rdh58wOAX9Hnue/6FcWfyeuz/UDcidVTXQ7Xytz//Tb0JJgFtiQjO7FbIA==",
       "cpu": [
         "x64"
       ],
@@ -73,9 +73,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.161.tgz",
-      "integrity": "sha512-QQbGTJ+2AFeP6+vsZQtafqeGZGX72jaHOjOyrhEcMk1T2DSrJV05J0xnkZT4yIOsByGosntTcY6963EfkuwuTg==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.177.tgz",
+      "integrity": "sha512-wBCbklkaDb483Ab4DUFfmJjZJKXz58YXPv+CiGsyjq1St19mbKEma5KKz3Ya9mlV8aLyh4zmLK2mEHPnF//Ipg==",
       "cpu": [
         "arm64"
       ],
@@ -86,9 +86,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.161.tgz",
-      "integrity": "sha512-y+RPkQ6ZFje6LP0WyGvM4yHp7IQAaxAbcKSP9QVzKtT9yWiDeqWSnPzdP2Rp3B+6Kd12MuhwIMAbiKS4onAusA==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.177.tgz",
+      "integrity": "sha512-v6PMDD3h2erLuTK5S2ZvExqdL3v44OyC70XpKhyqIUnyPaGR9YAMjh//EKdWC+mNvt6mIbRZpaDcHtbASVW8Rw==",
       "cpu": [
         "arm64"
       ],
@@ -99,9 +99,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.161.tgz",
-      "integrity": "sha512-gq4tvNRRcfSf8o35mLWKN351I6FowQa2n28YiZJBvZU1glQ3HKQM4srrXzjwLwv1VcndyWBfLxoaDB1I9BS++w==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.177.tgz",
+      "integrity": "sha512-WDP6puwPHscggNAfvIxyUSHSAjfUEkGRfnMXEPBHOqO+qjX2KGxeE13/ih3EVioeBVOUIqPui6VB05vXLa6T9Q==",
       "cpu": [
         "x64"
       ],
@@ -112,9 +112,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.161.tgz",
-      "integrity": "sha512-ev0eJhypbyatvSL+Cl2LqOos5+XZbgBMV6MJk7jIh/9dirMLwDj2JFlLlOnHdmIpFcznESZ/Z2wgMtqmOMUCHQ==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.177.tgz",
+      "integrity": "sha512-1cdEO06WoEsl1JnnLCPIlg/8x37GtBsTuj65gIpSjdrImNBjgIuMWVyceP4qaXhFjtQgYK1nx3TpaxEFVDOrDg==",
       "cpu": [
         "x64"
       ],
@@ -125,9 +125,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.161.tgz",
-      "integrity": "sha512-toJhVo/7RKyPc/IEGvgIcN/mPmGs38gnuDOrdtdxXoPR7WRkHcHfwprD5S9zV/pZAhuLhj/cznhno3G7b4Pnkg==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.177.tgz",
+      "integrity": "sha512-xLgDWnZaYohtFrkgEIkGZdP+rp4sXxAMbbpEvEp0LK1vAYmJam/ztT2yoK6gfI58IbToJq1WGUEX2HVnE65yOg==",
       "cpu": [
         "arm64"
       ],
@@ -138,9 +138,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.161",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.161.tgz",
-      "integrity": "sha512-QmYFeX/P7bt4diCZhXgazkmzLxL+uK1zwPaCSL2sIQyYGWAXiUulZ41TVLQbHglCBlKzUzVP9kwEXaAZye7LPA==",
+      "version": "0.3.177",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.177.tgz",
+      "integrity": "sha512-SIdQLbtF//rYK4KDBNpUPyjyui7NwCFPZ2/3vyW3TR8R8xynkNq3cLis90FnPSgxaSshi38vkJYWh+9kGDB7zg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.161",
+    "@anthropic-ai/claude-agent-sdk": "0.3.177",
     "@anthropic-ai/sdk": "0.97.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "zod": "4.4.3"

--- a/src/agent/events.rs
+++ b/src/agent/events.rs
@@ -40,6 +40,17 @@ pub enum ClientEvent {
     McpAuthRedirect { redirect: crate::agent::types::McpAuthRedirect },
     /// MCP operation failed and should be surfaced in the MCP config UI.
     McpOperationError { error: crate::agent::types::McpOperationError },
+    /// Dynamic MCP server replacement completed through the SDK.
+    McpSetServersResult { session_id: String, result: crate::agent::types::McpSetServersResult },
+    /// Claude CLI removed an MCP server from a persisted config scope.
+    McpConfigRemoveSucceeded {
+        cwd_raw: String,
+        server_name: String,
+        scope: String,
+        claude_path: PathBuf,
+    },
+    /// Claude CLI failed to remove an MCP server from persisted config.
+    McpConfigRemoveFailed { cwd_raw: String, server_name: String, scope: String, message: String },
     /// A prompt turn completed successfully.
     TurnComplete { terminal_reason: Option<crate::agent::types::TerminalReason> },
     /// `cancel` notification was accepted by the bridge.

--- a/src/agent/events.rs
+++ b/src/agent/events.rs
@@ -118,6 +118,7 @@ pub enum ClientEvent {
     McpSnapshotReceived {
         session_id: String,
         servers: Vec<model::McpServerStatus>,
+        source: Option<crate::agent::types::McpSnapshotSource>,
         error: Option<String>,
     },
     /// Usage refresh task started.

--- a/src/agent/events.rs
+++ b/src/agent/events.rs
@@ -26,6 +26,12 @@ pub enum ClientEvent {
         request: model::RequestQuestionRequest,
         response_tx: tokio::sync::oneshot::Sender<model::RequestQuestionResponse>,
     },
+    /// Turn-level `request_user_dialog` (e.g. `refusal_fallback_prompt`) that
+    /// needs a user decision. Not anchored to a tool call.
+    UserDialogRequest {
+        request: model::RequestUserDialogRequest,
+        response_tx: tokio::sync::oneshot::Sender<model::RequestUserDialogResponse>,
+    },
     /// MCP elicitation request that needs auth or other MCP input.
     McpElicitationRequest { request: crate::agent::types::ElicitationRequest },
     /// MCP elicitation completed in the SDK.

--- a/src/agent/model.rs
+++ b/src/agent/model.rs
@@ -290,10 +290,29 @@ impl McpServerToolPermissionPolicy {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum McpServerOrgMaxPermission {
+    Allow,
+    Ask,
+    Blocked,
+}
+
+impl McpServerOrgMaxPermission {
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Ask => "ask",
+            Self::Blocked => "blocked",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct McpServerToolPolicy {
     pub name: String,
-    pub permission_policy: McpServerToolPermissionPolicy,
+    pub permission_policy: Option<McpServerToolPermissionPolicy>,
+    pub org_max_permission: Option<McpServerOrgMaxPermission>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/agent/model.rs
+++ b/src/agent/model.rs
@@ -605,6 +605,24 @@ impl BashOutputMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ToolOutputMetadata {
     pub bash: Option<BashOutputMetadata>,
+    pub agent: Option<AgentOutputMetadata>,
+    pub web_fetch: Option<WebFetchOutputMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct AgentOutputMetadata {
+    pub resolved_model: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WebFetchOutputMetadata {
+    pub artifact_read: Option<WebFetchArtifactReadMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WebFetchArtifactReadMetadata {
+    pub slug: String,
+    pub ver: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -616,6 +634,12 @@ pub struct TaskMetadata {
     pub request_id: Option<String>,
     pub subagent_type: Option<String>,
     pub task_description: Option<String>,
+    pub task_type: Option<String>,
+    pub workflow_name: Option<String>,
+    pub prompt: Option<String>,
+    pub output_file: Option<String>,
+    pub summary: Option<String>,
+    pub terminal_status: Option<String>,
 }
 
 impl TaskMetadata {
@@ -665,6 +689,42 @@ impl TaskMetadata {
         self.task_description = task_description;
         self
     }
+
+    #[must_use]
+    pub fn task_type(mut self, task_type: Option<String>) -> Self {
+        self.task_type = task_type;
+        self
+    }
+
+    #[must_use]
+    pub fn workflow_name(mut self, workflow_name: Option<String>) -> Self {
+        self.workflow_name = workflow_name;
+        self
+    }
+
+    #[must_use]
+    pub fn prompt(mut self, prompt: Option<String>) -> Self {
+        self.prompt = prompt;
+        self
+    }
+
+    #[must_use]
+    pub fn output_file(mut self, output_file: Option<String>) -> Self {
+        self.output_file = output_file;
+        self
+    }
+
+    #[must_use]
+    pub fn summary(mut self, summary: Option<String>) -> Self {
+        self.summary = summary;
+        self
+    }
+
+    #[must_use]
+    pub fn terminal_status(mut self, terminal_status: Option<String>) -> Self {
+        self.terminal_status = terminal_status;
+        self
+    }
 }
 
 impl ToolOutputMetadata {
@@ -677,6 +737,51 @@ impl ToolOutputMetadata {
     pub fn bash(mut self, bash: Option<BashOutputMetadata>) -> Self {
         self.bash = bash;
         self
+    }
+
+    #[must_use]
+    pub fn agent(mut self, agent: Option<AgentOutputMetadata>) -> Self {
+        self.agent = agent;
+        self
+    }
+
+    #[must_use]
+    pub fn web_fetch(mut self, web_fetch: Option<WebFetchOutputMetadata>) -> Self {
+        self.web_fetch = web_fetch;
+        self
+    }
+}
+
+impl AgentOutputMetadata {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn resolved_model(mut self, resolved_model: Option<String>) -> Self {
+        self.resolved_model = resolved_model;
+        self
+    }
+}
+
+impl WebFetchOutputMetadata {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn artifact_read(mut self, artifact_read: Option<WebFetchArtifactReadMetadata>) -> Self {
+        self.artifact_read = artifact_read;
+        self
+    }
+}
+
+impl WebFetchArtifactReadMetadata {
+    #[must_use]
+    pub fn new(slug: impl Into<String>, ver: impl Into<String>) -> Self {
+        Self { slug: slug.into(), ver: ver.into() }
     }
 }
 

--- a/src/agent/model.rs
+++ b/src/agent/model.rs
@@ -110,12 +110,19 @@ impl Content {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContentChunk {
     pub content: ContentBlock,
+    pub source_message_uuid: Option<String>,
 }
 
 impl ContentChunk {
     #[must_use]
     pub fn new(content: ContentBlock) -> Self {
-        Self { content }
+        Self { content, source_message_uuid: None }
+    }
+
+    #[must_use]
+    pub fn source_message_uuid(mut self, source_message_uuid: Option<String>) -> Self {
+        self.source_message_uuid = source_message_uuid.filter(|uuid| !uuid.trim().is_empty());
+        self
     }
 }
 
@@ -363,6 +370,7 @@ pub struct ToolCall {
     pub title: String,
     pub kind: ToolKind,
     pub status: ToolCallStatus,
+    pub source_message_uuid: Option<String>,
     pub content: Vec<ToolCallContent>,
     pub raw_input: Option<serde_json::Value>,
     pub raw_output: Option<serde_json::Value>,
@@ -380,6 +388,7 @@ impl ToolCall {
             title: title.into(),
             kind: ToolKind::Think,
             status: ToolCallStatus::Pending,
+            source_message_uuid: None,
             content: Vec::new(),
             raw_input: None,
             raw_output: None,
@@ -399,6 +408,12 @@ impl ToolCall {
     #[must_use]
     pub fn status(mut self, status: ToolCallStatus) -> Self {
         self.status = status;
+        self
+    }
+
+    #[must_use]
+    pub fn source_message_uuid(mut self, source_message_uuid: Option<String>) -> Self {
+        self.source_message_uuid = source_message_uuid.filter(|uuid| !uuid.trim().is_empty());
         self
     }
 
@@ -523,6 +538,7 @@ impl ToolCallUpdateFields {
 #[allow(clippy::struct_field_names)]
 pub struct ToolCallUpdate {
     pub tool_call_id: String,
+    pub source_message_uuid: Option<String>,
     pub fields: ToolCallUpdateFields,
     pub meta: Option<serde_json::Value>,
 }
@@ -530,7 +546,13 @@ pub struct ToolCallUpdate {
 impl ToolCallUpdate {
     #[must_use]
     pub fn new(tool_call_id: impl Into<String>, fields: ToolCallUpdateFields) -> Self {
-        Self { tool_call_id: tool_call_id.into(), fields, meta: None }
+        Self { tool_call_id: tool_call_id.into(), source_message_uuid: None, fields, meta: None }
+    }
+
+    #[must_use]
+    pub fn source_message_uuid(mut self, source_message_uuid: Option<String>) -> Self {
+        self.source_message_uuid = source_message_uuid.filter(|uuid| !uuid.trim().is_empty());
+        self
     }
 
     #[must_use]
@@ -1245,6 +1267,28 @@ pub struct CompactionBoundary {
     pub pre_tokens: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TranscriptRetractionReason {
+    ModelRefusalFallback,
+    ModelFallback,
+    AssistantSupersedes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TranscriptRetraction {
+    pub message_uuids: Vec<String>,
+    pub reason: TranscriptRetractionReason,
+    pub request_id: Option<String>,
+    pub trigger: Option<String>,
+    pub direction: Option<String>,
+    pub original_model: Option<String>,
+    pub fallback_model: Option<String>,
+    pub api_refusal_category: Option<String>,
+    pub api_refusal_explanation: Option<String>,
+    pub content: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum SessionUpdate {
     AgentMessageChunk(ContentChunk),
@@ -1252,6 +1296,7 @@ pub enum SessionUpdate {
     AgentThoughtChunk(ContentChunk),
     ToolCall(ToolCall),
     ToolCallUpdate(ToolCallUpdate),
+    TranscriptRetraction(TranscriptRetraction),
     TaskStateUpdate(TaskStateUpdate),
     AvailableCommandsUpdate(AvailableCommandsUpdate),
     AvailableAgentsUpdate(AvailableAgentsUpdate),

--- a/src/agent/model.rs
+++ b/src/agent/model.rs
@@ -1591,3 +1591,87 @@ impl RequestQuestionRequest {
         Self { session_id: session_id.into(), tool_call, prompt, question_index, total_questions }
     }
 }
+
+/// Snake-case payload of a `refusal_fallback_prompt` dialog. `original_model`
+/// and `fallback_model` are always present; the rest is optional metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RefusalFallbackPayload {
+    pub original_model: String,
+    pub fallback_model: String,
+    pub api_refusal_category: Option<String>,
+    pub guidance_text: Option<String>,
+    pub retracted_message_uuids: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserDialogOption {
+    pub option_id: String,
+    pub label: String,
+}
+
+impl UserDialogOption {
+    #[must_use]
+    pub fn new(option_id: impl Into<String>, label: impl Into<String>) -> Self {
+        Self { option_id: option_id.into(), label: label.into() }
+    }
+}
+
+/// Turn-level `request_user_dialog` request surfaced to the app. Keyed by a
+/// bridge-generated `request_id`; it has no tool-call anchor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequestUserDialogRequest {
+    pub session_id: SessionId,
+    pub request_id: String,
+    pub dialog_kind: String,
+    pub payload: RefusalFallbackPayload,
+    pub options: Vec<UserDialogOption>,
+}
+
+impl RequestUserDialogRequest {
+    #[must_use]
+    pub fn new(
+        session_id: impl Into<SessionId>,
+        request_id: impl Into<String>,
+        dialog_kind: impl Into<String>,
+        payload: RefusalFallbackPayload,
+        options: Vec<UserDialogOption>,
+    ) -> Self {
+        Self {
+            session_id: session_id.into(),
+            request_id: request_id.into(),
+            dialog_kind: dialog_kind.into(),
+            payload,
+            options,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SelectedUserDialogOutcome {
+    pub option_id: String,
+}
+
+impl SelectedUserDialogOutcome {
+    #[must_use]
+    pub fn new(option_id: impl Into<String>) -> Self {
+        Self { option_id: option_id.into() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RequestUserDialogOutcome {
+    Selected(SelectedUserDialogOutcome),
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequestUserDialogResponse {
+    pub outcome: RequestUserDialogOutcome,
+}
+
+impl RequestUserDialogResponse {
+    #[must_use]
+    pub fn new(outcome: RequestUserDialogOutcome) -> Self {
+        Self { outcome }
+    }
+}

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -710,10 +710,21 @@ pub enum McpServerToolPermissionPolicy {
     Deny,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpServerOrgMaxPermission {
+    Allow,
+    Ask,
+    Blocked,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct McpServerToolPolicy {
     pub name: String,
-    pub permission_policy: McpServerToolPermissionPolicy,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permission_policy: Option<McpServerToolPermissionPolicy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_max_permission: Option<McpServerOrgMaxPermission>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -823,9 +834,9 @@ pub struct McpSetServersResult {
 #[cfg(test)]
 mod tests {
     use super::{
-        AccountInfo, ApiRetryError, AvailableModel, EffortLevel, McpServerStatus,
-        McpServerStatusConfig, McpServerToolPermissionPolicy, SessionStatus, SessionUpdate,
-        SystemNoticeSeverity, TranscriptRetractionReason,
+        AccountInfo, ApiRetryError, AvailableModel, EffortLevel, McpServerOrgMaxPermission,
+        McpServerStatus, McpServerStatusConfig, McpServerToolPermissionPolicy, SessionStatus,
+        SessionUpdate, SystemNoticeSeverity, TranscriptRetractionReason,
     };
 
     #[test]
@@ -980,7 +991,16 @@ mod tests {
                 "url": "https://mcp.notion.com/mcp",
                 "headers": { "Authorization": "Bearer token" },
                 "tools": [
-                    { "name": "search", "permission_policy": "always_ask" }
+                    {
+                        "name": "search",
+                        "permission_policy": "always_ask",
+                        "org_max_permission": "ask"
+                    },
+                    { "name": "lookup" },
+                    {
+                        "name": "write",
+                        "org_max_permission": "blocked"
+                    }
                 ],
                 "timeout": 5000,
                 "always_load": true
@@ -995,8 +1015,13 @@ mod tests {
         };
         assert_eq!(timeout, Some(5000));
         assert_eq!(always_load, Some(true));
-        assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0].permission_policy, McpServerToolPermissionPolicy::Ask);
+        assert_eq!(tools.len(), 3);
+        assert_eq!(tools[0].permission_policy, Some(McpServerToolPermissionPolicy::Ask));
+        assert_eq!(tools[0].org_max_permission, Some(McpServerOrgMaxPermission::Ask));
+        assert_eq!(tools[1].permission_policy, None);
+        assert_eq!(tools[1].org_max_permission, None);
+        assert_eq!(tools[2].permission_policy, None);
+        assert_eq!(tools[2].org_max_permission, Some(McpServerOrgMaxPermission::Blocked));
     }
 
     #[test]

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -855,6 +855,15 @@ pub struct McpSetServersResult {
     pub errors: BTreeMap<String, String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpSnapshotSource {
+    ReloadPlugins,
+    McpStatus,
+    McpSetServers,
+    Init,
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -169,6 +169,7 @@ pub struct ToolCall {
     pub title: String,
     pub kind: String,
     pub status: String,
+    pub source_message_uuid: Option<String>,
     pub content: Vec<ToolCallContent>,
     pub raw_input: Option<serde_json::Value>,
     pub raw_output: Option<String>,
@@ -181,7 +182,30 @@ pub struct ToolCall {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolCallUpdate {
     pub tool_call_id: String,
+    pub source_message_uuid: Option<String>,
     pub fields: ToolCallUpdateFields,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TranscriptRetractionReason {
+    ModelRefusalFallback,
+    ModelFallback,
+    AssistantSupersedes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TranscriptRetraction {
+    pub message_uuids: Vec<String>,
+    pub reason: TranscriptRetractionReason,
+    pub request_id: Option<String>,
+    pub trigger: Option<String>,
+    pub direction: Option<String>,
+    pub original_model: Option<String>,
+    pub fallback_model: Option<String>,
+    pub api_refusal_category: Option<String>,
+    pub api_refusal_explanation: Option<String>,
+    pub content: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -295,18 +319,25 @@ pub struct TaskStateUpdate {
 pub enum SessionUpdate {
     AgentMessageChunk {
         content: ContentBlock,
+        source_message_uuid: Option<String>,
     },
     UserMessageChunk {
         content: ContentBlock,
+        source_message_uuid: Option<String>,
     },
     AgentThoughtChunk {
         content: ContentBlock,
+        source_message_uuid: Option<String>,
     },
     ToolCall {
         tool_call: ToolCall,
     },
     ToolCallUpdate {
         tool_call_update: ToolCallUpdate,
+    },
+    TranscriptRetraction {
+        #[serde(flatten)]
+        retraction: TranscriptRetraction,
     },
     TaskStateUpdate {
         #[serde(flatten)]
@@ -756,7 +787,7 @@ mod tests {
     use super::{
         AccountInfo, ApiRetryError, AvailableModel, EffortLevel, McpServerStatus,
         McpServerStatusConfig, McpServerToolPermissionPolicy, SessionStatus, SessionUpdate,
-        SystemNoticeSeverity,
+        SystemNoticeSeverity, TranscriptRetractionReason,
     };
 
     #[test]
@@ -954,6 +985,48 @@ mod tests {
         assert_eq!(metadata.request_id.as_deref(), Some("request-1"));
         assert_eq!(metadata.subagent_type.as_deref(), Some("tester"));
         assert_eq!(metadata.task_description.as_deref(), Some("Validate the branch"));
+    }
+
+    #[test]
+    fn transcript_retraction_deserializes_with_metadata() {
+        let update: SessionUpdate = serde_json::from_value(serde_json::json!({
+            "type": "transcript_retraction",
+            "message_uuids": ["assistant-old", "tool-result-old"],
+            "reason": "model_refusal_fallback",
+            "request_id": "req-1",
+            "trigger": "refusal",
+            "direction": "retry",
+            "original_model": "claude-opus-4-1",
+            "fallback_model": "claude-sonnet-4-5",
+            "api_refusal_category": "cyber",
+            "api_refusal_explanation": "policy text",
+            "content": "Retried with fallback model"
+        }))
+        .expect("deserialize transcript retraction");
+
+        let SessionUpdate::TranscriptRetraction { retraction } = update else {
+            panic!("expected transcript retraction");
+        };
+        assert_eq!(retraction.message_uuids, vec!["assistant-old", "tool-result-old"]);
+        assert_eq!(retraction.reason, TranscriptRetractionReason::ModelRefusalFallback);
+        assert_eq!(retraction.request_id.as_deref(), Some("req-1"));
+        assert_eq!(retraction.original_model.as_deref(), Some("claude-opus-4-1"));
+        assert_eq!(retraction.fallback_model.as_deref(), Some("claude-sonnet-4-5"));
+    }
+
+    #[test]
+    fn transcript_updates_deserialize_source_message_uuid() {
+        let update: SessionUpdate = serde_json::from_value(serde_json::json!({
+            "type": "agent_message_chunk",
+            "source_message_uuid": "assistant-1",
+            "content": { "type": "text", "text": "hello" }
+        }))
+        .expect("deserialize source-tagged chunk");
+
+        let SessionUpdate::AgentMessageChunk { source_message_uuid, .. } = update else {
+            panic!("expected agent message chunk");
+        };
+        assert_eq!(source_message_uuid.as_deref(), Some("assistant-1"));
     }
 
     #[test]

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -236,6 +236,24 @@ pub struct BashOutputMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ToolOutputMetadata {
     pub bash: Option<BashOutputMetadata>,
+    pub agent: Option<AgentOutputMetadata>,
+    pub web_fetch: Option<WebFetchOutputMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct AgentOutputMetadata {
+    pub resolved_model: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WebFetchOutputMetadata {
+    pub artifact_read: Option<WebFetchArtifactReadMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WebFetchArtifactReadMetadata {
+    pub slug: String,
+    pub ver: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -247,6 +265,12 @@ pub struct TaskMetadata {
     pub request_id: Option<String>,
     pub subagent_type: Option<String>,
     pub task_description: Option<String>,
+    pub task_type: Option<String>,
+    pub workflow_name: Option<String>,
+    pub prompt: Option<String>,
+    pub output_file: Option<String>,
+    pub summary: Option<String>,
+    pub terminal_status: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1034,7 +1058,13 @@ mod tests {
                     "task_metadata": {
                         "request_id": "request-1",
                         "subagent_type": "tester",
-                        "task_description": "Validate the branch"
+                        "task_description": "Validate the branch",
+                        "task_type": "remote_agent",
+                        "workflow_name": "review-flow",
+                        "prompt": "Validate everything",
+                        "output_file": "C:/tmp/output.md",
+                        "summary": "Validation complete",
+                        "terminal_status": "completed"
                     }
                 }
             }
@@ -1048,6 +1078,49 @@ mod tests {
         assert_eq!(metadata.request_id.as_deref(), Some("request-1"));
         assert_eq!(metadata.subagent_type.as_deref(), Some("tester"));
         assert_eq!(metadata.task_description.as_deref(), Some("Validate the branch"));
+        assert_eq!(metadata.task_type.as_deref(), Some("remote_agent"));
+        assert_eq!(metadata.workflow_name.as_deref(), Some("review-flow"));
+        assert_eq!(metadata.prompt.as_deref(), Some("Validate everything"));
+        assert_eq!(metadata.output_file.as_deref(), Some("C:/tmp/output.md"));
+        assert_eq!(metadata.summary.as_deref(), Some("Validation complete"));
+        assert_eq!(metadata.terminal_status.as_deref(), Some("completed"));
+    }
+
+    #[test]
+    fn tool_output_metadata_deserializes_agent_and_artifact_read_fields() {
+        let update: SessionUpdate = serde_json::from_value(serde_json::json!({
+            "type": "tool_call_update",
+            "tool_call_update": {
+                "tool_call_id": "tool-1",
+                "fields": {
+                    "output_metadata": {
+                        "agent": {
+                            "resolved_model": "claude-sonnet-4-7"
+                        },
+                        "web_fetch": {
+                            "artifact_read": {
+                                "slug": "dashboard",
+                                "ver": "v3"
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("deserialize output metadata");
+
+        let SessionUpdate::ToolCallUpdate { tool_call_update } = update else {
+            panic!("expected tool call update");
+        };
+        let metadata = tool_call_update.fields.output_metadata.expect("output metadata");
+        let resolved_model = metadata.agent.and_then(|agent| agent.resolved_model);
+        assert_eq!(resolved_model.as_deref(), Some("claude-sonnet-4-7"));
+        let artifact_read = metadata
+            .web_fetch
+            .and_then(|web_fetch| web_fetch.artifact_read)
+            .expect("artifact read metadata");
+        assert_eq!(artifact_read.slug, "dashboard");
+        assert_eq!(artifact_read.ver, "v3");
     }
 
     #[test]

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -489,6 +489,44 @@ pub enum QuestionOutcome {
     Cancelled,
 }
 
+/// Host answer to a `refusal_fallback_prompt` user dialog. `option_id` carries
+/// the dialog's string-enum choice (`retry_fallback` | `edit_prompt`);
+/// declining maps to `Cancelled` (the CLI default).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum UserDialogOutcome {
+    Selected { option_id: String },
+    Cancelled,
+}
+
+/// Snake-case payload of a `refusal_fallback_prompt` dialog, as normalized by
+/// the bridge. `original_model`/`fallback_model` are always present; the rest is
+/// optional metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RefusalFallbackPayload {
+    pub original_model: String,
+    pub fallback_model: String,
+    pub api_refusal_category: Option<String>,
+    pub guidance_text: Option<String>,
+    pub retracted_message_uuids: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserDialogOption {
+    pub option_id: String,
+    pub label: String,
+}
+
+/// Turn-level `request_user_dialog` request the bridge emits for a refusal
+/// fallback. Keyed by a bridge-generated `request_id` (no tool-call anchor).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserDialogRequest {
+    pub request_id: String,
+    pub dialog_kind: String,
+    pub payload: RefusalFallbackPayload,
+    pub options: Vec<UserDialogOption>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ElicitationMode {

--- a/src/agent/wire.rs
+++ b/src/agent/wire.rs
@@ -372,6 +372,7 @@ pub enum BridgeEvent {
         session_id: String,
         #[serde(default)]
         servers: Vec<types::McpServerStatus>,
+        source: Option<types::McpSnapshotSource>,
         error: Option<String>,
     },
 }
@@ -660,6 +661,32 @@ mod tests {
                             "connection failed".to_owned()
                         )]),
                     },
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn mcp_snapshot_event_deserializes_source() {
+        let json = serde_json::json!({
+            "request_id": "req-mcp-snapshot",
+            "event": "mcp_snapshot",
+            "session_id": "session-1",
+            "source": "reload_plugins",
+            "servers": []
+        });
+
+        let decoded: EventEnvelope = serde_json::from_value(json).expect("deserialize");
+
+        assert_eq!(
+            decoded,
+            EventEnvelope {
+                request_id: Some("req-mcp-snapshot".to_owned()),
+                event: BridgeEvent::McpSnapshot {
+                    session_id: "session-1".to_owned(),
+                    servers: Vec::new(),
+                    source: Some(types::McpSnapshotSource::ReloadPlugins),
+                    error: None,
                 },
             }
         );

--- a/src/agent/wire.rs
+++ b/src/agent/wire.rs
@@ -314,6 +314,10 @@ pub enum BridgeEvent {
         session_id: String,
         error: types::McpOperationError,
     },
+    McpSetServersResult {
+        session_id: String,
+        result: types::McpSetServersResult,
+    },
     TurnComplete {
         session_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -387,6 +391,7 @@ impl BridgeEvent {
             Self::ElicitationComplete { .. } => "elicitation_complete",
             Self::McpAuthRedirect { .. } => "mcp_auth_redirect",
             Self::McpOperationError { .. } => "mcp_operation_error",
+            Self::McpSetServersResult { .. } => "mcp_set_servers_result",
             Self::TurnComplete { .. } => "turn_complete",
             Self::TurnError { .. } => "turn_error",
             Self::SlashError { .. } => "slash_error",
@@ -413,6 +418,7 @@ impl BridgeEvent {
             | Self::ElicitationComplete { session_id, .. }
             | Self::McpAuthRedirect { session_id, .. }
             | Self::McpOperationError { session_id, .. }
+            | Self::McpSetServersResult { session_id, .. }
             | Self::TurnComplete { session_id, .. }
             | Self::TurnError { session_id, .. }
             | Self::SlashError { session_id, .. }
@@ -445,6 +451,7 @@ impl BridgeEvent {
             | Self::ElicitationComplete { .. }
             | Self::McpAuthRedirect { .. }
             | Self::McpOperationError { .. }
+            | Self::McpSetServersResult { .. }
             | Self::TurnComplete { .. }
             | Self::TurnError { .. }
             | Self::SlashError { .. }
@@ -620,6 +627,42 @@ mod tests {
         let json = serde_json::to_string(&env).expect("serialize");
         let decoded: EventEnvelope = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(decoded, env);
+    }
+
+    #[test]
+    fn mcp_set_servers_result_event_deserializes() {
+        let json = serde_json::json!({
+            "request_id": "req-mcp-set",
+            "event": "mcp_set_servers_result",
+            "session_id": "session-1",
+            "result": {
+                "added": ["docs"],
+                "removed": ["plugin:Notion:notion"],
+                "errors": {
+                    "docs": "connection failed"
+                }
+            }
+        });
+
+        let decoded: EventEnvelope = serde_json::from_value(json).expect("deserialize");
+
+        assert_eq!(
+            decoded,
+            EventEnvelope {
+                request_id: Some("req-mcp-set".to_owned()),
+                event: BridgeEvent::McpSetServersResult {
+                    session_id: "session-1".to_owned(),
+                    result: types::McpSetServersResult {
+                        added: vec!["docs".to_owned()],
+                        removed: vec!["plugin:Notion:notion".to_owned()],
+                        errors: BTreeMap::from([(
+                            "docs".to_owned(),
+                            "connection failed".to_owned()
+                        )]),
+                    },
+                },
+            }
+        );
     }
 
     #[test]

--- a/src/agent/wire.rs
+++ b/src/agent/wire.rs
@@ -101,6 +101,11 @@ pub enum BridgeCommand {
         tool_call_id: String,
         outcome: types::QuestionOutcome,
     },
+    UserDialogResponse {
+        session_id: String,
+        request_id: String,
+        outcome: types::UserDialogOutcome,
+    },
     ElicitationResponse {
         session_id: String,
         elicitation_request_id: String,
@@ -168,6 +173,7 @@ impl BridgeCommand {
             Self::NewSession { .. } => "new_session",
             Self::PermissionResponse { .. } => "permission_response",
             Self::QuestionResponse { .. } => "question_response",
+            Self::UserDialogResponse { .. } => "user_dialog_response",
             Self::ElicitationResponse { .. } => "elicitation_response",
             Self::GetStatusSnapshot { .. } => "get_status_snapshot",
             Self::GetContextUsage { .. } => "get_context_usage",
@@ -197,6 +203,7 @@ impl BridgeCommand {
             | Self::RenameSession { session_id, .. }
             | Self::PermissionResponse { session_id, .. }
             | Self::QuestionResponse { session_id, .. }
+            | Self::UserDialogResponse { session_id, .. }
             | Self::ElicitationResponse { session_id, .. }
             | Self::GetStatusSnapshot { session_id }
             | Self::GetContextUsage { session_id }
@@ -230,6 +237,7 @@ impl BridgeCommand {
             | Self::GenerateSessionTitle { .. }
             | Self::RenameSession { .. }
             | Self::NewSession { .. }
+            | Self::UserDialogResponse { .. }
             | Self::ElicitationResponse { .. }
             | Self::GetStatusSnapshot { .. }
             | Self::GetContextUsage { .. }
@@ -284,6 +292,10 @@ pub enum BridgeEvent {
     QuestionRequest {
         session_id: String,
         request: types::QuestionRequest,
+    },
+    UserDialogRequest {
+        session_id: String,
+        request: types::UserDialogRequest,
     },
     ElicitationRequest {
         session_id: String,
@@ -370,6 +382,7 @@ impl BridgeEvent {
             Self::SessionUpdate { .. } => "session_update",
             Self::PermissionRequest { .. } => "permission_request",
             Self::QuestionRequest { .. } => "question_request",
+            Self::UserDialogRequest { .. } => "user_dialog_request",
             Self::ElicitationRequest { .. } => "elicitation_request",
             Self::ElicitationComplete { .. } => "elicitation_complete",
             Self::McpAuthRedirect { .. } => "mcp_auth_redirect",
@@ -395,6 +408,7 @@ impl BridgeEvent {
             | Self::SessionUpdate { session_id, .. }
             | Self::PermissionRequest { session_id, .. }
             | Self::QuestionRequest { session_id, .. }
+            | Self::UserDialogRequest { session_id, .. }
             | Self::ElicitationRequest { session_id, .. }
             | Self::ElicitationComplete { session_id, .. }
             | Self::McpAuthRedirect { session_id, .. }
@@ -426,6 +440,7 @@ impl BridgeEvent {
             | Self::AuthRequired { .. }
             | Self::ConnectionFailed { .. }
             | Self::SessionUpdate { .. }
+            | Self::UserDialogRequest { .. }
             | Self::ElicitationRequest { .. }
             | Self::ElicitationComplete { .. }
             | Self::McpAuthRedirect { .. }
@@ -587,6 +602,91 @@ mod tests {
         let json = serde_json::to_string(&env).expect("serialize");
         let decoded: EventEnvelope = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(decoded, env);
+    }
+
+    #[test]
+    fn user_dialog_response_command_serializes_selected_outcome() {
+        let env = CommandEnvelope {
+            request_id: None,
+            command: BridgeCommand::UserDialogResponse {
+                session_id: "s1".to_owned(),
+                request_id: "req-9".to_owned(),
+                outcome: types::UserDialogOutcome::Selected {
+                    option_id: "retry_fallback".to_owned(),
+                },
+            },
+        };
+
+        let json = serde_json::to_value(&env).expect("serialize");
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "command": "user_dialog_response",
+                "session_id": "s1",
+                "request_id": "req-9",
+                "outcome": { "outcome": "selected", "option_id": "retry_fallback" }
+            })
+        );
+    }
+
+    #[test]
+    fn user_dialog_response_command_serializes_cancelled_outcome() {
+        let env = CommandEnvelope {
+            request_id: None,
+            command: BridgeCommand::UserDialogResponse {
+                session_id: "s1".to_owned(),
+                request_id: "req-9".to_owned(),
+                outcome: types::UserDialogOutcome::Cancelled,
+            },
+        };
+
+        let json = serde_json::to_value(&env).expect("serialize");
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "command": "user_dialog_response",
+                "session_id": "s1",
+                "request_id": "req-9",
+                "outcome": { "outcome": "cancelled" }
+            })
+        );
+    }
+
+    #[test]
+    fn user_dialog_request_event_deserializes_snake_case_payload() {
+        let decoded: EventEnvelope = serde_json::from_value(serde_json::json!({
+            "event": "user_dialog_request",
+            "session_id": "session-1",
+            "request": {
+                "request_id": "req-9",
+                "dialog_kind": "refusal_fallback_prompt",
+                "payload": {
+                    "original_model": "claude-opus-4-8",
+                    "fallback_model": "claude-sonnet-4-6",
+                    "guidance_text": "This request was declined."
+                },
+                "options": [
+                    { "option_id": "retry_fallback", "label": "Switch to claude-sonnet-4-6" },
+                    { "option_id": "edit_prompt", "label": "Edit prompt and retry with claude-opus-4-8" }
+                ]
+            }
+        }))
+        .expect("deserialize user_dialog_request");
+
+        let BridgeEvent::UserDialogRequest { session_id, request } = decoded.event else {
+            panic!("expected user_dialog_request event");
+        };
+        assert_eq!(session_id, "session-1");
+        assert_eq!(request.request_id, "req-9");
+        assert_eq!(request.dialog_kind, "refusal_fallback_prompt");
+        assert_eq!(request.payload.original_model, "claude-opus-4-8");
+        assert_eq!(request.payload.fallback_model, "claude-sonnet-4-6");
+        assert_eq!(request.payload.guidance_text.as_deref(), Some("This request was declined."));
+        assert_eq!(request.payload.api_refusal_category, None);
+        assert_eq!(request.options.len(), 2);
+        assert_eq!(request.options[0].option_id, "retry_fallback");
     }
 
     #[test]

--- a/src/agent/wire.rs
+++ b/src/agent/wire.rs
@@ -556,10 +556,20 @@ mod tests {
                     types::McpServerConfig::Http {
                         url: "https://mcp.notion.com/mcp".to_owned(),
                         headers: BTreeMap::new(),
-                        tools: vec![types::McpServerToolPolicy {
-                            name: "search".to_owned(),
-                            permission_policy: types::McpServerToolPermissionPolicy::Allow,
-                        }],
+                        tools: vec![
+                            types::McpServerToolPolicy {
+                                name: "search".to_owned(),
+                                permission_policy: Some(
+                                    types::McpServerToolPermissionPolicy::Allow,
+                                ),
+                                org_max_permission: Some(types::McpServerOrgMaxPermission::Ask),
+                            },
+                            types::McpServerToolPolicy {
+                                name: "lookup".to_owned(),
+                                permission_policy: None,
+                                org_max_permission: Some(types::McpServerOrgMaxPermission::Blocked),
+                            },
+                        ],
                         timeout: Some(5000),
                         always_load: Some(true),
                     },
@@ -580,7 +590,15 @@ mod tests {
                         "url": "https://mcp.notion.com/mcp",
                         "headers": {},
                         "tools": [
-                            { "name": "search", "permission_policy": "always_allow" }
+                            {
+                                "name": "search",
+                                "permission_policy": "always_allow",
+                                "org_max_permission": "ask"
+                            },
+                            {
+                                "name": "lookup",
+                                "org_max_permission": "blocked"
+                            }
                         ],
                         "timeout": 5000,
                         "always_load": true

--- a/src/app/claude_cli.rs
+++ b/src/app/claude_cli.rs
@@ -1,0 +1,84 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub(crate) fn resolve_claude_path(cached_claude_path: Option<PathBuf>) -> Result<PathBuf, String> {
+    if let Some(path) = cached_claude_path
+        && path.is_file()
+    {
+        return Ok(path);
+    }
+    which::which("claude").map_err(|_| "claude CLI not found in PATH".to_owned())
+}
+
+pub(crate) fn parse_json_command<T>(
+    claude_path: &Path,
+    cwd_raw: &str,
+    args: &[&str],
+) -> Result<T, String>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let output = Command::new(claude_path)
+        .args(args)
+        .current_dir(cwd_raw)
+        .output()
+        .map_err(|error| format!("Failed to run `claude {}`: {error}", args.join(" ")))?;
+
+    if !output.status.success() {
+        return Err(command_failure_message(args, output.status.code(), &output.stderr));
+    }
+
+    serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("Failed to parse JSON from `claude {}`: {error}", args.join(" ")))
+}
+
+pub(crate) fn run_command(
+    claude_path: &Path,
+    cwd_raw: &str,
+    args: &[String],
+) -> Result<(), String> {
+    let output = Command::new(claude_path)
+        .args(args)
+        .current_dir(cwd_raw)
+        .output()
+        .map_err(|error| format!("Failed to run `claude {}`: {error}", args.join(" ")))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(command_failure_message(args, output.status.code(), &output.stderr))
+}
+
+pub(crate) async fn run_command_task(
+    cwd_raw: String,
+    cached_claude_path: Option<PathBuf>,
+    args: Vec<String>,
+) -> Result<PathBuf, String> {
+    tokio::task::spawn_blocking(move || {
+        let claude_path = resolve_claude_path(cached_claude_path)?;
+        run_command(&claude_path, &cwd_raw, &args)?;
+        Ok(claude_path)
+    })
+    .await
+    .map_err(|error| format!("Claude CLI task failed: {error}"))?
+}
+
+fn command_failure_message<S>(args: &[S], exit_code: Option<i32>, stderr: &[u8]) -> String
+where
+    S: AsRef<str>,
+{
+    let stderr = String::from_utf8_lossy(stderr).trim().to_owned();
+    let exit_code = exit_code.map_or_else(|| "unknown".to_owned(), |code| code.to_string());
+    let detail = if stderr.is_empty() {
+        format!("exit code {exit_code}")
+    } else {
+        format!("exit code {exit_code}: {stderr}")
+    };
+    let args = args.iter().map(AsRef::as_ref).collect::<Vec<_>>().join(" ");
+    format!("`claude {args}` failed: {detail}")
+}

--- a/src/app/config/edit.rs
+++ b/src/app/config/edit.rs
@@ -271,7 +271,7 @@ fn confirm_confirmation_overlay(app: &mut App) {
                 app.config.clear_overlay();
                 return;
             };
-            let Some(scope) = super::mcp::mcp_config_removal_scope(server) else {
+            let Some(scope) = super::mcp::mcp_config_removal_scope(app, server) else {
                 app.config.set_overlay_error("This MCP server cannot be removed from live config.");
                 return;
             };

--- a/src/app/config/edit.rs
+++ b/src/app/config/edit.rs
@@ -261,6 +261,36 @@ fn confirm_confirmation_overlay(app: &mut App) {
                 super::mcp::McpServerActionKind::ClearAuth,
             );
         }
+        ConfirmationAction::McpRemoveConfig => {
+            let Some(overlay) = app.config.mcp_details_overlay().cloned() else {
+                return;
+            };
+            let Some(server) =
+                app.mcp.servers.iter().find(|server| server.name == overlay.server_name)
+            else {
+                app.config.clear_overlay();
+                return;
+            };
+            let Some(scope) = super::mcp::mcp_config_removal_scope(server) else {
+                app.config.set_overlay_error("This MCP server cannot be removed from live config.");
+                return;
+            };
+            let action = match scope {
+                super::mcp::McpConfigScope::User => {
+                    super::mcp::McpServerActionKind::RemoveUserConfig
+                }
+                super::mcp::McpConfigScope::Local => {
+                    super::mcp::McpServerActionKind::RemoveLocalConfig
+                }
+                super::mcp::McpConfigScope::Project => {
+                    super::mcp::McpServerActionKind::RemoveProjectConfig
+                }
+                super::mcp::McpConfigScope::Dynamic => {
+                    super::mcp::McpServerActionKind::RemoveDynamicConfig
+                }
+            };
+            super::mcp_edit::execute_confirmed_mcp_server_action(app, action);
+        }
     }
 }
 

--- a/src/app/config/mcp.rs
+++ b/src/app/config/mcp.rs
@@ -1,7 +1,9 @@
 use super::{ConfigOverlayState, ConfigState, ConfigTab};
+use crate::agent::{events::ClientEvent, model, types};
 use crate::app::App;
 use crate::app::view::{self, FullscreenView};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum McpServerActionKind {
@@ -11,6 +13,10 @@ pub(crate) enum McpServerActionKind {
     Reconnect,
     Enable,
     Disable,
+    RemoveUserConfig,
+    RemoveLocalConfig,
+    RemoveProjectConfig,
+    RemoveDynamicConfig,
 }
 
 impl McpServerActionKind {
@@ -23,7 +29,70 @@ impl McpServerActionKind {
             Self::Reconnect => "Reconnect server",
             Self::Enable => "Enable server",
             Self::Disable => "Disable server",
+            Self::RemoveUserConfig
+            | Self::RemoveLocalConfig
+            | Self::RemoveProjectConfig
+            | Self::RemoveDynamicConfig => "Remove",
         }
+    }
+
+    #[must_use]
+    pub const fn mcp_config_scope(self) -> Option<McpConfigScope> {
+        match self {
+            Self::RemoveUserConfig => Some(McpConfigScope::User),
+            Self::RemoveLocalConfig => Some(McpConfigScope::Local),
+            Self::RemoveProjectConfig => Some(McpConfigScope::Project),
+            Self::RemoveDynamicConfig => Some(McpConfigScope::Dynamic),
+            Self::RefreshSnapshot
+            | Self::Authenticate
+            | Self::ClearAuth
+            | Self::Reconnect
+            | Self::Enable
+            | Self::Disable => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum McpConfigScope {
+    Local,
+    User,
+    Project,
+    Dynamic,
+}
+
+impl McpConfigScope {
+    #[must_use]
+    pub const fn cli_arg(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::User => "user",
+            Self::Project => "project",
+            Self::Dynamic => "dynamic",
+        }
+    }
+
+    #[must_use]
+    pub fn from_status_scope(scope: &str) -> Option<Self> {
+        match scope.trim() {
+            scope if scope.eq_ignore_ascii_case("user") => Some(Self::User),
+            scope if scope.eq_ignore_ascii_case("local") => Some(Self::Local),
+            scope if scope.eq_ignore_ascii_case("project") => Some(Self::Project),
+            scope if scope.eq_ignore_ascii_case("dynamic") => Some(Self::Dynamic),
+            _ => None,
+        }
+    }
+}
+
+#[must_use]
+pub(crate) const fn remove_action_for_mcp_config_scope(
+    scope: McpConfigScope,
+) -> McpServerActionKind {
+    match scope {
+        McpConfigScope::User => McpServerActionKind::RemoveUserConfig,
+        McpConfigScope::Local => McpServerActionKind::RemoveLocalConfig,
+        McpConfigScope::Project => McpServerActionKind::RemoveProjectConfig,
+        McpConfigScope::Dynamic => McpServerActionKind::RemoveDynamicConfig,
     }
 }
 
@@ -338,6 +407,390 @@ pub(crate) fn clear_mcp_server_auth(app: &mut App, server_name: &str) {
     }
 }
 
+pub(crate) fn remove_mcp_server_from_config(
+    app: &mut App,
+    server_name: &str,
+    scope: McpConfigScope,
+) {
+    if scope == McpConfigScope::Dynamic {
+        remove_dynamic_mcp_server_from_config(app, server_name);
+        return;
+    }
+    remove_persisted_mcp_server_from_config(app, server_name, scope);
+}
+
+fn remove_persisted_mcp_server_from_config(
+    app: &mut App,
+    server_name: &str,
+    scope: McpConfigScope,
+) {
+    if tokio::runtime::Handle::try_current().is_err() {
+        return;
+    }
+    let cwd_raw = app.cwd_raw.clone();
+    let cached_claude_path = app.mcp.claude_path.clone();
+    let server_name = server_name.to_owned();
+    let scope_name = scope.cli_arg().to_owned();
+    let args = vec![
+        "mcp".to_owned(),
+        "remove".to_owned(),
+        "--scope".to_owned(),
+        scope_name.clone(),
+        server_name.clone(),
+    ];
+    let event_tx = app.event_tx.clone();
+
+    app.mcp.in_flight = true;
+    app.mcp.last_error = None;
+    app.config.last_error = None;
+    app.config.status_message =
+        Some(format!("Removing MCP server {server_name} from {scope_name} config..."));
+
+    tokio::task::spawn_local(async move {
+        match crate::app::claude_cli::run_command_task(cwd_raw.clone(), cached_claude_path, args)
+            .await
+        {
+            Ok(claude_path) => {
+                let _ = event_tx.send(ClientEvent::McpConfigRemoveSucceeded {
+                    cwd_raw,
+                    server_name,
+                    scope: scope_name,
+                    claude_path,
+                });
+            }
+            Err(message) => {
+                let _ = event_tx.send(ClientEvent::McpConfigRemoveFailed {
+                    cwd_raw,
+                    server_name,
+                    scope: scope_name,
+                    message,
+                });
+            }
+        }
+    });
+}
+
+fn remove_dynamic_mcp_server_from_config(app: &mut App, server_name: &str) {
+    if app.mcp.pending_dynamic_config_removal.is_some() {
+        let formatted = format!(
+            "Failed to remove MCP server {server_name} from dynamic config: Another dynamic MCP removal is still in progress."
+        );
+        app.mcp.last_error = Some(formatted.clone());
+        app.config.last_error = Some(formatted);
+        app.config.status_message = None;
+        return;
+    }
+    let Some(conn) = app.conn.clone() else {
+        apply_mcp_config_remove_failure(
+            app,
+            server_name,
+            McpConfigScope::Dynamic.cli_arg(),
+            "No active bridge connection.",
+        );
+        return;
+    };
+    let Some(session_id) = app.session_id.as_ref().map(ToString::to_string) else {
+        apply_mcp_config_remove_failure(
+            app,
+            server_name,
+            McpConfigScope::Dynamic.cli_arg(),
+            "No active session.",
+        );
+        return;
+    };
+    let remaining_servers = match dynamic_mcp_servers_without(app, server_name) {
+        Ok(servers) => servers,
+        Err(message) => {
+            apply_mcp_config_remove_failure(
+                app,
+                server_name,
+                McpConfigScope::Dynamic.cli_arg(),
+                &message,
+            );
+            return;
+        }
+    };
+
+    app.mcp.in_flight = true;
+    app.mcp.last_error = None;
+    app.config.last_error = None;
+    app.config.status_message =
+        Some(format!("Removing MCP server {server_name} from dynamic config..."));
+    app.mcp.pending_dynamic_config_removal = Some(server_name.to_owned());
+
+    match conn.set_mcp_servers(session_id.clone(), remaining_servers) {
+        Ok(()) => {
+            tracing::info!(
+                target: crate::logging::targets::APP_CONFIG,
+                event_name = "mcp_dynamic_remove_requested",
+                message = "dynamic MCP removal requested",
+                outcome = "start",
+                session_id = %session_id,
+                server_name = %server_name,
+            );
+        }
+        Err(error) => {
+            app.mcp.pending_dynamic_config_removal = None;
+            tracing::warn!(
+                target: crate::logging::targets::APP_CONFIG,
+                event_name = "mcp_dynamic_remove_request_failed",
+                message = "failed to request dynamic MCP removal",
+                outcome = "failure",
+                session_id = %session_id,
+                server_name = %server_name,
+                error_message = %error,
+            );
+            apply_mcp_config_remove_failure(
+                app,
+                server_name,
+                McpConfigScope::Dynamic.cli_arg(),
+                &error.to_string(),
+            );
+        }
+    }
+}
+
+fn dynamic_mcp_servers_without(
+    app: &App,
+    server_name: &str,
+) -> Result<BTreeMap<String, types::McpServerConfig>, String> {
+    let removed_key = normalized_removed_config_key(McpConfigScope::Dynamic.cli_arg(), server_name);
+    let mut found_removed_server = false;
+    let mut servers = BTreeMap::new();
+
+    for server in app
+        .mcp
+        .servers
+        .iter()
+        .filter(|server| mcp_config_removal_scope(server) == Some(McpConfigScope::Dynamic))
+    {
+        if mcp_server_matches_removed_key(server, &removed_key) {
+            found_removed_server = true;
+            continue;
+        }
+        let config = dynamic_mcp_server_config_for_set_servers(server)?;
+        servers.insert(server.name.clone(), config);
+    }
+
+    if !found_removed_server {
+        return Err(format!("MCP server {server_name} is no longer present in dynamic config."));
+    }
+
+    Ok(servers)
+}
+
+fn dynamic_mcp_server_config_for_set_servers(
+    server: &model::McpServerStatus,
+) -> Result<types::McpServerConfig, String> {
+    let Some(config) = server.config.as_ref() else {
+        return Err(format!(
+            "Cannot safely preserve dynamic MCP server {} because the SDK snapshot did not include its config.",
+            server.name
+        ));
+    };
+
+    match config {
+        model::McpServerStatusConfig::Stdio { command, args, env, timeout, always_load } => {
+            Ok(types::McpServerConfig::Stdio {
+                command: command.clone(),
+                args: args.clone(),
+                env: env.clone(),
+                timeout: *timeout,
+                always_load: *always_load,
+            })
+        }
+        model::McpServerStatusConfig::Sse { url, headers, tools, timeout, always_load } => {
+            Ok(types::McpServerConfig::Sse {
+                url: url.clone(),
+                headers: headers.clone(),
+                tools: tools.iter().map(dynamic_mcp_tool_policy_for_set_servers).collect(),
+                timeout: *timeout,
+                always_load: *always_load,
+            })
+        }
+        model::McpServerStatusConfig::Http { url, headers, tools, timeout, always_load } => {
+            Ok(types::McpServerConfig::Http {
+                url: url.clone(),
+                headers: headers.clone(),
+                tools: tools.iter().map(dynamic_mcp_tool_policy_for_set_servers).collect(),
+                timeout: *timeout,
+                always_load: *always_load,
+            })
+        }
+        model::McpServerStatusConfig::Sdk { .. } => Err(format!(
+            "Cannot safely preserve dynamic MCP server {} because SDK-server instances cannot be represented by the Rust bridge.",
+            server.name
+        )),
+        model::McpServerStatusConfig::ClaudeaiProxy { .. } => Err(format!(
+            "Cannot safely preserve dynamic MCP server {} because Claude.ai proxy servers are not dynamic SDK configs.",
+            server.name
+        )),
+        model::McpServerStatusConfig::Unknown { raw_type } => Err(format!(
+            "Cannot safely preserve dynamic MCP server {} because its config type {raw_type} is unknown.",
+            server.name
+        )),
+    }
+}
+
+fn dynamic_mcp_tool_policy_for_set_servers(
+    policy: &model::McpServerToolPolicy,
+) -> types::McpServerToolPolicy {
+    types::McpServerToolPolicy {
+        name: policy.name.clone(),
+        permission_policy: policy
+            .permission_policy
+            .map(dynamic_mcp_tool_permission_policy_for_set_servers),
+        org_max_permission: policy
+            .org_max_permission
+            .map(dynamic_mcp_org_permission_for_set_servers),
+    }
+}
+
+const fn dynamic_mcp_tool_permission_policy_for_set_servers(
+    policy: model::McpServerToolPermissionPolicy,
+) -> types::McpServerToolPermissionPolicy {
+    match policy {
+        model::McpServerToolPermissionPolicy::Allow => types::McpServerToolPermissionPolicy::Allow,
+        model::McpServerToolPermissionPolicy::Ask => types::McpServerToolPermissionPolicy::Ask,
+        model::McpServerToolPermissionPolicy::Deny => types::McpServerToolPermissionPolicy::Deny,
+    }
+}
+
+const fn dynamic_mcp_org_permission_for_set_servers(
+    permission: model::McpServerOrgMaxPermission,
+) -> types::McpServerOrgMaxPermission {
+    match permission {
+        model::McpServerOrgMaxPermission::Allow => types::McpServerOrgMaxPermission::Allow,
+        model::McpServerOrgMaxPermission::Ask => types::McpServerOrgMaxPermission::Ask,
+        model::McpServerOrgMaxPermission::Blocked => types::McpServerOrgMaxPermission::Blocked,
+    }
+}
+
+pub(crate) fn apply_mcp_config_remove_success(
+    app: &mut App,
+    server_name: &str,
+    scope: &str,
+    claude_path: std::path::PathBuf,
+) {
+    let scope_name = McpConfigScope::from_status_scope(scope)
+        .map_or_else(|| normalize_mcp_config_scope_key(scope), |scope| scope.cli_arg().to_owned());
+    app.mcp.claude_path = Some(claude_path);
+    apply_mcp_config_remove_success_state(app, server_name, &scope_name);
+    crate::app::session_runtime::request_runtime_reload(app);
+    request_mcp_snapshot(app);
+}
+
+fn apply_mcp_dynamic_config_remove_success(app: &mut App, server_name: &str) {
+    apply_mcp_config_remove_success_state(app, server_name, McpConfigScope::Dynamic.cli_arg());
+    request_mcp_snapshot(app);
+}
+
+pub(crate) fn handle_mcp_set_servers_result(app: &mut App, result: &types::McpSetServersResult) {
+    let Some(server_name) = app.mcp.pending_dynamic_config_removal.take() else {
+        return;
+    };
+    if let Some((_, message)) =
+        result.errors.iter().find(|(name, _)| name.eq_ignore_ascii_case(&server_name))
+    {
+        apply_mcp_config_remove_failure(
+            app,
+            &server_name,
+            McpConfigScope::Dynamic.cli_arg(),
+            message,
+        );
+        return;
+    }
+
+    tracing::info!(
+        target: crate::logging::targets::APP_CONFIG,
+        event_name = "mcp_dynamic_remove_completed",
+        message = "dynamic MCP removal completed",
+        outcome = "success",
+        server_name = %server_name,
+        added_count = result.added.len(),
+        removed_count = result.removed.len(),
+        error_count = result.errors.len(),
+    );
+    apply_mcp_dynamic_config_remove_success(app, &server_name);
+}
+
+fn apply_mcp_config_remove_success_state(app: &mut App, server_name: &str, scope_name: &str) {
+    remember_removed_config_mcp_server(app, scope_name, server_name);
+    remove_matching_mcp_server_from_snapshot(app, scope_name, server_name);
+    app.config.mcp_selected_server_index =
+        app.config.mcp_selected_server_index.min(app.mcp.servers.len().saturating_sub(1));
+    app.mcp.last_error = None;
+    app.config.last_error = None;
+    app.config.status_message =
+        Some(format!("Removed MCP server {server_name} from {scope_name} config."));
+}
+
+fn remember_removed_config_mcp_server(app: &mut App, scope: &str, server_name: &str) {
+    app.mcp.removed_config_servers.insert(normalized_removed_config_key(scope, server_name));
+}
+
+fn remove_matching_mcp_server_from_snapshot(app: &mut App, scope: &str, server_name: &str) {
+    let removed_key = normalized_removed_config_key(scope, server_name);
+    app.mcp.servers.retain(|server| !mcp_server_matches_removed_key(server, &removed_key));
+}
+
+pub(crate) fn filter_removed_config_mcp_servers(
+    app: &App,
+    servers: &mut Vec<crate::agent::model::McpServerStatus>,
+) {
+    if app.mcp.removed_config_servers.is_empty() {
+        return;
+    }
+    servers.retain(|server| !is_removed_config_mcp_server_suppressed(app, server));
+}
+
+fn is_removed_config_mcp_server_suppressed(
+    app: &App,
+    server: &crate::agent::model::McpServerStatus,
+) -> bool {
+    app.mcp
+        .removed_config_servers
+        .iter()
+        .any(|removed_key| mcp_server_matches_removed_key(server, removed_key))
+}
+
+fn mcp_server_matches_removed_key(
+    server: &crate::agent::model::McpServerStatus,
+    removed_key: &(String, String),
+) -> bool {
+    server
+        .scope
+        .as_deref()
+        .is_some_and(|scope| normalized_removed_config_key(scope, &server.name) == *removed_key)
+}
+
+fn normalized_removed_config_key(scope: &str, server_name: &str) -> (String, String) {
+    (normalize_mcp_config_scope_key(scope), server_name.to_ascii_lowercase())
+}
+
+fn normalize_mcp_config_scope_key(scope: &str) -> String {
+    scope.trim().to_ascii_lowercase()
+}
+
+pub(crate) fn apply_mcp_config_remove_failure(
+    app: &mut App,
+    server_name: &str,
+    scope: &str,
+    message: &str,
+) {
+    app.mcp.in_flight = false;
+    let formatted =
+        format!("Failed to remove MCP server {server_name} from {scope} config: {message}");
+    app.mcp.last_error = Some(formatted.clone());
+    app.config.last_error = Some(formatted.clone());
+    app.config.status_message = None;
+    if app.config.overlay.is_some() {
+        app.config.set_overlay_error(formatted);
+    } else {
+        app.config.last_error = Some(formatted);
+    }
+}
+
 pub(crate) fn submit_mcp_oauth_callback_url(
     app: &mut App,
     server_name: &str,
@@ -470,6 +923,13 @@ pub(crate) fn open_mcp_server_details(
 }
 
 #[must_use]
+pub(crate) fn mcp_config_removal_scope(
+    server: &crate::agent::model::McpServerStatus,
+) -> Option<McpConfigScope> {
+    server.scope.as_deref().and_then(McpConfigScope::from_status_scope)
+}
+
+#[must_use]
 pub(crate) fn available_mcp_actions(
     server: &crate::agent::model::McpServerStatus,
 ) -> Vec<McpServerActionKind> {
@@ -489,6 +949,9 @@ pub(crate) fn available_mcp_actions(
         actions.push(McpServerActionKind::Reconnect);
         actions.push(McpServerActionKind::Disable);
     }
+    if let Some(scope) = mcp_config_removal_scope(server) {
+        actions.push(remove_action_for_mcp_config_scope(scope));
+    }
     actions
 }
 
@@ -497,13 +960,23 @@ pub(crate) fn is_mcp_action_available(
     server: &crate::agent::model::McpServerStatus,
     action: McpServerActionKind,
 ) -> bool {
-    !matches!(
-        (action, server.config.as_ref()),
-        (
-            McpServerActionKind::Authenticate,
+    match action {
+        McpServerActionKind::Authenticate => !matches!(
+            server.config.as_ref(),
             Some(crate::agent::model::McpServerStatusConfig::ClaudeaiProxy { .. })
-        )
-    )
+        ),
+        McpServerActionKind::RemoveUserConfig
+        | McpServerActionKind::RemoveLocalConfig
+        | McpServerActionKind::RemoveProjectConfig
+        | McpServerActionKind::RemoveDynamicConfig => {
+            action.mcp_config_scope() == mcp_config_removal_scope(server)
+        }
+        McpServerActionKind::RefreshSnapshot
+        | McpServerActionKind::ClearAuth
+        | McpServerActionKind::Reconnect
+        | McpServerActionKind::Enable
+        | McpServerActionKind::Disable => true,
+    }
 }
 
 pub(crate) fn present_mcp_elicitation_request(
@@ -610,6 +1083,18 @@ pub(crate) fn handle_mcp_operation_error(
     app: &mut App,
     error: &crate::agent::types::McpOperationError,
 ) {
+    if error.operation == "set-servers"
+        && let Some(server_name) = app.mcp.pending_dynamic_config_removal.take()
+    {
+        apply_mcp_config_remove_failure(
+            app,
+            &server_name,
+            McpConfigScope::Dynamic.cli_arg(),
+            &error.message,
+        );
+        return;
+    }
+
     app.mcp.in_flight = false;
     let formatted = format_mcp_operation_error(error);
     app.mcp.last_error = Some(formatted.clone());
@@ -635,6 +1120,7 @@ fn format_mcp_operation_error(error: &crate::agent::types::McpOperationError) ->
         "authenticate" => "authenticate",
         "clear-auth" => "clear auth for",
         "reconnect" => "reconnect",
+        "set-servers" => "update dynamic config for",
         "toggle" => "update",
         "submit-callback-url" => "submit callback URL for",
         other => other,

--- a/src/app/config/mcp.rs
+++ b/src/app/config/mcp.rs
@@ -1,6 +1,8 @@
 use super::{ConfigOverlayState, ConfigState, ConfigTab};
 use crate::agent::{events::ClientEvent, model, types};
 use crate::app::App;
+use crate::app::plugins::InstalledPluginEntry;
+use crate::app::state::types::{RemovedMcpServerGuard, RemovedMcpServerKey};
 use crate::app::view::{self, FullscreenView};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::collections::BTreeMap;
@@ -13,6 +15,7 @@ pub(crate) enum McpServerActionKind {
     Reconnect,
     Enable,
     Disable,
+    ManagePlugin,
     RemoveUserConfig,
     RemoveLocalConfig,
     RemoveProjectConfig,
@@ -29,6 +32,7 @@ impl McpServerActionKind {
             Self::Reconnect => "Reconnect server",
             Self::Enable => "Enable server",
             Self::Disable => "Disable server",
+            Self::ManagePlugin => "Manage plugin",
             Self::RemoveUserConfig
             | Self::RemoveLocalConfig
             | Self::RemoveProjectConfig
@@ -48,7 +52,8 @@ impl McpServerActionKind {
             | Self::ClearAuth
             | Self::Reconnect
             | Self::Enable
-            | Self::Disable => None,
+            | Self::Disable
+            | Self::ManagePlugin => None,
         }
     }
 }
@@ -59,6 +64,15 @@ pub(crate) enum McpConfigScope {
     User,
     Project,
     Dynamic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum McpServerOwnership<'a> {
+    Persisted(McpConfigScope),
+    SdkDynamic,
+    PluginOwned(&'a InstalledPluginEntry),
+    PluginOwnedUnknown,
+    RuntimeOnly,
 }
 
 impl McpConfigScope {
@@ -412,6 +426,14 @@ pub(crate) fn remove_mcp_server_from_config(
     server_name: &str,
     scope: McpConfigScope,
 ) {
+    if !is_mcp_config_removal_available(app, server_name, scope) {
+        let message = format!(
+            "MCP server {server_name} is not removable from {} config. Plugin-owned MCP servers must be managed from the plugin action menu.",
+            scope.cli_arg()
+        );
+        apply_mcp_config_remove_failure(app, server_name, scope.cli_arg(), &message);
+        return;
+    }
     if scope == McpConfigScope::Dynamic {
         remove_dynamic_mcp_server_from_config(app, server_name);
         return;
@@ -562,7 +584,7 @@ fn dynamic_mcp_servers_without(
         .mcp
         .servers
         .iter()
-        .filter(|server| mcp_config_removal_scope(server) == Some(McpConfigScope::Dynamic))
+        .filter(|server| mcp_config_removal_scope(app, server) == Some(McpConfigScope::Dynamic))
     {
         if mcp_server_matches_removed_key(server, &removed_key) {
             found_removed_server = true;
@@ -675,23 +697,44 @@ pub(crate) fn apply_mcp_config_remove_success(
     let scope_name = McpConfigScope::from_status_scope(scope)
         .map_or_else(|| normalize_mcp_config_scope_key(scope), |scope| scope.cli_arg().to_owned());
     app.mcp.claude_path = Some(claude_path);
-    apply_mcp_config_remove_success_state(app, server_name, &scope_name);
-    crate::app::session_runtime::request_runtime_reload(app);
-    request_mcp_snapshot(app);
+    apply_mcp_config_remove_success_state(
+        app,
+        server_name,
+        &scope_name,
+        Some(types::McpSnapshotSource::ReloadPlugins),
+    );
+    match crate::app::session_runtime::request_runtime_reload(app) {
+        crate::app::session_runtime::RuntimeReloadRequestOutcome::Requested => {
+            app.mcp.in_flight = true;
+            app.mcp.last_error = None;
+        }
+        crate::app::session_runtime::RuntimeReloadRequestOutcome::Unavailable => {
+            app.mcp.in_flight = false;
+        }
+        crate::app::session_runtime::RuntimeReloadRequestOutcome::Failed => {
+            app.mcp.in_flight = false;
+            app.mcp.last_error = Some("failed to request session runtime plugin reload".to_owned());
+        }
+    }
 }
 
 fn apply_mcp_dynamic_config_remove_success(app: &mut App, server_name: &str) {
-    apply_mcp_config_remove_success_state(app, server_name, McpConfigScope::Dynamic.cli_arg());
-    request_mcp_snapshot(app);
+    apply_mcp_config_remove_success_state(
+        app,
+        server_name,
+        McpConfigScope::Dynamic.cli_arg(),
+        Some(types::McpSnapshotSource::McpSetServers),
+    );
 }
 
 pub(crate) fn handle_mcp_set_servers_result(app: &mut App, result: &types::McpSetServersResult) {
-    let Some(server_name) = app.mcp.pending_dynamic_config_removal.take() else {
+    let Some(server_name) = app.mcp.pending_dynamic_config_removal.clone() else {
         return;
     };
     if let Some((_, message)) =
         result.errors.iter().find(|(name, _)| name.eq_ignore_ascii_case(&server_name))
     {
+        app.mcp.pending_dynamic_config_removal = None;
         apply_mcp_config_remove_failure(
             app,
             &server_name,
@@ -701,6 +744,25 @@ pub(crate) fn handle_mcp_set_servers_result(app: &mut App, result: &types::McpSe
         return;
     }
 
+    if !result.removed.iter().any(|removed| mcp_server_name_eq(removed, &server_name)) {
+        tracing::info!(
+            target: crate::logging::targets::APP_CONFIG,
+            event_name = "mcp_dynamic_remove_pending_confirmation",
+            message = "dynamic MCP removal waiting for confirming snapshot",
+            outcome = "pending",
+            server_name = %server_name,
+            added_count = result.added.len(),
+            removed_count = result.removed.len(),
+            error_count = result.errors.len(),
+        );
+        app.mcp.in_flight = true;
+        app.config.status_message = Some(format!(
+            "Removing MCP server {server_name} from dynamic config... Waiting for SDK confirmation."
+        ));
+        return;
+    }
+
+    app.mcp.pending_dynamic_config_removal = None;
     tracing::info!(
         target: crate::logging::targets::APP_CONFIG,
         event_name = "mcp_dynamic_remove_completed",
@@ -714,19 +776,128 @@ pub(crate) fn handle_mcp_set_servers_result(app: &mut App, result: &types::McpSe
     apply_mcp_dynamic_config_remove_success(app, &server_name);
 }
 
-fn apply_mcp_config_remove_success_state(app: &mut App, server_name: &str, scope_name: &str) {
-    remember_removed_config_mcp_server(app, scope_name, server_name);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PendingDynamicMcpRemovalConfirmation {
+    Confirmed { server_name: String },
+    Failed { server_name: String, message: String },
+}
+
+pub(crate) fn pending_dynamic_mcp_removal_confirmation_from_snapshot(
+    app: &App,
+    source: Option<types::McpSnapshotSource>,
+    error: Option<&str>,
+    servers: &[crate::agent::model::McpServerStatus],
+) -> Option<PendingDynamicMcpRemovalConfirmation> {
+    if source != Some(types::McpSnapshotSource::McpSetServers) {
+        return None;
+    }
+
+    let server_name = app.mcp.pending_dynamic_config_removal.as_ref()?.clone();
+    if let Some(message) = error {
+        return Some(PendingDynamicMcpRemovalConfirmation::Failed {
+            server_name,
+            message: format!("SDK snapshot failed after setMcpServers: {message}"),
+        });
+    }
+
+    if servers.iter().any(|server| mcp_server_name_eq(&server.name, &server_name)) {
+        return Some(PendingDynamicMcpRemovalConfirmation::Failed {
+            server_name,
+            message: "SDK setMcpServers completed without reporting an error, but the confirming snapshot still contains the server.".to_owned(),
+        });
+    }
+
+    Some(PendingDynamicMcpRemovalConfirmation::Confirmed { server_name })
+}
+
+pub(crate) fn apply_pending_dynamic_mcp_removal_confirmation(
+    app: &mut App,
+    confirmation: Option<PendingDynamicMcpRemovalConfirmation>,
+) {
+    let Some(confirmation) = confirmation else {
+        return;
+    };
+
+    match confirmation {
+        PendingDynamicMcpRemovalConfirmation::Confirmed { server_name } => {
+            if app
+                .mcp
+                .pending_dynamic_config_removal
+                .as_deref()
+                .is_some_and(|pending| mcp_server_name_eq(pending, &server_name))
+            {
+                app.mcp.pending_dynamic_config_removal = None;
+            }
+            tracing::info!(
+                target: crate::logging::targets::APP_CONFIG,
+                event_name = "mcp_dynamic_remove_confirmed",
+                message = "dynamic MCP removal confirmed by snapshot",
+                outcome = "success",
+                server_name = %server_name,
+            );
+            apply_mcp_config_remove_success_state(
+                app,
+                &server_name,
+                McpConfigScope::Dynamic.cli_arg(),
+                None,
+            );
+        }
+        PendingDynamicMcpRemovalConfirmation::Failed { server_name, message } => {
+            if app
+                .mcp
+                .pending_dynamic_config_removal
+                .as_deref()
+                .is_some_and(|pending| mcp_server_name_eq(pending, &server_name))
+            {
+                app.mcp.pending_dynamic_config_removal = None;
+            }
+            tracing::warn!(
+                target: crate::logging::targets::APP_CONFIG,
+                event_name = "mcp_dynamic_remove_confirmation_failed",
+                message = "dynamic MCP removal was not confirmed",
+                outcome = "failure",
+                server_name = %server_name,
+                error_message = %message,
+            );
+            apply_mcp_config_remove_failure(
+                app,
+                &server_name,
+                McpConfigScope::Dynamic.cli_arg(),
+                &message,
+            );
+        }
+    }
+}
+
+fn apply_mcp_config_remove_success_state(
+    app: &mut App,
+    server_name: &str,
+    scope_name: &str,
+    expected_source: Option<types::McpSnapshotSource>,
+) {
+    if let Some(expected_source) = expected_source {
+        remember_removed_config_mcp_server(app, scope_name, server_name, expected_source);
+    }
     remove_matching_mcp_server_from_snapshot(app, scope_name, server_name);
     app.config.mcp_selected_server_index =
         app.config.mcp_selected_server_index.min(app.mcp.servers.len().saturating_sub(1));
     app.mcp.last_error = None;
     app.config.last_error = None;
-    app.config.status_message =
-        Some(format!("Removed MCP server {server_name} from {scope_name} config."));
+    app.config.status_message = Some(format!(
+        "Removed MCP server {server_name} from {scope_name} config. You might need to run /new-session to apply MCP changes."
+    ));
 }
 
-fn remember_removed_config_mcp_server(app: &mut App, scope: &str, server_name: &str) {
-    app.mcp.removed_config_servers.insert(normalized_removed_config_key(scope, server_name));
+fn remember_removed_config_mcp_server(
+    app: &mut App,
+    scope: &str,
+    server_name: &str,
+    expected_source: types::McpSnapshotSource,
+) {
+    app.mcp.removed_config_servers.insert(
+        normalized_removed_config_key(scope, server_name),
+        RemovedMcpServerGuard { expected_source },
+    );
 }
 
 fn remove_matching_mcp_server_from_snapshot(app: &mut App, scope: &str, server_name: &str) {
@@ -744,28 +915,189 @@ pub(crate) fn filter_removed_config_mcp_servers(
     servers.retain(|server| !is_removed_config_mcp_server_suppressed(app, server));
 }
 
+pub(crate) fn filter_stale_plugin_mcp_servers(
+    app: &App,
+    source: Option<types::McpSnapshotSource>,
+    servers: &mut Vec<crate::agent::model::McpServerStatus>,
+) {
+    let stale_server_names = stale_plugin_mcp_server_names(app, servers);
+    suppress_stale_plugin_mcp_servers(source, servers, stale_server_names);
+}
+
+pub(crate) fn reconcile_stale_plugin_mcp_servers(app: &mut App) {
+    let stale_server_names = stale_plugin_mcp_server_names(app, &app.mcp.servers);
+    if stale_server_names.is_empty() {
+        return;
+    }
+
+    suppress_stale_plugin_mcp_servers(None, &mut app.mcp.servers, stale_server_names);
+    app.config.mcp_selected_server_index =
+        app.config.mcp_selected_server_index.min(app.mcp.servers.len().saturating_sub(1));
+    clear_missing_mcp_server_overlays(app);
+}
+
+fn stale_plugin_mcp_server_names(
+    app: &App,
+    servers: &[crate::agent::model::McpServerStatus],
+) -> Vec<String> {
+    servers
+        .iter()
+        .filter(|server| crate::app::plugins::is_stale_plugin_mcp_runtime_server(app, &server.name))
+        .map(|server| server.name.clone())
+        .collect()
+}
+
+fn suppress_stale_plugin_mcp_servers(
+    source: Option<types::McpSnapshotSource>,
+    servers: &mut Vec<crate::agent::model::McpServerStatus>,
+    stale_server_names: Vec<String>,
+) {
+    if stale_server_names.is_empty() {
+        return;
+    }
+
+    servers.retain(|server| {
+        !stale_server_names.iter().any(|stale_name| mcp_server_name_eq(stale_name, &server.name))
+    });
+    for server_name in stale_server_names {
+        tracing::info!(
+            target: crate::logging::targets::APP_CONFIG,
+            event_name = "mcp_stale_plugin_runtime_server_suppressed",
+            message = "stale plugin-owned MCP server suppressed from MCP list",
+            outcome = "suppressed",
+            source = ?source,
+            server_name = %server_name,
+        );
+    }
+}
+
+fn clear_missing_mcp_server_overlays(app: &mut App) {
+    let missing_server_name = match app.config.overlay.as_ref() {
+        Some(ConfigOverlayState::McpDetails(overlay)) => Some(overlay.server_name.as_str()),
+        Some(ConfigOverlayState::McpCallbackUrl(overlay)) => Some(overlay.server_name.as_str()),
+        Some(ConfigOverlayState::McpAuthRedirect(overlay)) => {
+            Some(overlay.redirect.server_name.as_str())
+        }
+        Some(ConfigOverlayState::McpElicitation(overlay)) => {
+            Some(overlay.request.server_name.as_str())
+        }
+        Some(
+            ConfigOverlayState::ModelAndEffort(_)
+            | ConfigOverlayState::OutputStyle(_)
+            | ConfigOverlayState::Language(_)
+            | ConfigOverlayState::SessionRename(_)
+            | ConfigOverlayState::Confirmation(_)
+            | ConfigOverlayState::InstalledPluginActions(_)
+            | ConfigOverlayState::PluginInstallActions(_)
+            | ConfigOverlayState::MarketplaceActions(_)
+            | ConfigOverlayState::AddMarketplace(_),
+        )
+        | None => None,
+    }
+    .is_some_and(|server_name| {
+        !app.mcp.servers.iter().any(|server| mcp_server_name_eq(&server.name, server_name))
+    });
+
+    if missing_server_name {
+        app.config.clear_overlay();
+    }
+}
+
+pub(crate) fn reconcile_removed_config_mcp_server_guards(
+    app: &mut App,
+    source: Option<types::McpSnapshotSource>,
+    error: Option<&str>,
+    servers: &[crate::agent::model::McpServerStatus],
+) -> Vec<McpConfigRemoveConfirmationFailure> {
+    let mut failures = Vec::new();
+    if app.mcp.removed_config_servers.is_empty() || error.is_some() {
+        return failures;
+    }
+    let Some(source) = source else {
+        return failures;
+    };
+    app.mcp.removed_config_servers.retain(|removed_key, guard| {
+        if guard.expected_source != source {
+            return true;
+        }
+
+        if let Some(server) =
+            servers.iter().find(|server| mcp_server_matches_removed_key(server, removed_key))
+        {
+            failures.push(McpConfigRemoveConfirmationFailure {
+                server_name: server.name.clone(),
+                scope: removed_key.scope.clone(),
+                message: format!(
+                    "Removal was reported as successful, but the confirming {} snapshot still contains the server.",
+                    mcp_snapshot_source_label(source),
+                ),
+            });
+        }
+
+        false
+    });
+    failures
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct McpConfigRemoveConfirmationFailure {
+    server_name: String,
+    scope: String,
+    message: String,
+}
+
+pub(crate) fn apply_removed_config_mcp_server_confirmation_failures(
+    app: &mut App,
+    failures: Vec<McpConfigRemoveConfirmationFailure>,
+) {
+    for failure in failures {
+        apply_mcp_config_remove_failure(
+            app,
+            &failure.server_name,
+            &failure.scope,
+            &failure.message,
+        );
+    }
+}
+
 fn is_removed_config_mcp_server_suppressed(
     app: &App,
     server: &crate::agent::model::McpServerStatus,
 ) -> bool {
     app.mcp
         .removed_config_servers
-        .iter()
+        .keys()
         .any(|removed_key| mcp_server_matches_removed_key(server, removed_key))
 }
 
 fn mcp_server_matches_removed_key(
     server: &crate::agent::model::McpServerStatus,
-    removed_key: &(String, String),
+    removed_key: &RemovedMcpServerKey,
 ) -> bool {
-    server
-        .scope
-        .as_deref()
-        .is_some_and(|scope| normalized_removed_config_key(scope, &server.name) == *removed_key)
+    match server.scope.as_deref() {
+        Some(scope) => normalized_removed_config_key(scope, &server.name) == *removed_key,
+        None => mcp_server_name_eq(&server.name, &removed_key.server_name),
+    }
 }
 
-fn normalized_removed_config_key(scope: &str, server_name: &str) -> (String, String) {
-    (normalize_mcp_config_scope_key(scope), server_name.to_ascii_lowercase())
+fn mcp_server_name_eq(left: &str, right: &str) -> bool {
+    left.eq_ignore_ascii_case(right)
+}
+
+const fn mcp_snapshot_source_label(source: types::McpSnapshotSource) -> &'static str {
+    match source {
+        types::McpSnapshotSource::ReloadPlugins => "reload_plugins",
+        types::McpSnapshotSource::McpStatus => "mcp_status",
+        types::McpSnapshotSource::McpSetServers => "mcp_set_servers",
+        types::McpSnapshotSource::Init => "init",
+    }
+}
+
+fn normalized_removed_config_key(scope: &str, server_name: &str) -> RemovedMcpServerKey {
+    RemovedMcpServerKey::new(
+        normalize_mcp_config_scope_key(scope),
+        server_name.to_ascii_lowercase(),
+    )
 }
 
 fn normalize_mcp_config_scope_key(scope: &str) -> String {
@@ -912,7 +1244,9 @@ pub(crate) fn open_mcp_server_details(
         app.mcp.servers.iter().find(|server| server.name == server_name).map_or(0, |server| {
             preferred_action
                 .and_then(|action| {
-                    available_mcp_actions(server).iter().position(|candidate| *candidate == action)
+                    available_mcp_actions(app, server)
+                        .iter()
+                        .position(|candidate| *candidate == action)
                 })
                 .unwrap_or(0)
         });
@@ -923,14 +1257,41 @@ pub(crate) fn open_mcp_server_details(
 }
 
 #[must_use]
+pub(crate) fn mcp_server_ownership<'a>(
+    app: &'a App,
+    server: &'a crate::agent::model::McpServerStatus,
+) -> McpServerOwnership<'a> {
+    if crate::app::plugins::is_plugin_mcp_runtime_server_name(&server.name) {
+        return crate::app::plugins::installed_mcp_plugin_for_runtime_server(app, &server.name)
+            .map_or(McpServerOwnership::PluginOwnedUnknown, McpServerOwnership::PluginOwned);
+    }
+
+    match server.scope.as_deref().and_then(McpConfigScope::from_status_scope) {
+        Some(McpConfigScope::User) => McpServerOwnership::Persisted(McpConfigScope::User),
+        Some(McpConfigScope::Local) => McpServerOwnership::Persisted(McpConfigScope::Local),
+        Some(McpConfigScope::Project) => McpServerOwnership::Persisted(McpConfigScope::Project),
+        Some(McpConfigScope::Dynamic) => McpServerOwnership::SdkDynamic,
+        None => McpServerOwnership::RuntimeOnly,
+    }
+}
+
+#[must_use]
 pub(crate) fn mcp_config_removal_scope(
+    app: &App,
     server: &crate::agent::model::McpServerStatus,
 ) -> Option<McpConfigScope> {
-    server.scope.as_deref().and_then(McpConfigScope::from_status_scope)
+    match mcp_server_ownership(app, server) {
+        McpServerOwnership::Persisted(scope) => Some(scope),
+        McpServerOwnership::SdkDynamic => Some(McpConfigScope::Dynamic),
+        McpServerOwnership::PluginOwned(_)
+        | McpServerOwnership::PluginOwnedUnknown
+        | McpServerOwnership::RuntimeOnly => None,
+    }
 }
 
 #[must_use]
 pub(crate) fn available_mcp_actions(
+    app: &App,
     server: &crate::agent::model::McpServerStatus,
 ) -> Vec<McpServerActionKind> {
     let mut actions = vec![McpServerActionKind::RefreshSnapshot];
@@ -949,14 +1310,24 @@ pub(crate) fn available_mcp_actions(
         actions.push(McpServerActionKind::Reconnect);
         actions.push(McpServerActionKind::Disable);
     }
-    if let Some(scope) = mcp_config_removal_scope(server) {
-        actions.push(remove_action_for_mcp_config_scope(scope));
+    match mcp_server_ownership(app, server) {
+        McpServerOwnership::Persisted(scope) => {
+            actions.push(remove_action_for_mcp_config_scope(scope));
+        }
+        McpServerOwnership::SdkDynamic => {
+            actions.push(McpServerActionKind::RemoveDynamicConfig);
+        }
+        McpServerOwnership::PluginOwned(_) => {
+            actions.push(McpServerActionKind::ManagePlugin);
+        }
+        McpServerOwnership::PluginOwnedUnknown | McpServerOwnership::RuntimeOnly => {}
     }
     actions
 }
 
 #[must_use]
 pub(crate) fn is_mcp_action_available(
+    app: &App,
     server: &crate::agent::model::McpServerStatus,
     action: McpServerActionKind,
 ) -> bool {
@@ -969,7 +1340,10 @@ pub(crate) fn is_mcp_action_available(
         | McpServerActionKind::RemoveLocalConfig
         | McpServerActionKind::RemoveProjectConfig
         | McpServerActionKind::RemoveDynamicConfig => {
-            action.mcp_config_scope() == mcp_config_removal_scope(server)
+            action.mcp_config_scope() == mcp_config_removal_scope(app, server)
+        }
+        McpServerActionKind::ManagePlugin => {
+            matches!(mcp_server_ownership(app, server), McpServerOwnership::PluginOwned(_))
         }
         McpServerActionKind::RefreshSnapshot
         | McpServerActionKind::ClearAuth
@@ -977,6 +1351,33 @@ pub(crate) fn is_mcp_action_available(
         | McpServerActionKind::Enable
         | McpServerActionKind::Disable => true,
     }
+}
+
+#[must_use]
+pub(crate) fn mcp_server_owner_summary(
+    app: &App,
+    server: &crate::agent::model::McpServerStatus,
+) -> Option<String> {
+    match mcp_server_ownership(app, server) {
+        McpServerOwnership::PluginOwned(entry) => {
+            Some(format!("Managed by plugin: {}", crate::app::plugins::display_label(&entry.id)))
+        }
+        McpServerOwnership::PluginOwnedUnknown => Some(
+            "Managed by a plugin. Refresh plugin inventory from the Plugins tab to manage it here."
+                .to_owned(),
+        ),
+        McpServerOwnership::Persisted(_)
+        | McpServerOwnership::SdkDynamic
+        | McpServerOwnership::RuntimeOnly => None,
+    }
+}
+
+fn is_mcp_config_removal_available(app: &App, server_name: &str, scope: McpConfigScope) -> bool {
+    app.mcp
+        .servers
+        .iter()
+        .find(|server| mcp_server_name_eq(&server.name, server_name))
+        .is_some_and(|server| mcp_config_removal_scope(app, server) == Some(scope))
 }
 
 pub(crate) fn present_mcp_elicitation_request(

--- a/src/app/config/mcp_edit.rs
+++ b/src/app/config/mcp_edit.rs
@@ -64,7 +64,7 @@ fn move_mcp_details_overlay_selection(app: &mut App, delta: isize) {
     else {
         return;
     };
-    let actions = available_mcp_actions(server);
+    let actions = available_mcp_actions(app, server);
     if actions.is_empty() {
         return;
     }
@@ -84,11 +84,11 @@ fn execute_selected_mcp_overlay_action(app: &mut App) {
         app.config.clear_overlay();
         return;
     };
-    let actions = available_mcp_actions(server);
+    let actions = available_mcp_actions(app, server);
     let Some(action) = actions.get(overlay.selected_index).copied() else {
         return;
     };
-    if !is_mcp_action_available(server, action) {
+    if !is_mcp_action_available(app, server, action) {
         return;
     }
 
@@ -133,6 +133,15 @@ fn execute_mcp_server_action(app: &mut App, server_name: &str, action: McpServer
         McpServerActionKind::Disable => {
             set_mcp_server_enabled(app, server_name, false);
         }
+        McpServerActionKind::ManagePlugin => {
+            if !crate::app::plugins::open_installed_actions_overlay_for_mcp_server(app, server_name)
+            {
+                app.config.set_overlay_error(
+                    "Refresh plugin inventory from the Plugins tab before managing this MCP server.",
+                );
+            }
+            return;
+        }
         McpServerActionKind::RemoveUserConfig
         | McpServerActionKind::RemoveLocalConfig
         | McpServerActionKind::RemoveProjectConfig
@@ -173,7 +182,7 @@ fn open_mcp_remove_confirmation(
         return;
     };
     let Some(_scope) = action.mcp_config_scope().filter(|scope| {
-        mcp_config_removal_scope(server).is_some_and(|server_scope| server_scope == *scope)
+        mcp_config_removal_scope(app, server).is_some_and(|server_scope| server_scope == *scope)
     }) else {
         app.config.set_overlay_error("This MCP server cannot be removed from live config.");
         return;

--- a/src/app/config/mcp_edit.rs
+++ b/src/app/config/mcp_edit.rs
@@ -6,8 +6,9 @@ use super::edit::{
 use super::mcp::{
     McpCallbackUrlOverlayState, McpServerActionKind, authenticate_mcp_server,
     available_mcp_actions, clear_mcp_server_auth, copy_text_to_clipboard, is_mcp_action_available,
-    open_mcp_server_details, reconnect_mcp_server, refresh_mcp_snapshot,
-    send_mcp_elicitation_response, set_mcp_server_enabled, submit_mcp_oauth_callback_url,
+    mcp_config_removal_scope, open_mcp_server_details, reconnect_mcp_server, refresh_mcp_snapshot,
+    remove_mcp_server_from_config, send_mcp_elicitation_response, set_mcp_server_enabled,
+    submit_mcp_oauth_callback_url,
 };
 use super::{ConfigOverlayState, ConfirmationAction, ConfirmationOverlayState};
 use crate::app::App;
@@ -96,6 +97,11 @@ fn execute_selected_mcp_overlay_action(app: &mut App) {
         return;
     }
 
+    if action.mcp_config_scope().is_some() {
+        open_mcp_remove_confirmation(app, overlay, action);
+        return;
+    }
+
     execute_mcp_server_action(app, &overlay.server_name, action);
 }
 
@@ -127,6 +133,15 @@ fn execute_mcp_server_action(app: &mut App, server_name: &str, action: McpServer
         McpServerActionKind::Disable => {
             set_mcp_server_enabled(app, server_name, false);
         }
+        McpServerActionKind::RemoveUserConfig
+        | McpServerActionKind::RemoveLocalConfig
+        | McpServerActionKind::RemoveProjectConfig
+        | McpServerActionKind::RemoveDynamicConfig => {
+            let Some(scope) = action.mcp_config_scope() else {
+                return;
+            };
+            remove_mcp_server_from_config(app, server_name, scope);
+        }
     }
 
     app.config.clear_overlay();
@@ -143,6 +158,35 @@ fn open_mcp_clear_auth_confirmation(app: &mut App, overlay: super::mcp::McpDetai
         cancel_label: "Cancel".to_owned(),
         selected_index: 0,
         action: ConfirmationAction::McpClearAuth,
+        previous: Box::new(ConfigOverlayState::McpDetails(overlay)),
+    }));
+}
+
+fn open_mcp_remove_confirmation(
+    app: &mut App,
+    overlay: super::mcp::McpDetailsOverlayState,
+    action: McpServerActionKind,
+) {
+    let Some(server) = app.mcp.servers.iter().find(|server| server.name == overlay.server_name)
+    else {
+        app.config.clear_overlay();
+        return;
+    };
+    let Some(_scope) = action.mcp_config_scope().filter(|scope| {
+        mcp_config_removal_scope(server).is_some_and(|server_scope| server_scope == *scope)
+    }) else {
+        app.config.set_overlay_error("This MCP server cannot be removed from live config.");
+        return;
+    };
+
+    let server_name = overlay.server_name.clone();
+    app.config.replace_overlay(ConfigOverlayState::Confirmation(ConfirmationOverlayState {
+        title: format!("Remove MCP server {server_name}"),
+        body: format!("Remove MCP server {server_name}? This cannot be reversed."),
+        confirm_label: "Remove".to_owned(),
+        cancel_label: "Cancel".to_owned(),
+        selected_index: 0,
+        action: ConfirmationAction::McpRemoveConfig,
         previous: Box::new(ConfigOverlayState::McpDetails(overlay)),
     }));
 }

--- a/src/app/config/mod.rs
+++ b/src/app/config/mod.rs
@@ -21,9 +21,14 @@ pub(crate) use edit::{
 pub(crate) use mcp::{
     McpAuthRedirectOverlayState, McpCallbackUrlOverlayState, McpDetailsOverlayState,
     McpElicitationOverlayState, apply_mcp_config_remove_failure, apply_mcp_config_remove_success,
-    available_mcp_actions, filter_removed_config_mcp_servers, handle_mcp_elicitation_completed,
-    handle_mcp_operation_error, handle_mcp_set_servers_result, is_mcp_action_available,
-    present_mcp_auth_redirect, present_mcp_elicitation_request, refresh_mcp_snapshot,
+    apply_pending_dynamic_mcp_removal_confirmation,
+    apply_removed_config_mcp_server_confirmation_failures, available_mcp_actions,
+    filter_removed_config_mcp_servers, filter_stale_plugin_mcp_servers,
+    handle_mcp_elicitation_completed, handle_mcp_operation_error, handle_mcp_set_servers_result,
+    is_mcp_action_available, mcp_server_owner_summary,
+    pending_dynamic_mcp_removal_confirmation_from_snapshot, present_mcp_auth_redirect,
+    present_mcp_elicitation_request, reconcile_removed_config_mcp_server_guards,
+    reconcile_stale_plugin_mcp_servers, refresh_mcp_snapshot,
 };
 pub(crate) use resolve::language_input_validation_message;
 use resolve::resolve_setting_document;

--- a/src/app/config/mod.rs
+++ b/src/app/config/mod.rs
@@ -20,9 +20,10 @@ pub(crate) use edit::{
 };
 pub(crate) use mcp::{
     McpAuthRedirectOverlayState, McpCallbackUrlOverlayState, McpDetailsOverlayState,
-    McpElicitationOverlayState, available_mcp_actions, handle_mcp_elicitation_completed,
-    handle_mcp_operation_error, is_mcp_action_available, present_mcp_auth_redirect,
-    present_mcp_elicitation_request, refresh_mcp_snapshot,
+    McpElicitationOverlayState, apply_mcp_config_remove_failure, apply_mcp_config_remove_success,
+    available_mcp_actions, filter_removed_config_mcp_servers, handle_mcp_elicitation_completed,
+    handle_mcp_operation_error, handle_mcp_set_servers_result, is_mcp_action_available,
+    present_mcp_auth_redirect, present_mcp_elicitation_request, refresh_mcp_snapshot,
 };
 pub(crate) use resolve::language_input_validation_message;
 use resolve::resolve_setting_document;
@@ -814,6 +815,7 @@ pub enum ConfirmationAction {
     InstalledPluginUninstall,
     MarketplaceRemove,
     McpClearAuth,
+    McpRemoveConfig,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::agent::model::{AvailableModel, EffortLevel};
+use crate::agent::model::{
+    AvailableModel, EffortLevel, McpServerConnectionStatus, McpServerStatus, McpServerStatusConfig,
+};
 use crate::agent::wire::BridgeCommand;
 use crate::app::AppStatus;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
@@ -55,6 +57,22 @@ fn app_with_status_connection()
         first_prompt: Some("First prompt".to_owned()),
     }];
     (app, rx)
+}
+
+fn connected_mcp_server_status(
+    name: &str,
+    scope: &str,
+    config: Option<McpServerStatusConfig>,
+) -> McpServerStatus {
+    McpServerStatus {
+        name: name.to_owned(),
+        status: McpServerConnectionStatus::Connected,
+        server_info: None,
+        error: None,
+        config,
+        scope: Some(scope.to_owned()),
+        tools: Vec::new(),
+    }
 }
 
 fn read_json_file(path: &Path) -> Value {
@@ -1527,6 +1545,392 @@ fn mcp_clear_auth_requires_confirmation_and_cancel_restores_details_overlay() {
     let restored = app.config.mcp_details_overlay().expect("restored mcp details overlay");
     assert_eq!(restored.server_name, "filesystem");
     assert_eq!(restored.selected_index, 1);
+}
+
+#[test]
+fn user_mcp_server_offers_matching_config_remove_action() {
+    let server = crate::agent::model::McpServerStatus {
+        name: "filesystem".to_owned(),
+        status: crate::agent::model::McpServerConnectionStatus::Connected,
+        server_info: None,
+        error: None,
+        config: None,
+        scope: Some("user".to_owned()),
+        tools: Vec::new(),
+    };
+
+    let actions = available_mcp_actions(&server);
+
+    assert!(actions.contains(&super::mcp::McpServerActionKind::RemoveUserConfig));
+    assert_eq!(super::mcp::McpServerActionKind::RemoveUserConfig.label(), "Remove");
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveLocalConfig));
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveProjectConfig));
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveDynamicConfig));
+    assert!(super::mcp::is_mcp_action_available(
+        &server,
+        super::mcp::McpServerActionKind::RemoveUserConfig
+    ));
+}
+
+#[test]
+fn dynamic_mcp_server_offers_matching_config_remove_action() {
+    let server = crate::agent::model::McpServerStatus {
+        name: "plugin:Notion:notion".to_owned(),
+        status: crate::agent::model::McpServerConnectionStatus::Connected,
+        server_info: None,
+        error: None,
+        config: Some(crate::agent::model::McpServerStatusConfig::Http {
+            url: "https://mcp.notion.com/mcp".to_owned(),
+            headers: std::collections::BTreeMap::new(),
+            timeout: None,
+            tools: Vec::new(),
+            always_load: None,
+        }),
+        scope: Some("dynamic".to_owned()),
+        tools: Vec::new(),
+    };
+
+    let actions = available_mcp_actions(&server);
+
+    assert!(actions.contains(&super::mcp::McpServerActionKind::RemoveDynamicConfig));
+    assert_eq!(super::mcp::McpServerActionKind::RemoveDynamicConfig.label(), "Remove");
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveUserConfig));
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveLocalConfig));
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveProjectConfig));
+    assert!(super::mcp::is_mcp_action_available(
+        &server,
+        super::mcp::McpServerActionKind::RemoveDynamicConfig
+    ));
+}
+
+#[test]
+fn mcp_config_remove_requires_confirmation_with_exact_scope() {
+    let (_dir, mut app) = open_settings_test_app();
+    app.config.active_tab = ConfigTab::Mcp;
+    app.mcp.servers = vec![crate::agent::model::McpServerStatus {
+        name: "filesystem".to_owned(),
+        status: crate::agent::model::McpServerConnectionStatus::Connected,
+        server_info: None,
+        error: None,
+        config: None,
+        scope: Some("user".to_owned()),
+        tools: Vec::new(),
+    }];
+    let remove_index = available_mcp_actions(&app.mcp.servers[0])
+        .iter()
+        .position(|action| *action == super::mcp::McpServerActionKind::RemoveUserConfig)
+        .expect("remove action");
+    app.config.overlay = Some(ConfigOverlayState::McpDetails(McpDetailsOverlayState {
+        server_name: "filesystem".to_owned(),
+        selected_index: remove_index,
+    }));
+
+    handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    let confirmation = app.config.confirmation_overlay().expect("confirmation overlay");
+    assert_eq!(confirmation.action, ConfirmationAction::McpRemoveConfig);
+    assert_eq!(confirmation.confirm_label, "Remove");
+    assert_eq!(confirmation.body, "Remove MCP server filesystem? This cannot be reversed.");
+}
+
+#[test]
+fn non_config_mcp_server_does_not_offer_remove_action() {
+    let server = crate::agent::model::McpServerStatus {
+        name: "claude.ai Google Drive".to_owned(),
+        status: crate::agent::model::McpServerConnectionStatus::Disabled,
+        server_info: None,
+        error: None,
+        config: Some(crate::agent::model::McpServerStatusConfig::ClaudeaiProxy {
+            url: "https://mcp-proxy.anthropic.com/v1/mcp/server".to_owned(),
+            id: "mcpsrv_test".to_owned(),
+            timeout: None,
+        }),
+        scope: Some("claudeai".to_owned()),
+        tools: Vec::new(),
+    };
+
+    let actions = available_mcp_actions(&server);
+
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveUserConfig));
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveLocalConfig));
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveProjectConfig));
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveDynamicConfig));
+}
+
+#[test]
+fn mcp_config_remove_success_reloads_runtime_and_refreshes_snapshot() {
+    let (_dir, mut app) = open_settings_test_app();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.mcp.servers = vec![
+        crate::agent::model::McpServerStatus {
+            name: "filesystem".to_owned(),
+            status: crate::agent::model::McpServerConnectionStatus::Connected,
+            server_info: None,
+            error: None,
+            config: None,
+            scope: Some("user".to_owned()),
+            tools: Vec::new(),
+        },
+        crate::agent::model::McpServerStatus {
+            name: "other".to_owned(),
+            status: crate::agent::model::McpServerConnectionStatus::Connected,
+            server_info: None,
+            error: None,
+            config: None,
+            scope: Some("user".to_owned()),
+            tools: Vec::new(),
+        },
+    ];
+
+    super::mcp::apply_mcp_config_remove_success(
+        &mut app,
+        "filesystem",
+        "user",
+        PathBuf::from("C:\\tools\\claude.exe"),
+    );
+
+    assert_eq!(app.mcp.claude_path, Some(PathBuf::from("C:\\tools\\claude.exe")));
+    assert!(app.mcp.removed_config_servers.contains(&("user".to_owned(), "filesystem".to_owned())));
+    assert_eq!(
+        app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["other"]
+    );
+    assert_eq!(
+        app.config.status_message.as_deref(),
+        Some("Removed MCP server filesystem from user config.")
+    );
+    let envelope = rx.try_recv().expect("runtime reload command");
+    assert_eq!(
+        envelope.command,
+        BridgeCommand::ReloadPlugins { session_id: "session-1".to_owned() }
+    );
+    let envelope = rx.try_recv().expect("mcp snapshot command");
+    assert_eq!(
+        envelope.command,
+        BridgeCommand::GetMcpSnapshot { session_id: "session-1".to_owned() }
+    );
+    assert!(app.mcp.in_flight);
+}
+
+#[test]
+fn dynamic_mcp_config_remove_uses_sdk_set_servers_and_preserves_other_dynamic_servers() {
+    let (_dir, mut app) = open_settings_test_app();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    let mut keep_headers = BTreeMap::new();
+    keep_headers.insert("Authorization".to_owned(), "Bearer token".to_owned());
+    app.mcp.servers = vec![
+        connected_mcp_server_status(
+            "plugin:Notion:notion",
+            "dynamic",
+            Some(crate::agent::model::McpServerStatusConfig::Http {
+                url: "https://mcp.notion.com/mcp".to_owned(),
+                headers: std::collections::BTreeMap::new(),
+                timeout: None,
+                tools: Vec::new(),
+                always_load: None,
+            }),
+        ),
+        connected_mcp_server_status(
+            "keep-dynamic",
+            "dynamic",
+            Some(crate::agent::model::McpServerStatusConfig::Http {
+                url: "https://example.test/mcp".to_owned(),
+                headers: keep_headers.clone(),
+                timeout: Some(5_000),
+                tools: vec![crate::agent::model::McpServerToolPolicy {
+                    name: "search".to_owned(),
+                    permission_policy: Some(
+                        crate::agent::model::McpServerToolPermissionPolicy::Ask,
+                    ),
+                    org_max_permission: Some(crate::agent::model::McpServerOrgMaxPermission::Ask),
+                }],
+                always_load: Some(true),
+            }),
+        ),
+        connected_mcp_server_status("fff", "user", None),
+    ];
+
+    super::mcp::remove_mcp_server_from_config(
+        &mut app,
+        "plugin:Notion:notion",
+        super::mcp::McpConfigScope::Dynamic,
+    );
+
+    let envelope = rx.try_recv().expect("mcp set servers command");
+    let BridgeCommand::McpSetServers { session_id, servers } = envelope.command else {
+        panic!("expected mcp_set_servers");
+    };
+    assert_eq!(session_id, "session-1");
+    assert_eq!(servers.len(), 1);
+    assert_eq!(
+        servers.get("keep-dynamic"),
+        Some(&crate::agent::types::McpServerConfig::Http {
+            url: "https://example.test/mcp".to_owned(),
+            headers: keep_headers,
+            tools: vec![crate::agent::types::McpServerToolPolicy {
+                name: "search".to_owned(),
+                permission_policy: Some(crate::agent::types::McpServerToolPermissionPolicy::Ask),
+                org_max_permission: Some(crate::agent::types::McpServerOrgMaxPermission::Ask),
+            }],
+            timeout: Some(5_000),
+            always_load: Some(true),
+        })
+    );
+    assert_eq!(app.mcp.pending_dynamic_config_removal.as_deref(), Some("plugin:Notion:notion"));
+    assert_eq!(
+        app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["plugin:Notion:notion", "keep-dynamic", "fff"]
+    );
+    assert!(rx.try_recv().is_err());
+
+    super::mcp::handle_mcp_set_servers_result(
+        &mut app,
+        &crate::agent::types::McpSetServersResult {
+            removed: vec!["plugin:Notion:notion".to_owned()],
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        app.mcp
+            .removed_config_servers
+            .contains(&("dynamic".to_owned(), "plugin:notion:notion".to_owned()))
+    );
+    assert_eq!(
+        app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["keep-dynamic", "fff"]
+    );
+    assert_eq!(
+        app.config.status_message.as_deref(),
+        Some("Removed MCP server plugin:Notion:notion from dynamic config.")
+    );
+    assert!(matches!(
+        rx.try_recv().expect("mcp snapshot command").command,
+        BridgeCommand::GetMcpSnapshot { .. }
+    ));
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn dynamic_mcp_config_remove_failure_from_sdk_keeps_server_visible() {
+    let (_dir, mut app) = open_settings_test_app();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.mcp.servers = vec![connected_mcp_server_status(
+        "plugin:Notion:notion",
+        "dynamic",
+        Some(crate::agent::model::McpServerStatusConfig::Http {
+            url: "https://mcp.notion.com/mcp".to_owned(),
+            headers: BTreeMap::new(),
+            timeout: None,
+            tools: Vec::new(),
+            always_load: None,
+        }),
+    )];
+
+    super::mcp::remove_mcp_server_from_config(
+        &mut app,
+        "plugin:Notion:notion",
+        super::mcp::McpConfigScope::Dynamic,
+    );
+    assert!(matches!(
+        rx.try_recv().expect("mcp set servers command").command,
+        BridgeCommand::McpSetServers { .. }
+    ));
+
+    super::mcp::handle_mcp_operation_error(
+        &mut app,
+        &crate::agent::types::McpOperationError {
+            server_name: None,
+            operation: "set-servers".to_owned(),
+            message: "dynamic update failed".to_owned(),
+        },
+    );
+
+    assert!(app.mcp.pending_dynamic_config_removal.is_none());
+    assert!(app.mcp.removed_config_servers.is_empty());
+    assert!(!app.mcp.in_flight);
+    assert_eq!(
+        app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["plugin:Notion:notion"]
+    );
+    let message = app.mcp.last_error.as_deref().expect("last MCP error");
+    assert!(
+        message.contains("Failed to remove MCP server plugin:Notion:notion from dynamic config")
+    );
+    assert!(message.contains("dynamic update failed"));
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn dynamic_mcp_config_remove_refuses_to_drop_unrepresentable_dynamic_servers() {
+    let (_dir, mut app) = open_settings_test_app();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.mcp.servers = vec![
+        connected_mcp_server_status(
+            "plugin:Notion:notion",
+            "dynamic",
+            Some(crate::agent::model::McpServerStatusConfig::Http {
+                url: "https://mcp.notion.com/mcp".to_owned(),
+                headers: BTreeMap::new(),
+                timeout: None,
+                tools: Vec::new(),
+                always_load: None,
+            }),
+        ),
+        connected_mcp_server_status(
+            "in-process",
+            "dynamic",
+            Some(crate::agent::model::McpServerStatusConfig::Sdk { name: "sdk-server".to_owned() }),
+        ),
+    ];
+
+    super::mcp::remove_mcp_server_from_config(
+        &mut app,
+        "plugin:Notion:notion",
+        super::mcp::McpConfigScope::Dynamic,
+    );
+
+    assert!(rx.try_recv().is_err());
+    assert!(!app.mcp.in_flight);
+    assert!(app.mcp.removed_config_servers.is_empty());
+    assert_eq!(
+        app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["plugin:Notion:notion", "in-process"]
+    );
+    let message = app.mcp.last_error.as_deref().expect("last MCP error");
+    assert!(
+        message.contains("Failed to remove MCP server plugin:Notion:notion from dynamic config")
+    );
+    assert!(
+        message.contains(
+            "Cannot safely preserve dynamic MCP server in-process because SDK-server instances cannot be represented by the Rust bridge"
+        )
+    );
+}
+
+#[test]
+fn mcp_config_remove_failure_surfaces_overlay_error() {
+    let (_dir, mut app) = open_settings_test_app();
+    app.mcp.in_flight = true;
+    app.config.overlay = Some(ConfigOverlayState::McpDetails(McpDetailsOverlayState {
+        server_name: "filesystem".to_owned(),
+        selected_index: 0,
+    }));
+
+    super::mcp::apply_mcp_config_remove_failure(&mut app, "filesystem", "user", "boom");
+
+    assert!(!app.mcp.in_flight);
+    let message = app.config.overlay_message.as_ref().expect("overlay message");
+    assert_eq!(message.kind, OverlayMessageKind::Error);
+    assert!(message.text.contains("Failed to remove MCP server filesystem from user config"));
 }
 
 #[test]

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -75,6 +75,66 @@ fn connected_mcp_server_status(
     }
 }
 
+fn installed_plugin_entry(id: &str) -> crate::app::plugins::InstalledPluginEntry {
+    installed_plugin_entry_with_scope(id, "user", None)
+}
+
+fn disabled_installed_plugin_entry(id: &str) -> crate::app::plugins::InstalledPluginEntry {
+    let mut entry = installed_plugin_entry(id);
+    entry.enabled = false;
+    entry
+}
+
+fn installed_plugin_entry_with_scope(
+    id: &str,
+    scope: &str,
+    project_path: Option<&str>,
+) -> crate::app::plugins::InstalledPluginEntry {
+    crate::app::plugins::InstalledPluginEntry {
+        id: id.to_owned(),
+        version: Some("1.0.0".to_owned()),
+        scope: scope.to_owned(),
+        enabled: true,
+        installed_at: None,
+        last_updated: None,
+        project_path: project_path.map(ToOwned::to_owned),
+        mcp_server_names: Vec::new(),
+    }
+}
+
+fn installed_mcp_plugin_entry(
+    id: &str,
+    mcp_server_names: &[&str],
+) -> crate::app::plugins::InstalledPluginEntry {
+    let mut entry = installed_plugin_entry(id);
+    entry.mcp_server_names = mcp_server_names.iter().map(|name| (*name).to_owned()).collect();
+    entry
+}
+
+fn notion_plugin_entry() -> crate::app::plugins::InstalledPluginEntry {
+    let mut entry = installed_mcp_plugin_entry("notion@claude-plugins-official", &["notion"]);
+    entry.version = Some("0.1.0".to_owned());
+    entry
+}
+
+fn dynamic_http_mcp_server_status(name: &str, url: &str) -> McpServerStatus {
+    connected_mcp_server_status(
+        name,
+        "dynamic",
+        Some(McpServerStatusConfig::Http {
+            url: url.to_owned(),
+            headers: BTreeMap::new(),
+            timeout: None,
+            tools: Vec::new(),
+            always_load: None,
+        }),
+    )
+}
+
+fn notion_mcp_server_status() -> McpServerStatus {
+    dynamic_http_mcp_server_status("plugin:Notion:notion", "https://mcp.notion.com/mcp")
+}
+
 fn read_json_file(path: &Path) -> Value {
     serde_json::from_str(&std::fs::read_to_string(path).expect("read")).expect("json")
 }
@@ -302,26 +362,8 @@ fn plugins_tab_uses_arrow_keys_for_inner_navigation() {
     app.config.active_tab = ConfigTab::Plugins;
     app.config.selected_setting_index = 3;
     app.plugins.installed = vec![
-        crate::app::plugins::InstalledPluginEntry {
-            id: "frontend-design@claude-plugins-official".to_owned(),
-            version: Some("1.0.0".to_owned()),
-            scope: "user".to_owned(),
-            enabled: true,
-            installed_at: None,
-            last_updated: None,
-            project_path: None,
-            capability: crate::app::plugins::PluginCapability::Skill,
-        },
-        crate::app::plugins::InstalledPluginEntry {
-            id: "rust-analyzer-lsp@claude-plugins-official".to_owned(),
-            version: Some("1.0.0".to_owned()),
-            scope: "user".to_owned(),
-            enabled: true,
-            installed_at: None,
-            last_updated: None,
-            project_path: None,
-            capability: crate::app::plugins::PluginCapability::Skill,
-        },
+        installed_plugin_entry("frontend-design@claude-plugins-official"),
+        installed_plugin_entry("rust-analyzer-lsp@claude-plugins-official"),
     ];
 
     handle_key(&mut app, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
@@ -355,16 +397,11 @@ fn installed_plugin_enter_opens_actions_overlay() {
     let (_dir, mut app) = open_settings_test_app();
     app.config.active_tab = ConfigTab::Plugins;
     app.cwd_raw = "C:\\work\\project-a".to_owned();
-    app.plugins.installed = vec![crate::app::plugins::InstalledPluginEntry {
-        id: "frontend-design@claude-plugins-official".to_owned(),
-        version: Some("1.0.0".to_owned()),
-        scope: "local".to_owned(),
-        enabled: true,
-        installed_at: None,
-        last_updated: None,
-        project_path: Some("C:\\work\\project-a".to_owned()),
-        capability: crate::app::plugins::PluginCapability::Skill,
-    }];
+    app.plugins.installed = vec![installed_plugin_entry_with_scope(
+        "frontend-design@claude-plugins-official",
+        "local",
+        Some("C:\\work\\project-a"),
+    )];
     app.plugins.marketplace = vec![crate::app::plugins::MarketplaceEntry {
         plugin_id: "frontend-design@claude-plugins-official".to_owned(),
         name: "frontend-design".to_owned(),
@@ -394,16 +431,8 @@ fn installed_plugin_enter_opens_actions_overlay() {
 fn installed_plugin_overlay_uses_up_down_and_escape() {
     let (_dir, mut app) = open_settings_test_app();
     app.config.active_tab = ConfigTab::Plugins;
-    app.plugins.installed = vec![crate::app::plugins::InstalledPluginEntry {
-        id: "frontend-design@claude-plugins-official".to_owned(),
-        version: Some("1.0.0".to_owned()),
-        scope: "user".to_owned(),
-        enabled: false,
-        installed_at: None,
-        last_updated: None,
-        project_path: None,
-        capability: crate::app::plugins::PluginCapability::Skill,
-    }];
+    app.plugins.installed =
+        vec![disabled_installed_plugin_entry("frontend-design@claude-plugins-official")];
 
     handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
     handle_key(&mut app, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
@@ -587,16 +616,8 @@ fn empty_marketplace_source_sets_overlay_error_and_keeps_overlay_open() {
 fn installed_plugin_uninstall_requires_confirmation_and_restores_previous_overlay_on_cancel() {
     let (_dir, mut app) = open_settings_test_app();
     app.config.active_tab = ConfigTab::Plugins;
-    app.plugins.installed = vec![crate::app::plugins::InstalledPluginEntry {
-        id: "frontend-design@claude-plugins-official".to_owned(),
-        version: Some("1.0.0".to_owned()),
-        scope: "user".to_owned(),
-        enabled: false,
-        installed_at: None,
-        last_updated: None,
-        project_path: None,
-        capability: crate::app::plugins::PluginCapability::Skill,
-    }];
+    app.plugins.installed =
+        vec![disabled_installed_plugin_entry("frontend-design@claude-plugins-official")];
 
     handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
     handle_key(&mut app, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
@@ -1549,6 +1570,7 @@ fn mcp_clear_auth_requires_confirmation_and_cancel_restores_details_overlay() {
 
 #[test]
 fn user_mcp_server_offers_matching_config_remove_action() {
+    let (_dir, app) = open_settings_test_app();
     let server = crate::agent::model::McpServerStatus {
         name: "filesystem".to_owned(),
         status: crate::agent::model::McpServerConnectionStatus::Connected,
@@ -1559,7 +1581,7 @@ fn user_mcp_server_offers_matching_config_remove_action() {
         tools: Vec::new(),
     };
 
-    let actions = available_mcp_actions(&server);
+    let actions = available_mcp_actions(&app, &server);
 
     assert!(actions.contains(&super::mcp::McpServerActionKind::RemoveUserConfig));
     assert_eq!(super::mcp::McpServerActionKind::RemoveUserConfig.label(), "Remove");
@@ -1567,30 +1589,18 @@ fn user_mcp_server_offers_matching_config_remove_action() {
     assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveProjectConfig));
     assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveDynamicConfig));
     assert!(super::mcp::is_mcp_action_available(
+        &app,
         &server,
         super::mcp::McpServerActionKind::RemoveUserConfig
     ));
 }
 
 #[test]
-fn dynamic_mcp_server_offers_matching_config_remove_action() {
-    let server = crate::agent::model::McpServerStatus {
-        name: "plugin:Notion:notion".to_owned(),
-        status: crate::agent::model::McpServerConnectionStatus::Connected,
-        server_info: None,
-        error: None,
-        config: Some(crate::agent::model::McpServerStatusConfig::Http {
-            url: "https://mcp.notion.com/mcp".to_owned(),
-            headers: std::collections::BTreeMap::new(),
-            timeout: None,
-            tools: Vec::new(),
-            always_load: None,
-        }),
-        scope: Some("dynamic".to_owned()),
-        tools: Vec::new(),
-    };
+fn true_dynamic_mcp_server_offers_matching_config_remove_action() {
+    let (_dir, app) = open_settings_test_app();
+    let server = dynamic_http_mcp_server_status("session-search", "https://example.test/mcp");
 
-    let actions = available_mcp_actions(&server);
+    let actions = available_mcp_actions(&app, &server);
 
     assert!(actions.contains(&super::mcp::McpServerActionKind::RemoveDynamicConfig));
     assert_eq!(super::mcp::McpServerActionKind::RemoveDynamicConfig.label(), "Remove");
@@ -1598,9 +1608,159 @@ fn dynamic_mcp_server_offers_matching_config_remove_action() {
     assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveLocalConfig));
     assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveProjectConfig));
     assert!(super::mcp::is_mcp_action_available(
+        &app,
         &server,
         super::mcp::McpServerActionKind::RemoveDynamicConfig
     ));
+}
+
+#[test]
+fn plugin_owned_mcp_server_offers_manage_plugin_instead_of_dynamic_remove() {
+    let (_dir, mut app) = open_settings_test_app();
+    app.plugins.installed = vec![notion_plugin_entry()];
+    let server = notion_mcp_server_status();
+
+    let actions = available_mcp_actions(&app, &server);
+
+    assert!(actions.contains(&super::mcp::McpServerActionKind::ManagePlugin));
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveDynamicConfig));
+    assert!(super::mcp::is_mcp_action_available(
+        &app,
+        &server,
+        super::mcp::McpServerActionKind::ManagePlugin
+    ));
+    assert!(!super::mcp::is_mcp_action_available(
+        &app,
+        &server,
+        super::mcp::McpServerActionKind::RemoveDynamicConfig
+    ));
+}
+
+#[test]
+fn plugin_owned_mcp_server_maps_to_installed_plugin_entry() {
+    let (_dir, mut app) = open_settings_test_app();
+    app.plugins.installed = vec![notion_plugin_entry()];
+
+    let owner =
+        crate::app::plugins::installed_mcp_plugin_for_runtime_server(&app, "plugin:Notion:notion")
+            .expect("plugin owner");
+
+    assert_eq!(owner.id, "notion@claude-plugins-official");
+    assert_eq!(owner.mcp_server_names, vec!["notion"]);
+}
+
+#[test]
+fn mcp_manage_plugin_action_opens_installed_plugin_actions_overlay() {
+    let (_dir, mut app) = open_settings_test_app();
+    app.config.active_tab = ConfigTab::Mcp;
+    app.plugins.installed = vec![notion_plugin_entry()];
+    app.mcp.servers = vec![notion_mcp_server_status()];
+    let manage_index = available_mcp_actions(&app, &app.mcp.servers[0])
+        .iter()
+        .position(|action| *action == super::mcp::McpServerActionKind::ManagePlugin)
+        .expect("manage plugin action");
+    app.config.overlay = Some(ConfigOverlayState::McpDetails(McpDetailsOverlayState {
+        server_name: "plugin:Notion:notion".to_owned(),
+        selected_index: manage_index,
+    }));
+
+    handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    let overlay = app.config.installed_plugin_actions_overlay().expect("plugin actions overlay");
+    assert_eq!(overlay.plugin_id, "notion@claude-plugins-official");
+    assert_eq!(overlay.scope, "user");
+    assert_eq!(
+        overlay.actions,
+        vec![
+            InstalledPluginActionKind::Disable,
+            InstalledPluginActionKind::Update,
+            InstalledPluginActionKind::Uninstall,
+        ]
+    );
+}
+
+#[test]
+fn unknown_plugin_owned_mcp_server_does_not_call_set_servers_for_dynamic_remove() {
+    let (_dir, mut app) = open_settings_test_app();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.mcp.servers = vec![dynamic_http_mcp_server_status(
+        "plugin:Unknown:unknown",
+        "https://unknown.example.test/mcp",
+    )];
+
+    let actions = available_mcp_actions(&app, &app.mcp.servers[0]);
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::ManagePlugin));
+    assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveDynamicConfig));
+
+    super::mcp::remove_mcp_server_from_config(
+        &mut app,
+        "plugin:Unknown:unknown",
+        super::mcp::McpConfigScope::Dynamic,
+    );
+
+    assert!(rx.try_recv().is_err());
+    assert!(app.mcp.pending_dynamic_config_removal.is_none());
+    assert!(!app.mcp.in_flight);
+    assert_eq!(
+        app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["plugin:Unknown:unknown"]
+    );
+    let message = app.mcp.last_error.as_deref().expect("last MCP error");
+    assert!(message.contains("not removable from dynamic config"));
+}
+
+#[test]
+fn stale_plugin_owned_mcp_server_is_filtered_after_plugin_inventory_refresh() {
+    let (_dir, mut app) = open_settings_test_app();
+    app.plugins.last_inventory_refresh_at = Some(std::time::Instant::now());
+    let mut servers =
+        vec![notion_mcp_server_status(), connected_mcp_server_status("fff", "user", None)];
+
+    super::mcp::filter_stale_plugin_mcp_servers(
+        &app,
+        Some(crate::agent::types::McpSnapshotSource::ReloadPlugins),
+        &mut servers,
+    );
+
+    assert_eq!(servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(), vec!["fff"]);
+}
+
+#[test]
+fn unknown_plugin_owned_mcp_server_stays_visible_before_plugin_inventory_refresh() {
+    let (_dir, app) = open_settings_test_app();
+    let mut servers = vec![notion_mcp_server_status()];
+
+    super::mcp::filter_stale_plugin_mcp_servers(
+        &app,
+        Some(crate::agent::types::McpSnapshotSource::McpStatus),
+        &mut servers,
+    );
+
+    assert_eq!(
+        servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["plugin:Notion:notion"]
+    );
+}
+
+#[test]
+fn installed_plugin_owned_mcp_server_survives_stale_filter() {
+    let (_dir, mut app) = open_settings_test_app();
+    app.plugins.last_inventory_refresh_at = Some(std::time::Instant::now());
+    app.plugins.installed = vec![notion_plugin_entry()];
+    let mut servers = vec![notion_mcp_server_status()];
+
+    super::mcp::filter_stale_plugin_mcp_servers(
+        &app,
+        Some(crate::agent::types::McpSnapshotSource::ReloadPlugins),
+        &mut servers,
+    );
+
+    assert_eq!(
+        servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["plugin:Notion:notion"]
+    );
 }
 
 #[test]
@@ -1616,7 +1776,7 @@ fn mcp_config_remove_requires_confirmation_with_exact_scope() {
         scope: Some("user".to_owned()),
         tools: Vec::new(),
     }];
-    let remove_index = available_mcp_actions(&app.mcp.servers[0])
+    let remove_index = available_mcp_actions(&app, &app.mcp.servers[0])
         .iter()
         .position(|action| *action == super::mcp::McpServerActionKind::RemoveUserConfig)
         .expect("remove action");
@@ -1635,6 +1795,7 @@ fn mcp_config_remove_requires_confirmation_with_exact_scope() {
 
 #[test]
 fn non_config_mcp_server_does_not_offer_remove_action() {
+    let (_dir, app) = open_settings_test_app();
     let server = crate::agent::model::McpServerStatus {
         name: "claude.ai Google Drive".to_owned(),
         status: crate::agent::model::McpServerConnectionStatus::Disabled,
@@ -1649,7 +1810,7 @@ fn non_config_mcp_server_does_not_offer_remove_action() {
         tools: Vec::new(),
     };
 
-    let actions = available_mcp_actions(&server);
+    let actions = available_mcp_actions(&app, &server);
 
     assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveUserConfig));
     assert!(!actions.contains(&super::mcp::McpServerActionKind::RemoveLocalConfig));
@@ -1658,7 +1819,7 @@ fn non_config_mcp_server_does_not_offer_remove_action() {
 }
 
 #[test]
-fn mcp_config_remove_success_reloads_runtime_and_refreshes_snapshot() {
+fn mcp_config_remove_success_reloads_runtime_without_extra_snapshot() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
     app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
@@ -1692,26 +1853,32 @@ fn mcp_config_remove_success_reloads_runtime_and_refreshes_snapshot() {
     );
 
     assert_eq!(app.mcp.claude_path, Some(PathBuf::from("C:\\tools\\claude.exe")));
-    assert!(app.mcp.removed_config_servers.contains(&("user".to_owned(), "filesystem".to_owned())));
+    let guard = app
+        .mcp
+        .removed_config_servers
+        .get(&crate::app::state::types::RemovedMcpServerKey::new(
+            "user".to_owned(),
+            "filesystem".to_owned(),
+        ))
+        .expect("removed MCP guard");
+    assert_eq!(guard.expected_source, crate::agent::types::McpSnapshotSource::ReloadPlugins);
     assert_eq!(
         app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
         vec!["other"]
     );
     assert_eq!(
         app.config.status_message.as_deref(),
-        Some("Removed MCP server filesystem from user config.")
+        Some(
+            "Removed MCP server filesystem from user config. You might need to run /new-session to apply MCP changes."
+        )
     );
     let envelope = rx.try_recv().expect("runtime reload command");
     assert_eq!(
         envelope.command,
         BridgeCommand::ReloadPlugins { session_id: "session-1".to_owned() }
     );
-    let envelope = rx.try_recv().expect("mcp snapshot command");
-    assert_eq!(
-        envelope.command,
-        BridgeCommand::GetMcpSnapshot { session_id: "session-1".to_owned() }
-    );
     assert!(app.mcp.in_flight);
+    assert!(rx.try_recv().is_err());
 }
 
 #[test]
@@ -1724,10 +1891,10 @@ fn dynamic_mcp_config_remove_uses_sdk_set_servers_and_preserves_other_dynamic_se
     keep_headers.insert("Authorization".to_owned(), "Bearer token".to_owned());
     app.mcp.servers = vec![
         connected_mcp_server_status(
-            "plugin:Notion:notion",
+            "session-search",
             "dynamic",
             Some(crate::agent::model::McpServerStatusConfig::Http {
-                url: "https://mcp.notion.com/mcp".to_owned(),
+                url: "https://search.example.test/mcp".to_owned(),
                 headers: std::collections::BTreeMap::new(),
                 timeout: None,
                 tools: Vec::new(),
@@ -1756,7 +1923,7 @@ fn dynamic_mcp_config_remove_uses_sdk_set_servers_and_preserves_other_dynamic_se
 
     super::mcp::remove_mcp_server_from_config(
         &mut app,
-        "plugin:Notion:notion",
+        "session-search",
         super::mcp::McpConfigScope::Dynamic,
     );
 
@@ -1780,52 +1947,54 @@ fn dynamic_mcp_config_remove_uses_sdk_set_servers_and_preserves_other_dynamic_se
             always_load: Some(true),
         })
     );
-    assert_eq!(app.mcp.pending_dynamic_config_removal.as_deref(), Some("plugin:Notion:notion"));
+    assert_eq!(app.mcp.pending_dynamic_config_removal.as_deref(), Some("session-search"));
     assert_eq!(
         app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
-        vec!["plugin:Notion:notion", "keep-dynamic", "fff"]
+        vec!["session-search", "keep-dynamic", "fff"]
     );
     assert!(rx.try_recv().is_err());
 
     super::mcp::handle_mcp_set_servers_result(
         &mut app,
         &crate::agent::types::McpSetServersResult {
-            removed: vec!["plugin:Notion:notion".to_owned()],
+            removed: vec!["session-search".to_owned()],
             ..Default::default()
         },
     );
 
-    assert!(
-        app.mcp
-            .removed_config_servers
-            .contains(&("dynamic".to_owned(), "plugin:notion:notion".to_owned()))
-    );
+    let guard = app
+        .mcp
+        .removed_config_servers
+        .get(&crate::app::state::types::RemovedMcpServerKey::new(
+            "dynamic".to_owned(),
+            "session-search".to_owned(),
+        ))
+        .expect("removed MCP guard");
+    assert_eq!(guard.expected_source, crate::agent::types::McpSnapshotSource::McpSetServers);
     assert_eq!(
         app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
         vec!["keep-dynamic", "fff"]
     );
     assert_eq!(
         app.config.status_message.as_deref(),
-        Some("Removed MCP server plugin:Notion:notion from dynamic config.")
+        Some(
+            "Removed MCP server session-search from dynamic config. You might need to run /new-session to apply MCP changes."
+        )
     );
-    assert!(matches!(
-        rx.try_recv().expect("mcp snapshot command").command,
-        BridgeCommand::GetMcpSnapshot { .. }
-    ));
     assert!(rx.try_recv().is_err());
 }
 
 #[test]
-fn dynamic_mcp_config_remove_failure_from_sdk_keeps_server_visible() {
+fn dynamic_mcp_config_remove_waits_for_snapshot_when_sdk_result_does_not_name_server() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
     app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
     app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.mcp.servers = vec![connected_mcp_server_status(
-        "plugin:Notion:notion",
+        "session-search",
         "dynamic",
         Some(crate::agent::model::McpServerStatusConfig::Http {
-            url: "https://mcp.notion.com/mcp".to_owned(),
+            url: "https://search.example.test/mcp".to_owned(),
             headers: BTreeMap::new(),
             timeout: None,
             tools: Vec::new(),
@@ -1835,7 +2004,202 @@ fn dynamic_mcp_config_remove_failure_from_sdk_keeps_server_visible() {
 
     super::mcp::remove_mcp_server_from_config(
         &mut app,
-        "plugin:Notion:notion",
+        "session-search",
+        super::mcp::McpConfigScope::Dynamic,
+    );
+    assert!(matches!(
+        rx.try_recv().expect("mcp set servers command").command,
+        BridgeCommand::McpSetServers { .. }
+    ));
+
+    super::mcp::handle_mcp_set_servers_result(
+        &mut app,
+        &crate::agent::types::McpSetServersResult::default(),
+    );
+
+    assert_eq!(app.mcp.pending_dynamic_config_removal.as_deref(), Some("session-search"));
+    assert!(app.mcp.removed_config_servers.is_empty());
+    assert_eq!(
+        app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["session-search"]
+    );
+    assert!(app.mcp.in_flight);
+    assert_eq!(
+        app.config.status_message.as_deref(),
+        Some(
+            "Removing MCP server session-search from dynamic config... Waiting for SDK confirmation."
+        )
+    );
+}
+
+#[test]
+fn dynamic_mcp_config_remove_fails_when_confirming_snapshot_still_contains_server() {
+    let (_dir, mut app) = open_settings_test_app();
+    app.mcp.pending_dynamic_config_removal = Some("session-search".to_owned());
+    app.mcp.in_flight = true;
+    app.mcp.servers = vec![connected_mcp_server_status(
+        "session-search",
+        "dynamic",
+        Some(crate::agent::model::McpServerStatusConfig::Http {
+            url: "https://search.example.test/mcp".to_owned(),
+            headers: BTreeMap::new(),
+            timeout: None,
+            tools: Vec::new(),
+            always_load: None,
+        }),
+    )];
+
+    let confirmation = super::mcp::pending_dynamic_mcp_removal_confirmation_from_snapshot(
+        &app,
+        Some(crate::agent::types::McpSnapshotSource::McpSetServers),
+        None,
+        &app.mcp.servers,
+    );
+    super::mcp::apply_pending_dynamic_mcp_removal_confirmation(&mut app, confirmation);
+
+    assert!(app.mcp.pending_dynamic_config_removal.is_none());
+    assert!(app.mcp.removed_config_servers.is_empty());
+    assert!(!app.mcp.in_flight);
+    assert_eq!(
+        app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["session-search"]
+    );
+    let message = app.mcp.last_error.as_deref().expect("last MCP error");
+    assert!(message.contains("Failed to remove MCP server session-search from dynamic config"));
+    assert!(message.contains("confirming snapshot still contains the server"));
+    assert!(app.config.status_message.is_none());
+}
+
+#[test]
+fn dynamic_mcp_config_remove_succeeds_when_confirming_snapshot_proves_absence() {
+    let (_dir, mut app) = open_settings_test_app();
+    app.mcp.pending_dynamic_config_removal = Some("session-search".to_owned());
+    app.mcp.in_flight = true;
+    app.mcp.servers = vec![
+        connected_mcp_server_status(
+            "session-search",
+            "dynamic",
+            Some(crate::agent::model::McpServerStatusConfig::Http {
+                url: "https://search.example.test/mcp".to_owned(),
+                headers: BTreeMap::new(),
+                timeout: None,
+                tools: Vec::new(),
+                always_load: None,
+            }),
+        ),
+        connected_mcp_server_status(
+            "keep-dynamic",
+            "dynamic",
+            Some(crate::agent::model::McpServerStatusConfig::Http {
+                url: "https://example.test/mcp".to_owned(),
+                headers: BTreeMap::new(),
+                timeout: None,
+                tools: Vec::new(),
+                always_load: None,
+            }),
+        ),
+    ];
+    let snapshot_servers = vec![connected_mcp_server_status(
+        "keep-dynamic",
+        "dynamic",
+        Some(crate::agent::model::McpServerStatusConfig::Http {
+            url: "https://example.test/mcp".to_owned(),
+            headers: BTreeMap::new(),
+            timeout: None,
+            tools: Vec::new(),
+            always_load: None,
+        }),
+    )];
+
+    let confirmation = super::mcp::pending_dynamic_mcp_removal_confirmation_from_snapshot(
+        &app,
+        Some(crate::agent::types::McpSnapshotSource::McpSetServers),
+        None,
+        &snapshot_servers,
+    );
+    app.mcp.servers = snapshot_servers;
+    app.mcp.in_flight = false;
+    super::mcp::apply_pending_dynamic_mcp_removal_confirmation(&mut app, confirmation);
+
+    assert!(app.mcp.pending_dynamic_config_removal.is_none());
+    assert!(app.mcp.removed_config_servers.is_empty());
+    assert_eq!(
+        app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["keep-dynamic"]
+    );
+    assert_eq!(
+        app.config.status_message.as_deref(),
+        Some(
+            "Removed MCP server session-search from dynamic config. You might need to run /new-session to apply MCP changes."
+        )
+    );
+}
+
+#[test]
+fn removed_config_guard_stops_suppressing_when_confirming_snapshot_still_contains_server() {
+    let (_dir, mut app) = open_settings_test_app();
+    app.mcp.removed_config_servers.insert(
+        crate::app::state::types::RemovedMcpServerKey::new(
+            "dynamic".to_owned(),
+            "session-search".to_owned(),
+        ),
+        crate::app::state::types::RemovedMcpServerGuard {
+            expected_source: crate::agent::types::McpSnapshotSource::McpSetServers,
+        },
+    );
+    let mut servers = vec![connected_mcp_server_status(
+        "session-search",
+        "dynamic",
+        Some(crate::agent::model::McpServerStatusConfig::Http {
+            url: "https://search.example.test/mcp".to_owned(),
+            headers: BTreeMap::new(),
+            timeout: None,
+            tools: Vec::new(),
+            always_load: None,
+        }),
+    )];
+
+    let failures = super::mcp::reconcile_removed_config_mcp_server_guards(
+        &mut app,
+        Some(crate::agent::types::McpSnapshotSource::McpSetServers),
+        None,
+        &servers,
+    );
+    super::mcp::filter_removed_config_mcp_servers(&app, &mut servers);
+    app.mcp.servers = servers;
+    super::mcp::apply_removed_config_mcp_server_confirmation_failures(&mut app, failures);
+
+    assert!(app.mcp.removed_config_servers.is_empty());
+    assert_eq!(
+        app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+        vec!["session-search"]
+    );
+    let message = app.mcp.last_error.as_deref().expect("last MCP error");
+    assert!(message.contains("Failed to remove MCP server session-search from dynamic config"));
+    assert!(message.contains("confirming mcp_set_servers snapshot still contains the server"));
+}
+
+#[test]
+fn dynamic_mcp_config_remove_failure_from_sdk_keeps_server_visible() {
+    let (_dir, mut app) = open_settings_test_app();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.mcp.servers = vec![connected_mcp_server_status(
+        "session-search",
+        "dynamic",
+        Some(crate::agent::model::McpServerStatusConfig::Http {
+            url: "https://search.example.test/mcp".to_owned(),
+            headers: BTreeMap::new(),
+            timeout: None,
+            tools: Vec::new(),
+            always_load: None,
+        }),
+    )];
+
+    super::mcp::remove_mcp_server_from_config(
+        &mut app,
+        "session-search",
         super::mcp::McpConfigScope::Dynamic,
     );
     assert!(matches!(
@@ -1857,12 +2221,10 @@ fn dynamic_mcp_config_remove_failure_from_sdk_keeps_server_visible() {
     assert!(!app.mcp.in_flight);
     assert_eq!(
         app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
-        vec!["plugin:Notion:notion"]
+        vec!["session-search"]
     );
     let message = app.mcp.last_error.as_deref().expect("last MCP error");
-    assert!(
-        message.contains("Failed to remove MCP server plugin:Notion:notion from dynamic config")
-    );
+    assert!(message.contains("Failed to remove MCP server session-search from dynamic config"));
     assert!(message.contains("dynamic update failed"));
     assert!(rx.try_recv().is_err());
 }
@@ -1875,10 +2237,10 @@ fn dynamic_mcp_config_remove_refuses_to_drop_unrepresentable_dynamic_servers() {
     app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.mcp.servers = vec![
         connected_mcp_server_status(
-            "plugin:Notion:notion",
+            "session-search",
             "dynamic",
             Some(crate::agent::model::McpServerStatusConfig::Http {
-                url: "https://mcp.notion.com/mcp".to_owned(),
+                url: "https://search.example.test/mcp".to_owned(),
                 headers: BTreeMap::new(),
                 timeout: None,
                 tools: Vec::new(),
@@ -1894,7 +2256,7 @@ fn dynamic_mcp_config_remove_refuses_to_drop_unrepresentable_dynamic_servers() {
 
     super::mcp::remove_mcp_server_from_config(
         &mut app,
-        "plugin:Notion:notion",
+        "session-search",
         super::mcp::McpConfigScope::Dynamic,
     );
 
@@ -1903,12 +2265,10 @@ fn dynamic_mcp_config_remove_refuses_to_drop_unrepresentable_dynamic_servers() {
     assert!(app.mcp.removed_config_servers.is_empty());
     assert_eq!(
         app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
-        vec!["plugin:Notion:notion", "in-process"]
+        vec!["session-search", "in-process"]
     );
     let message = app.mcp.last_error.as_deref().expect("last MCP error");
-    assert!(
-        message.contains("Failed to remove MCP server plugin:Notion:notion from dynamic config")
-    );
+    assert!(message.contains("Failed to remove MCP server session-search from dynamic config"));
     assert!(
         message.contains(
             "Cannot safely preserve dynamic MCP server in-process because SDK-server instances cannot be represented by the Rust bridge"
@@ -2046,6 +2406,7 @@ fn refresh_mcp_snapshot_if_needed_skips_outside_mcp_tab() {
 
 #[test]
 fn claudeai_proxy_server_shows_disabled_authenticate_action() {
+    let (_dir, app) = open_settings_test_app();
     let server = crate::agent::model::McpServerStatus {
         name: "claude.ai Google Calendar".to_owned(),
         status: crate::agent::model::McpServerConnectionStatus::NeedsAuth,
@@ -2062,10 +2423,11 @@ fn claudeai_proxy_server_shows_disabled_authenticate_action() {
         tools: Vec::new(),
     };
 
-    let actions = available_mcp_actions(&server);
+    let actions = available_mcp_actions(&app, &server);
 
     assert!(actions.contains(&super::mcp::McpServerActionKind::Authenticate));
     assert!(!super::mcp::is_mcp_action_available(
+        &app,
         &server,
         super::mcp::McpServerActionKind::Authenticate
     ));

--- a/src/app/connect/event_dispatch.rs
+++ b/src/app/connect/event_dispatch.rs
@@ -16,6 +16,7 @@ use super::bridge_lifecycle::emit_connection_failed;
 use super::type_converters::{
     convert_account_info, convert_current_model, convert_mode_state, map_available_models,
     map_mcp_server_status, map_permission_request, map_question_request, map_session_update,
+    map_user_dialog_request,
 };
 
 struct ConnectedEventData {
@@ -73,6 +74,9 @@ pub(super) fn handle_bridge_event(
         }
         crate::agent::wire::BridgeEvent::QuestionRequest { session_id, request } => {
             handle_question_request_event(event_tx, cmd_tx, session_id, request);
+        }
+        crate::agent::wire::BridgeEvent::UserDialogRequest { session_id, request } => {
+            handle_user_dialog_request_event(event_tx, cmd_tx, session_id, request);
         }
         crate::agent::wire::BridgeEvent::ElicitationRequest { session_id, request } => {
             handle_elicitation_request_event(event_tx, &session_id, request);
@@ -255,6 +259,28 @@ fn handle_question_request_event(
     }
 }
 
+fn handle_user_dialog_request_event(
+    event_tx: &mpsc::UnboundedSender<ClientEvent>,
+    cmd_tx: &mpsc::UnboundedSender<CommandEnvelope>,
+    session_id: String,
+    request: types::UserDialogRequest,
+) {
+    let (request, request_id) = map_user_dialog_request(&session_id, request);
+    let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+    if event_tx.send(ClientEvent::UserDialogRequest { request, response_tx }).is_ok() {
+        spawn_user_dialog_response_forwarder(cmd_tx.clone(), response_rx, session_id, request_id);
+    } else {
+        tracing::error!(
+            target: crate::logging::targets::APP_PERMISSION,
+            event_name = "user_dialog_request_dispatch_failed",
+            message = "failed to dispatch user dialog request to app event loop",
+            outcome = "failure",
+            session_id = %session_id,
+            request_id = %request_id,
+        );
+    }
+}
+
 fn handle_elicitation_request_event(
     event_tx: &mpsc::UnboundedSender<ClientEvent>,
     session_id: &str,
@@ -392,6 +418,66 @@ fn spawn_question_response_forwarder(
                 session_id = %session_id_for_log,
                 tool_call_id = %tool_call_id_for_log,
                 selected_option_count,
+            );
+        }
+    });
+}
+
+fn spawn_user_dialog_response_forwarder(
+    cmd_tx: mpsc::UnboundedSender<CommandEnvelope>,
+    response_rx: tokio::sync::oneshot::Receiver<model::RequestUserDialogResponse>,
+    session_id: String,
+    request_id: String,
+) {
+    tokio::task::spawn_local(async move {
+        let Ok(response) = response_rx.await else {
+            tracing::warn!(
+                target: crate::logging::targets::APP_PERMISSION,
+                event_name = "user_dialog_response_abandoned",
+                message = "user dialog response channel closed before bridge forwarding",
+                outcome = "dropped",
+                session_id = %session_id,
+                request_id = %request_id,
+            );
+            return;
+        };
+        let outcome = match response.outcome {
+            model::RequestUserDialogOutcome::Selected(selected) => {
+                types::UserDialogOutcome::Selected { option_id: selected.option_id }
+            }
+            model::RequestUserDialogOutcome::Cancelled => types::UserDialogOutcome::Cancelled,
+        };
+        let selected_option = match &outcome {
+            types::UserDialogOutcome::Selected { option_id } => option_id.clone(),
+            types::UserDialogOutcome::Cancelled => "cancelled".to_owned(),
+        };
+        let session_id_for_log = session_id.clone();
+        let request_id_for_log = request_id.clone();
+        if cmd_tx
+            .send(CommandEnvelope {
+                request_id: None,
+                command: BridgeCommand::UserDialogResponse { session_id, request_id, outcome },
+            })
+            .is_ok()
+        {
+            tracing::info!(
+                target: crate::logging::targets::APP_PERMISSION,
+                event_name = "user_dialog_response_forwarded",
+                message = "user dialog response forwarded to bridge",
+                outcome = "success",
+                session_id = %session_id_for_log,
+                request_id = %request_id_for_log,
+                selected_option = %selected_option,
+            );
+        } else {
+            tracing::error!(
+                target: crate::logging::targets::APP_PERMISSION,
+                event_name = "user_dialog_response_forward_failed",
+                message = "failed to forward user dialog response to bridge",
+                outcome = "failure",
+                session_id = %session_id_for_log,
+                request_id = %request_id_for_log,
+                selected_option = %selected_option,
             );
         }
     });

--- a/src/app/connect/event_dispatch.rs
+++ b/src/app/connect/event_dispatch.rs
@@ -95,6 +95,9 @@ pub(super) fn handle_bridge_event(
         crate::agent::wire::BridgeEvent::McpOperationError { error, .. } => {
             let _ = event_tx.send(ClientEvent::McpOperationError { error });
         }
+        crate::agent::wire::BridgeEvent::McpSetServersResult { session_id, result } => {
+            let _ = event_tx.send(ClientEvent::McpSetServersResult { session_id, result });
+        }
         crate::agent::wire::BridgeEvent::TurnComplete { terminal_reason, .. } => {
             let _ = event_tx.send(ClientEvent::TurnComplete { terminal_reason });
         }

--- a/src/app/connect/event_dispatch.rs
+++ b/src/app/connect/event_dispatch.rs
@@ -174,10 +174,11 @@ pub(super) fn handle_bridge_event(
         crate::agent::wire::BridgeEvent::ContextUsage { session_id, percentage } => {
             let _ = event_tx.send(ClientEvent::ContextUsageReceived { session_id, percentage });
         }
-        crate::agent::wire::BridgeEvent::McpSnapshot { session_id, servers, error } => {
+        crate::agent::wire::BridgeEvent::McpSnapshot { session_id, servers, source, error } => {
             let _ = event_tx.send(ClientEvent::McpSnapshotReceived {
                 session_id,
                 servers: servers.into_iter().map(map_mcp_server_status).collect(),
+                source,
                 error,
             });
         }

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -265,17 +265,23 @@ pub(super) fn convert_account_info(account: types::AccountInfo) -> model::Accoun
 #[allow(clippy::too_many_lines)]
 pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::SessionUpdate> {
     match update {
-        types::SessionUpdate::UserMessageChunk { content } => {
+        types::SessionUpdate::UserMessageChunk { content, source_message_uuid } => {
             let content = convert_content_block(content)?;
-            Some(model::SessionUpdate::UserMessageChunk(model::ContentChunk::new(content)))
+            Some(model::SessionUpdate::UserMessageChunk(
+                model::ContentChunk::new(content).source_message_uuid(source_message_uuid),
+            ))
         }
-        types::SessionUpdate::AgentMessageChunk { content } => {
+        types::SessionUpdate::AgentMessageChunk { content, source_message_uuid } => {
             let content = convert_content_block(content)?;
-            Some(model::SessionUpdate::AgentMessageChunk(model::ContentChunk::new(content)))
+            Some(model::SessionUpdate::AgentMessageChunk(
+                model::ContentChunk::new(content).source_message_uuid(source_message_uuid),
+            ))
         }
-        types::SessionUpdate::AgentThoughtChunk { content } => {
+        types::SessionUpdate::AgentThoughtChunk { content, source_message_uuid } => {
             let content = convert_content_block(content)?;
-            Some(model::SessionUpdate::AgentThoughtChunk(model::ContentChunk::new(content)))
+            Some(model::SessionUpdate::AgentThoughtChunk(
+                model::ContentChunk::new(content).source_message_uuid(source_message_uuid),
+            ))
         }
         types::SessionUpdate::ToolCall { tool_call } => {
             Some(model::SessionUpdate::ToolCall(convert_tool_call(tool_call)))
@@ -283,6 +289,9 @@ pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::
         types::SessionUpdate::ToolCallUpdate { tool_call_update } => {
             Some(model::SessionUpdate::ToolCallUpdate(convert_tool_call_update(tool_call_update)))
         }
+        types::SessionUpdate::TranscriptRetraction { retraction } => Some(
+            model::SessionUpdate::TranscriptRetraction(convert_transcript_retraction(retraction)),
+        ),
         types::SessionUpdate::TaskStateUpdate { update: task_update } => {
             Some(model::SessionUpdate::TaskStateUpdate(convert_task_state_update(task_update)))
         }
@@ -512,6 +521,7 @@ pub(super) fn convert_tool_call(tool_call: types::ToolCall) -> model::ToolCall {
         title,
         kind,
         status,
+        source_message_uuid,
         content,
         raw_input,
         raw_output,
@@ -524,6 +534,7 @@ pub(super) fn convert_tool_call(tool_call: types::ToolCall) -> model::ToolCall {
     let mut tc = model::ToolCall::new(tool_call_id, title)
         .kind(convert_tool_kind(&kind))
         .status(convert_tool_status(&status))
+        .source_message_uuid(source_message_uuid)
         .content(content.into_iter().filter_map(convert_tool_call_content).collect())
         .locations(
             locations
@@ -563,7 +574,8 @@ pub(super) fn convert_tool_call_update(update: types::ToolCallUpdate) -> model::
     let mut out = model::ToolCallUpdate::new(
         update.tool_call_id,
         convert_tool_call_update_fields(update.fields),
-    );
+    )
+    .source_message_uuid(update.source_message_uuid);
     if let Some(meta) = update_meta {
         out = out.meta(meta);
     }
@@ -609,6 +621,33 @@ pub(super) fn convert_tool_call_to_fields(
     }
 
     fields
+}
+
+fn convert_transcript_retraction(
+    retraction: types::TranscriptRetraction,
+) -> model::TranscriptRetraction {
+    model::TranscriptRetraction {
+        message_uuids: retraction.message_uuids,
+        reason: match retraction.reason {
+            types::TranscriptRetractionReason::ModelRefusalFallback => {
+                model::TranscriptRetractionReason::ModelRefusalFallback
+            }
+            types::TranscriptRetractionReason::ModelFallback => {
+                model::TranscriptRetractionReason::ModelFallback
+            }
+            types::TranscriptRetractionReason::AssistantSupersedes => {
+                model::TranscriptRetractionReason::AssistantSupersedes
+            }
+        },
+        request_id: retraction.request_id,
+        trigger: retraction.trigger,
+        direction: retraction.direction,
+        original_model: retraction.original_model,
+        fallback_model: retraction.fallback_model,
+        api_refusal_category: retraction.api_refusal_category,
+        api_refusal_explanation: retraction.api_refusal_explanation,
+        content: retraction.content,
+    }
 }
 
 pub(super) fn convert_tool_call_update_fields(
@@ -794,7 +833,7 @@ pub(super) fn convert_mode_state(mode: types::ModeState) -> ModeState {
 #[cfg(test)]
 mod tests {
     use super::{
-        convert_account_info, convert_current_model, convert_tool_call,
+        convert_account_info, convert_current_model, convert_tool_call, convert_tool_call_update,
         convert_tool_call_update_fields, map_available_commands_update, map_available_models,
         map_permission_request, map_question_request, map_session_update,
     };
@@ -1022,6 +1061,46 @@ mod tests {
     }
 
     #[test]
+    fn map_session_update_preserves_source_message_uuid() {
+        let mapped = map_session_update(types::SessionUpdate::AgentMessageChunk {
+            content: types::ContentBlock::Text { text: "hello".to_owned() },
+            source_message_uuid: Some("assistant-1".to_owned()),
+        })
+        .expect("message chunk should map");
+
+        let model::SessionUpdate::AgentMessageChunk(chunk) = mapped else {
+            panic!("expected agent message chunk");
+        };
+        assert_eq!(chunk.source_message_uuid.as_deref(), Some("assistant-1"));
+    }
+
+    #[test]
+    fn map_session_update_converts_transcript_retraction() {
+        let mapped = map_session_update(types::SessionUpdate::TranscriptRetraction {
+            retraction: types::TranscriptRetraction {
+                message_uuids: vec!["old-1".to_owned()],
+                reason: types::TranscriptRetractionReason::AssistantSupersedes,
+                request_id: Some("req-1".to_owned()),
+                trigger: None,
+                direction: None,
+                original_model: None,
+                fallback_model: None,
+                api_refusal_category: None,
+                api_refusal_explanation: None,
+                content: None,
+            },
+        })
+        .expect("transcript retraction should map");
+
+        let model::SessionUpdate::TranscriptRetraction(retraction) = mapped else {
+            panic!("expected transcript retraction");
+        };
+        assert_eq!(retraction.message_uuids, vec!["old-1"]);
+        assert_eq!(retraction.reason, model::TranscriptRetractionReason::AssistantSupersedes);
+        assert_eq!(retraction.request_id.as_deref(), Some("req-1"));
+    }
+
+    #[test]
     fn map_permission_request_preserves_display_metadata() {
         let (request, tool_call_id) = map_permission_request(
             "session-1",
@@ -1031,6 +1110,7 @@ mod tests {
                     title: "Bash npm test".to_owned(),
                     kind: "execute".to_owned(),
                     status: "in_progress".to_owned(),
+                    source_message_uuid: None,
                     content: Vec::new(),
                     raw_input: None,
                     raw_output: None,
@@ -1075,6 +1155,7 @@ mod tests {
                     title: "Pick target".to_owned(),
                     kind: "other".to_owned(),
                     status: "in_progress".to_owned(),
+                    source_message_uuid: None,
                     content: Vec::new(),
                     raw_input: Some(serde_json::json!({ "source": "ask_user_question" })),
                     raw_output: None,
@@ -1163,6 +1244,17 @@ mod tests {
     }
 
     #[test]
+    fn convert_tool_call_update_preserves_source_message_uuid() {
+        let update = convert_tool_call_update(types::ToolCallUpdate {
+            tool_call_id: "tool-1".to_owned(),
+            source_message_uuid: Some("user-result".to_owned()),
+            fields: types::ToolCallUpdateFields::default(),
+        });
+
+        assert_eq!(update.source_message_uuid.as_deref(), Some("user-result"));
+    }
+
+    #[test]
     fn map_available_commands_update_preserves_source_and_generation() {
         let update = map_available_commands_update(
             vec![types::AvailableCommand {
@@ -1227,6 +1319,7 @@ mod tests {
             title: "Agent task".to_owned(),
             kind: "think".to_owned(),
             status: "killed".to_owned(),
+            source_message_uuid: Some("assistant-tool".to_owned()),
             content: Vec::new(),
             raw_input: None,
             raw_output: None,
@@ -1245,6 +1338,7 @@ mod tests {
         });
 
         assert_eq!(tool_call.status, model::ToolCallStatus::Killed);
+        assert_eq!(tool_call.source_message_uuid.as_deref(), Some("assistant-tool"));
         assert_eq!(
             tool_call.task_metadata,
             Some(
@@ -1267,6 +1361,7 @@ mod tests {
             title: "Write src/main.rs".to_owned(),
             kind: "edit".to_owned(),
             status: "completed".to_owned(),
+            source_message_uuid: None,
             content: vec![types::ToolCallContent::Diff {
                 old_path: "src/main.rs".to_owned(),
                 new_path: "src/main.rs".to_owned(),
@@ -1299,6 +1394,7 @@ mod tests {
             title: "ReadMcpResource docs file://manual.pdf".to_owned(),
             kind: "read".to_owned(),
             status: "completed".to_owned(),
+            source_message_uuid: None,
             content: vec![types::ToolCallContent::McpResource {
                 uri: "file://manual.pdf".to_owned(),
                 mime_type: Some("application/pdf".to_owned()),

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -743,10 +743,21 @@ pub(super) fn convert_tool_call_update_fields(
 fn convert_tool_output_metadata(
     output_metadata: types::ToolOutputMetadata,
 ) -> model::ToolOutputMetadata {
-    model::ToolOutputMetadata::new().bash(output_metadata.bash.map(|bash| {
-        model::BashOutputMetadata::new()
-            .assistant_auto_backgrounded(bash.assistant_auto_backgrounded)
-    }))
+    model::ToolOutputMetadata::new()
+        .bash(output_metadata.bash.map(|bash| {
+            model::BashOutputMetadata::new()
+                .assistant_auto_backgrounded(bash.assistant_auto_backgrounded)
+        }))
+        .agent(
+            output_metadata.agent.map(|agent| {
+                model::AgentOutputMetadata::new().resolved_model(agent.resolved_model)
+            }),
+        )
+        .web_fetch(output_metadata.web_fetch.map(|web_fetch| {
+            model::WebFetchOutputMetadata::new().artifact_read(web_fetch.artifact_read.map(
+                |artifact| model::WebFetchArtifactReadMetadata::new(artifact.slug, artifact.ver),
+            ))
+        }))
 }
 
 fn convert_permission_display(
@@ -769,6 +780,12 @@ fn convert_task_metadata(task_metadata: types::TaskMetadata) -> model::TaskMetad
         .request_id(task_metadata.request_id)
         .subagent_type(task_metadata.subagent_type)
         .task_description(task_metadata.task_description)
+        .task_type(task_metadata.task_type)
+        .workflow_name(task_metadata.workflow_name)
+        .prompt(task_metadata.prompt)
+        .output_file(task_metadata.output_file)
+        .summary(task_metadata.summary)
+        .terminal_status(task_metadata.terminal_status)
 }
 
 fn convert_tool_call_content(
@@ -1273,15 +1290,34 @@ mod tests {
             status: Some("completed".to_owned()),
             output_metadata: Some(types::ToolOutputMetadata {
                 bash: Some(types::BashOutputMetadata { assistant_auto_backgrounded: Some(true) }),
+                agent: Some(types::AgentOutputMetadata {
+                    resolved_model: Some("claude-sonnet-4-7".to_owned()),
+                }),
+                web_fetch: Some(types::WebFetchOutputMetadata {
+                    artifact_read: Some(types::WebFetchArtifactReadMetadata {
+                        slug: "dashboard".to_owned(),
+                        ver: "v2".to_owned(),
+                    }),
+                }),
             }),
             ..types::ToolCallUpdateFields::default()
         });
 
         assert_eq!(
             fields.output_metadata,
-            Some(model::ToolOutputMetadata::new().bash(Some(
-                model::BashOutputMetadata::new().assistant_auto_backgrounded(Some(true)),
-            )))
+            Some(
+                model::ToolOutputMetadata::new()
+                    .bash(Some(
+                        model::BashOutputMetadata::new().assistant_auto_backgrounded(Some(true)),
+                    ))
+                    .agent(Some(
+                        model::AgentOutputMetadata::new()
+                            .resolved_model(Some("claude-sonnet-4-7".to_owned())),
+                    ))
+                    .web_fetch(Some(model::WebFetchOutputMetadata::new().artifact_read(Some(
+                        model::WebFetchArtifactReadMetadata::new("dashboard", "v2"),
+                    ))))
+            )
         );
     }
 
@@ -1335,6 +1371,12 @@ mod tests {
                 request_id: Some("request-1".to_owned()),
                 subagent_type: Some("tester".to_owned()),
                 task_description: Some("Validate changes".to_owned()),
+                task_type: Some("remote_agent".to_owned()),
+                workflow_name: Some("release-check".to_owned()),
+                prompt: Some("Run validation".to_owned()),
+                output_file: Some("C:/tmp/output.md".to_owned()),
+                summary: Some("Validation complete".to_owned()),
+                terminal_status: Some("completed".to_owned()),
             }),
             ..types::ToolCallUpdateFields::default()
         });
@@ -1349,7 +1391,13 @@ mod tests {
                     .backgrounded(Some(true))
                     .request_id(Some("request-1".to_owned()))
                     .subagent_type(Some("tester".to_owned()))
-                    .task_description(Some("Validate changes".to_owned())),
+                    .task_description(Some("Validate changes".to_owned()))
+                    .task_type(Some("remote_agent".to_owned()))
+                    .workflow_name(Some("release-check".to_owned()))
+                    .prompt(Some("Run validation".to_owned()))
+                    .output_file(Some("C:/tmp/output.md".to_owned()))
+                    .summary(Some("Validation complete".to_owned()))
+                    .terminal_status(Some("completed".to_owned())),
             )
         );
     }
@@ -1374,6 +1422,12 @@ mod tests {
                 request_id: Some("request-2".to_owned()),
                 subagent_type: Some("reviewer".to_owned()),
                 task_description: Some("Review changes".to_owned()),
+                task_type: Some("local_workflow".to_owned()),
+                workflow_name: Some("review-flow".to_owned()),
+                prompt: Some("Review changes".to_owned()),
+                output_file: Some("C:/tmp/review.md".to_owned()),
+                summary: Some("Review stopped".to_owned()),
+                terminal_status: Some("killed".to_owned()),
             }),
             locations: Vec::new(),
             meta: None,
@@ -1391,7 +1445,13 @@ mod tests {
                     .backgrounded(Some(false))
                     .request_id(Some("request-2".to_owned()))
                     .subagent_type(Some("reviewer".to_owned()))
-                    .task_description(Some("Review changes".to_owned())),
+                    .task_description(Some("Review changes".to_owned()))
+                    .task_type(Some("local_workflow".to_owned()))
+                    .workflow_name(Some("review-flow".to_owned()))
+                    .prompt(Some("Review changes".to_owned()))
+                    .output_file(Some("C:/tmp/review.md".to_owned()))
+                    .summary(Some("Review stopped".to_owned()))
+                    .terminal_status(Some("killed".to_owned())),
             )
         );
     }

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -66,10 +66,21 @@ fn map_mcp_tool_permission_policy(
     }
 }
 
+fn map_mcp_server_org_max_permission(
+    permission: types::McpServerOrgMaxPermission,
+) -> model::McpServerOrgMaxPermission {
+    match permission {
+        types::McpServerOrgMaxPermission::Allow => model::McpServerOrgMaxPermission::Allow,
+        types::McpServerOrgMaxPermission::Ask => model::McpServerOrgMaxPermission::Ask,
+        types::McpServerOrgMaxPermission::Blocked => model::McpServerOrgMaxPermission::Blocked,
+    }
+}
+
 fn map_mcp_tool_policy(policy: types::McpServerToolPolicy) -> model::McpServerToolPolicy {
     model::McpServerToolPolicy {
         name: policy.name,
-        permission_policy: map_mcp_tool_permission_policy(policy.permission_policy),
+        permission_policy: policy.permission_policy.map(map_mcp_tool_permission_policy),
+        org_max_permission: policy.org_max_permission.map(map_mcp_server_org_max_permission),
     }
 }
 
@@ -1467,10 +1478,18 @@ mod tests {
             config: Some(types::McpServerStatusConfig::Http {
                 url: "https://mcp.notion.com/mcp".to_owned(),
                 headers: std::collections::BTreeMap::new(),
-                tools: vec![types::McpServerToolPolicy {
-                    name: "search".to_owned(),
-                    permission_policy: types::McpServerToolPermissionPolicy::Deny,
-                }],
+                tools: vec![
+                    types::McpServerToolPolicy {
+                        name: "search".to_owned(),
+                        permission_policy: Some(types::McpServerToolPermissionPolicy::Deny),
+                        org_max_permission: Some(types::McpServerOrgMaxPermission::Blocked),
+                    },
+                    types::McpServerToolPolicy {
+                        name: "lookup".to_owned(),
+                        permission_policy: None,
+                        org_max_permission: Some(types::McpServerOrgMaxPermission::Ask),
+                    },
+                ],
                 timeout: Some(5000),
                 always_load: Some(true),
             }),
@@ -1487,7 +1506,10 @@ mod tests {
         };
         assert_eq!(timeout, Some(5000));
         assert_eq!(always_load, Some(true));
-        assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0].permission_policy, model::McpServerToolPermissionPolicy::Deny);
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].permission_policy, Some(model::McpServerToolPermissionPolicy::Deny));
+        assert_eq!(tools[0].org_max_permission, Some(model::McpServerOrgMaxPermission::Blocked));
+        assert_eq!(tools[1].permission_policy, None);
+        assert_eq!(tools[1].org_max_permission, Some(model::McpServerOrgMaxPermission::Ask));
     }
 }

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -494,6 +494,37 @@ pub(super) fn map_question_request(
     )
 }
 
+/// Convert a wire `user_dialog_request` into the app model. Returns the model
+/// request and the synthetic `request_id` used as its focus-queue/index key.
+pub(super) fn map_user_dialog_request(
+    session_id: &str,
+    request: types::UserDialogRequest,
+) -> (model::RequestUserDialogRequest, String) {
+    let request_id = request.request_id.clone();
+    let payload = model::RefusalFallbackPayload {
+        original_model: request.payload.original_model,
+        fallback_model: request.payload.fallback_model,
+        api_refusal_category: request.payload.api_refusal_category,
+        guidance_text: request.payload.guidance_text,
+        retracted_message_uuids: request.payload.retracted_message_uuids,
+    };
+    let options = request
+        .options
+        .into_iter()
+        .map(|option| model::UserDialogOption::new(option.option_id, option.label))
+        .collect();
+    (
+        model::RequestUserDialogRequest::new(
+            model::SessionId::new(session_id),
+            request_id.clone(),
+            request.dialog_kind,
+            payload,
+            options,
+        ),
+        request_id,
+    )
+}
+
 pub(super) fn convert_content_block(content: types::ContentBlock) -> Option<model::ContentBlock> {
     match content {
         types::ContentBlock::Text { text } => {

--- a/src/app/events/client.rs
+++ b/src/app/events/client.rs
@@ -190,6 +190,11 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                 return;
             }
             crate::app::plugins::apply_runtime_reload_failure(app, &message);
+            if app.mcp.in_flight {
+                app.mcp.in_flight = false;
+                app.mcp.last_error =
+                    Some(format!("Failed to reload MCP server snapshot: {message}"));
+            }
         }
         ClientEvent::SessionReplaced {
             session_id,
@@ -277,7 +282,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             }
             crate::app::session_runtime::apply_context_usage_snapshot(app, percentage);
         }
-        ClientEvent::McpSnapshotReceived { session_id, mut servers, error } => {
+        ClientEvent::McpSnapshotReceived { session_id, mut servers, source, error } => {
             if app.session_id.as_ref().map(ToString::to_string).as_deref()
                 != Some(session_id.as_str())
             {
@@ -291,7 +296,22 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                 );
                 return;
             }
+            let pending_dynamic_mcp_removal_confirmation =
+                crate::app::config::pending_dynamic_mcp_removal_confirmation_from_snapshot(
+                    app,
+                    source,
+                    error.as_deref(),
+                    &servers,
+                );
+            let remove_confirmation_failures =
+                crate::app::config::reconcile_removed_config_mcp_server_guards(
+                    app,
+                    source,
+                    error.as_deref(),
+                    &servers,
+                );
             crate::app::config::filter_removed_config_mcp_servers(app, &mut servers);
+            crate::app::config::filter_stale_plugin_mcp_servers(app, source, &mut servers);
             let server_count = servers.len();
             let error_present = error.is_some();
             let server_diagnostics = mcp_server_diagnostic_summaries(&servers);
@@ -321,12 +341,21 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                     app.config.clear_overlay();
                 }
             }
+            crate::app::config::apply_pending_dynamic_mcp_removal_confirmation(
+                app,
+                pending_dynamic_mcp_removal_confirmation,
+            );
+            crate::app::config::apply_removed_config_mcp_server_confirmation_failures(
+                app,
+                remove_confirmation_failures,
+            );
             tracing::info!(
                 target: crate::logging::targets::APP_CONFIG,
                 event_name = "mcp_snapshot_applied",
                 message = "MCP snapshot applied",
                 outcome = "success",
                 session_id = %session_id,
+                source = ?source,
                 server_count,
                 error_present,
                 servers = ?server_diagnostics,

--- a/src/app/events/client.rs
+++ b/src/app/events/client.rs
@@ -81,6 +81,36 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
         ClientEvent::McpOperationError { error } => {
             crate::app::config::handle_mcp_operation_error(app, &error);
         }
+        ClientEvent::McpSetServersResult { session_id, result } => {
+            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+                != Some(session_id.as_str())
+            {
+                return;
+            }
+            crate::app::config::handle_mcp_set_servers_result(app, &result);
+        }
+        ClientEvent::McpConfigRemoveSucceeded { cwd_raw, server_name, scope, claude_path } => {
+            if app.cwd_raw != cwd_raw {
+                return;
+            }
+            crate::app::config::apply_mcp_config_remove_success(
+                app,
+                &server_name,
+                &scope,
+                claude_path,
+            );
+        }
+        ClientEvent::McpConfigRemoveFailed { cwd_raw, server_name, scope, message } => {
+            if app.cwd_raw != cwd_raw {
+                return;
+            }
+            crate::app::config::apply_mcp_config_remove_failure(
+                app,
+                &server_name,
+                &scope,
+                &message,
+            );
+        }
         ClientEvent::McpElicitationCompleted { elicitation_id, server_name } => {
             crate::app::config::handle_mcp_elicitation_completed(app, &elicitation_id, server_name);
         }
@@ -247,7 +277,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             }
             crate::app::session_runtime::apply_context_usage_snapshot(app, percentage);
         }
-        ClientEvent::McpSnapshotReceived { session_id, servers, error } => {
+        ClientEvent::McpSnapshotReceived { session_id, mut servers, error } => {
             if app.session_id.as_ref().map(ToString::to_string).as_deref()
                 != Some(session_id.as_str())
             {
@@ -261,6 +291,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                 );
                 return;
             }
+            crate::app::config::filter_removed_config_mcp_servers(app, &mut servers);
             let server_count = servers.len();
             let error_present = error.is_some();
             let server_diagnostics = mcp_server_diagnostic_summaries(&servers);

--- a/src/app/events/client.rs
+++ b/src/app/events/client.rs
@@ -69,6 +69,9 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
         ClientEvent::QuestionRequest { request, response_tx } => {
             turn::handle_question_request_event(app, request, response_tx);
         }
+        ClientEvent::UserDialogRequest { request, response_tx } => {
+            turn::handle_user_dialog_request_event(app, request, response_tx);
+        }
         ClientEvent::McpElicitationRequest { request } => {
             crate::app::config::present_mcp_elicitation_request(app, request);
         }

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -1818,6 +1818,7 @@ mod tests {
             scope: None,
             tools: Vec::new(),
         });
+        app.mcp.removed_config_servers.insert(("user".to_owned(), "supabase".to_owned()));
 
         handle_client_event(&mut app, connected_event("claude-updated"));
 
@@ -1830,6 +1831,7 @@ mod tests {
         );
         assert!(app.mcp.in_flight);
         assert!(app.mcp.servers.is_empty());
+        assert!(app.mcp.removed_config_servers.is_empty());
     }
 
     #[test]
@@ -2217,6 +2219,7 @@ mod tests {
         assert!(app.tasks.is_empty());
         assert!(app.mention.is_none());
         assert!(app.mcp.servers.is_empty());
+        assert!(app.mcp.removed_config_servers.is_empty());
         assert_eq!(app.cwd_raw, "/replacement");
         assert_eq!(app.cwd, "/replacement");
         let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first() else {
@@ -2424,6 +2427,44 @@ mod tests {
 
         assert_eq!(app.mcp.servers.len(), 1);
         assert_eq!(app.mcp.servers[0].name, "current");
+    }
+
+    #[test]
+    fn removed_config_mcp_server_is_filtered_from_current_session_snapshot() {
+        let mut app = make_test_app();
+        app.session_id = Some(model::SessionId::new("current-session"));
+        app.mcp.removed_config_servers.insert(("user".to_owned(), "notion".to_owned()));
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::McpSnapshotReceived {
+                session_id: "current-session".into(),
+                servers: vec![
+                    crate::agent::model::McpServerStatus {
+                        name: "notion".into(),
+                        status: crate::agent::model::McpServerConnectionStatus::Connected,
+                        server_info: None,
+                        error: None,
+                        config: None,
+                        scope: Some("user".into()),
+                        tools: Vec::new(),
+                    },
+                    crate::agent::model::McpServerStatus {
+                        name: "fff".into(),
+                        status: crate::agent::model::McpServerConnectionStatus::Connected,
+                        server_info: None,
+                        error: None,
+                        config: None,
+                        scope: Some("user".into()),
+                        tools: Vec::new(),
+                    },
+                ],
+                error: None,
+            },
+        );
+
+        assert_eq!(app.mcp.servers.len(), 1);
+        assert_eq!(app.mcp.servers[0].name, "fff");
     }
 
     #[test]

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -5,6 +5,7 @@ mod api_retry;
 mod client;
 mod notices;
 mod rate_limit;
+mod retraction;
 mod session;
 mod session_reset;
 mod streaming;
@@ -229,6 +230,7 @@ fn handle_session_update_event(app: &mut App, update: model::SessionUpdate) {
         model::SessionUpdate::AgentMessageChunk(_)
             | model::SessionUpdate::ToolCall(_)
             | model::SessionUpdate::ToolCallUpdate(_)
+            | model::SessionUpdate::TranscriptRetraction(_)
             | model::SessionUpdate::CompactionBoundary(_)
     );
     handle_session_update(app, update);
@@ -247,6 +249,9 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
         model::SessionUpdate::ToolCall(tc) => tool_calls::handle_tool_call(app, tc),
         model::SessionUpdate::ToolCallUpdate(tcu) => {
             tool_updates::handle_tool_call_update_session(app, &tcu);
+        }
+        model::SessionUpdate::TranscriptRetraction(retraction) => {
+            retraction::handle_transcript_retraction(app, &retraction);
         }
         model::SessionUpdate::TaskStateUpdate(update) => {
             tracing::debug!(
@@ -565,6 +570,7 @@ mod tests {
     fn tool_call(id: &str, status: model::ToolCallStatus) -> ToolCallInfo {
         ToolCallInfo {
             id: id.into(),
+            source_message_uuids: Vec::new(),
             title: id.into(),
             sdk_tool_name: "Read".into(),
             raw_input: None,
@@ -621,6 +627,30 @@ mod tests {
             vec![MessageBlock::Text(TextBlock::from_complete(text))],
             None,
         )
+    }
+
+    fn source_text(text: &str, source_message_uuid: &str) -> MessageBlock {
+        MessageBlock::Text(
+            TextBlock::from_complete(text).with_source_message_uuid(Some(source_message_uuid)),
+        )
+    }
+
+    fn transcript_retraction(
+        message_uuids: Vec<&str>,
+        reason: model::TranscriptRetractionReason,
+    ) -> model::SessionUpdate {
+        model::SessionUpdate::TranscriptRetraction(model::TranscriptRetraction {
+            message_uuids: message_uuids.into_iter().map(str::to_owned).collect(),
+            reason,
+            request_id: None,
+            trigger: None,
+            direction: None,
+            original_model: None,
+            fallback_model: None,
+            api_refusal_category: None,
+            api_refusal_explanation: None,
+            content: None,
+        })
     }
 
     #[derive(Debug, PartialEq, Eq)]
@@ -738,6 +768,94 @@ mod tests {
         assert_eq!(app.chat_render.live_region.hidden_rows_above, 3);
         assert_eq!(app.chat_render.live_region.viewport_height, 9);
         assert_eq!(app.chat_render.live_region.last_rendered_rows, 7);
+    }
+
+    #[test]
+    fn transcript_retraction_removes_matching_text_blocks_only() {
+        let mut app = App::test_default();
+        app.messages.push(assistant_msg(vec![
+            source_text("stale", "old-assistant"),
+            source_text("keep", "new-assistant"),
+        ]));
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(transcript_retraction(
+                vec!["old-assistant", "old-assistant", "unknown"],
+                model::TranscriptRetractionReason::ModelRefusalFallback,
+            )),
+        );
+
+        assert_eq!(app.messages.len(), 1);
+        assert_eq!(app.messages[0].blocks.len(), 1);
+        let MessageBlock::Text(block) = &app.messages[0].blocks[0] else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "keep");
+        assert!(block.has_source_message_uuid("new-assistant"));
+    }
+
+    #[test]
+    fn transcript_retraction_removes_tool_blocks_and_rebuilds_indices() {
+        let mut app = App::test_default();
+        let mut stale_tool = tool_call("tool-old", model::ToolCallStatus::Completed);
+        stale_tool.source_message_uuids =
+            vec!["assistant-tool".to_owned(), "user-result".to_owned()];
+        stale_tool.sdk_tool_name = "Bash".to_owned();
+        stale_tool.terminal_id = Some("term-old".to_owned());
+        app.messages.push(assistant_msg(vec![
+            MessageBlock::ToolCall(Box::new(stale_tool)),
+            source_text("replacement", "assistant-new"),
+        ]));
+        app.index_tool_call("tool-old".to_owned(), 0, 0);
+        app.sync_terminal_tool_call("term-old".to_owned(), 0, 0);
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(transcript_retraction(
+                vec!["user-result"],
+                model::TranscriptRetractionReason::ModelFallback,
+            )),
+        );
+
+        assert!(app.lookup_tool_call("tool-old").is_none());
+        assert!(app.terminal_tool_calls.is_empty());
+        assert_eq!(app.messages.len(), 1);
+        assert_eq!(app.messages[0].blocks.len(), 1);
+        let MessageBlock::Text(block) = &app.messages[0].blocks[0] else {
+            panic!("expected replacement text");
+        };
+        assert_eq!(block.text, "replacement");
+    }
+
+    #[test]
+    fn transcript_retraction_then_replacement_leaves_canonical_assistant_content() {
+        let mut app = App::test_default();
+        app.messages.push(assistant_msg(vec![source_text("stale", "assistant-old")]));
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(transcript_retraction(
+                vec!["assistant-old"],
+                model::TranscriptRetractionReason::AssistantSupersedes,
+            )),
+        );
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(model::SessionUpdate::AgentMessageChunk(
+                model::ContentChunk::new(model::ContentBlock::Text(model::TextContent::new(
+                    "replacement",
+                )))
+                .source_message_uuid(Some("assistant-new".to_owned())),
+            )),
+        );
+
+        assert_eq!(app.messages.len(), 1);
+        let MessageBlock::Text(block) = &app.messages[0].blocks[0] else {
+            panic!("expected replacement text");
+        };
+        assert_eq!(block.text, "replacement");
+        assert!(block.has_source_message_uuid("assistant-new"));
     }
 
     fn first_block_text(msg: &ChatMessage) -> &str {

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -685,6 +685,9 @@ mod tests {
         ImageAttachment {
             count: usize,
         },
+        UserDialog {
+            request_id: String,
+        },
     }
 
     fn message_snapshots(app: &App) -> Vec<MessageSnapshot> {
@@ -721,6 +724,9 @@ mod tests {
             },
             MessageBlock::ImageAttachment(block) => {
                 BlockSnapshot::ImageAttachment { count: block.count }
+            }
+            MessageBlock::UserDialog(block) => {
+                BlockSnapshot::UserDialog { request_id: block.request_id.clone() }
             }
         }
     }
@@ -866,6 +872,9 @@ mod tests {
             Some(MessageBlock::Welcome(_)) => panic!("expected text-like block, found welcome"),
             Some(MessageBlock::ImageAttachment(_)) => {
                 panic!("expected text-like block, found image attachment")
+            }
+            Some(MessageBlock::UserDialog(_)) => {
+                panic!("expected text-like block, found user dialog")
             }
             None => panic!("expected message block"),
         }
@@ -1205,7 +1214,8 @@ mod tests {
                 MessageBlock::Notice(notice) => notice.text.text == expected,
                 MessageBlock::ToolCall(_)
                 | MessageBlock::Welcome(_)
-                | MessageBlock::ImageAttachment(_) => false,
+                | MessageBlock::ImageAttachment(_)
+                | MessageBlock::UserDialog(_) => false,
             })
         })
     }

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -592,6 +592,19 @@ mod tests {
         }
     }
 
+    fn installed_plugin_entry(id: &str) -> crate::app::plugins::InstalledPluginEntry {
+        crate::app::plugins::InstalledPluginEntry {
+            id: id.to_owned(),
+            version: None,
+            scope: "user".to_owned(),
+            enabled: true,
+            installed_at: None,
+            last_updated: None,
+            project_path: None,
+            mcp_server_names: Vec::new(),
+        }
+    }
+
     fn task_item(id: &str, subject: &str, status: model::TaskStatus) -> model::TaskItem {
         model::TaskItem {
             task_id: id.to_owned(),
@@ -1818,7 +1831,15 @@ mod tests {
             scope: None,
             tools: Vec::new(),
         });
-        app.mcp.removed_config_servers.insert(("user".to_owned(), "supabase".to_owned()));
+        app.mcp.removed_config_servers.insert(
+            crate::app::state::types::RemovedMcpServerKey::new(
+                "user".to_owned(),
+                "supabase".to_owned(),
+            ),
+            crate::app::state::types::RemovedMcpServerGuard {
+                expected_source: crate::agent::types::McpSnapshotSource::ReloadPlugins,
+            },
+        );
 
         handle_client_event(&mut app, connected_event("claude-updated"));
 
@@ -1968,16 +1989,7 @@ mod tests {
             api_key_source: None,
             api_provider: None,
         });
-        app.plugins.installed.push(crate::app::plugins::InstalledPluginEntry {
-            id: "old-plugin".into(),
-            version: None,
-            scope: "user".into(),
-            enabled: true,
-            installed_at: None,
-            last_updated: None,
-            project_path: None,
-            capability: crate::app::plugins::PluginCapability::Skill,
-        });
+        app.plugins.installed.push(installed_plugin_entry("old-plugin"));
         app.plugins.last_inventory_refresh_at = Some(Instant::now());
         app.config.pending_session_title_change =
             Some(crate::app::config::PendingSessionTitleChangeState {
@@ -2421,6 +2433,7 @@ mod tests {
                     scope: None,
                     tools: Vec::new(),
                 }],
+                source: Some(crate::agent::types::McpSnapshotSource::McpStatus),
                 error: None,
             },
         );
@@ -2433,7 +2446,15 @@ mod tests {
     fn removed_config_mcp_server_is_filtered_from_current_session_snapshot() {
         let mut app = make_test_app();
         app.session_id = Some(model::SessionId::new("current-session"));
-        app.mcp.removed_config_servers.insert(("user".to_owned(), "notion".to_owned()));
+        app.mcp.removed_config_servers.insert(
+            crate::app::state::types::RemovedMcpServerKey::new(
+                "user".to_owned(),
+                "notion".to_owned(),
+            ),
+            crate::app::state::types::RemovedMcpServerGuard {
+                expected_source: crate::agent::types::McpSnapshotSource::ReloadPlugins,
+            },
+        );
 
         handle_client_event(
             &mut app,
@@ -2459,12 +2480,88 @@ mod tests {
                         tools: Vec::new(),
                     },
                 ],
+                source: Some(crate::agent::types::McpSnapshotSource::McpStatus),
                 error: None,
             },
         );
 
         assert_eq!(app.mcp.servers.len(), 1);
         assert_eq!(app.mcp.servers[0].name, "fff");
+        assert_eq!(app.mcp.removed_config_servers.len(), 1);
+    }
+
+    #[test]
+    fn removed_config_mcp_guard_clears_after_matching_source_snapshot_proves_absence() {
+        let mut app = make_test_app();
+        app.session_id = Some(model::SessionId::new("current-session"));
+        app.mcp.removed_config_servers.insert(
+            crate::app::state::types::RemovedMcpServerKey::new(
+                "user".to_owned(),
+                "notion".to_owned(),
+            ),
+            crate::app::state::types::RemovedMcpServerGuard {
+                expected_source: crate::agent::types::McpSnapshotSource::ReloadPlugins,
+            },
+        );
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::McpSnapshotReceived {
+                session_id: "current-session".into(),
+                servers: vec![crate::agent::model::McpServerStatus {
+                    name: "fff".into(),
+                    status: crate::agent::model::McpServerConnectionStatus::Connected,
+                    server_info: None,
+                    error: None,
+                    config: None,
+                    scope: Some("user".into()),
+                    tools: Vec::new(),
+                }],
+                source: Some(crate::agent::types::McpSnapshotSource::ReloadPlugins),
+                error: None,
+            },
+        );
+
+        assert_eq!(app.mcp.servers.len(), 1);
+        assert_eq!(app.mcp.servers[0].name, "fff");
+        assert!(app.mcp.removed_config_servers.is_empty());
+    }
+
+    #[test]
+    fn removed_config_mcp_guard_stays_after_matching_source_snapshot_error() {
+        let mut app = make_test_app();
+        app.session_id = Some(model::SessionId::new("current-session"));
+        app.mcp.removed_config_servers.insert(
+            crate::app::state::types::RemovedMcpServerKey::new(
+                "user".to_owned(),
+                "notion".to_owned(),
+            ),
+            crate::app::state::types::RemovedMcpServerGuard {
+                expected_source: crate::agent::types::McpSnapshotSource::ReloadPlugins,
+            },
+        );
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::McpSnapshotReceived {
+                session_id: "current-session".into(),
+                servers: vec![crate::agent::model::McpServerStatus {
+                    name: "fff".into(),
+                    status: crate::agent::model::McpServerConnectionStatus::Connected,
+                    server_info: None,
+                    error: None,
+                    config: None,
+                    scope: Some("user".into()),
+                    tools: Vec::new(),
+                }],
+                source: Some(crate::agent::types::McpSnapshotSource::ReloadPlugins),
+                error: Some("reload failed".to_owned()),
+            },
+        );
+
+        assert_eq!(app.mcp.servers.len(), 1);
+        assert_eq!(app.mcp.servers[0].name, "fff");
+        assert_eq!(app.mcp.removed_config_servers.len(), 1);
     }
 
     #[test]
@@ -2501,16 +2598,7 @@ mod tests {
             ClientEvent::PluginsInventoryUpdated {
                 cwd_raw: "/old".into(),
                 snapshot: crate::app::plugins::PluginsInventorySnapshot {
-                    installed: vec![crate::app::plugins::InstalledPluginEntry {
-                        id: "stale-plugin".into(),
-                        version: None,
-                        scope: "user".into(),
-                        enabled: true,
-                        installed_at: None,
-                        last_updated: None,
-                        project_path: None,
-                        capability: crate::app::plugins::PluginCapability::Skill,
-                    }],
+                    installed: vec![installed_plugin_entry("stale-plugin")],
                     marketplace: Vec::new(),
                     marketplaces: Vec::new(),
                 },

--- a/src/app/events/retraction.rs
+++ b/src/app/events/retraction.rs
@@ -1,0 +1,92 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+
+use super::super::{App, MessageBlock, MessageRole};
+use crate::agent::model;
+
+pub(super) fn handle_transcript_retraction(
+    app: &mut App,
+    retraction: &model::TranscriptRetraction,
+) {
+    let message_uuids: HashSet<&str> = retraction
+        .message_uuids
+        .iter()
+        .map(String::as_str)
+        .filter(|uuid| !uuid.trim().is_empty())
+        .collect();
+    if message_uuids.is_empty() {
+        return;
+    }
+
+    let mut removed_blocks = 0usize;
+    let mut removed_messages = 0usize;
+    let mut changed = false;
+    let mut rebuild_indices = false;
+
+    for msg_idx in (0..app.messages.len()).rev() {
+        let (removed, empty_assistant) = match app.messages.get_mut(msg_idx) {
+            Some(message) => {
+                let before_len = message.blocks.len();
+                message.blocks.retain(|block| {
+                    let retract = block_matches_retraction(block, &message_uuids);
+                    if retract && matches!(block, MessageBlock::ToolCall(_)) {
+                        rebuild_indices = true;
+                    }
+                    !retract
+                });
+                (
+                    before_len.saturating_sub(message.blocks.len()),
+                    message.blocks.is_empty() && matches!(message.role, MessageRole::Assistant),
+                )
+            }
+            None => continue,
+        };
+        if removed == 0 {
+            continue;
+        }
+
+        changed = true;
+        removed_blocks = removed_blocks.saturating_add(removed);
+        if empty_assistant {
+            if app.remove_message_tracked(msg_idx).is_some() {
+                removed_messages = removed_messages.saturating_add(1);
+            }
+        } else {
+            app.sync_after_message_blocks_changed(msg_idx);
+        }
+    }
+
+    if rebuild_indices {
+        app.rebuild_tool_indices_and_terminal_refs();
+    }
+
+    tracing::info!(
+        target: crate::logging::targets::APP_SESSION,
+        event_name = "transcript_retraction_applied",
+        message = "transcript retraction applied",
+        outcome = if changed { "success" } else { "noop" },
+        reason = ?retraction.reason,
+        requested_uuid_count = message_uuids.len(),
+        removed_block_count = removed_blocks,
+        removed_message_count = removed_messages,
+        request_id = retraction.request_id.as_deref().unwrap_or(""),
+        original_model = retraction.original_model.as_deref().unwrap_or(""),
+        fallback_model = retraction.fallback_model.as_deref().unwrap_or(""),
+    );
+}
+
+fn block_matches_retraction(block: &MessageBlock, message_uuids: &HashSet<&str>) -> bool {
+    match block {
+        MessageBlock::Text(block) => {
+            block.source_message_uuids.iter().any(|uuid| message_uuids.contains(uuid.as_str()))
+        }
+        MessageBlock::ToolCall(tool_call) => {
+            tool_call.source_message_uuids.iter().any(|uuid| message_uuids.contains(uuid.as_str()))
+        }
+        MessageBlock::Notice(_) | MessageBlock::Welcome(_) | MessageBlock::ImageAttachment(_) => {
+            false
+        }
+    }
+}

--- a/src/app/events/retraction.rs
+++ b/src/app/events/retraction.rs
@@ -85,8 +85,9 @@ fn block_matches_retraction(block: &MessageBlock, message_uuids: &HashSet<&str>)
         MessageBlock::ToolCall(tool_call) => {
             tool_call.source_message_uuids.iter().any(|uuid| message_uuids.contains(uuid.as_str()))
         }
-        MessageBlock::Notice(_) | MessageBlock::Welcome(_) | MessageBlock::ImageAttachment(_) => {
-            false
-        }
+        MessageBlock::Notice(_)
+        | MessageBlock::Welcome(_)
+        | MessageBlock::ImageAttachment(_)
+        | MessageBlock::UserDialog(_) => false,
     }
 }

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -116,9 +116,13 @@ fn append_resume_user_message_chunk(app: &mut App, chunk: &model::ContentChunk) 
         if let Some(MessageBlock::Text(block)) = last.blocks.last_mut() {
             block.text.push_str(&text.text);
             block.markdown.append(&text.text);
+            block.add_source_message_uuid(chunk.source_message_uuid.as_deref());
             block.cache.invalidate();
         } else {
-            last.blocks.push(MessageBlock::Text(TextBlock::from_complete(&text.text)));
+            last.blocks.push(MessageBlock::Text(
+                TextBlock::from_complete(&text.text)
+                    .with_source_message_uuid(chunk.source_message_uuid.as_deref()),
+            ));
         }
         let last_idx = app.messages.len().saturating_sub(1);
         app.sync_after_message_blocks_changed(last_idx);
@@ -127,7 +131,10 @@ fn append_resume_user_message_chunk(app: &mut App, chunk: &model::ContentChunk) 
 
     app.push_message_tracked(ChatMessage::new(
         MessageRole::User,
-        vec![MessageBlock::Text(TextBlock::from_complete(&text.text))],
+        vec![MessageBlock::Text(
+            TextBlock::from_complete(&text.text)
+                .with_source_message_uuid(chunk.source_message_uuid.as_deref()),
+        )],
         None,
     ));
 }

--- a/src/app/events/streaming.rs
+++ b/src/app/events/streaming.rs
@@ -19,7 +19,11 @@ pub(super) fn handle_agent_message_chunk(app: &mut App, chunk: model::ContentChu
     if let Some(owner_idx) = app.active_turn_assistant_idx()
         && let Some(owner) = app.messages.get_mut(owner_idx)
     {
-        append_agent_stream_text(&mut owner.blocks, &text.text);
+        append_agent_stream_text(
+            &mut owner.blocks,
+            &text.text,
+            chunk.source_message_uuid.as_deref(),
+        );
         app.sync_after_message_blocks_changed(owner_idx);
         return;
     }
@@ -27,7 +31,11 @@ pub(super) fn handle_agent_message_chunk(app: &mut App, chunk: model::ContentChu
     if let Some(last) = app.messages.last_mut()
         && matches!(last.role, MessageRole::Assistant)
     {
-        append_agent_stream_text(&mut last.blocks, &text.text);
+        append_agent_stream_text(
+            &mut last.blocks,
+            &text.text,
+            chunk.source_message_uuid.as_deref(),
+        );
         let last_idx = app.messages.len().saturating_sub(1);
         app.bind_active_turn_assistant(last_idx);
         app.sync_after_message_blocks_changed(last_idx);
@@ -35,21 +43,26 @@ pub(super) fn handle_agent_message_chunk(app: &mut App, chunk: model::ContentChu
     }
 
     let mut blocks = Vec::new();
-    append_agent_stream_text(&mut blocks, &text.text);
+    append_agent_stream_text(&mut blocks, &text.text, chunk.source_message_uuid.as_deref());
     app.push_message_tracked(ChatMessage::new(MessageRole::Assistant, blocks, None));
     app.bind_active_turn_assistant_to_tail();
 }
 
-pub(super) fn append_agent_stream_text(blocks: &mut Vec<MessageBlock>, chunk: &str) {
+pub(super) fn append_agent_stream_text(
+    blocks: &mut Vec<MessageBlock>,
+    chunk: &str,
+    source_message_uuid: Option<&str>,
+) {
     if chunk.is_empty() {
         return;
     }
     if let Some(MessageBlock::Text(block)) = blocks.last_mut() {
         block.text.push_str(chunk);
         block.markdown.append(chunk);
+        block.add_source_message_uuid(source_message_uuid);
         block.cache.invalidate();
     } else {
-        blocks.push(new_text_block(chunk.to_owned()));
+        blocks.push(new_text_block(chunk.to_owned(), source_message_uuid));
     }
 
     let split_count = split_tail_text_block(blocks);
@@ -64,8 +77,8 @@ pub(super) fn append_agent_stream_text(blocks: &mut Vec<MessageBlock>, chunk: &s
     crate::perf::mark_with("text_block_frozen_count", "count", text_block_count.saturating_sub(1));
 }
 
-fn new_text_block(text: String) -> MessageBlock {
-    MessageBlock::Text(TextBlock::new(text))
+fn new_text_block(text: String, source_message_uuid: Option<&str>) -> MessageBlock {
+    MessageBlock::Text(TextBlock::new(text).with_source_message_uuid(source_message_uuid))
 }
 
 fn split_tail_text_block(blocks: &mut Vec<MessageBlock>) -> usize {
@@ -84,9 +97,10 @@ fn split_tail_text_block(blocks: &mut Vec<MessageBlock>) -> usize {
             break;
         };
 
-        let (tail_id, completed, remainder) = match blocks.get(tail_idx) {
+        let (tail_id, source_message_uuids, completed, remainder) = match blocks.get(tail_idx) {
             Some(MessageBlock::Text(block)) => (
                 block.id,
+                block.source_message_uuids.clone(),
                 block.text[..split.split_at].to_owned(),
                 block.text[split.split_at..].to_owned(),
             ),
@@ -97,19 +111,30 @@ fn split_tail_text_block(blocks: &mut Vec<MessageBlock>) -> usize {
             break;
         }
 
-        blocks[tail_idx] = MessageBlock::Text(TextBlock::new_with_id(tail_id, remainder));
-        blocks.insert(tail_idx, completed_text_block(completed, split));
+        blocks[tail_idx] = MessageBlock::Text(
+            TextBlock::new_with_id(tail_id, remainder)
+                .with_source_message_uuids(source_message_uuids.clone()),
+        );
+        blocks.insert(tail_idx, completed_text_block(completed, split, source_message_uuids));
         split_count += 1;
     }
     split_count
 }
 
-fn completed_text_block(text: String, split: TextSplitDecision) -> MessageBlock {
+fn completed_text_block(
+    text: String,
+    split: TextSplitDecision,
+    source_message_uuids: Vec<String>,
+) -> MessageBlock {
     let trailing_spacing = match split.kind {
         TextSplitKind::Generic => TextBlockSpacing::None,
         TextSplitKind::ParagraphBoundary => TextBlockSpacing::ParagraphBreak,
     };
-    MessageBlock::Text(TextBlock::new(text).with_trailing_spacing(trailing_spacing))
+    MessageBlock::Text(
+        TextBlock::new(text)
+            .with_source_message_uuids(source_message_uuids)
+            .with_trailing_spacing(trailing_spacing),
+    )
 }
 
 pub(super) fn find_text_block_split(text: &str) -> Option<TextSplitDecision> {
@@ -153,5 +178,31 @@ mod tests {
         assert_eq!(first.trailing_spacing, TextBlockSpacing::ParagraphBreak);
         assert_eq!(second.text, "second");
         assert_eq!(second.trailing_spacing, TextBlockSpacing::None);
+    }
+
+    #[test]
+    fn streaming_text_keeps_contiguous_chunks_in_one_block_when_source_uuid_changes() {
+        let mut app = App::test_default();
+        app.status = crate::app::AppStatus::Thinking;
+        app.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+        app.bind_active_turn_assistant(0);
+
+        for (text, source_message_uuid) in
+            [("H", "assistant-part-1"), ("ello!", "assistant-part-2")]
+        {
+            handle_agent_message_chunk(
+                &mut app,
+                model::ContentChunk::new(model::ContentBlock::Text(model::TextContent::new(text)))
+                    .source_message_uuid(Some(source_message_uuid.to_owned())),
+            );
+        }
+
+        assert_eq!(app.messages[0].blocks.len(), 1);
+        let Some(MessageBlock::Text(block)) = app.messages[0].blocks.first() else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "Hello!");
+        assert!(block.has_source_message_uuid("assistant-part-1"));
+        assert!(block.has_source_message_uuid("assistant-part-2"));
     }
 }

--- a/src/app/events/tool_calls.rs
+++ b/src/app/events/tool_calls.rs
@@ -115,6 +115,11 @@ fn build_tool_info_from_tool_call(
 
     let mut tool_info = ToolCallInfo {
         id: tc.tool_call_id,
+        source_message_uuids: tc
+            .source_message_uuid
+            .filter(|uuid| !uuid.trim().is_empty())
+            .into_iter()
+            .collect(),
         title: shorten_tool_title(&tc.title, &app.cwd_raw),
         sdk_tool_name,
         raw_input: tc.raw_input,
@@ -206,6 +211,9 @@ fn update_existing_tool_call(app: &mut App, mi: usize, bi: usize, tool_info: &To
         changed |= sync_if_changed(&mut existing.content, &tool_info.content);
         changed |= sync_if_changed(&mut existing.sdk_tool_name, &tool_info.sdk_tool_name);
         changed |= sync_if_changed(&mut existing.hidden, &tool_info.hidden);
+        for source_message_uuid in &tool_info.source_message_uuids {
+            changed |= existing.add_source_message_uuid(Some(source_message_uuid));
+        }
         changed |= existing.set_raw_input(tool_info.raw_input.clone());
         changed |= sync_if_changed(&mut existing.output_metadata, &tool_info.output_metadata);
         changed |= sync_if_changed(&mut existing.task_metadata, &tool_info.task_metadata);

--- a/src/app/events/tool_updates.rs
+++ b/src/app/events/tool_updates.rs
@@ -247,6 +247,33 @@ fn apply_tool_call_task_metadata_update(
     if task_metadata.is_backgrounded.is_some() {
         merged.is_backgrounded = task_metadata.is_backgrounded;
     }
+    if task_metadata.request_id.is_some() {
+        merged.request_id.clone_from(&task_metadata.request_id);
+    }
+    if task_metadata.subagent_type.is_some() {
+        merged.subagent_type.clone_from(&task_metadata.subagent_type);
+    }
+    if task_metadata.task_description.is_some() {
+        merged.task_description.clone_from(&task_metadata.task_description);
+    }
+    if task_metadata.task_type.is_some() {
+        merged.task_type.clone_from(&task_metadata.task_type);
+    }
+    if task_metadata.workflow_name.is_some() {
+        merged.workflow_name.clone_from(&task_metadata.workflow_name);
+    }
+    if task_metadata.prompt.is_some() {
+        merged.prompt.clone_from(&task_metadata.prompt);
+    }
+    if task_metadata.output_file.is_some() {
+        merged.output_file.clone_from(&task_metadata.output_file);
+    }
+    if task_metadata.summary.is_some() {
+        merged.summary.clone_from(&task_metadata.summary);
+    }
+    if task_metadata.terminal_status.is_some() {
+        merged.terminal_status.clone_from(&task_metadata.terminal_status);
+    }
     if tc.task_metadata.as_ref() == Some(&merged) {
         return false;
     }
@@ -868,8 +895,17 @@ mod tests {
 
         let backgrounded_update = model::ToolCallUpdate::new(
             tool_id,
-            model::ToolCallUpdateFields::new()
-                .task_metadata(model::TaskMetadata::new().backgrounded(Some(true))),
+            model::ToolCallUpdateFields::new().task_metadata(
+                model::TaskMetadata::new()
+                    .backgrounded(Some(true))
+                    .request_id(Some("request-1".to_owned()))
+                    .subagent_type(Some("reviewer".to_owned()))
+                    .task_description(Some("Review branch".to_owned()))
+                    .task_type(Some("remote_agent".to_owned()))
+                    .workflow_name(Some("review-flow".to_owned()))
+                    .prompt(Some("Review the branch".to_owned()))
+                    .output_file(Some("C:/tmp/review.md".to_owned())),
+            ),
         );
         handle_tool_call_update_session(&mut app, &backgrounded_update);
 
@@ -884,6 +920,16 @@ mod tests {
         );
         handle_tool_call_update_session(&mut app, &timing_update);
 
+        let terminal_update = model::ToolCallUpdate::new(
+            tool_id,
+            model::ToolCallUpdateFields::new().task_metadata(
+                model::TaskMetadata::new()
+                    .summary(Some("Stopped after validation".to_owned()))
+                    .terminal_status(Some("killed".to_owned())),
+            ),
+        );
+        handle_tool_call_update_session(&mut app, &terminal_update);
+
         let MessageBlock::ToolCall(tc) = &app.messages[0].blocks[0] else {
             panic!("expected tool call block");
         };
@@ -894,7 +940,16 @@ mod tests {
                     .error(Some("Task stopped by parent agent".to_owned()))
                     .end_time(Some(1234))
                     .total_paused_ms(Some(250))
-                    .backgrounded(Some(true)),
+                    .backgrounded(Some(true))
+                    .request_id(Some("request-1".to_owned()))
+                    .subagent_type(Some("reviewer".to_owned()))
+                    .task_description(Some("Review branch".to_owned()))
+                    .task_type(Some("remote_agent".to_owned()))
+                    .workflow_name(Some("review-flow".to_owned()))
+                    .prompt(Some("Review the branch".to_owned()))
+                    .output_file(Some("C:/tmp/review.md".to_owned()))
+                    .summary(Some("Stopped after validation".to_owned()))
+                    .terminal_status(Some("killed".to_owned())),
             )
         );
     }

--- a/src/app/events/tool_updates.rs
+++ b/src/app/events/tool_updates.rs
@@ -109,6 +109,7 @@ fn apply_tool_call_update_to_indexed_block(
     {
         let tc = tc.as_mut();
         let mut changed = false;
+        changed |= tc.add_source_message_uuid(tcu.source_message_uuid.as_deref());
         changed |= apply_tool_call_status_update(tc, tcu.fields.status);
         changed |= apply_tool_call_title_update(tc, tcu.fields.title.as_deref(), &app.cwd_raw);
         changed |= apply_tool_call_content_update(
@@ -640,6 +641,7 @@ mod tests {
     ) -> ToolCallInfo {
         ToolCallInfo {
             id: id.to_owned(),
+            source_message_uuids: Vec::new(),
             title: format!("tool {id}"),
             sdk_tool_name: "Bash".to_owned(),
             raw_input: None,
@@ -668,6 +670,7 @@ mod tests {
     fn make_task_tool_call(id: &str, status: model::ToolCallStatus) -> ToolCallInfo {
         ToolCallInfo {
             id: id.to_owned(),
+            source_message_uuids: Vec::new(),
             title: format!("task {id}"),
             sdk_tool_name: "Agent".to_owned(),
             raw_input: None,

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -4,6 +4,7 @@
 use super::super::{
     App, AppStatus, CancelOrigin, ChatMessage, FocusTarget, InlinePermission, InlineQuestion,
     InvalidationLevel, MessageBlock, MessageRole, NoticeStage, SystemSeverity, TextBlock,
+    UserDialogBlock,
 };
 use super::clear_compaction_state;
 use super::rate_limit::{format_rate_limit_summary, rate_limit_notice_key};
@@ -221,6 +222,68 @@ pub(super) fn handle_question_request_event(
         app.invalidate_layout(InvalidationLevel::MessageChanged(mi));
         app.request_chat_mutable_rebuild();
     }
+}
+
+pub(super) fn handle_user_dialog_request_event(
+    app: &mut App,
+    request: model::RequestUserDialogRequest,
+    response_tx: tokio::sync::oneshot::Sender<model::RequestUserDialogResponse>,
+) {
+    let session_id = request.session_id.to_string();
+    let request_id = request.request_id.clone();
+    let dialog_kind = request.dialog_kind.clone();
+    let option_count = request.options.len();
+
+    if app.pending_interaction_ids.iter().any(|id| id == &request_id) {
+        tracing::warn!(
+            target: crate::logging::targets::APP_PERMISSION,
+            event_name = "user_dialog_request_rejected",
+            message = "duplicate user dialog request rejected",
+            outcome = "dropped",
+            session_id = %session_id,
+            request_id = %request_id,
+            reason = "duplicate_pending_interaction",
+        );
+        let _ = response_tx.send(model::RequestUserDialogResponse::new(
+            model::RequestUserDialogOutcome::Cancelled,
+        ));
+        return;
+    }
+
+    let auto_focus = app.pending_interaction_ids.is_empty() && !app.has_draft_input_for_focus();
+    let mi = app.messages.len();
+    let bi = 0;
+    let mut block = UserDialogBlock::new(request, response_tx);
+    block.focused = auto_focus;
+    app.push_message_tracked(ChatMessage::new(
+        MessageRole::System(Some(SystemSeverity::Warning)),
+        vec![MessageBlock::UserDialog(block)],
+        None,
+    ));
+    app.index_tool_call(request_id.clone(), mi, bi);
+    app.pending_interaction_ids.push(request_id.clone());
+    if auto_focus {
+        app.claim_focus_target(FocusTarget::Permission);
+    }
+    app.notifications.notify(
+        app.config.preferred_notification_channel_effective(),
+        super::super::notify::NotifyEvent::QuestionRequired,
+    );
+    app.sync_render_cache_slot(mi, bi);
+    app.recompute_message_retained_bytes(mi);
+    app.invalidate_layout(InvalidationLevel::MessageChanged(mi));
+    app.request_chat_mutable_rebuild();
+    tracing::info!(
+        target: crate::logging::targets::APP_PERMISSION,
+        event_name = "user_dialog_request_applied",
+        message = "user dialog request applied as inline system chooser",
+        outcome = "success",
+        session_id = %session_id,
+        request_id = %request_id,
+        dialog_kind = %dialog_kind,
+        option_count,
+        focused = auto_focus,
+    );
 }
 
 fn reject_permission_request(

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -685,6 +685,7 @@ mod tests {
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(crate::app::ToolCallInfo {
                 id: tool_id.to_owned(),
+                source_message_uuids: Vec::new(),
                 title: "tool".to_owned(),
                 sdk_tool_name: "Bash".to_owned(),
                 raw_input: None,

--- a/src/app/inline_interactions.rs
+++ b/src/app/inline_interactions.rs
@@ -12,11 +12,13 @@ fn interaction_id_is_valid(app: &App, tool_id: &str) -> bool {
     let Some((mi, bi)) = app.lookup_tool_call(tool_id) else {
         return false;
     };
-    matches!(
-        app.messages.get(mi).and_then(|msg| msg.blocks.get(bi)),
-        Some(MessageBlock::ToolCall(tc))
-            if tc.pending_permission.is_some() || tc.pending_question.is_some()
-    )
+    match app.messages.get(mi).and_then(|msg| msg.blocks.get(bi)) {
+        Some(MessageBlock::ToolCall(tc)) => {
+            tc.pending_permission.is_some() || tc.pending_question.is_some()
+        }
+        Some(MessageBlock::UserDialog(dialog)) => !dialog.answered,
+        _ => false,
+    }
 }
 
 pub(super) fn focused_interaction(app: &App) -> Option<&ToolCallInfo> {
@@ -65,23 +67,33 @@ pub(super) fn set_interaction_focused(app: &mut App, queue_index: usize, focused
         return;
     };
     let mut invalidated = false;
-    if let Some(msg) = app.messages.get_mut(mi)
-        && let Some(MessageBlock::ToolCall(tc)) = msg.blocks.get_mut(bi)
-    {
-        let tc = tc.as_mut();
-        if let Some(ref mut perm) = tc.pending_permission
-            && perm.focused != focused
-        {
-            perm.focused = focused;
-            tc.invalidate_render_cache();
-            invalidated = true;
-        }
-        if let Some(ref mut question) = tc.pending_question
-            && question.focused != focused
-        {
-            question.focused = focused;
-            tc.invalidate_render_cache();
-            invalidated = true;
+    if let Some(msg) = app.messages.get_mut(mi) {
+        match msg.blocks.get_mut(bi) {
+            Some(MessageBlock::ToolCall(tc)) => {
+                let tc = tc.as_mut();
+                if let Some(ref mut perm) = tc.pending_permission
+                    && perm.focused != focused
+                {
+                    perm.focused = focused;
+                    tc.invalidate_render_cache();
+                    invalidated = true;
+                }
+                if let Some(ref mut question) = tc.pending_question
+                    && question.focused != focused
+                {
+                    question.focused = focused;
+                    tc.invalidate_render_cache();
+                    invalidated = true;
+                }
+            }
+            Some(MessageBlock::UserDialog(dialog)) => {
+                if dialog.focused != focused {
+                    dialog.focused = focused;
+                    dialog.cache.invalidate();
+                    invalidated = true;
+                }
+            }
+            _ => {}
         }
     }
     if invalidated {
@@ -92,10 +104,35 @@ pub(super) fn set_interaction_focused(app: &mut App, queue_index: usize, focused
 }
 
 pub(super) fn focused_interaction_is_active(app: &App) -> bool {
-    focused_interaction(app).is_some_and(|tc| {
-        tc.pending_permission.as_ref().is_some_and(|permission| permission.focused)
-            || tc.pending_question.as_ref().is_some_and(|question| question.focused)
-    })
+    let Some(tool_id) = focused_interaction_id(app) else {
+        return false;
+    };
+    let Some((mi, bi)) = app.tool_call_index.get(tool_id).copied() else {
+        return false;
+    };
+    match app.messages.get(mi).and_then(|msg| msg.blocks.get(bi)) {
+        Some(MessageBlock::ToolCall(tc)) => {
+            tc.pending_permission.as_ref().is_some_and(|permission| permission.focused)
+                || tc.pending_question.as_ref().is_some_and(|question| question.focused)
+        }
+        Some(MessageBlock::UserDialog(dialog)) => dialog.focused && !dialog.answered,
+        _ => false,
+    }
+}
+
+/// Whether the head of the interaction queue is a focused, unanswered user
+/// dialog. Used by key dispatch to route navigation/confirm to the dialog.
+pub(super) fn has_focused_user_dialog(app: &App) -> bool {
+    let Some(tool_id) = focused_interaction_id(app) else {
+        return false;
+    };
+    let Some((mi, bi)) = app.tool_call_index.get(tool_id).copied() else {
+        return false;
+    };
+    matches!(
+        app.messages.get(mi).and_then(|msg| msg.blocks.get(bi)),
+        Some(MessageBlock::UserDialog(dialog)) if dialog.focused && !dialog.answered
+    )
 }
 
 pub(super) fn clear_inline_interaction_focus(app: &mut App) {
@@ -107,25 +144,37 @@ pub(super) fn clear_inline_interaction_focus(app: &mut App) {
         let Some((mi, bi)) = app.tool_call_index.get(&tool_id).copied() else {
             continue;
         };
-        if let Some(msg) = app.messages.get_mut(mi)
-            && let Some(MessageBlock::ToolCall(tc)) = msg.blocks.get_mut(bi)
-        {
-            let tc = tc.as_mut();
+        if let Some(msg) = app.messages.get_mut(mi) {
             let mut interaction_changed = false;
-            if let Some(ref mut perm) = tc.pending_permission
-                && perm.focused
-            {
-                perm.focused = false;
-                interaction_changed = true;
-            }
-            if let Some(ref mut question) = tc.pending_question
-                && question.focused
-            {
-                question.focused = false;
-                interaction_changed = true;
+            match msg.blocks.get_mut(bi) {
+                Some(MessageBlock::ToolCall(tc)) => {
+                    let tc = tc.as_mut();
+                    if let Some(ref mut perm) = tc.pending_permission
+                        && perm.focused
+                    {
+                        perm.focused = false;
+                        interaction_changed = true;
+                    }
+                    if let Some(ref mut question) = tc.pending_question
+                        && question.focused
+                    {
+                        question.focused = false;
+                        interaction_changed = true;
+                    }
+                    if interaction_changed {
+                        tc.invalidate_render_cache();
+                    }
+                }
+                Some(MessageBlock::UserDialog(dialog)) => {
+                    if dialog.focused {
+                        dialog.focused = false;
+                        dialog.cache.invalidate();
+                        interaction_changed = true;
+                    }
+                }
+                _ => {}
             }
             if interaction_changed {
-                tc.invalidate_render_cache();
                 app.sync_render_cache_slot(mi, bi);
                 app.recompute_message_retained_bytes(mi);
                 app.invalidate_layout(InvalidationLevel::MessageChanged(mi));

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -431,7 +431,9 @@ fn execute_interaction_action(
     action: InteractionAction,
     key: KeyEvent,
 ) -> KeyOutcome {
-    if questions::has_focused_question(app) {
+    if super::inline_interactions::has_focused_user_dialog(app) {
+        super::user_dialog::execute_user_dialog_action(app, action, key)
+    } else if questions::has_focused_question(app) {
         questions::execute_question_action(app, action, key)
     } else {
         permissions::execute_permission_action(app, action, key)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,7 @@
 
 pub(crate) mod auth;
 mod cache_policy;
+pub(crate) mod claude_cli;
 pub(crate) mod clipboard_image;
 pub(crate) mod config;
 mod connect;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod terminal_runtime;
 mod trust;
 mod update_check;
 pub(crate) mod usage;
+mod user_dialog;
 mod view;
 
 pub(crate) const AUTOCOMPLETE_VISIBLE_ROWS: usize = 5;
@@ -67,8 +68,8 @@ pub use state::{
     RecentSessionInfo, SelectionPoint, SessionPickerState, SessionUsageState, SystemSeverity,
     TerminalSize, TerminalSizeChange, TerminalSnapshotMode, TextBlock, TextBlockSpacing,
     ToolCallInfo, ToolCallScope, TurnNoticeLocation, TurnNoticeRef, UpdateNoticeState,
-    UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow, WelcomeBlock,
-    hash_text_block_content, hash_welcome_block_content, is_execute_tool_name,
+    UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow, UserDialogBlock,
+    WelcomeBlock, hash_text_block_content, hash_welcome_block_content, is_execute_tool_name,
 };
 pub use trust::TrustSelection;
 pub use update_check::start_update_check;

--- a/src/app/permissions.rs
+++ b/src/app/permissions.rs
@@ -283,6 +283,7 @@ mod tests {
     fn test_tool_call(id: &str) -> ToolCallInfo {
         ToolCallInfo {
             id: id.to_owned(),
+            source_message_uuids: Vec::new(),
             title: format!("Tool {id}"),
             sdk_tool_name: "Read".to_owned(),
             raw_input: None,

--- a/src/app/plugins/cli.rs
+++ b/src/app/plugins/cli.rs
@@ -2,10 +2,10 @@ use super::{
     InstalledPluginEntry, MarketplaceEntry, MarketplaceSourceEntry, PluginCapability,
     PluginsInventorySnapshot,
 };
+use crate::app::claude_cli;
 use serde::Deserialize;
 use serde_json::Value;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 #[derive(Debug, Deserialize)]
 struct InstalledPluginJson {
@@ -54,7 +54,7 @@ pub(super) async fn refresh_inventory(
     cached_claude_path: Option<PathBuf>,
 ) -> Result<(PluginsInventorySnapshot, PathBuf), String> {
     tokio::task::spawn_blocking(move || {
-        let claude_path = resolve_claude_path(cached_claude_path)?;
+        let claude_path = claude_cli::resolve_claude_path(cached_claude_path)?;
         let snapshot = refresh_inventory_blocking(&claude_path, &cwd_raw)?;
         Ok((snapshot, claude_path))
     })
@@ -68,8 +68,8 @@ pub(super) async fn run_cli_command_and_refresh(
     args: Vec<String>,
 ) -> Result<(PluginsInventorySnapshot, PathBuf), String> {
     tokio::task::spawn_blocking(move || {
-        let claude_path = resolve_claude_path(cached_claude_path)?;
-        run_command(&claude_path, &cwd_raw, &args)?;
+        let claude_path = claude_cli::resolve_claude_path(cached_claude_path)?;
+        claude_cli::run_command(&claude_path, &cwd_raw, &args)?;
         let snapshot = refresh_inventory_blocking(&claude_path, &cwd_raw)?;
         Ok((snapshot, claude_path))
     })
@@ -77,30 +77,21 @@ pub(super) async fn run_cli_command_and_refresh(
     .map_err(|error| format!("Plugin CLI action task failed: {error}"))?
 }
 
-fn resolve_claude_path(cached_claude_path: Option<PathBuf>) -> Result<PathBuf, String> {
-    if let Some(path) = cached_claude_path
-        && path.is_file()
-    {
-        return Ok(path);
-    }
-    which::which("claude").map_err(|_| "claude CLI not found in PATH".to_owned())
-}
-
 fn refresh_inventory_blocking(
     claude_path: &Path,
     cwd_raw: &str,
 ) -> Result<PluginsInventorySnapshot, String> {
-    let installed = parse_json_command::<Vec<InstalledPluginJson>>(
+    let installed = claude_cli::parse_json_command::<Vec<InstalledPluginJson>>(
         claude_path,
         cwd_raw,
         &["plugin", "list", "--json"],
     )?;
-    let available = parse_json_command::<MarketplaceListJson>(
+    let available = claude_cli::parse_json_command::<MarketplaceListJson>(
         claude_path,
         cwd_raw,
         &["plugin", "list", "--available", "--json"],
     )?;
-    let marketplaces = parse_json_command::<Vec<MarketplaceSourceJson>>(
+    let marketplaces = claude_cli::parse_json_command::<Vec<MarketplaceSourceJson>>(
         claude_path,
         cwd_raw,
         &["plugin", "marketplace", "list", "--json"],
@@ -160,54 +151,6 @@ fn refresh_inventory_blocking(
         marketplace: marketplace_entries,
         marketplaces: marketplace_sources,
     })
-}
-
-fn parse_json_command<T>(claude_path: &Path, cwd_raw: &str, args: &[&str]) -> Result<T, String>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let output = Command::new(claude_path)
-        .args(args)
-        .current_dir(cwd_raw)
-        .output()
-        .map_err(|error| format!("Failed to run `claude {}`: {error}", args.join(" ")))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-        let exit_code =
-            output.status.code().map_or_else(|| "unknown".to_owned(), |code| code.to_string());
-        let detail = if stderr.is_empty() {
-            format!("exit code {exit_code}")
-        } else {
-            format!("exit code {exit_code}: {stderr}")
-        };
-        return Err(format!("`claude {}` failed: {detail}", args.join(" ")));
-    }
-
-    serde_json::from_slice(&output.stdout)
-        .map_err(|error| format!("Failed to parse JSON from `claude {}`: {error}", args.join(" ")))
-}
-
-fn run_command(claude_path: &Path, cwd_raw: &str, args: &[String]) -> Result<(), String> {
-    let output = Command::new(claude_path)
-        .args(args)
-        .current_dir(cwd_raw)
-        .output()
-        .map_err(|error| format!("Failed to run `claude {}`: {error}", args.join(" ")))?;
-
-    if output.status.success() {
-        return Ok(());
-    }
-
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    let exit_code =
-        output.status.code().map_or_else(|| "unknown".to_owned(), |code| code.to_string());
-    let detail = if stderr.is_empty() {
-        format!("exit code {exit_code}")
-    } else {
-        format!("exit code {exit_code}: {stderr}")
-    };
-    Err(format!("`claude {}` failed: {detail}", args.join(" ")))
 }
 
 #[cfg(test)]

--- a/src/app/plugins/cli.rs
+++ b/src/app/plugins/cli.rs
@@ -1,10 +1,10 @@
 use super::{
-    InstalledPluginEntry, MarketplaceEntry, MarketplaceSourceEntry, PluginCapability,
-    PluginsInventorySnapshot,
+    InstalledPluginEntry, MarketplaceEntry, MarketplaceSourceEntry, PluginsInventorySnapshot,
 };
 use crate::app::claude_cli;
 use serde::Deserialize;
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Deserialize)]
@@ -19,8 +19,8 @@ struct InstalledPluginJson {
     last_updated: Option<String>,
     #[serde(rename = "projectPath")]
     project_path: Option<String>,
-    #[serde(rename = "mcpServers")]
-    mcp_servers: Option<Value>,
+    #[serde(default, rename = "mcpServers")]
+    mcp_servers: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -97,23 +97,8 @@ fn refresh_inventory_blocking(
         &["plugin", "marketplace", "list", "--json"],
     )?;
 
-    let mut installed_entries = installed
-        .into_iter()
-        .map(|entry| InstalledPluginEntry {
-            id: entry.id,
-            version: entry.version,
-            scope: entry.scope,
-            enabled: entry.enabled,
-            installed_at: entry.installed_at,
-            last_updated: entry.last_updated,
-            project_path: entry.project_path,
-            capability: if entry.mcp_servers.is_some() {
-                PluginCapability::Mcp
-            } else {
-                PluginCapability::Skill
-            },
-        })
-        .collect::<Vec<_>>();
+    let mut installed_entries =
+        installed.into_iter().map(installed_entry_from_json).collect::<Vec<_>>();
     installed_entries.sort_by_cached_key(|entry| entry.id.to_ascii_lowercase());
 
     let mut marketplace_entries = available
@@ -151,6 +136,26 @@ fn refresh_inventory_blocking(
         marketplace: marketplace_entries,
         marketplaces: marketplace_sources,
     })
+}
+
+fn installed_entry_from_json(entry: InstalledPluginJson) -> InstalledPluginEntry {
+    let mcp_server_names = mcp_server_names_from_map(&entry.mcp_servers);
+    InstalledPluginEntry {
+        id: entry.id,
+        version: entry.version,
+        scope: entry.scope,
+        enabled: entry.enabled,
+        installed_at: entry.installed_at,
+        last_updated: entry.last_updated,
+        project_path: entry.project_path,
+        mcp_server_names,
+    }
+}
+
+fn mcp_server_names_from_map(servers: &BTreeMap<String, Value>) -> Vec<String> {
+    let mut names = servers.keys().cloned().collect::<Vec<_>>();
+    names.sort_by_key(|name| name.to_ascii_lowercase());
+    names
 }
 
 #[cfg(test)]
@@ -200,22 +205,9 @@ mod tests {
 "#;
 
         let parsed = serde_json::from_str::<Vec<InstalledPluginJson>>(json).expect("parse json");
-        let entry = InstalledPluginEntry {
-            id: parsed[0].id.clone(),
-            version: parsed[0].version.clone(),
-            scope: parsed[0].scope.clone(),
-            enabled: parsed[0].enabled,
-            installed_at: parsed[0].installed_at.clone(),
-            last_updated: parsed[0].last_updated.clone(),
-            project_path: parsed[0].project_path.clone(),
-            capability: if parsed[0].mcp_servers.is_some() {
-                PluginCapability::Mcp
-            } else {
-                PluginCapability::Skill
-            },
-        };
+        let entry = installed_entry_from_json(parsed.into_iter().next().expect("entry"));
 
-        assert_eq!(entry.capability, PluginCapability::Mcp);
+        assert_eq!(entry.mcp_server_names, vec!["supabase"]);
     }
 
     #[test]

--- a/src/app/plugins/mod.rs
+++ b/src/app/plugins/mod.rs
@@ -53,22 +53,6 @@ impl PluginsViewTab {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PluginCapability {
-    Skill,
-    Mcp,
-}
-
-impl PluginCapability {
-    #[must_use]
-    pub const fn label(self) -> &'static str {
-        match self {
-            Self::Skill => "SKILL",
-            Self::Mcp => "MCP",
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstalledPluginEntry {
     pub id: String,
@@ -78,7 +62,7 @@ pub struct InstalledPluginEntry {
     pub installed_at: Option<String>,
     pub last_updated: Option<String>,
     pub project_path: Option<String>,
-    pub capability: PluginCapability,
+    pub mcp_server_names: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -347,6 +331,7 @@ pub(crate) fn apply_inventory_refresh_success(
     app.plugins.last_inventory_refresh_at = Some(Instant::now());
     app.plugins.claude_path = Some(claude_path);
     clamp_selection(app);
+    crate::app::config::reconcile_stale_plugin_mcp_servers(app);
     if should_reload_runtime {
         start_runtime_reload(app, "Plugin inventory refreshed".to_owned());
     } else {
@@ -515,11 +500,14 @@ fn open_marketplace_overlay(app: &mut App) -> bool {
 }
 
 fn open_installed_actions_overlay(app: &mut App) -> bool {
-    let selected = selected_installed_entry(app).cloned();
-    let Some(entry) = selected else {
+    let Some(entry) = selected_installed_entry(app).cloned() else {
         return false;
     };
+    open_installed_actions_overlay_for_entry(app, entry);
+    true
+}
 
+fn open_installed_actions_overlay_for_entry(app: &mut App, entry: InstalledPluginEntry) {
     let title = display_label(&entry.id);
     let description = installed_overlay_description(app, &entry);
     let actions = installed_overlay_actions(&entry);
@@ -534,7 +522,6 @@ fn open_installed_actions_overlay(app: &mut App) -> bool {
             actions,
         },
     ));
-    true
 }
 
 fn open_plugin_install_overlay(app: &mut App) -> bool {
@@ -952,6 +939,7 @@ pub(crate) fn apply_cli_action_success(app: &mut App, result: PluginsCliActionSu
     app.plugins.last_inventory_refresh_at = Some(Instant::now());
     app.plugins.claude_path = Some(result.claude_path);
     clamp_selection(app);
+    crate::app::config::reconcile_stale_plugin_mcp_servers(app);
     start_runtime_reload(app, result.message);
 }
 
@@ -1061,20 +1049,27 @@ fn installed_action_success_message(
     title: &str,
     scope: &str,
 ) -> String {
-    match action {
+    let message = match action {
         InstalledPluginActionKind::Enable => format!("Enabled {title} in {scope} scope"),
         InstalledPluginActionKind::Disable => format!("Disabled {title} in {scope} scope"),
         InstalledPluginActionKind::Update => format!("Updated {title} in {scope} scope"),
         InstalledPluginActionKind::Uninstall => format!("Uninstalled {title} from {scope} scope"),
-    }
+    };
+    with_new_session_hint(message)
 }
 
 fn plugin_install_success_message(action: PluginInstallActionKind, title: &str) -> String {
-    match action {
+    let message = match action {
         PluginInstallActionKind::User => format!("Installed {title} for user scope"),
         PluginInstallActionKind::Project => format!("Installed {title} for project scope"),
         PluginInstallActionKind::Local => format!("Installed {title} locally"),
-    }
+    };
+    with_new_session_hint(message)
+}
+
+fn with_new_session_hint(mut message: String) -> String {
+    message.push_str(". You might need to run /new-session to apply plugin changes.");
+    message
 }
 
 fn marketplace_action_command(
@@ -1149,6 +1144,83 @@ fn installed_overlay_description(app: &App, entry: &InstalledPluginEntry) -> Str
 
 fn selected_installed_entry(app: &App) -> Option<&InstalledPluginEntry> {
     ordered_installed(&app.plugins, &app.cwd_raw).get(app.plugins.installed_selected_index).copied()
+}
+
+pub(crate) fn open_installed_actions_overlay_for_mcp_server(
+    app: &mut App,
+    server_name: &str,
+) -> bool {
+    let Some(entry) = installed_mcp_plugin_for_runtime_server(app, server_name).cloned() else {
+        return false;
+    };
+    open_installed_actions_overlay_for_entry(app, entry);
+    true
+}
+
+pub(crate) fn installed_mcp_plugin_for_runtime_server<'a>(
+    app: &'a App,
+    server_name: &str,
+) -> Option<&'a InstalledPluginEntry> {
+    let runtime_name = parse_plugin_mcp_runtime_server_name(server_name)?;
+    app.plugins
+        .installed
+        .iter()
+        .filter(|entry| installed_entry_applies_to_project(entry, &app.cwd_raw))
+        .filter(|entry| {
+            entry
+                .mcp_server_names
+                .iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(runtime_name.mcp_server_name))
+        })
+        .find(|entry| plugin_entry_matches_runtime_name(entry, runtime_name.plugin_name))
+}
+
+pub(crate) fn is_stale_plugin_mcp_runtime_server(app: &App, server_name: &str) -> bool {
+    is_plugin_mcp_runtime_server_name(server_name)
+        && app.plugins.last_inventory_refresh_at.is_some()
+        && installed_mcp_plugin_for_runtime_server(app, server_name).is_none()
+}
+
+pub(crate) fn is_plugin_mcp_runtime_server_name(server_name: &str) -> bool {
+    parse_plugin_mcp_runtime_server_name(server_name).is_some()
+}
+
+struct PluginMcpRuntimeServerName<'a> {
+    plugin_name: &'a str,
+    mcp_server_name: &'a str,
+}
+
+fn parse_plugin_mcp_runtime_server_name(
+    server_name: &str,
+) -> Option<PluginMcpRuntimeServerName<'_>> {
+    let (prefix, rest) = server_name.split_once(':')?;
+    if !prefix.eq_ignore_ascii_case("plugin") {
+        return None;
+    }
+    let (plugin_name, mcp_server_name) = rest.split_once(':')?;
+    if plugin_name.trim().is_empty() || mcp_server_name.trim().is_empty() {
+        return None;
+    }
+    Some(PluginMcpRuntimeServerName { plugin_name, mcp_server_name })
+}
+
+fn plugin_entry_matches_runtime_name(
+    entry: &InstalledPluginEntry,
+    runtime_plugin_name: &str,
+) -> bool {
+    let runtime = normalize_plugin_runtime_identifier(runtime_plugin_name);
+    let id_base = entry.id.split('@').next().unwrap_or(entry.id.as_str());
+    [
+        normalize_plugin_runtime_identifier(id_base),
+        normalize_plugin_runtime_identifier(&display_label(id_base)),
+        normalize_plugin_runtime_identifier(&entry.id),
+    ]
+    .into_iter()
+    .any(|candidate| !candidate.is_empty() && candidate == runtime)
+}
+
+fn normalize_plugin_runtime_identifier(value: &str) -> String {
+    value.chars().filter(char::is_ascii_alphanumeric).map(|ch| ch.to_ascii_lowercase()).collect()
 }
 
 fn selected_marketplace_plugin(app: &App) -> Option<&MarketplaceEntry> {
@@ -1311,6 +1383,14 @@ fn is_visible_installed_entry(entry: &InstalledPluginEntry, current_project: &st
     }
 }
 
+fn installed_entry_applies_to_project(
+    entry: &InstalledPluginEntry,
+    current_project_raw: &str,
+) -> bool {
+    let current_project = normalize_project_path(current_project_raw);
+    is_visible_installed_entry(entry, &current_project)
+}
+
 fn marketplace_plugin_matches(entry: &MarketplaceEntry, query: &str) -> bool {
     if query.is_empty() {
         return true;
@@ -1353,18 +1433,32 @@ mod tests {
         (app, rx)
     }
 
+    fn installed_plugin_entry(
+        id: &str,
+        scope: &str,
+        project_path: Option<&str>,
+        mcp_server_names: &[&str],
+    ) -> InstalledPluginEntry {
+        InstalledPluginEntry {
+            id: id.to_owned(),
+            version: Some("1.0.0".to_owned()),
+            scope: scope.to_owned(),
+            enabled: true,
+            installed_at: None,
+            last_updated: None,
+            project_path: project_path.map(ToOwned::to_owned),
+            mcp_server_names: mcp_server_names.iter().map(|name| (*name).to_owned()).collect(),
+        }
+    }
+
     fn sample_snapshot() -> PluginsInventorySnapshot {
         PluginsInventorySnapshot {
-            installed: vec![InstalledPluginEntry {
-                id: "frontend-design@claude-plugins-official".to_owned(),
-                version: Some("1.0.0".to_owned()),
-                scope: "user".to_owned(),
-                enabled: true,
-                installed_at: None,
-                last_updated: None,
-                project_path: None,
-                capability: PluginCapability::Skill,
-            }],
+            installed: vec![installed_plugin_entry(
+                "frontend-design@claude-plugins-official",
+                "user",
+                None,
+                &[],
+            )],
             marketplace: vec![],
             marketplaces: vec![],
         }
@@ -1394,6 +1488,22 @@ mod tests {
             "Frontend Design From Claude Plugins Official"
         );
         assert_eq!(display_label("claude-plugins-official"), "Claude Plugins Official");
+    }
+
+    #[test]
+    fn plugin_success_messages_hint_new_session() {
+        assert_eq!(
+            plugin_install_success_message(PluginInstallActionKind::User, "Notion"),
+            "Installed Notion for user scope. You might need to run /new-session to apply plugin changes."
+        );
+        assert_eq!(
+            installed_action_success_message(
+                InstalledPluginActionKind::Uninstall,
+                "Notion",
+                "user",
+            ),
+            "Uninstalled Notion from user scope. You might need to run /new-session to apply plugin changes."
+        );
     }
 
     #[test]
@@ -1431,46 +1541,25 @@ mod tests {
     fn ordered_installed_keeps_only_user_and_current_project_entries() {
         let state = PluginsState {
             installed: vec![
-                InstalledPluginEntry {
-                    id: "other-local@claude-plugins-official".to_owned(),
-                    version: None,
-                    scope: "local".to_owned(),
-                    enabled: true,
-                    installed_at: None,
-                    last_updated: None,
-                    project_path: Some("C:\\work\\project-a".to_owned()),
-                    capability: PluginCapability::Skill,
-                },
-                InstalledPluginEntry {
-                    id: "user-plugin@claude-plugins-official".to_owned(),
-                    version: None,
-                    scope: "user".to_owned(),
-                    enabled: true,
-                    installed_at: None,
-                    last_updated: None,
-                    project_path: None,
-                    capability: PluginCapability::Skill,
-                },
-                InstalledPluginEntry {
-                    id: "current-local@claude-plugins-official".to_owned(),
-                    version: None,
-                    scope: "local".to_owned(),
-                    enabled: true,
-                    installed_at: None,
-                    last_updated: None,
-                    project_path: Some("C:\\work\\project-b".to_owned()),
-                    capability: PluginCapability::Skill,
-                },
-                InstalledPluginEntry {
-                    id: "managed-plugin@claude-plugins-official".to_owned(),
-                    version: None,
-                    scope: "managed".to_owned(),
-                    enabled: true,
-                    installed_at: None,
-                    last_updated: None,
-                    project_path: None,
-                    capability: PluginCapability::Mcp,
-                },
+                installed_plugin_entry(
+                    "other-local@claude-plugins-official",
+                    "local",
+                    Some("C:\\work\\project-a"),
+                    &[],
+                ),
+                installed_plugin_entry("user-plugin@claude-plugins-official", "user", None, &[]),
+                installed_plugin_entry(
+                    "current-local@claude-plugins-official",
+                    "local",
+                    Some("C:\\work\\project-b"),
+                    &[],
+                ),
+                installed_plugin_entry(
+                    "managed-plugin@claude-plugins-official",
+                    "managed",
+                    None,
+                    &["managed"],
+                ),
             ],
             ..PluginsState::default()
         };
@@ -1530,6 +1619,57 @@ mod tests {
             app.plugins.pending_runtime_reload_success_message.as_deref(),
             Some("Updated plugin")
         );
+    }
+
+    #[test]
+    fn cli_action_success_reconciles_stale_plugin_mcp_servers() {
+        let (mut app, mut rx) = app_with_connection();
+        app.mcp.servers = vec![
+            model::McpServerStatus {
+                name: "plugin:Notion:notion".to_owned(),
+                status: model::McpServerConnectionStatus::Connected,
+                server_info: None,
+                error: None,
+                config: None,
+                scope: Some("dynamic".to_owned()),
+                tools: Vec::new(),
+            },
+            model::McpServerStatus {
+                name: "fff".to_owned(),
+                status: model::McpServerConnectionStatus::Connected,
+                server_info: None,
+                error: None,
+                config: None,
+                scope: Some("user".to_owned()),
+                tools: Vec::new(),
+            },
+        ];
+        app.config.overlay = Some(crate::app::config::ConfigOverlayState::McpDetails(
+            crate::app::config::McpDetailsOverlayState {
+                server_name: "plugin:Notion:notion".to_owned(),
+                selected_index: 0,
+            },
+        ));
+
+        apply_cli_action_success(
+            &mut app,
+            PluginsCliActionSuccess {
+                snapshot: sample_snapshot(),
+                message: "Uninstalled plugin".to_owned(),
+                claude_path: std::path::PathBuf::from("C:\\tools\\claude.exe"),
+            },
+        );
+
+        let envelope = rx.try_recv().expect("reload command");
+        assert!(matches!(
+            envelope.command,
+            BridgeCommand::ReloadPlugins { session_id } if session_id == "session-1"
+        ));
+        assert_eq!(
+            app.mcp.servers.iter().map(|server| server.name.as_str()).collect::<Vec<_>>(),
+            vec!["fff"]
+        );
+        assert!(app.config.overlay.is_none());
     }
 
     #[test]

--- a/src/app/questions.rs
+++ b/src/app/questions.rs
@@ -509,6 +509,7 @@ mod tests {
     fn test_tool_call(id: &str) -> ToolCallInfo {
         ToolCallInfo {
             id: id.to_owned(),
+            source_message_uuids: Vec::new(),
             title: format!("Tool {id}"),
             sdk_tool_name: "AskUserQuestion".to_owned(),
             raw_input: None,

--- a/src/app/state/history_retention.rs
+++ b/src/app/state/history_retention.rs
@@ -312,7 +312,7 @@ impl super::App {
         *old_bytes = new_bytes;
     }
 
-    pub(super) fn rebuild_tool_indices_and_terminal_refs(&mut self) {
+    pub(crate) fn rebuild_tool_indices_and_terminal_refs(&mut self) {
         self.tool_call_index.clear();
         self.clear_terminal_tool_call_tracking();
         self.active_task_ids.clear();

--- a/src/app/state/history_retention.rs
+++ b/src/app/state/history_retention.rs
@@ -56,17 +56,17 @@ impl super::App {
         if matches!(msg.role, MessageRole::Welcome) {
             return true;
         }
-        msg.blocks.iter().any(|block| {
-            if let MessageBlock::ToolCall(tc) = block {
+        msg.blocks.iter().any(|block| match block {
+            MessageBlock::ToolCall(tc) => {
                 tc.pending_permission.is_some()
                     || tc.pending_question.is_some()
                     || matches!(
                         tc.status,
                         model::ToolCallStatus::Pending | model::ToolCallStatus::InProgress
                     )
-            } else {
-                false
             }
+            MessageBlock::UserDialog(dialog) => !dialog.answered,
+            _ => false,
         })
     }
 
@@ -198,6 +198,20 @@ impl super::App {
                     total =
                         total.saturating_add(size_of::<super::messages::ImageAttachmentBlock>());
                 }
+                MessageBlock::UserDialog(dialog) => {
+                    total = total
+                        .saturating_add(size_of::<super::messages::UserDialogBlock>())
+                        .saturating_add(dialog.request_id.capacity())
+                        .saturating_add(dialog.payload.original_model.capacity())
+                        .saturating_add(dialog.payload.fallback_model.capacity())
+                        .saturating_add(
+                            dialog
+                                .options
+                                .iter()
+                                .map(|option| option.option_id.capacity() + option.label.capacity())
+                                .sum::<usize>(),
+                        );
+                }
             }
         }
         total
@@ -322,24 +336,35 @@ impl super::App {
         let mut terminal_tool_calls = Vec::new();
         for (msg_idx, msg) in self.messages.iter_mut().enumerate() {
             for (block_idx, block) in msg.blocks.iter_mut().enumerate() {
-                if let MessageBlock::ToolCall(tc) = block {
-                    let tc = tc.as_mut();
-                    self.tool_call_index.insert(tc.id.clone(), (msg_idx, block_idx));
-                    if let Some(terminal_id) = Self::tracked_terminal_id_for_tool(tc) {
-                        let entry =
-                            super::TerminalToolCallRef::new(terminal_id, msg_idx, block_idx);
-                        if terminal_tool_call_membership.insert(entry.clone()) {
-                            terminal_tool_calls.push(entry);
+                match block {
+                    MessageBlock::ToolCall(tc) => {
+                        let tc = tc.as_mut();
+                        self.tool_call_index.insert(tc.id.clone(), (msg_idx, block_idx));
+                        if let Some(terminal_id) = Self::tracked_terminal_id_for_tool(tc) {
+                            let entry =
+                                super::TerminalToolCallRef::new(terminal_id, msg_idx, block_idx);
+                            if terminal_tool_call_membership.insert(entry.clone()) {
+                                terminal_tool_calls.push(entry);
+                            }
+                        }
+                        if let Some(permission) = tc.pending_permission.as_mut() {
+                            permission.focused = false;
+                            pending_interaction_ids.push(tc.id.clone());
+                        }
+                        if let Some(question) = tc.pending_question.as_mut() {
+                            question.focused = false;
+                            pending_interaction_ids.push(tc.id.clone());
                         }
                     }
-                    if let Some(permission) = tc.pending_permission.as_mut() {
-                        permission.focused = false;
-                        pending_interaction_ids.push(tc.id.clone());
+                    MessageBlock::UserDialog(dialog) => {
+                        self.tool_call_index
+                            .insert(dialog.request_id.clone(), (msg_idx, block_idx));
+                        if !dialog.answered {
+                            dialog.focused = false;
+                            pending_interaction_ids.push(dialog.request_id.clone());
+                        }
                     }
-                    if let Some(question) = tc.pending_question.as_mut() {
-                        question.focused = false;
-                        pending_interaction_ids.push(tc.id.clone());
-                    }
+                    _ => {}
                 }
             }
         }
@@ -382,14 +407,22 @@ impl super::App {
         if let Some(first_id) = self.pending_interaction_ids.first().cloned() {
             self.claim_focus_target(super::super::focus::FocusTarget::Permission);
             if let Some((msg_idx, block_idx)) = self.lookup_tool_call(&first_id)
-                && let Some(MessageBlock::ToolCall(tc)) =
+                && let Some(block) =
                     self.messages.get_mut(msg_idx).and_then(|m| m.blocks.get_mut(block_idx))
             {
-                if let Some(permission) = tc.pending_permission.as_mut() {
-                    permission.focused = true;
-                }
-                if let Some(question) = tc.pending_question.as_mut() {
-                    question.focused = true;
+                match block {
+                    MessageBlock::ToolCall(tc) => {
+                        if let Some(permission) = tc.pending_permission.as_mut() {
+                            permission.focused = true;
+                        }
+                        if let Some(question) = tc.pending_question.as_mut() {
+                            question.focused = true;
+                        }
+                    }
+                    MessageBlock::UserDialog(dialog) if !dialog.answered => {
+                        dialog.focused = true;
+                    }
+                    _ => {}
                 }
             }
         } else {

--- a/src/app/state/messages.rs
+++ b/src/app/state/messages.rs
@@ -4,6 +4,7 @@
 use super::block_cache::BlockCache;
 use super::tool_call_info::ToolCallInfo;
 use super::types::MessageUsage;
+use crate::agent::model;
 use ratatui::style::Color;
 use ratatui::text::Line;
 use std::collections::hash_map::DefaultHasher;
@@ -445,6 +446,47 @@ pub enum MessageBlock {
     Welcome(WelcomeBlock),
     /// Indicates N images were attached to this user message.
     ImageAttachment(ImageAttachmentBlock),
+    /// Turn-level user dialog (e.g. `refusal_fallback_prompt`) rendered inline as
+    /// a selectable chooser. Not anchored to a tool call.
+    UserDialog(UserDialogBlock),
+}
+
+/// Inline chooser for a turn-level `request_user_dialog`. Carries the oneshot
+/// responder back to the bridge; `response_tx` is taken once the user answers.
+pub struct UserDialogBlock {
+    pub id: MessageBlockId,
+    pub request_id: String,
+    pub payload: model::RefusalFallbackPayload,
+    pub options: Vec<model::UserDialogOption>,
+    pub selected_index: usize,
+    /// Whether this dialog currently has keyboard focus (shows the selection
+    /// arrow and accepts navigation/confirm input).
+    pub focused: bool,
+    /// Set once the user has answered; the block then renders as resolved and is
+    /// removed from the focus queue.
+    pub answered: bool,
+    pub response_tx: Option<tokio::sync::oneshot::Sender<model::RequestUserDialogResponse>>,
+    pub cache: BlockCache,
+}
+
+impl UserDialogBlock {
+    #[must_use]
+    pub fn new(
+        request: model::RequestUserDialogRequest,
+        response_tx: tokio::sync::oneshot::Sender<model::RequestUserDialogResponse>,
+    ) -> Self {
+        Self {
+            id: MessageBlockId::new(),
+            request_id: request.request_id,
+            payload: request.payload,
+            options: request.options,
+            selected_index: 0,
+            focused: false,
+            answered: false,
+            response_tx: Some(response_tx),
+            cache: BlockCache::default(),
+        }
+    }
 }
 
 /// Lightweight block for image attachment indicators. Carries a [`BlockCache`]

--- a/src/app/state/messages.rs
+++ b/src/app/state/messages.rs
@@ -310,6 +310,7 @@ impl TextBlockSpacing {
 
 pub struct TextBlock {
     pub id: MessageBlockId,
+    pub source_message_uuids: Vec<String>,
     pub text: String,
     pub cache: BlockCache,
     pub markdown: IncrementalMarkdown,
@@ -332,6 +333,7 @@ impl TextBlock {
     pub fn new_with_id(id: MessageBlockId, text: String) -> Self {
         Self {
             id,
+            source_message_uuids: Vec::new(),
             markdown: IncrementalMarkdown::from_complete(&text),
             text,
             cache: BlockCache::default(),
@@ -342,6 +344,38 @@ impl TextBlock {
     #[must_use]
     pub fn from_complete(text: &str) -> Self {
         Self::new(text.to_owned())
+    }
+
+    #[must_use]
+    pub fn with_source_message_uuid(mut self, source_message_uuid: Option<&str>) -> Self {
+        self.add_source_message_uuid(source_message_uuid);
+        self
+    }
+
+    #[must_use]
+    pub fn with_source_message_uuids(mut self, source_message_uuids: Vec<String>) -> Self {
+        for source_message_uuid in source_message_uuids {
+            self.add_source_message_uuid(Some(&source_message_uuid));
+        }
+        self
+    }
+
+    pub fn add_source_message_uuid(&mut self, source_message_uuid: Option<&str>) -> bool {
+        let Some(source_message_uuid) =
+            source_message_uuid.map(str::trim).filter(|uuid| !uuid.is_empty())
+        else {
+            return false;
+        };
+        if self.source_message_uuids.iter().any(|uuid| uuid == source_message_uuid) {
+            return false;
+        }
+        self.source_message_uuids.push(source_message_uuid.to_owned());
+        true
+    }
+
+    #[must_use]
+    pub fn has_source_message_uuid(&self, source_message_uuid: &str) -> bool {
+        self.source_message_uuids.iter().any(|uuid| uuid == source_message_uuid)
     }
 
     #[must_use]

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -1569,6 +1569,7 @@ mod tests {
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(ToolCallInfo {
                 id: id.to_owned(),
+                source_message_uuids: Vec::new(),
                 title: format!("tool {id}"),
                 sdk_tool_name: "Read".to_owned(),
                 raw_input: None,
@@ -1601,6 +1602,7 @@ mod tests {
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(ToolCallInfo {
                 id: id.to_owned(),
+                source_message_uuids: Vec::new(),
                 title: format!("tool {id}"),
                 sdk_tool_name: "Bash".to_owned(),
                 raw_input: None,
@@ -1630,6 +1632,7 @@ mod tests {
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(ToolCallInfo {
                 id: id.to_owned(),
+                source_message_uuids: Vec::new(),
                 title: format!("tool {id}"),
                 sdk_tool_name: "Read".to_owned(),
                 raw_input: None,

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -20,8 +20,8 @@ pub(crate) use messages::MarkdownRenderKey;
 pub use messages::{
     ChatMessage, ChatMessageId, HistoryOutputId, ImageAttachmentBlock, IncrementalMarkdown,
     MessageBlock, MessageBlockId, MessageRole, NoticeBlock, NoticeDedupKey, RateLimitIncidentKey,
-    SystemSeverity, TextBlock, TextBlockSpacing, WelcomeBlock, hash_text_block_content,
-    hash_welcome_block_content,
+    SystemSeverity, TextBlock, TextBlockSpacing, UserDialogBlock, WelcomeBlock,
+    hash_text_block_content, hash_welcome_block_content,
 };
 pub use tool_call_info::{
     InlinePermission, InlineQuestion, TerminalSnapshotMode, ToolCallInfo, is_execute_tool_name,
@@ -1666,6 +1666,37 @@ mod tests {
         )
     }
 
+    fn pending_user_dialog_message(request_id: &str) -> ChatMessage {
+        let (tx, _rx) = tokio::sync::oneshot::channel();
+        ChatMessage::new(
+            MessageRole::System(Some(SystemSeverity::Warning)),
+            vec![MessageBlock::UserDialog(UserDialogBlock::new(
+                model::RequestUserDialogRequest::new(
+                    "session-1",
+                    request_id,
+                    "refusal_fallback_prompt",
+                    model::RefusalFallbackPayload {
+                        original_model: "claude-opus-4-8".to_owned(),
+                        fallback_model: "claude-sonnet-4-6".to_owned(),
+                        ..Default::default()
+                    },
+                    vec![
+                        model::UserDialogOption::new(
+                            "retry_fallback",
+                            "Switch to claude-sonnet-4-6",
+                        ),
+                        model::UserDialogOption::new(
+                            "edit_prompt",
+                            "Edit prompt and retry with claude-opus-4-8",
+                        ),
+                    ],
+                ),
+                tx,
+            ))],
+            None,
+        )
+    }
+
     #[test]
     fn enforce_render_cache_budget_evicts_lru_block() {
         let mut app = make_test_app();
@@ -1982,6 +2013,35 @@ mod tests {
                 .iter()
                 .any(|block| matches!(block, MessageBlock::ToolCall(tc) if tc.id == "tool-perm"))
         }));
+    }
+
+    #[test]
+    fn enforce_history_retention_preserves_and_rebuilds_pending_user_dialog() {
+        let mut app = make_test_app();
+        app.messages = vec![
+            ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
+            user_text_message("droppable"),
+            pending_user_dialog_message("dialog-1"),
+        ];
+        app.index_tool_call("dialog-1".to_owned(), 99, 99);
+        app.pending_interaction_ids = vec!["stale-dialog".to_owned(), "dialog-1".to_owned()];
+        app.history_retention.max_bytes = 1;
+
+        let stats = app.enforce_history_retention();
+
+        assert_eq!(stats.dropped_messages, 1);
+        assert_eq!(app.lookup_tool_call("dialog-1"), Some((2, 0)));
+        assert_eq!(app.pending_interaction_ids, vec!["dialog-1".to_owned()]);
+        let Some((msg_idx, block_idx)) = app.lookup_tool_call("dialog-1") else {
+            panic!("expected rebuilt dialog index");
+        };
+        let Some(MessageBlock::UserDialog(dialog)) =
+            app.messages.get(msg_idx).and_then(|msg| msg.blocks.get(block_idx))
+        else {
+            panic!("expected user dialog block");
+        };
+        assert!(dialog.focused);
+        assert!(!dialog.answered);
     }
 
     #[test]

--- a/src/app/state/render_budget.rs
+++ b/src/app/state/render_budget.rs
@@ -48,6 +48,7 @@ impl super::App {
             MessageBlock::Welcome(welcome) => &welcome.cache,
             MessageBlock::ToolCall(tc) => &tc.cache,
             MessageBlock::ImageAttachment(img) => &img.cache,
+            MessageBlock::UserDialog(dialog) => &dialog.cache,
         }
     }
 
@@ -316,6 +317,7 @@ impl super::App {
             MessageBlock::Welcome(welcome) => welcome.cache.evict_cached_render(),
             MessageBlock::ToolCall(tc) => tc.cache.evict_cached_render(),
             MessageBlock::ImageAttachment(img) => img.cache.evict_cached_render(),
+            MessageBlock::UserDialog(dialog) => dialog.cache.evict_cached_render(),
         };
         if removed > 0 {
             self.sync_render_cache_slot(msg_idx, block_idx);

--- a/src/app/state/tool_call_info.rs
+++ b/src/app/state/tool_call_info.rs
@@ -6,6 +6,7 @@ use crate::agent::model;
 
 pub struct ToolCallInfo {
     pub id: String,
+    pub source_message_uuids: Vec<String>,
     pub title: String,
     /// The SDK tool name from `meta.claudeCode.toolName` when available.
     /// Falls back to a derived name when metadata is absent.
@@ -46,6 +47,24 @@ pub enum TerminalSnapshotMode {
 }
 
 impl ToolCallInfo {
+    pub fn add_source_message_uuid(&mut self, source_message_uuid: Option<&str>) -> bool {
+        let Some(source_message_uuid) =
+            source_message_uuid.map(str::trim).filter(|uuid| !uuid.is_empty())
+        else {
+            return false;
+        };
+        if self.source_message_uuids.iter().any(|uuid| uuid == source_message_uuid) {
+            return false;
+        }
+        self.source_message_uuids.push(source_message_uuid.to_owned());
+        true
+    }
+
+    #[must_use]
+    pub fn has_source_message_uuid(&self, source_message_uuid: &str) -> bool {
+        self.source_message_uuids.iter().any(|uuid| uuid == source_message_uuid)
+    }
+
     pub(crate) fn estimate_json_value_bytes(value: &serde_json::Value) -> usize {
         serde_json::to_string(value).map_or(0, |json| json.len())
     }

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -141,6 +141,9 @@ pub struct McpState {
     pub servers: Vec<model::McpServerStatus>,
     pub in_flight: bool,
     pub last_error: Option<String>,
+    pub claude_path: Option<std::path::PathBuf>,
+    pub removed_config_servers: std::collections::BTreeSet<(String, String)>,
+    pub pending_dynamic_config_removal: Option<String>,
     pub pending_elicitation: Option<crate::agent::types::ElicitationRequest>,
 }
 

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -142,9 +142,28 @@ pub struct McpState {
     pub in_flight: bool,
     pub last_error: Option<String>,
     pub claude_path: Option<std::path::PathBuf>,
-    pub removed_config_servers: std::collections::BTreeSet<(String, String)>,
+    pub removed_config_servers:
+        std::collections::BTreeMap<RemovedMcpServerKey, RemovedMcpServerGuard>,
     pub pending_dynamic_config_removal: Option<String>,
     pub pending_elicitation: Option<crate::agent::types::ElicitationRequest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RemovedMcpServerKey {
+    pub scope: String,
+    pub server_name: String,
+}
+
+impl RemovedMcpServerKey {
+    #[must_use]
+    pub fn new(scope: String, server_name: String) -> Self {
+        Self { scope, server_name }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemovedMcpServerGuard {
+    pub expected_source: crate::agent::types::McpSnapshotSource,
 }
 
 pub const DEFAULT_RENDER_CACHE_BUDGET_BYTES: usize = 24 * 1024 * 1024;

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -227,6 +227,7 @@ mod tests {
     ) -> ToolCallInfo {
         ToolCallInfo {
             id: id.to_owned(),
+            source_message_uuids: Vec::new(),
             title: title.to_owned(),
             sdk_tool_name: sdk_tool_name.to_owned(),
             raw_input: Some(raw_input),

--- a/src/app/terminal.rs
+++ b/src/app/terminal.rs
@@ -159,6 +159,7 @@ mod tests {
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(ToolCallInfo {
                 id: id.to_owned(),
+                source_message_uuids: Vec::new(),
                 title: format!("tool {id}"),
                 sdk_tool_name: "Bash".to_owned(),
                 raw_input: None,

--- a/src/app/user_dialog.rs
+++ b/src/app/user_dialog.rs
@@ -1,0 +1,313 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+//! Key handling for the inline turn-level user dialog (`refusal_fallback_prompt`).
+//!
+//! Mirrors [`super::permissions::execute_permission_action`] but drives a
+//! standalone [`MessageBlock::UserDialog`] block rather than an interaction
+//! anchored on a tool call. Vertical navigation moves the selection within the
+//! dialog's options; `Confirm` sends the chosen option, `Cancel` declines.
+
+use super::inline_interactions::{
+    clear_inline_interaction_focus, focus_next_inline_interaction, focused_interaction_id,
+    has_focused_user_dialog, pop_next_valid_interaction_id,
+};
+use super::{App, InvalidationLevel, MessageBlock, MessageRole};
+use crate::agent::model;
+use crate::app::keymap::InteractionAction;
+use crate::app::keys::KeyOutcome;
+use crossterm::event::KeyEvent;
+
+const EDIT_PROMPT_OPTION_ID: &str = "edit_prompt";
+
+pub(super) fn execute_user_dialog_action(
+    app: &mut App,
+    action: InteractionAction,
+    _key: KeyEvent,
+) -> KeyOutcome {
+    if !has_focused_user_dialog(app) {
+        return KeyOutcome::Ignored;
+    }
+
+    match action {
+        InteractionAction::MovePrevious => {
+            move_dialog_selection(app, -1);
+            KeyOutcome::Handled(true)
+        }
+        InteractionAction::MoveNext => {
+            move_dialog_selection(app, 1);
+            KeyOutcome::Handled(true)
+        }
+        InteractionAction::Confirm => {
+            respond_dialog(app, DialogResolution::Selected);
+            KeyOutcome::Handled(true)
+        }
+        InteractionAction::Cancel => {
+            respond_dialog(app, DialogResolution::Cancelled);
+            KeyOutcome::Handled(true)
+        }
+        InteractionAction::FocusNext => {
+            clear_inline_interaction_focus(app);
+            KeyOutcome::Handled(true)
+        }
+        InteractionAction::MoveStart
+        | InteractionAction::MoveEnd
+        | InteractionAction::ToggleSelection
+        | InteractionAction::ToggleNotes => KeyOutcome::Ignored,
+    }
+}
+
+fn focused_dialog_slot(app: &App) -> Option<(usize, usize)> {
+    let tool_id = focused_interaction_id(app)?;
+    app.tool_call_index.get(tool_id).copied()
+}
+
+fn move_dialog_selection(app: &mut App, delta: i32) {
+    let Some((mi, bi)) = focused_dialog_slot(app) else {
+        return;
+    };
+    let mut changed = false;
+    if let Some(MessageBlock::UserDialog(dialog)) =
+        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+    {
+        if dialog.options.is_empty() {
+            return;
+        }
+        let max = dialog.options.len() - 1;
+        let next = if delta < 0 {
+            dialog.selected_index.saturating_sub(1)
+        } else {
+            (dialog.selected_index + 1).min(max)
+        };
+        if next != dialog.selected_index {
+            dialog.selected_index = next;
+            dialog.cache.invalidate();
+            changed = true;
+        }
+    }
+    if changed {
+        app.sync_render_cache_slot(mi, bi);
+        app.recompute_message_retained_bytes(mi);
+        app.invalidate_layout(InvalidationLevel::MessageChanged(mi));
+        app.request_chat_mutable_rebuild();
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DialogResolution {
+    Selected,
+    Cancelled,
+}
+
+fn respond_dialog(app: &mut App, resolution: DialogResolution) {
+    let Some(tool_id) = pop_next_valid_interaction_id(app) else {
+        return;
+    };
+    let Some((mi, bi)) = app.tool_call_index.get(&tool_id).copied() else {
+        return;
+    };
+    let Some(MessageBlock::UserDialog(dialog)) =
+        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+    else {
+        return;
+    };
+
+    let mut repopulate_composer = false;
+    if let Some(response_tx) = dialog.response_tx.take() {
+        let selected_option_id = match resolution {
+            DialogResolution::Selected => {
+                dialog.options.get(dialog.selected_index).map(|option| option.option_id.clone())
+            }
+            DialogResolution::Cancelled => None,
+        };
+        let outcome = if let Some(option_id) = selected_option_id {
+            repopulate_composer = option_id == EDIT_PROMPT_OPTION_ID;
+            tracing::info!(
+                target: crate::logging::targets::APP_PERMISSION,
+                event_name = "user_dialog_response_applied",
+                message = "user dialog response applied",
+                outcome = "success",
+                request_id = %dialog.request_id,
+                option_id = %option_id,
+            );
+            model::RequestUserDialogOutcome::Selected(model::SelectedUserDialogOutcome::new(
+                option_id,
+            ))
+        } else {
+            tracing::info!(
+                target: crate::logging::targets::APP_PERMISSION,
+                event_name = "user_dialog_response_applied",
+                message = "user dialog declined",
+                outcome = "success",
+                request_id = %dialog.request_id,
+                option_id = "cancelled",
+            );
+            model::RequestUserDialogOutcome::Cancelled
+        };
+        let _ = response_tx.send(model::RequestUserDialogResponse::new(outcome));
+        dialog.answered = true;
+        dialog.focused = false;
+        dialog.cache.invalidate();
+        app.sync_render_cache_slot(mi, bi);
+        app.recompute_message_retained_bytes(mi);
+        app.invalidate_layout(InvalidationLevel::MessageChanged(mi));
+        app.request_chat_mutable_rebuild();
+    }
+
+    // `edit_prompt` keeps the original model but asks the user to revise their
+    // prompt. The original text is not in the payload, so reconstruct it from
+    // the local message store (best-effort: leave the composer empty if absent).
+    if repopulate_composer {
+        repopulate_composer_from_last_user_message(app);
+    }
+
+    // Releases the Permission focus target once the queue drains, returning
+    // focus to the composer.
+    focus_next_inline_interaction(app);
+}
+
+fn repopulate_composer_from_last_user_message(app: &mut App) {
+    let last_user_text = app.messages.iter().rev().find_map(|message| {
+        if !matches!(message.role, MessageRole::User) {
+            return None;
+        }
+        message.blocks.iter().rev().find_map(|block| {
+            if let MessageBlock::Text(text) = block { Some(text.text.clone()) } else { None }
+        })
+    });
+    if let Some(text) = last_user_text {
+        app.input.set_text(&text);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{App, AppStatus, ChatMessage, SystemSeverity, TextBlock, UserDialogBlock};
+    use crossterm::event::{KeyCode, KeyModifiers};
+    use tokio::sync::oneshot;
+
+    fn dialog_request(request_id: &str) -> model::RequestUserDialogRequest {
+        model::RequestUserDialogRequest::new(
+            model::SessionId::new("session-1"),
+            request_id,
+            "refusal_fallback_prompt",
+            model::RefusalFallbackPayload {
+                original_model: "claude-opus-4-8".to_owned(),
+                fallback_model: "claude-sonnet-4-6".to_owned(),
+                ..Default::default()
+            },
+            vec![
+                model::UserDialogOption::new("retry_fallback", "Switch to claude-sonnet-4-6"),
+                model::UserDialogOption::new(
+                    "edit_prompt",
+                    "Edit prompt and retry with claude-opus-4-8",
+                ),
+            ],
+        )
+    }
+
+    fn add_user_dialog(
+        app: &mut App,
+        request_id: &str,
+        focused: bool,
+    ) -> oneshot::Receiver<model::RequestUserDialogResponse> {
+        let msg_idx = app.messages.len();
+        let (tx, rx) = oneshot::channel();
+        let mut block = UserDialogBlock::new(dialog_request(request_id), tx);
+        block.focused = focused;
+        app.messages.push(ChatMessage::new(
+            MessageRole::System(Some(SystemSeverity::Warning)),
+            vec![MessageBlock::UserDialog(block)],
+            None,
+        ));
+        app.index_tool_call(request_id.to_owned(), msg_idx, 0);
+        app.pending_interaction_ids.push(request_id.to_owned());
+        rx
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn confirm_sends_retry_fallback_by_default() {
+        let mut app = App::test_default();
+        app.status = AppStatus::Ready;
+        let mut rx = add_user_dialog(&mut app, "dialog-1", true);
+
+        let outcome =
+            execute_user_dialog_action(&mut app, InteractionAction::Confirm, key(KeyCode::Enter));
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+
+        let response = rx.try_recv().expect("dialog should receive a response");
+        let model::RequestUserDialogOutcome::Selected(selected) = response.outcome else {
+            panic!("expected a selected outcome");
+        };
+        assert_eq!(selected.option_id, "retry_fallback");
+        assert!(!app.pending_interaction_ids.iter().any(|id| id == "dialog-1"));
+    }
+
+    #[test]
+    fn move_next_then_confirm_sends_edit_prompt_and_repopulates_composer() {
+        let mut app = App::test_default();
+        app.status = AppStatus::Ready;
+        app.messages.push(ChatMessage::new(
+            MessageRole::User,
+            vec![MessageBlock::Text(TextBlock::from_complete("original prompt text"))],
+            None,
+        ));
+        let mut rx = add_user_dialog(&mut app, "dialog-1", true);
+
+        let outcome =
+            execute_user_dialog_action(&mut app, InteractionAction::MoveNext, key(KeyCode::Down));
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+
+        let outcome =
+            execute_user_dialog_action(&mut app, InteractionAction::Confirm, key(KeyCode::Enter));
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+
+        let response = rx.try_recv().expect("dialog should receive a response");
+        let model::RequestUserDialogOutcome::Selected(selected) = response.outcome else {
+            panic!("expected a selected outcome");
+        };
+        assert_eq!(selected.option_id, "edit_prompt");
+        assert_eq!(app.input.text(), "original prompt text");
+    }
+
+    #[test]
+    fn cancel_sends_cancelled_outcome() {
+        let mut app = App::test_default();
+        app.status = AppStatus::Ready;
+        let mut rx = add_user_dialog(&mut app, "dialog-1", true);
+
+        let outcome =
+            execute_user_dialog_action(&mut app, InteractionAction::Cancel, key(KeyCode::Esc));
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+
+        let response = rx.try_recv().expect("dialog should receive a response");
+        assert!(matches!(response.outcome, model::RequestUserDialogOutcome::Cancelled));
+        assert!(app.input.text().is_empty());
+        assert!(!app.pending_interaction_ids.iter().any(|id| id == "dialog-1"));
+    }
+
+    #[test]
+    fn move_previous_clamps_at_first_option() {
+        let mut app = App::test_default();
+        app.status = AppStatus::Ready;
+        let _rx = add_user_dialog(&mut app, "dialog-1", true);
+
+        // Already at index 0; MovePrevious must not underflow.
+        let outcome =
+            execute_user_dialog_action(&mut app, InteractionAction::MovePrevious, key(KeyCode::Up));
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+
+        let (mi, bi) = app.lookup_tool_call("dialog-1").expect("indexed dialog");
+        let Some(MessageBlock::UserDialog(dialog)) =
+            app.messages.get(mi).and_then(|m| m.blocks.get(bi))
+        else {
+            panic!("expected user dialog block");
+        };
+        assert_eq!(dialog.selected_index, 0);
+    }
+}

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -1156,6 +1156,23 @@ mod tests {
             .collect()
     }
 
+    fn installed_plugin_entry(
+        id: &str,
+        scope: &str,
+        project_path: Option<&str>,
+    ) -> crate::app::plugins::InstalledPluginEntry {
+        crate::app::plugins::InstalledPluginEntry {
+            id: id.to_owned(),
+            version: Some("1.0.0".to_owned()),
+            scope: scope.to_owned(),
+            enabled: true,
+            installed_at: None,
+            last_updated: None,
+            project_path: project_path.map(ToOwned::to_owned),
+            mcp_server_names: Vec::new(),
+        }
+    }
+
     fn render_config_text(width: u16, height: u16, mut app: App) -> String {
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).expect("terminal");
@@ -1895,16 +1912,8 @@ mod tests {
         let mut app = App::test_default();
         app.surface_mode = crate::app::SurfaceMode::Fullscreen(crate::app::FullscreenView::Config);
         app.config.active_tab = crate::app::ConfigTab::Plugins;
-        app.plugins.installed = vec![crate::app::plugins::InstalledPluginEntry {
-            id: "frontend-design@claude-plugins-official".to_owned(),
-            version: Some("1.0.0".to_owned()),
-            scope: "user".to_owned(),
-            enabled: true,
-            installed_at: None,
-            last_updated: None,
-            project_path: None,
-            capability: crate::app::plugins::PluginCapability::Skill,
-        }];
+        app.plugins.installed =
+            vec![installed_plugin_entry("frontend-design@claude-plugins-official", "user", None)];
         app.plugins.marketplace = vec![crate::app::plugins::MarketplaceEntry {
             plugin_id: "frontend-design@claude-plugins-official".to_owned(),
             name: "frontend-design".to_owned(),
@@ -1995,36 +2004,17 @@ mod tests {
         app.surface_mode = crate::app::SurfaceMode::Fullscreen(crate::app::FullscreenView::Config);
         app.config.active_tab = crate::app::ConfigTab::Plugins;
         app.plugins.installed = vec![
-            crate::app::plugins::InstalledPluginEntry {
-                id: "other-local@claude-plugins-official".to_owned(),
-                version: Some("1.0.0".to_owned()),
-                scope: "local".to_owned(),
-                enabled: true,
-                installed_at: None,
-                last_updated: None,
-                project_path: Some("C:\\work\\project-a".to_owned()),
-                capability: crate::app::plugins::PluginCapability::Skill,
-            },
-            crate::app::plugins::InstalledPluginEntry {
-                id: "user-plugin@claude-plugins-official".to_owned(),
-                version: Some("1.0.0".to_owned()),
-                scope: "user".to_owned(),
-                enabled: true,
-                installed_at: None,
-                last_updated: None,
-                project_path: None,
-                capability: crate::app::plugins::PluginCapability::Skill,
-            },
-            crate::app::plugins::InstalledPluginEntry {
-                id: "current-local@claude-plugins-official".to_owned(),
-                version: Some("1.0.0".to_owned()),
-                scope: "local".to_owned(),
-                enabled: true,
-                installed_at: None,
-                last_updated: None,
-                project_path: Some("C:\\work\\project-b".to_owned()),
-                capability: crate::app::plugins::PluginCapability::Skill,
-            },
+            installed_plugin_entry(
+                "other-local@claude-plugins-official",
+                "local",
+                Some("C:\\work\\project-a"),
+            ),
+            installed_plugin_entry("user-plugin@claude-plugins-official", "user", None),
+            installed_plugin_entry(
+                "current-local@claude-plugins-official",
+                "local",
+                Some("C:\\work\\project-b"),
+            ),
         ];
 
         terminal

--- a/src/ui/config/mcp.rs
+++ b/src/ui/config/mcp.rs
@@ -594,12 +594,19 @@ fn append_mcp_runtime_config_lines(
             Color::White,
         ));
         for tool in tools {
-            lines.push(detail_kv(
-                &format!("  {}", tool.name),
-                tool.permission_policy.label(),
-                Color::White,
-            ));
+            let policy_summary = format_mcp_tool_policy_summary(tool);
+            lines.push(detail_kv(&format!("  {}", tool.name), &policy_summary, Color::White));
         }
+    }
+}
+
+fn format_mcp_tool_policy_summary(tool: &crate::agent::model::McpServerToolPolicy) -> String {
+    let permission = tool.permission_policy.map_or("not specified", |policy| policy.label());
+    match tool.org_max_permission {
+        Some(org_max_permission) => {
+            format!("{permission}, org max {}", org_max_permission.label())
+        }
+        None => permission.to_owned(),
     }
 }
 
@@ -839,7 +846,10 @@ mod tests {
                     headers: BTreeMap::new(),
                     tools: vec![crate::agent::model::McpServerToolPolicy {
                         name: "search".to_owned(),
-                        permission_policy: crate::agent::model::McpServerToolPermissionPolicy::Ask,
+                        permission_policy: Some(
+                            crate::agent::model::McpServerToolPermissionPolicy::Ask,
+                        ),
+                        org_max_permission: None,
                     }],
                     timeout: Some(5000),
                     always_load: Some(true),
@@ -896,10 +906,20 @@ mod tests {
         let lines = config_lines(&McpServerStatusConfig::Http {
             url: "https://mcp.notion.com/mcp".to_owned(),
             headers: BTreeMap::new(),
-            tools: vec![crate::agent::model::McpServerToolPolicy {
-                name: "search".to_owned(),
-                permission_policy: crate::agent::model::McpServerToolPermissionPolicy::Deny,
-            }],
+            tools: vec![
+                crate::agent::model::McpServerToolPolicy {
+                    name: "search".to_owned(),
+                    permission_policy: Some(
+                        crate::agent::model::McpServerToolPermissionPolicy::Deny,
+                    ),
+                    org_max_permission: None,
+                },
+                crate::agent::model::McpServerToolPolicy {
+                    name: "lookup".to_owned(),
+                    permission_policy: None,
+                    org_max_permission: Some(crate::agent::model::McpServerOrgMaxPermission::Ask),
+                },
+            ],
             timeout: Some(5000),
             always_load: Some(true),
         });
@@ -909,5 +929,8 @@ mod tests {
         assert!(text.contains("enabled"));
         assert!(text.contains("search"));
         assert!(text.contains("always deny"));
+        assert!(text.contains("lookup"));
+        assert!(text.contains("not specified"));
+        assert!(text.contains("org max ask"));
     }
 }

--- a/src/ui/config/mcp.rs
+++ b/src/ui/config/mcp.rs
@@ -7,7 +7,9 @@ use super::theme;
 use crate::agent::model::{McpServerConnectionStatus, McpServerStatus, McpServerStatusConfig};
 use crate::agent::types::{ElicitationAction, ElicitationMode};
 use crate::app::App;
-use crate::app::config::{available_mcp_actions, is_mcp_action_available};
+use crate::app::config::{
+    available_mcp_actions, is_mcp_action_available, mcp_server_owner_summary,
+};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Margin, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -66,7 +68,8 @@ pub(super) fn render_details_overlay(frame: &mut Frame, area: Rect, app: &App) {
     };
 
     let server = app.mcp.servers.iter().find(|server| server.name == overlay.server_name);
-    let action_lines = server.map_or_else(Vec::new, |server| mcp_action_lines(server, overlay));
+    let action_lines =
+        server.map_or_else(Vec::new, |server| mcp_action_lines(app, server, overlay));
     let rendered = render_overlay_shell(
         frame,
         area,
@@ -88,7 +91,8 @@ pub(super) fn render_details_overlay(frame: &mut Frame, area: Rect, app: &App) {
     );
 
     if action_lines.is_empty() {
-        let body = server.map_or_else(server_missing_lines, server_detail_lines);
+        let body =
+            server.map_or_else(server_missing_lines, |server| server_detail_lines(app, server));
         frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), rendered.body_area);
         return;
     }
@@ -103,7 +107,7 @@ pub(super) fn render_details_overlay(frame: &mut Frame, area: Rect, app: &App) {
         .constraints([Constraint::Min(1), Constraint::Length(1), Constraint::Length(action_height)])
         .split(rendered.body_area);
 
-    let body = server.map_or_else(server_missing_lines, server_detail_lines);
+    let body = server.map_or_else(server_missing_lines, |server| server_detail_lines(app, server));
     frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), sections[0]);
     render_overlay_separator(frame, sections[1]);
     let action_scroll =
@@ -350,7 +354,7 @@ fn server_list_lines(server: &McpServerStatus, selected: bool) -> Vec<Line<'stat
     ]
 }
 
-fn server_detail_lines(server: &McpServerStatus) -> Vec<Line<'static>> {
+fn server_detail_lines(app: &App, server: &McpServerStatus) -> Vec<Line<'static>> {
     let mut lines = vec![
         section_heading("Status"),
         detail_kv("Status", status_label(server.status), status_color(server.status)),
@@ -363,6 +367,10 @@ fn server_detail_lines(server: &McpServerStatus) -> Vec<Line<'static>> {
         detail_kv("Transport", transport_label(server.config.as_ref()), Color::White),
         detail_kv("Tools", &tool_summary(server.tools.len()), Color::White),
     ];
+
+    if let Some(owner) = mcp_server_owner_summary(app, server) {
+        lines.push(detail_kv("Owner", &owner, Color::White));
+    }
 
     if let Some(info) = server.server_info.as_ref() {
         lines.push(detail_kv("Server name", &info.name, Color::White));
@@ -399,10 +407,11 @@ fn server_missing_lines() -> Vec<Line<'static>> {
 }
 
 fn mcp_action_lines(
+    app: &App,
     server: &McpServerStatus,
     overlay: &crate::app::config::McpDetailsOverlayState,
 ) -> Vec<Line<'static>> {
-    let actions = available_mcp_actions(server);
+    let actions = available_mcp_actions(app, server);
     if actions.is_empty() {
         return vec![detail_value("No actions available.", theme::DIM)];
     }
@@ -414,7 +423,7 @@ fn mcp_action_lines(
             format!("{} {}", if selected { ">" } else { " " }, action.label()),
             overlay_line_style(selected, true),
         )];
-        if !is_mcp_action_available(server, action) {
+        if !is_mcp_action_available(app, server, action) {
             spans.push(Span::styled("  ", Style::default()));
             spans.push(badge_span("not available", Color::Black, theme::STATUS_WARNING));
         }

--- a/src/ui/config/mcp.rs
+++ b/src/ui/config/mcp.rs
@@ -338,7 +338,7 @@ fn server_list_lines(server: &McpServerStatus, selected: bool) -> Vec<Line<'stat
                 status_color(server.status),
             ),
             Span::styled(" ", Style::default()),
-            badge_span(server.scope.as_deref().unwrap_or("session"), Color::White, Color::DarkGray),
+            badge_span(scope_label(server.scope.as_deref()), Color::White, Color::DarkGray),
             Span::styled(" ", Style::default()),
             badge_span(transport_label(server.config.as_ref()), Color::Black, Color::White),
         ]),
@@ -359,7 +359,7 @@ fn server_detail_lines(server: &McpServerStatus) -> Vec<Line<'static>> {
             if matches!(server.status, McpServerConnectionStatus::Disabled) { "No" } else { "Yes" },
             Color::White,
         ),
-        detail_kv("Scope", server.scope.as_deref().unwrap_or("session"), Color::White),
+        detail_kv("Scope", scope_label(server.scope.as_deref()), Color::White),
         detail_kv("Transport", transport_label(server.config.as_ref()), Color::White),
         detail_kv("Tools", &tool_summary(server.tools.len()), Color::White),
     ];
@@ -737,6 +737,10 @@ fn status_label(status: McpServerConnectionStatus) -> &'static str {
         McpServerConnectionStatus::Pending => "pending",
         McpServerConnectionStatus::Disabled => "disabled",
     }
+}
+
+fn scope_label(scope: Option<&str>) -> &str {
+    scope.filter(|value| !value.trim().is_empty()).unwrap_or("unspecified")
 }
 
 fn transport_label(config: Option<&McpServerStatusConfig>) -> &'static str {

--- a/src/ui/config/plugins.rs
+++ b/src/ui/config/plugins.rs
@@ -1,7 +1,7 @@
 use super::theme;
 use crate::app::App;
 use crate::app::plugins::{
-    PluginCapability, PluginsViewTab, display_label, filtered_marketplace_plugins,
+    InstalledPluginEntry, PluginsViewTab, display_label, filtered_marketplace_plugins,
     ordered_installed, search_enabled, visible_marketplaces,
 };
 use ratatui::Frame;
@@ -171,7 +171,11 @@ fn installed_list(app: &App, viewport_width: u16, viewport_height: u16) -> Rende
             let selected =
                 index == app.plugins.installed_selected_index && !app.plugins.search_focused;
             let mut lines = vec![
-                title_line_with_badge(&display_label(&entry.id), Some(entry.capability), selected),
+                title_line_with_badge(
+                    &display_label(&entry.id),
+                    Some(installed_plugin_badge(entry)),
+                    selected,
+                ),
                 meta_line(
                     &format!(
                         "{} | {}{}",
@@ -284,11 +288,14 @@ fn title_line(text: &str, selected: bool) -> Line<'static> {
     title_line_with_badge(text, None, selected)
 }
 
-fn title_line_with_badge(
-    text: &str,
-    capability: Option<PluginCapability>,
-    selected: bool,
-) -> Line<'static> {
+#[derive(Clone, Copy)]
+struct TitleBadge {
+    label: &'static str,
+    fg: Color,
+    bg: Color,
+}
+
+fn title_line_with_badge(text: &str, badge: Option<TitleBadge>, selected: bool) -> Line<'static> {
     let mut spans = vec![Span::styled(
         text.to_owned(),
         if selected {
@@ -297,12 +304,11 @@ fn title_line_with_badge(
             Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
         },
     )];
-    if let Some(capability) = capability {
+    if let Some(badge) = badge {
         spans.push(Span::styled("  ", Style::default().fg(theme::DIM)));
-        let (fg, bg) = capability_badge_colors(capability);
         spans.push(Span::styled(
-            format!(" {} ", capability.label()),
-            Style::default().fg(fg).bg(bg).add_modifier(Modifier::BOLD),
+            format!(" {} ", badge.label),
+            Style::default().fg(badge.fg).bg(badge.bg).add_modifier(Modifier::BOLD),
         ));
     }
     Line::from(spans)
@@ -380,10 +386,11 @@ fn visual_line_height(line: &Line<'static>, viewport_width: u16) -> usize {
     visual_width.div_ceil(width)
 }
 
-fn capability_badge_colors(capability: PluginCapability) -> (Color, Color) {
-    match capability {
-        PluginCapability::Skill => (Color::White, Color::Rgb(64, 64, 64)),
-        PluginCapability::Mcp => (Color::White, Color::Rgb(34, 92, 124)),
+fn installed_plugin_badge(entry: &InstalledPluginEntry) -> TitleBadge {
+    if entry.mcp_server_names.is_empty() {
+        TitleBadge { label: "SKILL", fg: Color::White, bg: Color::Rgb(64, 64, 64) }
+    } else {
+        TitleBadge { label: "MCP", fg: Color::White, bg: Color::Rgb(34, 92, 124) }
     }
 }
 

--- a/src/ui/footer_rows.rs
+++ b/src/ui/footer_rows.rs
@@ -549,6 +549,7 @@ mod tests {
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(ToolCallInfo {
                 id: "perm-1".into(),
+                source_message_uuids: Vec::new(),
                 title: "Read".into(),
                 sdk_tool_name: "Read".into(),
                 raw_input: None,

--- a/src/ui/inline_chat_rows.rs
+++ b/src/ui/inline_chat_rows.rs
@@ -259,6 +259,10 @@ fn render_user_system_live_rows(
         return RenderedMessageRows::skipped_transcript_content();
     }
 
+    // A message hosting an unanswered user dialog must stay in the live
+    // (mutable) region so its chooser re-renders on focus/selection changes;
+    // committing it would freeze it in immutable scrollback.
+    let commit_ready = !message_has_pending_user_dialog(&app.messages[msg_idx]);
     let rendered = build_user_system_message_rows(
         &mut app.messages[msg_idx],
         message_render_context(current_mode_id, width),
@@ -271,9 +275,16 @@ fn render_user_system_live_rows(
             block_idx: None,
             kind: LiveRowBoundaryKind::Message,
             start_row: 0,
-            commit_ready: true,
+            commit_ready,
         },
     )
+}
+
+fn message_has_pending_user_dialog(message: &ChatMessage) -> bool {
+    message
+        .blocks
+        .iter()
+        .any(|block| matches!(block, MessageBlock::UserDialog(dialog) if !dialog.answered))
 }
 
 fn render_assistant_live_rows(
@@ -425,7 +436,8 @@ fn welcome_output_ids(message: &ChatMessage) -> Vec<HistoryOutputId> {
             MessageBlock::Text(_)
             | MessageBlock::Notice(_)
             | MessageBlock::ToolCall(_)
-            | MessageBlock::ImageAttachment(_) => None,
+            | MessageBlock::ImageAttachment(_)
+            | MessageBlock::UserDialog(_) => None,
         })
         .unwrap_or_else(|| vec![HistoryOutputId::Message(message.id)])
 }
@@ -471,7 +483,8 @@ fn welcome_message_commit_ready(message: &ChatMessage) -> bool {
             MessageBlock::Text(_)
             | MessageBlock::Notice(_)
             | MessageBlock::ToolCall(_)
-            | MessageBlock::ImageAttachment(_) => None,
+            | MessageBlock::ImageAttachment(_)
+            | MessageBlock::UserDialog(_) => None,
         })
         .is_some_and(|welcome| {
             welcome_value_ready(&welcome.subscription) && welcome_value_ready(&welcome.session_id)
@@ -762,7 +775,9 @@ fn assistant_render_items_from_message(
                 });
                 previous_kind = Some(current_kind);
             }
-            MessageBlock::Welcome(_) | MessageBlock::ImageAttachment(_) => {}
+            MessageBlock::Welcome(_)
+            | MessageBlock::ImageAttachment(_)
+            | MessageBlock::UserDialog(_) => {}
         }
     }
 
@@ -780,7 +795,8 @@ fn last_visible_assistant_block_idx(message: &ChatMessage) -> Option<usize> {
         MessageBlock::Text(_)
         | MessageBlock::ToolCall(_)
         | MessageBlock::Welcome(_)
-        | MessageBlock::ImageAttachment(_) => None,
+        | MessageBlock::ImageAttachment(_)
+        | MessageBlock::UserDialog(_) => None,
     })
 }
 

--- a/src/ui/inline_chat_rows.rs
+++ b/src/ui/inline_chat_rows.rs
@@ -1302,6 +1302,7 @@ mod tests {
     ) -> MessageBlock {
         let mut tool = ToolCallInfo {
             id: id.to_owned(),
+            source_message_uuids: Vec::new(),
             title: "Child Tool".to_owned(),
             sdk_tool_name: "Bash".to_owned(),
             raw_input: None,

--- a/src/ui/message_rows.rs
+++ b/src/ui/message_rows.rs
@@ -1,7 +1,9 @@
 // Copyright 2025 Simon Peter Rothgang
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::app::{ChatMessage, MessageBlock, MessageRole, SystemSeverity, TextBlock};
+use crate::app::{
+    ChatMessage, MessageBlock, MessageRole, SystemSeverity, TextBlock, UserDialogBlock,
+};
 use crate::ui::theme;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -101,11 +103,75 @@ fn append_system_blocks(msg: &mut ChatMessage, width: u16, rows: &mut MessageRow
                     rows.push_blank();
                 }
             }
+            MessageBlock::UserDialog(dialog) => {
+                rows.push_lines(render_user_dialog_lines(dialog));
+                rows.push_blank();
+            }
             MessageBlock::ToolCall(_)
             | MessageBlock::Welcome(_)
             | MessageBlock::ImageAttachment(_) => {}
         }
     }
+}
+
+/// Render a `refusal_fallback_prompt` dialog as an inline selectable chooser.
+/// While pending, the focused option shows a `▸` arrow and a help line; once
+/// answered, the resolved choice is shown without controls.
+fn render_user_dialog_lines(dialog: &UserDialogBlock) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    let title = if let Some(guidance) =
+        dialog.payload.guidance_text.as_deref().map(str::trim).filter(|text| !text.is_empty())
+    {
+        guidance.to_owned()
+    } else {
+        format!("{} declined this request.", dialog.payload.original_model)
+    };
+    lines.push(Line::from(Span::styled(
+        title,
+        Style::default().fg(theme::STATUS_WARNING).add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::default());
+
+    if dialog.answered {
+        let resolved = dialog
+            .options
+            .get(dialog.selected_index)
+            .map_or_else(|| "Declined".to_owned(), |option| option.label.clone());
+        lines.push(Line::from(Span::styled(
+            format!("  Resolved: {resolved}"),
+            Style::default().fg(theme::DIM),
+        )));
+        return lines;
+    }
+
+    for (index, option) in dialog.options.iter().enumerate() {
+        let is_selected = dialog.focused && index == dialog.selected_index;
+        let mut spans = Vec::new();
+        if is_selected {
+            spans.push(Span::styled(
+                "\u{25b8} ",
+                Style::default().fg(theme::RUST_ORANGE).add_modifier(Modifier::BOLD),
+            ));
+        } else {
+            spans.push(Span::raw("  "));
+        }
+        let label_style = if is_selected {
+            Style::default().fg(theme::RUST_ORANGE).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::Gray)
+        };
+        spans.push(Span::styled(option.label.clone(), label_style));
+        lines.push(Line::from(spans));
+    }
+
+    lines.push(Line::default());
+    let help = if dialog.focused {
+        "\u{2191}\u{2193} select  enter confirm  esc decline"
+    } else {
+        "\u{25cb} Waiting for input... (Tab to focus)"
+    };
+    lines.push(Line::from(Span::styled(help, Style::default().fg(theme::DIM))));
+    lines
 }
 
 fn text_block_lines(

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -58,6 +58,9 @@ pub fn tool_name_label(sdk_tool_name: &str) -> (&'static str, &'static str) {
         "REPL" => ("\u{03bb}", "REPL"),
         "Monitor" => ("\u{25c9}", "Monitor"),
         "Workflow" => ("\u{25c7}", "Workflow"),
+        "Projects" => ("\u{25a6}", "Projects"),
+        "Artifact" => ("\u{25c8}", "Artifact"),
+        "ShowOnboardingRolePicker" => ("\u{2299}", "Role"),
         "EnterWorktree" => ("\u{21c4}", "EnterWorktree"),
         "ExitWorktree" => ("\u{21c4}", "ExitWorktree"),
         _ => ("\u{25cb}", "Tool"),
@@ -120,6 +123,13 @@ mod tests {
     fn monitor_and_workflow_tools_use_background_task_labels_and_icons() {
         assert_eq!(tool_name_label("Monitor"), ("\u{25c9}", "Monitor"));
         assert_eq!(tool_name_label("Workflow"), ("\u{25c7}", "Workflow"));
+    }
+
+    #[test]
+    fn project_artifact_and_role_tools_use_specific_labels_and_icons() {
+        assert_eq!(tool_name_label("Projects"), ("\u{25a6}", "Projects"));
+        assert_eq!(tool_name_label("Artifact"), ("\u{25c8}", "Artifact"));
+        assert_eq!(tool_name_label("ShowOnboardingRolePicker"), ("\u{2299}", "Role"));
     }
 
     #[test]

--- a/src/ui/tool_call/artifact.rs
+++ b/src/ui/tool_call/artifact.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Rendering helpers for SDK `Artifact` tool calls.
+
+use crate::agent::model;
+use crate::app::ToolCallInfo;
+use crate::ui::diff::strip_outer_code_fence;
+use ratatui::text::Line;
+
+use super::errors::render_failed_tool_text_content;
+use super::fields::{self, ToolField};
+
+pub(super) fn is_artifact_tool(tc: &ToolCallInfo) -> bool {
+    tc.sdk_tool_name == "Artifact"
+}
+
+pub(super) fn has_structured_body(tc: &ToolCallInfo) -> bool {
+    tc.raw_input.is_some() || !tc.content.is_empty()
+}
+
+pub(super) fn render_tool_content(tc: &ToolCallInfo) -> Option<Vec<Line<'static>>> {
+    if !is_artifact_tool(tc) {
+        return None;
+    }
+
+    let mut lines = render_input_content(tc);
+    lines.extend(render_text_content(tc));
+    Some(lines)
+}
+
+fn render_input_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
+    let input = tc.raw_input.as_ref().and_then(serde_json::Value::as_object);
+    let mut artifact_fields = Vec::new();
+
+    if let Some(input) = input {
+        if let Some(label) = json_string(input, "label") {
+            artifact_fields.push(ToolField::new("Label", label));
+        }
+        if let Some(file_path) = json_string(input, "file_path") {
+            artifact_fields.push(ToolField::new("File path", file_path));
+        }
+        if let Some(url) = json_string(input, "url") {
+            artifact_fields.push(ToolField::new("URL", url));
+        }
+    }
+
+    fields::render_fields(artifact_fields)
+}
+
+fn render_text_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    for content in &tc.content {
+        let model::ToolCallContent::Content(content) = content else {
+            continue;
+        };
+        let model::ContentBlock::Text(text) = &content.content else {
+            continue;
+        };
+        render_text_block(tc, &text.text, &mut lines);
+    }
+    lines
+}
+
+fn render_text_block(tc: &ToolCallInfo, text: &str, lines: &mut Vec<Line<'static>>) {
+    let stripped = strip_outer_code_fence(text);
+    if let Some(failed_lines) = render_failed_tool_text_content(tc.status, &stripped) {
+        lines.extend(failed_lines);
+        return;
+    }
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&stripped)
+        && let Some(object) = value.as_object()
+    {
+        lines.extend(render_output_object(object));
+        return;
+    }
+    lines.extend(
+        stripped
+            .lines()
+            .map(str::trim_end)
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| Line::from(line.to_owned())),
+    );
+}
+
+fn render_output_object(object: &serde_json::Map<String, serde_json::Value>) -> Vec<Line<'static>> {
+    let mut artifact_fields = Vec::new();
+    if let Some(title) = json_string(object, "title") {
+        artifact_fields.push(ToolField::new("Title", title));
+    }
+    if let Some(url) = json_string(object, "url") {
+        artifact_fields.push(ToolField::new("URL", url));
+    }
+    if let Some(path) = json_string(object, "path") {
+        artifact_fields.push(ToolField::new("Path", path));
+    }
+    if let Some(version) = json_string(object, "version") {
+        artifact_fields.push(ToolField::new("Version", version));
+    }
+    if let Some(mcp_dropped) = json_string(object, "mcpDropped") {
+        artifact_fields.push(ToolField::new("MCP dropped", mcp_dropped));
+    }
+    fields::render_fields(artifact_fields)
+}
+
+fn json_string<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<&'a str> {
+    object.get(key).and_then(serde_json::Value::as_str).filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{BlockCache, TerminalSnapshotMode};
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    fn artifact_tool_call(raw_input: serde_json::Value, content: Option<&str>) -> ToolCallInfo {
+        let mut tc = ToolCallInfo {
+            id: "tc-artifact".to_owned(),
+            source_message_uuids: Vec::new(),
+            title: "Artifact: dashboard".to_owned(),
+            sdk_tool_name: "Artifact".to_owned(),
+            raw_input: Some(raw_input),
+            raw_input_bytes: 0,
+            output_metadata: None,
+            task_metadata: None,
+            status: model::ToolCallStatus::Completed,
+            content: Vec::new(),
+            hidden: false,
+            terminal_id: None,
+            terminal_command: None,
+            terminal_output: None,
+            terminal_output_len: 0,
+            terminal_bytes_seen: 0,
+            terminal_snapshot_mode: TerminalSnapshotMode::AppendOnly,
+            cache: BlockCache::default(),
+            pending_permission: None,
+            pending_question: None,
+        };
+        if let Some(content) = content {
+            tc.content = vec![model::ToolCallContent::from(content)];
+        }
+        tc
+    }
+
+    fn rendered_line_texts(lines: &[Line<'static>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn renders_input_and_output_fields() {
+        let tc = artifact_tool_call(
+            json!({
+                "file_path": "C:/work/dashboard.html",
+                "label": "dashboard",
+                "url": "https://artifact.local/old"
+            }),
+            Some(
+                r#"{"url":"https://artifact.local/new","path":"C:/work/dashboard.html","title":"Dashboard","version":"v2"}"#,
+            ),
+        );
+
+        let lines = render_tool_content(&tc).expect("artifact content");
+
+        assert_eq!(
+            rendered_line_texts(&lines),
+            vec![
+                "Label: dashboard",
+                "File path: C:/work/dashboard.html",
+                "URL: https://artifact.local/old",
+                "Title: Dashboard",
+                "URL: https://artifact.local/new",
+                "Path: C:/work/dashboard.html",
+                "Version: v2",
+            ]
+        );
+    }
+}

--- a/src/ui/tool_call/cron.rs
+++ b/src/ui/tool_call/cron.rs
@@ -174,6 +174,7 @@ mod tests {
     ) -> ToolCallInfo {
         let mut tc = ToolCallInfo {
             id: "tc-cron".to_owned(),
+            source_message_uuids: Vec::new(),
             title: "tc-cron".to_owned(),
             sdk_tool_name: sdk_tool_name.to_owned(),
             raw_input: Some(raw_input),

--- a/src/ui/tool_call/interactions.rs
+++ b/src/ui/tool_call/interactions.rs
@@ -429,6 +429,7 @@ mod tests {
     fn test_tool_call(sdk_tool_name: &str) -> ToolCallInfo {
         ToolCallInfo {
             id: "tool-1".into(),
+            source_message_uuids: Vec::new(),
             title: "Tool".into(),
             sdk_tool_name: sdk_tool_name.into(),
             raw_input: None,

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -9,12 +9,14 @@
 //! - [`interactions`] -- inline permissions, questions, and plan approvals
 //! - [`errors`] -- error rendering and tool-use error extraction
 
+mod artifact;
 mod cron;
 mod errors;
 mod execute;
 mod fields;
 mod interactions;
 mod monitor;
+mod projects;
 mod push_notification;
 mod remote_trigger;
 mod repl;
@@ -176,6 +178,21 @@ fn tool_output_badge_spans(tc: &ToolCallInfo) -> Vec<Span<'static>> {
         ));
     }
 
+    if matches!(tc.sdk_tool_name.as_str(), "Agent" | "Task") {
+        if let Some(agent_type) = agent_requested_type_badge(tc) {
+            badges.push(Span::styled(
+                format!("  [type: {agent_type}]"),
+                Style::default().fg(Color::LightBlue).add_modifier(Modifier::BOLD),
+            ));
+        }
+        if let Some(model) = agent_display_model_badge(tc) {
+            badges.push(Span::styled(
+                format!("  [model: {model}]"),
+                Style::default().fg(Color::LightBlue).add_modifier(Modifier::BOLD),
+            ));
+        }
+    }
+
     if tc.task_is_backgrounded() {
         badges.push(Span::styled(
             "  [backgrounded]",
@@ -184,6 +201,37 @@ fn tool_output_badge_spans(tc: &ToolCallInfo) -> Vec<Span<'static>> {
     }
 
     badges
+}
+
+fn tool_raw_input_string<'a>(tc: &'a ToolCallInfo, key: &str) -> Option<&'a str> {
+    tc.raw_input
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+        .and_then(|input| input.get(key))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn agent_requested_type_badge(tc: &ToolCallInfo) -> Option<String> {
+    let name = tool_raw_input_string(tc, "name")?;
+    let subagent_type = tool_raw_input_string(tc, "subagent_type")?;
+    let expected_title = format!("{}: {name}", tc.sdk_tool_name);
+    if name == subagent_type || tc.title.trim() != expected_title {
+        return None;
+    }
+    Some(subagent_type.to_owned())
+}
+
+fn agent_display_model_badge(tc: &ToolCallInfo) -> Option<String> {
+    tc.output_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.agent.as_ref())
+        .and_then(|agent| agent.resolved_model.as_deref())
+        .map(str::trim)
+        .filter(|resolved_model| !resolved_model.is_empty())
+        .or_else(|| tool_raw_input_string(tc, "model"))
+        .map(str::to_owned)
 }
 
 fn tool_display_title<'a>(
@@ -352,6 +400,59 @@ mod tests {
         let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
 
         assert!(rendered.contains("[backgrounded]"));
+    }
+
+    #[test]
+    fn render_tool_call_title_shows_resolved_model_badge_for_subagents() {
+        let mut tc = test_tool_call("reviewer", "Agent", model::ToolCallStatus::Completed);
+        tc.output_metadata = Some(model::ToolOutputMetadata::new().agent(Some(
+            model::AgentOutputMetadata::new().resolved_model(Some("claude-sonnet-4-7".to_owned())),
+        )));
+
+        let line = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 100, 0);
+        let rendered: String = line.spans.iter().map(|span| span.content.as_ref()).collect();
+
+        assert!(rendered.contains("reviewer"));
+        assert!(rendered.contains("[model: claude-sonnet-4-7]"));
+    }
+
+    #[test]
+    fn render_tool_call_title_shows_running_agent_type_and_requested_model_from_input() {
+        let mut tc =
+            test_tool_call("Agent: review-worker", "Agent", model::ToolCallStatus::InProgress);
+        tc.raw_input = Some(serde_json::json!({
+            "name": "review-worker",
+            "subagent_type": "general-purpose",
+            "model": "opus",
+        }));
+
+        let line = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 120, 0);
+        let rendered: String = line.spans.iter().map(|span| span.content.as_ref()).collect();
+
+        assert!(rendered.contains("Agent: review-worker"));
+        assert!(rendered.contains("[type: general-purpose]"));
+        assert!(rendered.contains("[model: opus]"));
+    }
+
+    #[test]
+    fn render_tool_call_title_prefers_resolved_model_over_requested_model() {
+        let mut tc =
+            test_tool_call("Agent: review-worker", "Agent", model::ToolCallStatus::Completed);
+        tc.raw_input = Some(serde_json::json!({
+            "name": "review-worker",
+            "subagent_type": "general-purpose",
+            "model": "opus",
+        }));
+        tc.output_metadata = Some(model::ToolOutputMetadata::new().agent(Some(
+            model::AgentOutputMetadata::new().resolved_model(Some("claude-opus-4-8".to_owned())),
+        )));
+
+        let line = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 120, 0);
+        let rendered: String = line.spans.iter().map(|span| span.content.as_ref()).collect();
+
+        assert!(rendered.contains("[type: general-purpose]"));
+        assert!(rendered.contains("[model: claude-opus-4-8]"));
+        assert!(!rendered.contains("[model: opus]"));
     }
 
     #[test]

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -219,6 +219,7 @@ mod tests {
     ) -> ToolCallInfo {
         ToolCallInfo {
             id: id.to_owned(),
+            source_message_uuids: Vec::new(),
             title: id.to_owned(),
             sdk_tool_name: sdk_tool_name.to_owned(),
             raw_input: None,
@@ -396,6 +397,7 @@ mod tests {
     fn bash_title_does_not_wrap_for_long_title() {
         let tc = ToolCallInfo {
             id: "tc-1".into(),
+            source_message_uuids: Vec::new(),
             title: "echo very long command title with markdown **bold** and path /a/b/c/d/e/f"
                 .into(),
             sdk_tool_name: "Bash".into(),
@@ -931,6 +933,7 @@ mod tests {
     fn content_summary_only_extracts_tool_use_error_for_failed_execute() {
         let tc = ToolCallInfo {
             id: "tc-1".into(),
+            source_message_uuids: Vec::new(),
             title: "Bash".into(),
             sdk_tool_name: "Bash".into(),
             raw_input: None,
@@ -957,6 +960,7 @@ mod tests {
     fn content_summary_extracts_tool_use_error_for_failed_execute() {
         let tc = ToolCallInfo {
             id: "tc-1".into(),
+            source_message_uuids: Vec::new(),
             title: "Bash".into(),
             sdk_tool_name: "Bash".into(),
             raw_input: None,
@@ -993,6 +997,7 @@ mod tests {
     fn content_summary_uses_first_terminal_line_for_failed_execute() {
         let tc = ToolCallInfo {
             id: "tc-2".into(),
+            source_message_uuids: Vec::new(),
             title: "Bash".into(),
             sdk_tool_name: "Bash".into(),
             raw_input: None,
@@ -1041,6 +1046,7 @@ mod tests {
     fn render_execute_content_keeps_tail_output() {
         let tc = ToolCallInfo {
             id: "tc-3".into(),
+            source_message_uuids: Vec::new(),
             title: "Bash".into(),
             sdk_tool_name: "Bash".into(),
             raw_input: None,

--- a/src/ui/tool_call/monitor.rs
+++ b/src/ui/tool_call/monitor.rs
@@ -179,6 +179,7 @@ mod tests {
     ) -> ToolCallInfo {
         let mut tc = ToolCallInfo {
             id: "tc-monitor".to_owned(),
+            source_message_uuids: Vec::new(),
             title: "Monitor".to_owned(),
             sdk_tool_name: "Monitor".to_owned(),
             raw_input: Some(raw_input),

--- a/src/ui/tool_call/projects.rs
+++ b/src/ui/tool_call/projects.rs
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Rendering helpers for SDK `Projects` tool calls.
+
+use crate::agent::model;
+use crate::app::ToolCallInfo;
+use crate::ui::diff::strip_outer_code_fence;
+use ratatui::text::Line;
+
+use super::errors::render_failed_tool_text_content;
+use super::fields::{self, ToolField};
+
+pub(super) fn is_projects_tool(tc: &ToolCallInfo) -> bool {
+    tc.sdk_tool_name == "Projects"
+}
+
+pub(super) fn has_structured_body(tc: &ToolCallInfo) -> bool {
+    tc.raw_input.is_some() || !tc.content.is_empty()
+}
+
+pub(super) fn render_tool_content(tc: &ToolCallInfo) -> Option<Vec<Line<'static>>> {
+    if !is_projects_tool(tc) {
+        return None;
+    }
+
+    let mut lines = render_input_content(tc);
+    lines.extend(render_text_content(tc));
+    Some(lines)
+}
+
+fn render_input_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
+    let input = tc.raw_input.as_ref().and_then(serde_json::Value::as_object);
+    let mut project_fields = Vec::new();
+
+    if let Some(input) = input {
+        if let Some(method) = json_string(input, "method") {
+            project_fields.push(ToolField::new("Method", project_method_label(method)));
+        }
+        if let Some(path) = json_string(input, "path") {
+            project_fields.push(ToolField::new("Path", path));
+        }
+        if let Some(query) = json_string(input, "query") {
+            project_fields.push(ToolField::new("Query", query));
+        }
+        if let Some(local_path) = json_string(input, "local_path") {
+            project_fields.push(ToolField::new("Local path", local_path));
+        }
+        if let Some(n) = json_i64(input, "n") {
+            project_fields.push(ToolField::new("Limit", n.to_string()));
+        }
+        if let Some(force) = json_bool(input, "force") {
+            project_fields.push(ToolField::new("Force", boolean_label(force)));
+        }
+    }
+
+    fields::render_fields(project_fields)
+}
+
+fn render_text_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    for content in &tc.content {
+        let model::ToolCallContent::Content(content) = content else {
+            continue;
+        };
+        let model::ContentBlock::Text(text) = &content.content else {
+            continue;
+        };
+        render_text_block(tc, &text.text, &mut lines);
+    }
+    lines
+}
+
+fn render_text_block(tc: &ToolCallInfo, text: &str, lines: &mut Vec<Line<'static>>) {
+    let stripped = strip_outer_code_fence(text);
+    if let Some(failed_lines) = render_failed_tool_text_content(tc.status, &stripped) {
+        lines.extend(failed_lines);
+        return;
+    }
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&stripped)
+        && let Some(object) = value.as_object()
+    {
+        lines.extend(render_output_object(object));
+        return;
+    }
+    lines.extend(
+        stripped
+            .lines()
+            .map(str::trim_end)
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| Line::from(line.to_owned())),
+    );
+}
+
+fn render_output_object(object: &serde_json::Map<String, serde_json::Value>) -> Vec<Line<'static>> {
+    let mut project_fields = Vec::new();
+    if let Some(method) = json_string(object, "method") {
+        project_fields.push(ToolField::new("Method", project_method_label(method)));
+    }
+    if let Some(notice) = json_string(object, "notice") {
+        project_fields.push(ToolField::new("Notice", notice));
+    }
+
+    match json_string(object, "method") {
+        Some("project_info") => render_project_info_fields(object, &mut project_fields),
+        Some("project_read") => render_project_read_fields(object, &mut project_fields),
+        Some("project_search") => render_project_search_fields(object, &mut project_fields),
+        Some("project_write") => render_project_write_fields(object, &mut project_fields),
+        Some("project_delete") => render_project_delete_fields(object, &mut project_fields),
+        _ => {}
+    }
+
+    fields::render_fields(project_fields)
+}
+
+fn render_project_info_fields<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    project_fields: &mut Vec<ToolField<'a>>,
+) {
+    if let Some(name) = json_string(object, "name") {
+        project_fields.push(ToolField::new("Name", name.to_owned()));
+    }
+    if let Some(description) = json_string(object, "description") {
+        project_fields.push(ToolField::new("Description", description.to_owned()));
+    }
+    if let Some(docs) = json_array_len(object, "docs") {
+        project_fields.push(ToolField::new("Docs", docs.to_string()));
+    }
+    if let Some(files) = json_array_len(object, "files") {
+        project_fields.push(ToolField::new("Files", files.to_string()));
+    }
+    if let Some(knowledge) = object.get("knowledge").and_then(compact_json) {
+        project_fields.push(ToolField::new("Knowledge", knowledge));
+    }
+}
+
+fn render_project_read_fields<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    project_fields: &mut Vec<ToolField<'a>>,
+) {
+    if let Some(path) = json_string(object, "path") {
+        project_fields.push(ToolField::new("Path", path.to_owned()));
+    }
+    if let Some(file_kind) = json_string(object, "file_kind") {
+        project_fields.push(ToolField::new("File kind", file_kind.to_owned()));
+    }
+    if let Some(local_file) = json_string(object, "local_file") {
+        project_fields.push(ToolField::new("Local file", local_file.to_owned()));
+    }
+    if let Some(content) = json_string(object, "content") {
+        project_fields.push(ToolField::new("Content", content.to_owned()));
+    }
+}
+
+fn render_project_search_fields<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    project_fields: &mut Vec<ToolField<'a>>,
+) {
+    if let Some(rag) = json_bool(object, "rag") {
+        project_fields.push(ToolField::new("RAG", boolean_label(rag)));
+    }
+    if let Some(hits) = json_array_len(object, "hits") {
+        project_fields.push(ToolField::new("Hits", hits.to_string()));
+    }
+    if let Some(docs) = json_string_array(object.get("docs")) {
+        project_fields.push(ToolField::new("Docs", docs.join(", ")));
+    }
+}
+
+fn render_project_write_fields<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    project_fields: &mut Vec<ToolField<'a>>,
+) {
+    if let Some(path) = json_string(object, "path") {
+        project_fields.push(ToolField::new("Path", path.to_owned()));
+    }
+    if let Some(doc_uuid) = json_string(object, "doc_uuid") {
+        project_fields.push(ToolField::new("Doc UUID", doc_uuid.to_owned()));
+    }
+    if let Some(replaced) = json_bool(object, "replaced") {
+        project_fields.push(ToolField::new("Replaced", boolean_label(replaced)));
+    }
+}
+
+fn render_project_delete_fields<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    project_fields: &mut Vec<ToolField<'a>>,
+) {
+    if let Some(path) = json_string(object, "path") {
+        project_fields.push(ToolField::new("Path", path.to_owned()));
+    }
+    if let Some(deleted) = json_bool(object, "deleted") {
+        project_fields.push(ToolField::new("Deleted", boolean_label(deleted)));
+    }
+}
+
+fn project_method_label(method: &str) -> String {
+    method.strip_prefix("project_").unwrap_or(method).replace('_', " ")
+}
+
+fn boolean_label(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
+}
+
+fn compact_json(value: &serde_json::Value) -> Option<String> {
+    if value.is_null() {
+        return None;
+    }
+    if let Some(text) = value.as_str() {
+        let trimmed = text.trim();
+        return (!trimmed.is_empty()).then(|| trimmed.to_owned());
+    }
+    if value.as_array().is_some_and(Vec::is_empty) {
+        return None;
+    }
+    if value.as_object().is_some_and(serde_json::Map::is_empty) {
+        return None;
+    }
+    serde_json::to_string(value).ok()
+}
+
+fn json_string<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<&'a str> {
+    object.get(key).and_then(serde_json::Value::as_str).filter(|value| !value.is_empty())
+}
+
+fn json_bool(object: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<bool> {
+    object.get(key).and_then(serde_json::Value::as_bool)
+}
+
+fn json_i64(object: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<i64> {
+    object.get(key).and_then(serde_json::Value::as_i64)
+}
+
+fn json_array_len(object: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<usize> {
+    object.get(key).and_then(serde_json::Value::as_array).map(Vec::len)
+}
+
+fn json_string_array(value: Option<&serde_json::Value>) -> Option<Vec<String>> {
+    let values = value?
+        .as_array()?
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    (!values.is_empty()).then_some(values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{BlockCache, TerminalSnapshotMode};
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    fn projects_tool_call(raw_input: serde_json::Value, content: Option<&str>) -> ToolCallInfo {
+        let mut tc = ToolCallInfo {
+            id: "tc-projects".to_owned(),
+            source_message_uuids: Vec::new(),
+            title: "Projects: search rendering".to_owned(),
+            sdk_tool_name: "Projects".to_owned(),
+            raw_input: Some(raw_input),
+            raw_input_bytes: 0,
+            output_metadata: None,
+            task_metadata: None,
+            status: model::ToolCallStatus::Completed,
+            content: Vec::new(),
+            hidden: false,
+            terminal_id: None,
+            terminal_command: None,
+            terminal_output: None,
+            terminal_output_len: 0,
+            terminal_bytes_seen: 0,
+            terminal_snapshot_mode: TerminalSnapshotMode::AppendOnly,
+            cache: BlockCache::default(),
+            pending_permission: None,
+            pending_question: None,
+        };
+        if let Some(content) = content {
+            tc.content = vec![model::ToolCallContent::from(content)];
+        }
+        tc
+    }
+
+    fn rendered_line_texts(lines: &[Line<'static>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn renders_search_input_and_output_fields() {
+        let tc = projects_tool_call(
+            json!({
+                "method": "project_search",
+                "query": "rendering",
+                "n": 2
+            }),
+            Some(
+                r#"{"method":"project_search","rag":true,"hits":[{"name":"notes"}],"docs":["docs/rendering.md"]}"#,
+            ),
+        );
+
+        let lines = render_tool_content(&tc).expect("projects content");
+
+        assert_eq!(
+            rendered_line_texts(&lines),
+            vec![
+                "Method: search",
+                "Query: rendering",
+                "Limit: 2",
+                "Method: search",
+                "RAG: yes",
+                "Hits: 1",
+                "Docs: docs/rendering.md",
+            ]
+        );
+    }
+
+    #[test]
+    fn renders_write_input_and_output_fields() {
+        let tc = projects_tool_call(
+            json!({
+                "method": "project_write",
+                "path": "claude/migration.md",
+                "local_path": "tmp/migration.md",
+                "force": true
+            }),
+            Some(
+                r#"{"method":"project_write","path":"claude/migration.md","doc_uuid":"doc-1","replaced":false}"#,
+            ),
+        );
+
+        let lines = render_tool_content(&tc).expect("projects content");
+
+        assert_eq!(
+            rendered_line_texts(&lines),
+            vec![
+                "Method: write",
+                "Path: claude/migration.md",
+                "Local path: tmp/migration.md",
+                "Force: yes",
+                "Method: write",
+                "Path: claude/migration.md",
+                "Doc UUID: doc-1",
+                "Replaced: no",
+            ]
+        );
+    }
+}

--- a/src/ui/tool_call/push_notification.rs
+++ b/src/ui/tool_call/push_notification.rs
@@ -161,6 +161,7 @@ mod tests {
     ) -> ToolCallInfo {
         let mut tc = ToolCallInfo {
             id: "tc-push-notification".to_owned(),
+            source_message_uuids: Vec::new(),
             title: "PushNotification".to_owned(),
             sdk_tool_name: "PushNotification".to_owned(),
             raw_input: Some(raw_input),

--- a/src/ui/tool_call/remote_trigger.rs
+++ b/src/ui/tool_call/remote_trigger.rs
@@ -130,6 +130,7 @@ mod tests {
     ) -> ToolCallInfo {
         let mut tc = ToolCallInfo {
             id: "tc-remote-trigger".to_owned(),
+            source_message_uuids: Vec::new(),
             title: "RemoteTrigger".to_owned(),
             sdk_tool_name: "RemoteTrigger".to_owned(),
             raw_input: Some(raw_input),

--- a/src/ui/tool_call/repl.rs
+++ b/src/ui/tool_call/repl.rs
@@ -229,6 +229,7 @@ mod tests {
     ) -> ToolCallInfo {
         let mut tc = ToolCallInfo {
             id: "tc-repl".to_owned(),
+            source_message_uuids: Vec::new(),
             title: "REPL".to_owned(),
             sdk_tool_name: "REPL".to_owned(),
             raw_input: Some(raw_input),

--- a/src/ui/tool_call/schedule_wakeup.rs
+++ b/src/ui/tool_call/schedule_wakeup.rs
@@ -187,6 +187,7 @@ mod tests {
     ) -> ToolCallInfo {
         let mut tc = ToolCallInfo {
             id: "tc-schedule-wakeup".to_owned(),
+            source_message_uuids: Vec::new(),
             title: "ScheduleWakeup".to_owned(),
             sdk_tool_name: "ScheduleWakeup".to_owned(),
             raw_input: Some(raw_input),

--- a/src/ui/tool_call/standard.rs
+++ b/src/ui/tool_call/standard.rs
@@ -19,9 +19,10 @@ use super::errors::{
 };
 use super::interactions::{render_permission_lines, render_question_lines};
 use super::{
-    TOOL_BODY_MAX_LINES, ToolCallRenderContext, cron, execute, markdown_inline_spans, monitor,
-    push_notification, remote_trigger, repl, schedule_wakeup, status_icon, tasks,
-    tool_display_title, tool_output_badge_spans, truncate_spans_to_width, workflow, worktree,
+    TOOL_BODY_MAX_LINES, ToolCallRenderContext, artifact, cron, execute, markdown_inline_spans,
+    monitor, projects, push_notification, remote_trigger, repl, schedule_wakeup, status_icon,
+    tasks, tool_display_title, tool_output_badge_spans, truncate_spans_to_width, workflow,
+    worktree,
 };
 
 pub(super) const WRITE_DIFF_MAX_LINES: usize = TOOL_BODY_MAX_LINES;
@@ -128,6 +129,16 @@ pub(super) fn tool_call_has_body(tc: &ToolCallInfo) -> bool {
     }
     if workflow::is_workflow_tool(tc) {
         return workflow::has_structured_body(tc)
+            || tc.pending_permission.is_some()
+            || tc.pending_question.is_some();
+    }
+    if projects::is_projects_tool(tc) {
+        return projects::has_structured_body(tc)
+            || tc.pending_permission.is_some()
+            || tc.pending_question.is_some();
+    }
+    if artifact::is_artifact_tool(tc) {
+        return artifact::has_structured_body(tc)
             || tc.pending_permission.is_some()
             || tc.pending_question.is_some();
     }
@@ -335,6 +346,16 @@ fn render_tool_content(tc: &ToolCallInfo, width: u16) -> Vec<Line<'static>> {
         && let Some(workflow_lines) = workflow::render_tool_content(tc)
     {
         return workflow_lines;
+    }
+    if projects::is_projects_tool(tc)
+        && let Some(projects_lines) = projects::render_tool_content(tc)
+    {
+        return projects_lines;
+    }
+    if artifact::is_artifact_tool(tc)
+        && let Some(artifact_lines) = artifact::render_tool_content(tc)
+    {
+        return artifact_lines;
     }
 
     if tc.is_execute_tool() {

--- a/src/ui/tool_call/tasks.rs
+++ b/src/ui/tool_call/tasks.rs
@@ -347,6 +347,7 @@ mod tests {
     ) -> ToolCallInfo {
         let mut tc = ToolCallInfo {
             id: "tc-task".to_owned(),
+            source_message_uuids: Vec::new(),
             title: "tc-task".to_owned(),
             sdk_tool_name: sdk_tool_name.to_owned(),
             raw_input: Some(raw_input),

--- a/src/ui/tool_call/workflow.rs
+++ b/src/ui/tool_call/workflow.rs
@@ -100,6 +100,8 @@ fn field_label(label: &str) -> Option<&'static str> {
     match label {
         "status" | "Status" => Some("Status"),
         "taskId" | "Task ID" => Some("Task ID"),
+        "taskType" | "Task type" => Some("Task type"),
+        "workflowName" | "Workflow name" => Some("Workflow name"),
         "runId" | "Run ID" => Some("Run ID"),
         "summary" | "Summary" => Some("Summary"),
         "transcriptDir" | "Transcript dir" => Some("Transcript dir"),
@@ -232,7 +234,7 @@ mod tests {
         let tc = workflow_tool_call(
             json!({}),
             Some(
-                "Status: async launched\nTask ID: wf-1\nRun ID: run-1\nSummary: started\nTranscript dir: C:/tmp/transcripts\nScript path: C:/tmp/workflow.js\nSession URL: https://claude.ai/session/1\nWarning: branch diverged",
+                "Status: async launched\nTask ID: wf-1\nTask type: local_workflow\nWorkflow name: spec\nRun ID: run-1\nSummary: started\nTranscript dir: C:/tmp/transcripts\nScript path: C:/tmp/workflow.js\nSession URL: https://claude.ai/session/1\nWarning: branch diverged",
             ),
             model::ToolCallStatus::InProgress,
         );
@@ -244,6 +246,8 @@ mod tests {
             vec![
                 "Status: async launched",
                 "Task ID: wf-1",
+                "Task type: local_workflow",
+                "Workflow name: spec",
                 "Run ID: run-1",
                 "Summary: started",
                 "Transcript dir: C:/tmp/transcripts",

--- a/src/ui/tool_call/workflow.rs
+++ b/src/ui/tool_call/workflow.rs
@@ -165,6 +165,7 @@ mod tests {
     ) -> ToolCallInfo {
         let mut tc = ToolCallInfo {
             id: "tc-workflow".to_owned(),
+            source_message_uuids: Vec::new(),
             title: "Workflow".to_owned(),
             sdk_tool_name: "Workflow".to_owned(),
             raw_input: Some(raw_input),

--- a/src/ui/tool_call/worktree.rs
+++ b/src/ui/tool_call/worktree.rs
@@ -128,6 +128,7 @@ mod tests {
     ) -> ToolCallInfo {
         let mut tc = ToolCallInfo {
             id: "tc-worktree".to_owned(),
+            source_message_uuids: Vec::new(),
             title: "tc-worktree".to_owned(),
             sdk_tool_name: sdk_tool_name.to_owned(),
             raw_input: Some(raw_input),


### PR DESCRIPTION
## Summary

- Bumps both package surfaces from `@anthropic-ai/claude-agent-sdk@0.3.161` to `0.3.177`.
- Updates the TypeScript bridge and Rust wire/app layers for the newer SDK message, model, dialog, task, tool, MCP, and plugin surfaces.
- Adds host handling for transcript retractions, refusal fallback dialogs, assistant supersedes metadata, richer task lifecycle updates, and newer tool output families.
- Improves MCP handling for scoped config removal, dynamic SDK-managed servers, plugin-owned MCP servers, plugin inventory reloads, and runtime snapshot confirmation.
- Filters unavailable Fable models while preserving unknown future model IDs, and expands regression coverage for the 0.3.177 migration paths.

## Why

The project needs to run against `@anthropic-ai/claude-agent-sdk@0.3.177` without dropping newer SDK/runtime behavior or exposing stale state in the TUI. The migration keeps the bridge and Rust app aligned with the current SDK contract by preserving new message metadata, supporting host dialog requests, mapping newer task/tool surfaces, handling MCP ownership more precisely, and keeping model availability defensive.

Branch history is organized as an 11-commit migration series on `migrate/agent-sdk-0.3.177`, starting with the dependency bump and layering bridge/Rust compatibility, transcript and dialog handling, tool rendering, MCP/plugin ownership, model filtering, and regression coverage.

Closes #N/A

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `npm run build` in `agent-sdk`
  - `npm test` in `agent-sdk`
- Manual:
  - Not run.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- This title follows the recent merged migration PR style: `feat(agent-sdk): migrate Claude Agent SDK to 0.3.161`.
