### PR TITLE
chore(release): prepare 0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.3] - 2026-06-16 [Changes][v0.12.3]
+
+### Documentation
+
+- **Agent SDK billing notice** (@srothgan): Anthropic paused the Agent SDK credit change documented in (#165, @srothgan); SDK usage still draws from normal Claude subscription limits. Shrink the README warning to a compact note linking the [support article](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan).
+
+### Fixes
+
+- **Startup repaint and PowerShell rendering** (#193, @srothgan): Smooth the startup repaint and fix PowerShell tool-call rendering.
+
+### CI and Dependencies
+
+- **SDK monitor and advisory checks** (#186, #187, @srothgan): Add an Agent SDK update monitor and advisory quality checks.
+- **Rust dependency updates** (#189, #190, #191, #192): Bump `uuid` to `1.23.3`, `time` to `0.3.49`, `ignore` to `0.4.26`, and `which` to `8.0.3`.
+- **Workflow action bump** (#188): Bump `actions/upload-artifact` to `7`.
+
 ## [0.12.2] - 2026-06-14 [Changes][v0.12.2]
 
 ### Features
@@ -589,6 +605,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.12.3]: https://github.com/srothgan/claude-code-rust/compare/v0.12.2...v0.12.3
 [v0.12.2]: https://github.com/srothgan/claude-code-rust/compare/v0.12.1...v0.12.2
 [v0.12.1]: https://github.com/srothgan/claude-code-rust/compare/v0.12.0...v0.12.1
 [v0.12.0]: https://github.com/srothgan/claude-code-rust/compare/v0.11.3...v0.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -38,12 +38,8 @@ claude-rs
 
 Full documentation is available at [srothgan.github.io/claude-code-rust](https://srothgan.github.io/claude-code-rust/).
 
-> [!WARNING]
-> **Agent SDK billing changes on June 15, 2026.** Anthropic says Agent SDK usage, `claude -p`, Claude Code GitHub Actions, and third-party Agent SDK apps will use a separate monthly Agent SDK credit instead of normal interactive Claude or Claude Code subscription limits. Because Claude Code Rust wraps the Agent SDK, treat usage through this project as Agent SDK usage. If that credit is exhausted, continued use may require enabling extra usage billed at standard API rates, or requests may pause until the credit refreshes.
->
-> Sources:
-> - [Anthropic support: Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
-> - [ClaudeDevs announcement](https://x.com/ClaudeDevs/status/2054610152817619388)
+> [!NOTE]
+> **Agent SDK billing unchanged.** Anthropic has paused the previously announced Agent SDK credit change. For now nothing changes: Claude Agent SDK usage — including `claude -p` and third-party apps like this one — still draws from your normal Claude subscription limits. See [Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan).
 
 ## Why
 
@@ -85,7 +81,7 @@ This project is not affiliated with, endorsed by, or supported by Anthropic.
 
 A quick note on where this project stands, since I know people worry about this kind of thing: claude-code-rust is a terminal UI that I wrote from scratch in Rust. It is not a fork, copy or port of the latest Claude Code source leak -- it talks to Anthropic's official [Agent SDK](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/agent-sdk) as a runtime dependency instead, the same way any other third-party tool would. No Anthropic source code was read or used as reference at any point during development.
 
-The project authenticates through your existing Claude Code account via the Agent SDK, and the Agent SDK's terms allow building on top of it. Billing, credits, limits, and overage behavior are controlled by Anthropic, including the Agent SDK credit change noted above. Other community projects do the same. As far as I can tell, using this project is fine -- but I am a single maintainer, not a lawyer. If anything changes on Anthropic's end, I will update this section and adjust the project accordingly.
+The project authenticates through your existing Claude Code account via the Agent SDK, and the Agent SDK's terms allow building on top of it. Billing, credits, limits, and overage behavior are controlled by Anthropic, including any future changes Anthropic may make to how Agent SDK usage is metered. Other community projects do the same. As far as I can tell, using this project is fine -- but I am a single maintainer, not a lawyer. If anything changes on Anthropic's end, I will update this section and adjust the project accordingly.
 
 This project's source code is licensed under [Apache-2.0](LICENSE). The Agent SDK itself is proprietary and governed by [Anthropic's Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms).
 


### PR DESCRIPTION
## Summary

Prepare the 0.12.3 release and update the Agent SDK billing notice.

- Shrink the README Agent SDK billing notice from a multi-source warning to a compact note. Anthropic paused the previously announced Agent SDK credit change, so usage still draws from normal Claude subscription limits.
- Bump Cargo package metadata from 0.12.2 to 0.12.3.
- Add the 0.12.3 changelog entry and compare link.
- Leave npm package versioning to `release-npm.yml`, which syncs from `Cargo.toml`.

## Why

The Agent SDK credit change documented in #165 was reversed by Anthropic. Cutting 0.12.3 surfaces the corrected notice on npm so users see the current billing position instead of a warning that no longer applies. See [Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan).

## Release Analysis

This release covers first-parent squash merges since `v0.12.2`:

- #186, #187: Agent SDK update monitor and advisory quality checks.
- #188: `actions/upload-artifact` bump.
- #189, #190, #191, #192: Rust dependency bumps.
- #193: smoother startup repaint and PowerShell tool-call rendering.

## Changes

### Release Metadata

- `Cargo.toml`: set `claude-code-rust` to `0.12.3`.
- `Cargo.lock`: update the local package entry to `0.12.3`.
- `CHANGELOG.md`: add the 0.12.3 section 

### Documentation

- `README.md`: replace the `[!WARNING]` billing block with a compact `[!NOTE]` linking the support article, and drop the now-resolved credit-change reference from the legal notice.

## Validation

- Automated: N/A -- release prep only (versioning, changelog, README docs).
- Manual: Verified the README notice reflects the paused credit change and links the support article; verified `Cargo.toml`/`Cargo.lock` report `0.12.3`. User-facing behavior changes were merged and validated on `main` before cutting 0.12.3.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: Yes -- README billing notice and CHANGELOG.
