### PR TITLE
fix(ui): smooth startup repaint and PowerShell tool rendering

### DIFF
--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -18,6 +18,7 @@ import {
   emitEffortConfigOptionUpdate,
   handleTaskSystemMessage,
   handleSdkMessage,
+  isShellToolName,
   mapSdkAccountInfo,
   mapAvailableAgents,
   mapAvailableModels,
@@ -3354,6 +3355,7 @@ test("requestAskUserQuestionAnswers preserves previews and annotations in update
 
 test("normalizeToolKind maps known tool names", () => {
   assert.equal(normalizeToolKind("Bash"), "execute");
+  assert.equal(normalizeToolKind("PowerShell"), "execute");
   assert.equal(normalizeToolKind("Delete"), "delete");
   assert.equal(normalizeToolKind("Move"), "move");
   assert.equal(normalizeToolKind("EnterWorktree"), "other");
@@ -3377,6 +3379,22 @@ test("normalizeToolKind maps known tool names", () => {
   assert.equal(normalizeToolKind("EnterPlanMode"), "switch_mode");
   assert.equal(normalizeToolKind("ExitPlanMode"), "switch_mode");
   assert.equal(normalizeToolKind("TodoWrite"), normalizeToolKind("FutureUnknownTool"));
+});
+
+test("isShellToolName recognizes only supported shell tools", () => {
+  assert.equal(isShellToolName("Bash"), true);
+  assert.equal(isShellToolName("PowerShell"), true);
+  assert.equal(isShellToolName("Shell"), false);
+  assert.equal(isShellToolName("bash"), false);
+});
+
+test("shell tool titles use input command", () => {
+  assert.equal(createToolCall("tc-bash-title", "Bash", { command: "git status" }).title, "git status");
+  assert.equal(
+    createToolCall("tc-powershell-title", "PowerShell", { command: "Get-ChildItem" }).title,
+    "Get-ChildItem",
+  );
+  assert.equal(createToolCall("tc-powershell-empty", "PowerShell", {}).title, "Terminal");
 });
 
 test("parseFastModeState accepts known values and rejects unknown values", () => {
@@ -4728,6 +4746,29 @@ test("buildToolResultFields ignores model-facing Bash stale read hints", () => {
   );
 
   assert.equal(fields.raw_output, "real stdout");
+  assert.equal(fields.output_metadata, undefined);
+});
+
+test("buildToolResultFields maps PowerShell structured output like shell output", () => {
+  const base = createToolCall("tc-powershell", "PowerShell", { command: "Get-ChildItem" });
+  const fields = buildToolResultFields(
+    false,
+    {
+      stdout: "stdout line",
+      stderr: "stderr line",
+      interrupted: true,
+    },
+    base,
+    {
+      result: {
+        stdout: "stdout line",
+        stderr: "stderr line",
+        interrupted: true,
+      },
+    },
+  );
+
+  assert.equal(fields.raw_output, "stdout line\nstderr line\nCommand was aborted before completion.");
   assert.equal(fields.output_metadata, undefined);
 });
 

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -69,6 +69,7 @@ export { CACHE_SPLIT_POLICY, previewKilobyteLabel } from "./bridge/cache_policy.
 export {
   buildToolResultFields,
   createToolCall,
+  isShellToolName,
   normalizeToolKind,
   normalizeToolResultText,
   unwrapToolUseResult,

--- a/agent-sdk/src/bridge/tooling.ts
+++ b/agent-sdk/src/bridge/tooling.ts
@@ -68,6 +68,10 @@ function isAgentLikeToolName(name: string): boolean {
   return name === "Agent" || name === "Task";
 }
 
+export function isShellToolName(name: string): boolean {
+  return name === "Bash" || name === "PowerShell";
+}
+
 function agentInputTitle(name: string, input: Record<string, unknown>): string | undefined {
   if (!isAgentLikeToolName(name)) {
     return undefined;
@@ -162,9 +166,10 @@ function formatGrepTitle(input: Record<string, unknown>): string {
 }
 
 export function normalizeToolKind(name: string): string {
+  if (isShellToolName(name)) {
+    return "execute";
+  }
   switch (name) {
-    case "Bash":
-      return "execute";
     case "Read":
     case "ReadMcpResource":
       return "read";
@@ -221,7 +226,7 @@ export function toolTitle(
   if (agentTitle) {
     return agentTitle;
   }
-  if (name === "Bash") {
+  if (isShellToolName(name)) {
     const command = typeof input.command === "string" ? input.command : "";
     return command || "Terminal";
   }
@@ -789,7 +794,7 @@ function editDiffFromResult(rawResult: unknown, rawInput: Json | undefined): Too
   return editDiffFromInput(rawInput);
 }
 
-function findBashResultRecord(
+function findShellResultRecord(
   rawResult: unknown,
   rawContent: unknown,
 ): Record<string, unknown> | undefined {
@@ -803,7 +808,7 @@ function findBashResultRecord(
   );
 }
 
-function bashBackgroundMessage(record: Record<string, unknown>): string {
+function shellBackgroundMessage(record: Record<string, unknown>): string {
   const backgroundTaskId =
     typeof record.backgroundTaskId === "string" ? record.backgroundTaskId : "";
   if (!backgroundTaskId) {
@@ -818,7 +823,7 @@ function bashBackgroundMessage(record: Record<string, unknown>): string {
   return `Command is running in background with ID: ${backgroundTaskId}.`;
 }
 
-function buildBashDisplayOutput(record: Record<string, unknown>): string {
+function buildShellDisplayOutput(record: Record<string, unknown>): string {
   const segments: string[] = [];
   const stdout = typeof record.stdout === "string" ? record.stdout : "";
   const stderr = typeof record.stderr === "string" ? record.stderr : "";
@@ -831,7 +836,7 @@ function buildBashDisplayOutput(record: Record<string, unknown>): string {
   if (record.interrupted === true) {
     segments.push("Command was aborted before completion.");
   }
-  const backgroundMessage = bashBackgroundMessage(record);
+  const backgroundMessage = shellBackgroundMessage(record);
   if (backgroundMessage) {
     segments.push(backgroundMessage);
   }
@@ -2129,10 +2134,12 @@ export function buildToolResultFields(
     }
     return fields;
   }
-  const bashResultRecord = toolName === "Bash" ? findBashResultRecord(rawResult, rawContent) : undefined;
+  const shellResultRecord = isShellToolName(toolName)
+    ? findShellResultRecord(rawResult, rawContent)
+    : undefined;
   const normalizedRawOutput = normalizeToolResultText(rawContent, isError);
-  const rawOutput = bashResultRecord
-    ? buildBashDisplayOutput(bashResultRecord)
+  const rawOutput = shellResultRecord
+    ? buildShellDisplayOutput(shellResultRecord)
     : normalizedRawOutput || JSON.stringify(rawContent);
   if (rawOutput && !(isTaskToolName(toolName) && !isError)) {
     fields.raw_output = rawOutput;

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -1803,6 +1803,19 @@ mod tests {
     }
 
     #[test]
+    fn connected_session_preserves_inline_viewport_for_startup_welcome_transition() {
+        let mut app = make_test_app();
+        app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
+        app.surface_dirty.chat.rebuild = ChatRebuildKind::None;
+        app.surface_dirty.chat.repaint = false;
+
+        handle_client_event(&mut app, connected_event("claude-updated"));
+
+        assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::None);
+        assert!(app.surface_dirty.chat.repaint);
+    }
+
+    #[test]
     fn connected_keeps_subscription_placeholder_until_status_snapshot_arrives() {
         let mut app = make_test_app();
         app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "old", "/test", "old"));

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -1333,6 +1333,38 @@ mod tests {
     }
 
     #[test]
+    fn powershell_raw_input_update_does_not_populate_terminal_command() {
+        let mut app = make_test_app();
+        let tc = model::ToolCall::new("tc-pwsh", "Terminal")
+            .kind(model::ToolKind::Execute)
+            .status(model::ToolCallStatus::InProgress)
+            .meta(serde_json::json!({"claudeCode": {"toolName": "PowerShell"}}));
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)),
+        );
+
+        let fields = model::ToolCallUpdateFields::new()
+            .raw_input(serde_json::json!({ "command": "Get-ChildItem" }));
+        let update = model::ToolCallUpdate::new("tc-pwsh", fields);
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionUpdate(model::SessionUpdate::ToolCallUpdate(update)),
+        );
+
+        let Some((mi, bi)) = app.lookup_tool_call("tc-pwsh") else {
+            panic!("tool call not indexed");
+        };
+        let Some(MessageBlock::ToolCall(tc)) = app.messages.get(mi).and_then(|m| m.blocks.get(bi))
+        else {
+            panic!("tool call block missing");
+        };
+        assert_eq!(tc.sdk_tool_name, "PowerShell");
+        assert_eq!(tc.terminal_command, None);
+        assert_eq!(tc.raw_input, Some(serde_json::json!({ "command": "Get-ChildItem" })));
+    }
+
+    #[test]
     fn late_tool_update_for_removed_tool_does_not_corrupt_active_task_set() {
         let mut app = make_test_app();
         app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -7,7 +7,7 @@ use super::super::state::RecentSessionInfo;
 use super::super::view::{self, FullscreenView};
 use super::super::{App, AppStatus, LoginHint, SystemSeverity, UpdateNoticeState};
 use super::push_system_message_with_severity;
-use super::session_reset::{load_resume_history, reset_for_new_session};
+use super::session_reset::{ChatResetRenderMode, load_resume_history, reset_for_new_session};
 use crate::agent::client::AgentConnection;
 use crate::agent::events::ServiceStatusSeverity;
 use crate::agent::model;
@@ -34,7 +34,14 @@ pub(super) fn handle_connected_client_event(
         app.conn = Some(slot.conn);
     }
     apply_session_cwd(app, cwd);
-    reset_for_new_session(app, session_id, current_model, mode, true);
+    reset_for_new_session(
+        app,
+        session_id,
+        current_model,
+        mode,
+        true,
+        ChatResetRenderMode::PreserveInlineViewport,
+    );
     app.available_models = available_models;
     app.sync_welcome_snapshot();
     if !history_updates.is_empty() {
@@ -299,7 +306,14 @@ pub(super) fn handle_session_replaced_event(
     app.pending_auto_submit_after_cancel = false;
     apply_session_cwd(app, cwd);
     app.available_models = available_models;
-    reset_for_new_session(app, session_id, current_model, mode, false);
+    reset_for_new_session(
+        app,
+        session_id,
+        current_model,
+        mode,
+        false,
+        ChatResetRenderMode::ClearVisibleTranscript,
+    );
     app.request_chat_session_boundary_rebuild();
     app.sync_welcome_snapshot();
     if !history_updates.is_empty() {

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -4,12 +4,19 @@
 use super::super::{App, ChatMessage, MessageBlock, MessageRole, TextBlock};
 use crate::agent::model;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ChatResetRenderMode {
+    PreserveInlineViewport,
+    ClearVisibleTranscript,
+}
+
 pub(super) fn reset_for_new_session(
     app: &mut App,
     session_id: model::SessionId,
     current_model: model::CurrentModel,
     mode: Option<super::super::ModeState>,
     preserve_current_welcome_tip: bool,
+    render_mode: ChatResetRenderMode,
 ) {
     crate::agent::events::kill_all_terminals(&app.terminals);
 
@@ -18,7 +25,7 @@ pub(super) fn reset_for_new_session(
     reset_input_state_for_new_session(app);
     reset_interaction_state_for_new_session(app);
     reset_render_state_for_new_session(app);
-    reset_cache_and_footer_state_for_new_session(app);
+    reset_cache_and_footer_state_for_new_session(app, render_mode);
     app.sync_git_context();
 }
 
@@ -94,12 +101,15 @@ fn reset_render_state_for_new_session(app: &mut App) {
     app.subagent = None;
 }
 
-fn reset_cache_and_footer_state_for_new_session(app: &mut App) {
+fn reset_cache_and_footer_state_for_new_session(app: &mut App, render_mode: ChatResetRenderMode) {
     app.clear_terminal_tool_call_tracking();
     app.mcp = super::super::McpState::default();
     crate::app::usage::reset_for_session_change(app);
     crate::app::plugins::reset_for_session_change(app);
-    app.request_chat_visible_rebuild();
+    match render_mode {
+        ChatResetRenderMode::PreserveInlineViewport => app.request_chat_repaint(),
+        ChatResetRenderMode::ClearVisibleTranscript => app.request_chat_visible_rebuild(),
+    }
 }
 
 fn append_resume_user_message_chunk(app: &mut App, chunk: &model::ContentChunk) {
@@ -171,9 +181,9 @@ pub(super) fn load_resume_history(app: &mut App, history_updates: &[model::Sessi
 
 #[cfg(test)]
 mod tests {
-    use super::reset_for_new_session;
+    use super::{ChatResetRenderMode, reset_for_new_session};
     use crate::agent::model;
-    use crate::app::{App, ChatMessage};
+    use crate::app::{App, ChatMessage, ChatRebuildKind};
 
     #[test]
     fn session_reset_clears_chat_render_measurement_state() {
@@ -191,6 +201,7 @@ mod tests {
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
             false,
+            ChatResetRenderMode::ClearVisibleTranscript,
         );
 
         assert_eq!(app.chat_render.terminal_width, 0);
@@ -198,5 +209,45 @@ mod tests {
         assert_eq!(app.chat_render.composer.total_rows, 0);
         assert!(!app.chat_render.live_region.anchor_valid);
         assert_eq!(app.chat_render.live_region.last_rendered_rows, 0);
+    }
+
+    #[test]
+    fn startup_session_reset_preserves_inline_viewport_for_diffed_repaint() {
+        let mut app = App::test_default();
+        app.messages.push(ChatMessage::welcome("1.2.3", "-", "/workspace/demo", "-"));
+        app.surface_dirty.chat.rebuild = ChatRebuildKind::None;
+        app.surface_dirty.chat.repaint = false;
+
+        reset_for_new_session(
+            &mut app,
+            model::SessionId::new("session-2"),
+            model::CurrentModel::new("test", "test", "test").authoritative(true),
+            None,
+            true,
+            ChatResetRenderMode::PreserveInlineViewport,
+        );
+
+        assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::None);
+        assert!(app.surface_dirty.chat.repaint);
+    }
+
+    #[test]
+    fn replacement_session_reset_requests_visible_transcript_clear() {
+        let mut app = App::test_default();
+        app.messages.push(ChatMessage::welcome("1.2.3", "Pro", "/workspace/demo", "session-1"));
+        app.surface_dirty.chat.rebuild = ChatRebuildKind::None;
+        app.surface_dirty.chat.repaint = false;
+
+        reset_for_new_session(
+            &mut app,
+            model::SessionId::new("session-2"),
+            model::CurrentModel::new("test", "test", "test").authoritative(true),
+            None,
+            false,
+            ChatResetRenderMode::ClearVisibleTranscript,
+        );
+
+        assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::VisibleScreen);
+        assert!(app.surface_dirty.chat.repaint);
     }
 }

--- a/src/app/events/tool_calls.rs
+++ b/src/app/events/tool_calls.rs
@@ -107,7 +107,8 @@ fn build_tool_info_from_tool_call(
     let terminal_command = terminal_id.as_ref().and_then(|terminal_id| {
         app.terminals.borrow().get(terminal_id).map(|terminal| terminal.command.clone())
     });
-    let initial_execute_output = if super::super::is_execute_tool_name(&sdk_tool_name) {
+    let is_execute_tool = super::super::is_execute_tool_name(&sdk_tool_name);
+    let initial_execute_output = if is_execute_tool {
         tc.raw_output.as_ref().and_then(raw_output_to_terminal_text)
     } else {
         None

--- a/src/app/state/tool_call_info.rs
+++ b/src/app/state/tool_call_info.rs
@@ -19,7 +19,7 @@ pub struct ToolCallInfo {
     pub content: Vec<model::ToolCallContent>,
     /// Hidden tool calls are subagent children - not rendered directly.
     pub hidden: bool,
-    /// Terminal ID if this is a Bash-like SDK tool call with a running/completed terminal.
+    /// Terminal ID if this is a shell SDK tool call with a running/completed terminal.
     pub terminal_id: Option<String>,
     /// The shell command that was executed (e.g. "echo hello && ls -la").
     pub terminal_command: Option<String>,
@@ -136,7 +136,7 @@ impl ToolCallInfo {
 
 #[must_use]
 pub fn is_execute_tool_name(tool_name: &str) -> bool {
-    tool_name.eq_ignore_ascii_case("bash")
+    tool_name.eq_ignore_ascii_case("bash") || tool_name.eq_ignore_ascii_case("powershell")
 }
 
 #[must_use]
@@ -173,4 +173,17 @@ pub struct InlineQuestion {
     pub focused: bool,
     pub question_index: usize,
     pub total_questions: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_execute_tool_name;
+
+    #[test]
+    fn execute_tool_names_include_supported_shells() {
+        assert!(is_execute_tool_name("Bash"));
+        assert!(is_execute_tool_name("PowerShell"));
+        assert!(is_execute_tool_name("powershell"));
+        assert!(!is_execute_tool_name("Shell"));
+    }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -41,7 +41,8 @@ pub fn tool_name_label(sdk_tool_name: &str) -> (&'static str, &'static str) {
         "Glob" => ("\u{2315}", "Glob"),
         "Grep" => ("\u{2315}", "Grep"),
         "LS" => ("\u{2315}", "LS"),
-        "Bash" => ("\u{27e9}", "Bash"),
+        "Bash" => ("$ \u{27e9}", "Bash"),
+        "PowerShell" => ("PS \u{27e9}", "PowerShell"),
         "Task" | "Agent" => ("\u{25c7}", "Subagent"),
         "TaskCreate" | "TaskUpdate" | "TaskGet" | "TaskList" | "TaskOutput" | "TaskStop" => {
             ("\u{25a1}", "Task")
@@ -141,5 +142,11 @@ mod tests {
     #[test]
     fn unknown_tools_use_generic_fallback() {
         assert_eq!(tool_name_label("UnknownFutureTool"), ("\u{25cb}", "Tool"));
+    }
+
+    #[test]
+    fn shell_tools_use_distinct_shell_labels_and_icons() {
+        assert_eq!(tool_name_label("Bash"), ("$ \u{27e9}", "Bash"));
+        assert_eq!(tool_name_label("PowerShell"), ("PS \u{27e9}", "PowerShell"));
     }
 }

--- a/src/ui/tool_call/execute.rs
+++ b/src/ui/tool_call/execute.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Simon Peter Rothgang
 // SPDX-License-Identifier: Apache-2.0
 
-//! Content rendering for Execute/Bash tool calls.
+//! Content rendering for Execute/shell tool calls.
 
 use crate::agent::model;
 use crate::app::ToolCallInfo;
@@ -12,19 +12,12 @@ use ratatui::text::{Line, Span};
 
 use super::{TOOL_BODY_MAX_LINES, errors::render_failed_tool_text_content};
 
-/// Render Execute/Bash content lines WITHOUT any border decoration.
+/// Render Execute/shell content lines WITHOUT any border decoration.
 /// This is width-independent and safe to cache across resizes.
 /// Returns command and output lines only; permission/question controls are appended
 /// by the standard body renderer so they are never hidden by the content cap.
 pub(super) fn render_execute_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> = Vec::new();
-
-    if let Some(ref cmd) = tc.terminal_command {
-        let mut spans =
-            vec![Span::styled("$ ", Style::default().fg(theme::DIM).add_modifier(Modifier::BOLD))];
-        spans.push(Span::styled(cmd.clone(), Style::default().fg(theme::DIM)));
-        lines.push(Line::from(spans));
-    }
 
     let mut body_lines: Vec<Line<'static>> = Vec::new();
 

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -599,15 +599,33 @@ mod tests {
             .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
             .collect();
 
-        assert_eq!(rendered_text.len(), 3);
-        assert!(rendered_text[1].starts_with("      $ echo hi"));
-        assert!(rendered_text[2].starts_with("      hi"));
+        assert_eq!(rendered_text.len(), 2);
+        assert!(rendered_text[1].starts_with("      hi"));
+        assert!(!rendered_text.iter().any(|line| line.contains("echo hi")));
         assert!(
             rendered_text
                 .iter()
                 .all(|line| !line.contains('\u{256D}') && !line.contains('\u{2570}'))
         );
         assert!(rendered_text.iter().all(|line| !line.starts_with("  \u{2502}")));
+    }
+
+    #[test]
+    fn powershell_execute_body_omits_command_prompt() {
+        let mut tc =
+            test_tool_call("tc-powershell-prompt", "PowerShell", model::ToolCallStatus::Completed);
+        tc.terminal_command = Some("Get-ChildItem".to_owned());
+        tc.terminal_output = Some("Directory listing".to_owned());
+
+        let lines = execute::render_execute_content(&tc);
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
+            .collect();
+
+        assert_eq!(rendered.first().map(String::as_str), Some("Directory listing"));
+        assert!(!rendered.iter().any(|line| line.contains("Get-ChildItem")));
+        assert!(!rendered.iter().any(|line| line.contains("PS>")));
     }
 
     #[test]
@@ -1237,10 +1255,10 @@ mod tests {
             .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
             .collect();
         assert_eq!(rendered.len(), super::TOOL_BODY_MAX_LINES);
-        assert!(rendered[0].contains("$ cd path with spaces"));
-        assert!(rendered[1].contains("lines hidden"));
+        assert!(rendered[0].contains("lines hidden"));
         assert!(!rendered.iter().any(|line| line == "line 0"));
-        assert!(rendered.iter().any(|line| line == "line 23"));
+        assert!(!rendered.iter().any(|line| line.contains("cd path with spaces")));
+        assert!(rendered.iter().any(|line| line == "line 22"));
         assert_eq!(rendered.last().map(String::as_str), Some("line 29"));
     }
 
@@ -1260,7 +1278,7 @@ mod tests {
             .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
             .collect();
 
-        assert!(rendered[0].contains("$ cd path with spaces"));
+        assert!(!rendered.iter().any(|line| line.contains("$ cd path with spaces")));
         assert!(
             rendered
                 .iter()

--- a/src/ui/tool_call/standard.rs
+++ b/src/ui/tool_call/standard.rs
@@ -148,8 +148,7 @@ pub(super) fn tool_call_has_body(tc: &ToolCallInfo) -> bool {
         || tc.pending_permission.is_some()
         || tc.pending_question.is_some()
         || (tc.is_execute_tool()
-            && (tc.terminal_command.is_some()
-                || tc.terminal_output.is_some()
+            && (tc.terminal_output.is_some()
                 || matches!(tc.status, model::ToolCallStatus::InProgress)))
 }
 
@@ -446,9 +445,7 @@ fn is_read_tool(tc: &ToolCallInfo) -> bool {
 }
 
 fn protected_content_source_lines(tc: &ToolCallInfo, lines: &[Line<'static>]) -> usize {
-    let mut count = if tc.is_execute_tool() && tc.terminal_command.is_some() {
-        1
-    } else if is_read_tool(tc) {
+    let mut count = if is_read_tool(tc) {
         READ_BODY_HEAD_LINES
     } else {
         leading_diff_metadata_line_count(lines)


### PR DESCRIPTION
## Summary

- Smooth the startup welcome repaint path so connecting a new session updates the inline welcome without forcing a visible transcript rebuild.
- Treat `PowerShell` as a first-class shell execute tool alongside `Bash` in the bridge and TUI.
- Render shell commands in the tool header/title only, while execute bodies show terminal output/status without duplicating the command.

## Why

PowerShell tool calls were falling back to generic tool behavior instead of using the execute renderer, which made command output harder to read and inconsistent with Bash. The startup session reset path also used the same visible transcript rebuild behavior as replacement sessions, causing unnecessary welcome repaint churn during initial connection.

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `npm.cmd test` in `agent-sdk`
- Manual:
  - Reviewed shell tool rendering behavior to keep command text in the header/title and out of execute body content.
- Screenshot/video (if UI changed): Not captured

## Notes

- Breaking changes: N/A
- Docs updated: N/A
