### PR TITLE
feat(ui): improve MCP tool call display`

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -18,6 +18,7 @@ mod session_picker;
 mod spinner_verbs;
 pub mod theme;
 mod tool_call;
+pub(crate) mod tool_display;
 mod trusted;
 mod two_column_list;
 mod welcome;

--- a/src/ui/tool_call/interactions.rs
+++ b/src/ui/tool_call/interactions.rs
@@ -6,6 +6,7 @@
 use crate::agent::model::PermissionOptionKind;
 use crate::app::{InlinePermission, InlineQuestion, ToolCallInfo};
 use crate::ui::theme;
+use crate::ui::tool_display;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
@@ -135,10 +136,16 @@ fn permission_display_lines(
 
 fn is_redundant_permission_header(tc: &ToolCallInfo, value: &str) -> bool {
     let normalized = normalize_permission_header(value);
-    let tool_label = normalize_permission_header(theme::tool_name_label(&tc.sdk_tool_name).1);
+    let tool_label = tool_display::tool_name_label(&tc.sdk_tool_name);
+    let tool_label = normalize_permission_header(tool_label.label.as_ref());
+    let display_title = tool_display::tool_title(&tc.sdk_tool_name, &tc.title);
+    let display_title = normalize_permission_header(display_title.as_ref());
     let sdk_name = normalize_permission_header(&tc.sdk_tool_name);
     let title = normalize_permission_header(&tc.title);
-    normalized == tool_label || normalized == sdk_name || normalized == title
+    normalized == tool_label
+        || normalized == display_title
+        || normalized == sdk_name
+        || normalized == title
 }
 
 fn normalize_permission_header(value: &str) -> String {
@@ -555,6 +562,29 @@ mod tests {
 
         assert!(!rendered.contains("\n  Bash\n"));
         assert!(rendered.contains("This command reads project files"));
+    }
+
+    #[test]
+    fn permission_display_metadata_hides_redundant_mcp_display_title() {
+        let mut tc = test_tool_call("mcp__claude_ai_Strava__list_activities");
+        tc.title = tc.sdk_tool_name.clone();
+        let mut perm = test_permission(PermissionOptionKind::AllowOnce);
+        perm.display = Some(
+            PermissionDisplay::new()
+                .title(Some("Strava: List activities".to_owned()))
+                .description(Some("This action reads activity metadata".to_owned())),
+        );
+
+        let rendered = render_permission_lines(&tc, &perm)
+            .into_iter()
+            .map(|line| {
+                line.spans.into_iter().map(|span| span.content.into_owned()).collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(!rendered.contains("\n  Strava: List activities\n"));
+        assert!(rendered.contains("This action reads activity metadata"));
     }
 
     #[test]

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -32,6 +32,7 @@ use crate::agent::model;
 use crate::app::ToolCallInfo;
 use crate::ui::markdown;
 use crate::ui::theme;
+use crate::ui::tool_display;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -246,7 +247,7 @@ fn tool_display_title<'a>(
         }
     }
 
-    Cow::Borrowed(&tc.title)
+    tool_display::tool_title(&tc.sdk_tool_name, &tc.title)
 }
 
 // ---------------------------------------------------------------------------
@@ -468,6 +469,49 @@ mod tests {
     }
 
     #[test]
+    fn tool_display_title_formats_raw_mcp_titles() {
+        let tc = test_tool_call(
+            "mcp__claude_ai_Strava__list_activities",
+            "mcp__claude_ai_Strava__list_activities",
+            model::ToolCallStatus::Completed,
+        );
+
+        assert_eq!(
+            tool_display_title(&tc, ToolCallRenderContext::default()),
+            "Strava: List activities"
+        );
+    }
+
+    #[test]
+    fn tool_display_title_keeps_non_raw_mcp_titles() {
+        let mut tc = test_tool_call(
+            "mcp__claude_ai_Strava__list_activities",
+            "mcp__claude_ai_Strava__list_activities",
+            model::ToolCallStatus::Completed,
+        );
+        tc.title = "Recent Strava activities".to_owned();
+
+        assert_eq!(
+            tool_display_title(&tc, ToolCallRenderContext::default()),
+            "Recent Strava activities"
+        );
+    }
+
+    #[test]
+    fn tool_display_title_keeps_malformed_mcp_titles_raw() {
+        let tc = test_tool_call(
+            "mcp__fff_find_files",
+            "mcp__fff_find_files",
+            model::ToolCallStatus::Completed,
+        );
+
+        assert_eq!(
+            tool_display_title(&tc, ToolCallRenderContext::default()),
+            "mcp__fff_find_files"
+        );
+    }
+
+    #[test]
     fn standard_title_uses_plan_alias_for_write() {
         let tc = test_tool_call("Write notes/plan.md", "Write", model::ToolCallStatus::Completed);
 
@@ -492,6 +536,23 @@ mod tests {
             standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 80, 0);
 
         assert_eq!(rendered.spans.get(1).map(|span| span.content.as_ref()), Some("\u{25cb} "));
+    }
+
+    #[test]
+    fn standard_title_uses_mcp_icon_and_readable_title() {
+        let tc = test_tool_call(
+            "mcp__fff__find_files",
+            "mcp__fff__find_files",
+            model::ToolCallStatus::Completed,
+        );
+
+        let rendered =
+            standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 80, 0);
+        let text: String = rendered.spans.iter().map(|span| span.content.as_ref()).collect();
+
+        assert_eq!(rendered.spans.get(1).map(|span| span.content.as_ref()), Some("\u{232c} "));
+        assert!(text.contains("fff: Find files"));
+        assert!(!text.contains("mcp__fff__find_files"));
     }
 
     #[test]

--- a/src/ui/tool_call/standard.rs
+++ b/src/ui/tool_call/standard.rs
@@ -9,6 +9,7 @@ use crate::ui::diff::{is_markdown_file, lang_from_title, render_diff, strip_oute
 use crate::ui::highlight;
 use crate::ui::markdown;
 use crate::ui::theme;
+use crate::ui::tool_display;
 use crate::ui::wrap::wrap_lines_to_physical_rows;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -45,12 +46,12 @@ pub(super) fn render_tool_call_title(
     spinner_frame: usize,
 ) -> Line<'static> {
     let (icon, icon_color) = status_icon(tc.status, spinner_frame);
-    let (kind_icon, kind_name) = theme::tool_name_label(&tc.sdk_tool_name);
+    let kind_label = tool_display::tool_name_label(&tc.sdk_tool_name);
     let kind_icon_span = if let Some((task_marker, task_marker_style)) = tasks::title_marker(tc) {
         Span::styled(format!("{task_marker} "), task_marker_style)
     } else {
         Span::styled(
-            format!("{kind_icon} "),
+            format!("{} ", kind_label.icon),
             Style::default().fg(ratatui::style::Color::White).add_modifier(Modifier::BOLD),
         )
     };
@@ -59,7 +60,7 @@ pub(super) fn render_tool_call_title(
         vec![Span::styled(format!("  {icon} "), Style::default().fg(icon_color)), kind_icon_span];
     if tc.is_execute_tool() {
         title_spans.push(Span::styled(
-            format!("{kind_name} "),
+            format!("{} ", kind_label.label.as_ref()),
             Style::default().fg(ratatui::style::Color::White).add_modifier(Modifier::BOLD),
         ));
     }

--- a/src/ui/tool_display.rs
+++ b/src/ui/tool_display.rs
@@ -1,0 +1,287 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+//! Presentation-only formatting for tool names and titles.
+
+use std::borrow::Cow;
+
+use crate::ui::theme;
+
+const MCP_PREFIX: &str = "mcp__";
+const MCP_ICON: &str = "\u{232c}";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ToolLabel<'a> {
+    pub(crate) icon: &'static str,
+    pub(crate) label: Cow<'a, str>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct McpToolDisplay {
+    pub(crate) server: String,
+    pub(crate) tool: String,
+}
+
+impl McpToolDisplay {
+    #[must_use]
+    pub(crate) fn title(&self) -> String {
+        format!("{}: {}", self.server, self.tool)
+    }
+}
+
+#[must_use]
+pub(crate) fn parse_mcp_tool_name(raw: &str) -> Option<McpToolDisplay> {
+    let rest = raw.strip_prefix(MCP_PREFIX)?;
+    let (server_raw, tool_raw) = rest.split_once("__")?;
+    if server_raw.is_empty() || tool_raw.is_empty() {
+        return None;
+    }
+
+    Some(McpToolDisplay {
+        server: humanize_server_name(server_raw).unwrap_or_else(|| server_raw.to_owned()),
+        tool: humanize_tool_name(tool_raw).unwrap_or_else(|| tool_raw.to_owned()),
+    })
+}
+
+#[must_use]
+pub(crate) fn tool_name_label(sdk_tool_name: &str) -> ToolLabel<'_> {
+    if let Some(display) = parse_mcp_tool_name(sdk_tool_name) {
+        return ToolLabel { icon: MCP_ICON, label: Cow::Owned(display.server) };
+    }
+
+    let (icon, label) = theme::tool_name_label(sdk_tool_name);
+    ToolLabel { icon, label: Cow::Borrowed(label) }
+}
+
+#[must_use]
+pub(crate) fn tool_title<'a>(raw_tool_name: &'a str, raw_title: &'a str) -> Cow<'a, str> {
+    let title = if raw_title.is_empty() { raw_tool_name } else { raw_title };
+    if title == raw_tool_name
+        && let Some(display) = parse_mcp_tool_name(raw_tool_name)
+    {
+        return Cow::Owned(display.title());
+    }
+
+    Cow::Borrowed(title)
+}
+
+fn humanize_server_name(raw: &str) -> Option<String> {
+    let words = clean_server_words(split_identifier_words(raw));
+    join_non_empty(words.into_iter().map(|word| format_server_word(&word)))
+}
+
+fn clean_server_words(mut words: Vec<String>) -> Vec<String> {
+    if words.len() > 2
+        && words[0].eq_ignore_ascii_case("claude")
+        && words[1].eq_ignore_ascii_case("ai")
+    {
+        words.drain(0..2);
+    }
+    if words.len() > 1 && words[0].eq_ignore_ascii_case("plugin") {
+        words.remove(0);
+    }
+
+    let mut seen = Vec::new();
+    let mut out = Vec::new();
+    for word in words {
+        let key = word.to_ascii_lowercase();
+        if seen.iter().any(|existing| existing == &key) {
+            continue;
+        }
+        seen.push(key);
+        out.push(word);
+    }
+    out
+}
+
+fn humanize_tool_name(raw: &str) -> Option<String> {
+    let words = split_identifier_words(raw);
+    join_non_empty(
+        words.into_iter().enumerate().map(|(index, word)| format_tool_word(&word, index == 0)),
+    )
+}
+
+fn split_identifier_words(raw: &str) -> Vec<String> {
+    let chars = raw.chars().collect::<Vec<_>>();
+    let mut words = Vec::new();
+    let mut current = String::new();
+
+    for (index, ch) in chars.iter().copied().enumerate() {
+        if !ch.is_ascii_alphanumeric() {
+            push_identifier_word(&mut words, &mut current);
+            continue;
+        }
+
+        if starts_identifier_word(&current, ch, chars.get(index + 1).copied()) {
+            push_identifier_word(&mut words, &mut current);
+        }
+        current.push(ch);
+    }
+    push_identifier_word(&mut words, &mut current);
+
+    words
+}
+
+fn starts_identifier_word(current: &str, ch: char, next: Option<char>) -> bool {
+    let Some(previous) = current.chars().last() else {
+        return false;
+    };
+
+    (previous.is_ascii_lowercase() && ch.is_ascii_uppercase())
+        || (previous.is_ascii_uppercase()
+            && ch.is_ascii_uppercase()
+            && current.len() > 1
+            && next.is_some_and(|next| next.is_ascii_lowercase()))
+}
+
+fn push_identifier_word(words: &mut Vec<String>, current: &mut String) {
+    if !current.is_empty() {
+        words.push(std::mem::take(current));
+    }
+}
+
+fn format_server_word(word: &str) -> String {
+    if word.chars().any(|ch| ch.is_ascii_uppercase()) || word.len() <= 4 {
+        return word.to_owned();
+    }
+    capitalize_ascii(&word.to_ascii_lowercase())
+}
+
+fn format_tool_word(word: &str, first: bool) -> String {
+    if has_intentional_case(word) {
+        return word.to_owned();
+    }
+
+    let normalized = word.to_ascii_lowercase();
+    if first { capitalize_ascii(&normalized) } else { normalized }
+}
+
+fn has_intentional_case(word: &str) -> bool {
+    word.chars().filter(char::is_ascii_uppercase).count() > 1
+}
+
+fn capitalize_ascii(value: &str) -> String {
+    let Some(first) = value.chars().next() else {
+        return String::new();
+    };
+    let mut out = String::with_capacity(value.len());
+    out.push(first.to_ascii_uppercase());
+    out.push_str(&value[first.len_utf8()..]);
+    out
+}
+
+fn join_non_empty(words: impl Iterator<Item = String>) -> Option<String> {
+    let mut out = String::new();
+    for word in words {
+        if word.is_empty() {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(&word);
+    }
+    (!out.is_empty()).then_some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MCP_ICON, parse_mcp_tool_name, tool_name_label, tool_title};
+    use unicode_width::UnicodeWidthStr;
+
+    #[test]
+    fn parse_mcp_tool_name_formats_known_examples() {
+        let cases = [
+            (
+                "mcp__claude_ai_Strava__list_activities",
+                "Strava",
+                "List activities",
+                "Strava: List activities",
+            ),
+            (
+                "mcp__claude_ai_Strava__get_activity_streams",
+                "Strava",
+                "Get activity streams",
+                "Strava: Get activity streams",
+            ),
+            ("mcp__fff__find_files", "fff", "Find files", "fff: Find files"),
+            (
+                "mcp__plugin_Notion_notion__notion-search",
+                "Notion",
+                "Notion search",
+                "Notion: Notion search",
+            ),
+        ];
+
+        for (raw, server, tool, title) in cases {
+            let display = parse_mcp_tool_name(raw).expect("valid MCP tool name");
+            assert_eq!(display.server, server);
+            assert_eq!(display.tool, tool);
+            assert_eq!(display.title(), title);
+        }
+    }
+
+    #[test]
+    fn parse_mcp_tool_name_requires_non_empty_server_and_tool_segments() {
+        for raw in ["mcp__missing_separator", "mcp____find_files", "mcp__fff__", "not_mcp__x__y"] {
+            assert_eq!(parse_mcp_tool_name(raw), None);
+        }
+    }
+
+    #[test]
+    fn parse_mcp_tool_name_preserves_raw_segments_when_humanizing_has_no_words() {
+        let display = parse_mcp_tool_name("mcp__---__...").expect("valid MCP wrapper");
+        assert_eq!(display.server, "---");
+        assert_eq!(display.tool, "...");
+        assert_eq!(display.title(), "---: ...");
+    }
+
+    #[test]
+    fn tool_name_label_uses_mcp_icon_and_server_label() {
+        let label = tool_name_label("mcp__claude_ai_Strava__get_gear");
+        assert_eq!(label.icon, MCP_ICON);
+        assert_eq!(label.label.as_ref(), "Strava");
+    }
+
+    #[test]
+    fn mcp_icon_is_single_column() {
+        assert_eq!(UnicodeWidthStr::width(MCP_ICON), 1);
+    }
+
+    #[test]
+    fn tool_name_label_keeps_generic_fallback_for_unknown_non_mcp_tools() {
+        let label = tool_name_label("UnknownFutureTool");
+        assert_eq!(label.icon, "\u{25cb}");
+        assert_eq!(label.label.as_ref(), "Tool");
+    }
+
+    #[test]
+    fn tool_title_formats_raw_mcp_titles_only() {
+        assert_eq!(
+            tool_title(
+                "mcp__claude_ai_Strava__get_athlete_profile",
+                "mcp__claude_ai_Strava__get_athlete_profile",
+            )
+            .as_ref(),
+            "Strava: Get athlete profile",
+        );
+        assert_eq!(
+            tool_title("mcp__claude_ai_Strava__get_athlete_zones", "Athlete zones").as_ref(),
+            "Athlete zones",
+        );
+    }
+
+    #[test]
+    fn tool_title_falls_back_to_raw_name_for_unknown_mcp_shapes() {
+        assert_eq!(
+            tool_title("mcp__fff_find_files", "mcp__fff_find_files").as_ref(),
+            "mcp__fff_find_files",
+        );
+    }
+
+    #[test]
+    fn tool_title_uses_tool_name_when_title_is_empty() {
+        assert_eq!(tool_title("mcp__fff__find_files", "").as_ref(), "fff: Find files");
+        assert_eq!(tool_title("UnknownFutureTool", "").as_ref(), "UnknownFutureTool");
+    }
+}


### PR DESCRIPTION
## Summary

This PR improves how MCP tool calls are presented in the TUI without changing the underlying tool-call model or event data.

Previously, MCP tools were rendered as unknown tools, so the header used the generic icon and displayed raw identifiers such as:

```text
mcp__claude_ai_Strava__list_activities
mcp__fff__find_files
mcp__plugin_Notion_notion__notion-search
```

This change adds a presentation-layer formatter that keeps raw `sdk_tool_name` and `title` values intact, while rendering clearer labels for users:

```text
⌬ Strava: List activities
⌬ fff: Find files
⌬ Notion: Notion search
```

## Details

- Adds `src/ui/tool_display.rs` as a shared UI-only formatter for tool names and titles.
- Detects MCP tool names in the `mcp__<server>__<tool>` shape.
- Humanizes server and tool segments deterministically:
  - strips low-signal wrapper tokens such as `claude_ai` and `plugin` when a better server name remains,
  - deduplicates repeated server words such as `Notion_notion`,
  - splits identifiers across `_`, `-`, `.`, `/`, and camel-case boundaries,
  - preserves raw segments when parsing or humanization cannot produce a safer readable value.
- Uses the dedicated `⌬` MCP icon instead of the generic unknown-tool icon.
- Formats raw MCP titles only when `title == sdk_tool_name`.
- Preserves richer non-raw titles from the bridge, so future SDK or MCP title improvements are not flattened.
- Reuses the same formatter in permission-header de-duplication so permission prompts do not repeat the newly formatted title.

## Safety And Compatibility

The parser is intentionally presentation-only. It does not mutate stored tool names, event payloads, logs, permission identifiers, raw titles, or bridge metadata.

Unknown non-MCP tools still use the existing generic `○ Tool` fallback. Malformed MCP-like values remain visible as raw identifiers rather than disappearing or being replaced with a misleading label.

The `⌬` icon is a normal Unicode glyph, not private-use or emoji, and is covered by a test asserting that `unicode-width` treats it as single-column for TUI layout.

## Examples

```text
mcp__claude_ai_Strava__list_activities
=> Strava: List activities

mcp__claude_ai_Strava__get_activity_streams
=> Strava: Get activity streams

mcp__fff__find_files
=> fff: Find files

mcp__plugin_Notion_notion__notion-search
=> Notion: Notion search
```

Malformed or unknown shapes intentionally stay raw:

```text
mcp__fff_find_files
=> mcp__fff_find_files
```

## Validation

Passed locally:

```text
cargo fmt --all -- --check
cargo test mcp_icon
cargo test standard_title_uses_mcp_icon_and_readable_title
cargo test mcp
cargo clippy --all-targets --all-features -- -D warnings
cargo check --offline
cargo test
```