### PR TITLE
ci: advisory-quality-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,25 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  unsafe-code:
+    name: Unsafe Code Warning
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    env:
+      RUSTFLAGS: ""
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # `cargo rustc` applies `-W unsafe-code` only to the selected project target,
+      # avoiding dependency noise from low-level terminal/platform crates.
+      - name: Warn on unsafe in library target
+        continue-on-error: true
+        run: cargo rustc --lib --all-features -- -W unsafe-code
+      - name: Warn on unsafe in binary target
+        continue-on-error: true
+        run: cargo rustc --bin claude-rs --all-features -- -W unsafe-code
+
   msrv:
     name: MSRV Check
     runs-on: ubuntu-latest

--- a/.github/workflows/duplication.yml
+++ b/.github/workflows/duplication.yml
@@ -1,0 +1,50 @@
+name: Duplicate Code
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: duplicate-code-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  jscpd:
+    name: jscpd warning scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      JSCPD_WARNING_THRESHOLD: "3.0"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run duplicate code scan
+        run: npm run quality:duplicates
+
+      - name: Publish duplicate code warning summary
+        if: always()
+        run: npm run quality:duplicates:summary
+
+      - name: Upload duplicate code report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jscpd-report
+          path: jscpd-report/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ node_modules/
 /vendor/
 /agent-sdk/dist/
 /docs/book/
+/jscpd-report/
 
 # Local Claude Code config
 .claude/

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,25 @@
+{
+  "reporters": ["console", "json", "html"],
+  "output": "jscpd-report",
+  "mode": "mild",
+  "minLines": 10,
+  "minTokens": 100,
+  "ignore": [
+    "**/target/**",
+    "**/node_modules/**",
+    "**/.npm-cache/**",
+    "**/vendor/**",
+    "**/agent-sdk/dist/**",
+    "**/docs/book/**",
+    "**/.claude/**",
+    "**/.codex/**",
+    "**/notes/**",
+    "**/analysis/**",
+    "**/jscpd-report/**",
+    "**/report/**",
+    "**/*.test.ts",
+    "**/tests.rs",
+    "**/*.lock",
+    "**/*.log"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,9 @@
       "bin": {
         "claude-rs": "bin/claude-rs.js"
       },
+      "devDependencies": {
+        "jscpd": "5.0.9"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -402,6 +405,90 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/cpd-darwin-arm64": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/cpd-darwin-arm64/-/cpd-darwin-arm64-5.0.9.tgz",
+      "integrity": "sha512-hUYQKrUUmlYxl2MDD8GYESpcKc5M5eGMjiHTK+O8ooCj1ogPiNHXg+aIeDl6BuLu7v3jFDcCu5fVqtcpHzAKpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/cpd-darwin-x64": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/cpd-darwin-x64/-/cpd-darwin-x64-5.0.9.tgz",
+      "integrity": "sha512-viCFEUhUQnGundSMFq9ixi+RxfRiNDQsWP/CZErMlf20fM5h9zTtrHI9liNyRQn+ZtQUTTpabQ4PpzDV530bMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/cpd-linux-arm64-gnu": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/cpd-linux-arm64-gnu/-/cpd-linux-arm64-gnu-5.0.9.tgz",
+      "integrity": "sha512-BxiLx9haM+AhDlkyFoe1ro1w4/dvAteyEGytv4XraaRNntw2NMFX1Fsa9I8waegpXydM6E0lPWRWqkG59rin3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/cpd-linux-x64-gnu": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/cpd-linux-x64-gnu/-/cpd-linux-x64-gnu-5.0.9.tgz",
+      "integrity": "sha512-VC2bUEJ0KRZ3fJijqqFcrBl6a69vmHrrNoJkSPtFwFju8x7ce2Vs9ntEmlxeB7Ho4mIzN8OYOrlCeqyNdAZcUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/cpd-linux-x64-musl": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/cpd-linux-x64-musl/-/cpd-linux-x64-musl-5.0.9.tgz",
+      "integrity": "sha512-YJekKRRgAhez2+Rrbt42fp8cJuNi/PtGuBb8jIzEtegXRRBG9CE9HaoTy0mS3JeiQuwxiT0Fnz2j8hR9gDbq0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/cpd-windows-x64-msvc": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/cpd-windows-x64-msvc/-/cpd-windows-x64-msvc-5.0.9.tgz",
+      "integrity": "sha512-Z54yLFmRjIgTMqzeUxbZzgxj8gWxB/jjMi/QOkBOLx9yHHwzhW8MukpY7JhCOmlvPOOn6pjSVrMTxChliDcYAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -836,6 +923,28 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jscpd": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-5.0.9.tgz",
+      "integrity": "sha512-52zn0erBrRCCLvKulOs/UNUsL2fAmnMRUUbwbJhfUmqI9jtVSQ2Hk20F7m58JnkmgBEoyNBSTTomrF8K+H4fLA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cpd": "run-jscpd.js",
+        "jscpd": "run-jscpd.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "cpd-darwin-arm64": "5.0.9",
+        "cpd-darwin-x64": "5.0.9",
+        "cpd-linux-arm64-gnu": "5.0.9",
+        "cpd-linux-x64-gnu": "5.0.9",
+        "cpd-linux-x64-musl": "5.0.9",
+        "cpd-windows-x64-msvc": "5.0.9"
       }
     },
     "node_modules/json-schema-to-ts": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,12 @@
   },
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",
-    "prepack": "npm --prefix agent-sdk run build"
+    "prepack": "npm --prefix agent-sdk run build",
+    "quality:duplicates": "jscpd --config .jscpd.json src agent-sdk/src scripts bin --no-tips --no-colors",
+    "quality:duplicates:summary": "node scripts/jscpd-warning-summary.mjs jscpd-report/jscpd-report.json"
+  },
+  "devDependencies": {
+    "jscpd": "5.0.9"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/jscpd-warning-summary.mjs
+++ b/scripts/jscpd-warning-summary.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+
+const reportPath = process.argv[2] ?? "jscpd-report/jscpd-report.json";
+const warningThreshold = Number.parseFloat(process.env.JSCPD_WARNING_THRESHOLD ?? "3.0");
+
+function escapeWorkflowCommand(value) {
+  return String(value).replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+}
+
+function markdownCell(value) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function asNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function formatPercent(value) {
+  return `${asNumber(value).toFixed(2)}%`;
+}
+
+function formatLocation(location) {
+  if (!location?.name) {
+    return "unknown";
+  }
+  const name = String(location.name).replaceAll("\\", "/");
+  const start = asNumber(location.start, asNumber(location.startLoc?.line, 1));
+  const end = asNumber(location.end, asNumber(location.endLoc?.line, start));
+  return `${name}:${start}-${end}`;
+}
+
+function appendSummary(markdown) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    fs.appendFileSync(summaryPath, `${markdown}\n`);
+  }
+}
+
+function emitWarning(message) {
+  console.log(`::warning title=Duplicate code soft threshold::${escapeWorkflowCommand(message)}`);
+}
+
+if (!fs.existsSync(reportPath)) {
+  const message = `jscpd report not found at ${reportPath}; duplicate-code summary was skipped.`;
+  emitWarning(message);
+  appendSummary(`### Duplicate Code Scan\n\n${message}\n`);
+  process.exit(0);
+}
+
+const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+const total = report.statistics?.total ?? {};
+const formats = report.statistics?.formats ?? {};
+const duplicates = Array.isArray(report.duplicates) ? report.duplicates : [];
+
+const percentage = asNumber(total.percentage);
+const clones = asNumber(total.clones, duplicates.length);
+const duplicatedLines = asNumber(total.duplicatedLines);
+const totalLines = asNumber(total.lines);
+const duplicatedTokens = asNumber(total.duplicatedTokens);
+const totalTokens = asNumber(total.tokens);
+
+const status =
+  percentage >= warningThreshold
+    ? `Warning: duplicated lines are ${formatPercent(percentage)}, above the ${formatPercent(warningThreshold)} soft threshold.`
+    : `OK: duplicated lines are ${formatPercent(percentage)}, below the ${formatPercent(warningThreshold)} soft threshold.`;
+
+console.log(status);
+console.log(
+  `jscpd found ${clones} clones across ${totalLines} lines and ${totalTokens} tokens ` +
+    `(${duplicatedLines} duplicated lines, ${duplicatedTokens} duplicated tokens).`,
+);
+
+if (percentage >= warningThreshold) {
+  emitWarning(
+    `jscpd found ${formatPercent(percentage)} duplicated lines (${clones} clones), ` +
+      `above the ${formatPercent(warningThreshold)} advisory threshold. ` +
+      "This workflow is warning-only and does not block the PR.",
+  );
+}
+
+const formatRows = Object.entries(formats)
+  .sort(([, left], [, right]) => asNumber(right.percentage) - asNumber(left.percentage))
+  .map(([format, stats]) =>
+    [
+      markdownCell(format),
+      asNumber(stats.sources),
+      asNumber(stats.clones),
+      asNumber(stats.duplicatedLines),
+      formatPercent(stats.percentage),
+    ].join(" | "),
+  );
+
+const topDuplicates = [...duplicates]
+  .sort((left, right) => asNumber(right.lines) - asNumber(left.lines))
+  .slice(0, 10)
+  .map((duplicate) =>
+    [
+      asNumber(duplicate.lines),
+      asNumber(duplicate.tokens),
+      markdownCell(duplicate.format ?? "unknown"),
+      markdownCell(formatLocation(duplicate.firstFile)),
+      markdownCell(formatLocation(duplicate.secondFile)),
+    ].join(" | "),
+  );
+
+const summary = [
+  "### Duplicate Code Scan",
+  "",
+  status,
+  "",
+  "| Metric | Value |",
+  "| --- | ---: |",
+  `| Clones | ${clones} |`,
+  `| Duplicated lines | ${duplicatedLines} / ${totalLines} (${formatPercent(percentage)}) |`,
+  `| Duplicated tokens | ${duplicatedTokens} / ${totalTokens} (${formatPercent(total.percentageTokens)}) |`,
+  `| Soft threshold | ${formatPercent(warningThreshold)} |`,
+  "",
+  "| Format | Files | Clones | Duplicated lines | Duplicated lines % |",
+  "| --- | ---: | ---: | ---: | ---: |",
+  ...formatRows,
+  "",
+  "| Lines | Tokens | Format | First location | Second location |",
+  "| ---: | ---: | --- | --- | --- |",
+  ...(topDuplicates.length > 0 ? topDuplicates : ["| 0 | 0 | none | n/a | n/a |"]),
+  "",
+  "The complete JSON and HTML reports are attached as the `jscpd-report` workflow artifact.",
+  "",
+].join("\n");
+
+appendSummary(summary);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -280,6 +280,7 @@ fn suspend_tui_process(
 }
 
 #[cfg(unix)]
+#[allow(unsafe_code)]
 fn suspend_current_process() -> anyhow::Result<()> {
     // SAFETY: `raise` targets the current process with a constant signal and does
     // not dereference pointers or rely on external memory validity.


### PR DESCRIPTION
## Summary

- Add a pull-request-only unsafe-code warning check for the Rust library and binary targets.
- Scope the existing Unix `libc::raise(SIGTSTP)` unsafe block as the reviewed unsafe-code exception.
- Add a jscpd duplicate-code quality scan with JSON/HTML artifacts and a warning summary.
- Add npm scripts and ignore rules for local duplicate-code reports.

## Why

The unsafe-code check keeps new project-owned unsafe Rust visible without reporting dependency noise from terminal, async, platform, or rendering crates. The jscpd workflow adds an advisory duplication signal so reviewers can track copy-paste drift without blocking normal development.

Closes N/A

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo rustc --lib --all-features -- -W unsafe-code`
  - `cargo rustc --bin claude-rs --all-features -- -W unsafe-code`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `npm run quality:duplicates`
  - `npm run quality:duplicates:summary`
- Manual:
  - Reviewed `cargo geiger` output and confirmed the only project-owned unsafe code is the Unix process suspend FFI call.
  - Confirmed jscpd reports 97 clones and 2.33% duplicated lines, below the 3.00% advisory threshold.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Both new quality signals are intended as PR review aids, not hard blockers.
