### PR TITLE
chore(release): prepare 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.2] - 2026-06-14 [Changes][v0.12.2]
+
+### Features
+
+- **Claude Agent SDK 0.3.177 migration** (#180, #182, @srothgan): Refresh the bridge for new SDK metadata, task events, dialogs, retractions, retry errors, and MCP status.
+- **Opus 4.8 and effort controls** (#180, @srothgan): Add `/opus-version 4.8`, `/effort`, `xhigh`, session-only `max`, and live `/agent` switching.
+- **MCP configuration management** (#180, #182, @srothgan): Add scoped server removal and track dynamic, plugin-owned, persisted, and runtime-only servers.
+
+### UI
+
+- **Structured SDK tool rendering** (#180, #182, @srothgan): Add readable renderers for new task, automation, workflow, MCP, search, project, artifact, and agent tool outputs.
+- **MCP tool-call display** (#184, @srothgan): Show readable MCP titles with a dedicated icon while keeping raw tool names intact.
+- **Config dialog overlays** (#180, @srothgan): Tighten fullscreen dialogs, confirmations, and small-screen overflow.
+
+### Fixes
+
+- **SDK compatibility hardening** (#180, #182, @srothgan): Normalize retry errors, overage fields, unavailable models, mirror errors, resume task replay, and MCP snapshot refresh.
+- **Plugin and MCP scope accuracy** (#180, #182, @srothgan): Filter plugin lists and stale MCP servers by the scopes that are actually active.
+
+### Diagnostics
+
+- **Timestamped runtime logs** (#183, @srothgan): Write default diagnostics to per-run files under `logs/runtime` with bounded retention.
+
+### Documentation
+
+- **Commands and diagnostics manual updates** (#180, #183, @srothgan): Document `/effort`, `/opus-version 4.8`, settings behavior, and diagnostics paths.
+
+### CI and Dependencies
+
+- **Agent SDK package refresh** (#180, #182, @srothgan): Update the Agent SDK bridge packages and npm lockfiles.
+- **Rust dependency updates** (#176, #177, #178, #179): Bump `unicode-segmentation` to `1.13.3`, `uuid` to `1.23.2`, `reqwest` to `0.13.4`, and `ratatui` to `0.30.1`.
+- **Pages workflow updates** (#173, #174, #175): Bump `actions/upload-pages-artifact` to `5`, `actions/deploy-pages` to `5`, and `actions/configure-pages` to `6`.
+
 ## [0.12.1] - 2026-05-28 [Changes][v0.12.1]
 
 ### Documentation
@@ -556,6 +589,8 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.12.2]: https://github.com/srothgan/claude-code-rust/compare/v0.12.1...v0.12.2
+[v0.12.1]: https://github.com/srothgan/claude-code-rust/compare/v0.12.0...v0.12.1
 [v0.12.0]: https://github.com/srothgan/claude-code-rust/compare/v0.11.3...v0.12.0
 [v0.11.3]: https://github.com/srothgan/claude-code-rust/compare/v0.11.2...v0.11.3
 [v0.11.2]: https://github.com/srothgan/claude-code-rust/compare/v0.11.1...v0.11.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,5 +1,2 @@
-# Changelog
-
-The changelog below is included from the repository root `CHANGELOG.md`.
 
 {{#include ../../CHANGELOG.md}}


### PR DESCRIPTION
## Summary

Prepare the 0.12.2 release metadata and changelog.

- Add the 0.12.2 changelog entry.
- Bump Cargo package metadata from 0.12.1 to 0.12.2.
- Add missing changelog compare links for 0.12.1 and 0.12.2.
- Leave npm package versioning to `release-npm.yml`, which syncs from `Cargo.toml`.

## Release Analysis

This release covers first-parent squash merges since `v0.12.1`:

- #173, #174, #175: GitHub Pages action bumps.
- #176, #177, #178, #179: Rust dependency bumps.
- #180, #182: Claude Agent SDK migrations through `0.3.177`.
- #183: timestamped runtime diagnostics logs.
- #184: MCP tool call display improvements.

Anthropic's current Opus 4.8 docs list `claude-opus-4-8` as the API model ID and describe it as compatible with existing Opus 4.7 code paths while adding new behavior such as documented effort defaults, fast mode, and a lower prompt-cache minimum. The changelog entry reflects the local work needed for this app: Opus 4.8 selection, effort controls, SDK bridge compatibility, MCP metadata, and newer SDK tool rendering.

Sources:

- https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-8
- https://platform.claude.com/docs/en/about-claude/models/migration-guide
- https://code.claude.com/docs/en/agent-sdk/typescript

## Changes

### Release Metadata

- `Cargo.toml`: set `claude-code-rust` to `0.12.2`.
- `Cargo.lock`: update the local package entry to `0.12.2`.
- `CHANGELOG.md`: add the 0.12.2 section and compare links.

### Changelog Highlights

- Claude Agent SDK bridge refresh through `0.3.177`.
- Opus 4.8, `/effort`, `xhigh`, session-only `max`, and live `/agent` switching.
- Scoped MCP server removal and clearer MCP ownership tracking.
- Readable rendering for newer SDK tool output shapes.
- Timestamped runtime logs under `logs/runtime`.
- Rust dependency and Pages workflow bumps.

## Validation

- did not run it
