### PR TITLE
ci(dependabot): add npm version updates for root and agent-sdk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,41 @@ updates:
       - "area: ci"
     commit-message:
       prefix: "ci"
+
+  # npm dependencies (root package)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "type: dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # npm dependencies (agent-sdk bridge)
+  - package-ecosystem: "npm"
+    directory: "/agent-sdk"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "type: dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Add npm version updates to Dependabot, covering both npm manifests:

- Root package (`/`)
- Agent SDK bridge (`/agent-sdk`)

Minor and patch updates are grouped per directory (`npm-minor-patch` group) to reduce PR noise; major updates still open individually for deliberate review. Schedule, commit prefix (`chore` with scope), and labels match the existing cargo/github-actions entries.

## Why

Dependabot previously only managed `cargo` and `github-actions`, so the npm dependency trees in `package.json` and `agent-sdk/package.json` received no routine version-update PRs. This closes that gap. It complements the recently enabled Dependabot security updates (which already handle CVE-driven bumps) by also keeping npm dependencies current outside of advisories.

Closes #

## Validation

- Automated: Dependabot config validation runs on push; existing CI unaffected (config-only change).
- Manual: Verified both `package.json`/`package-lock.json` (root) and `agent-sdk/package.json`/`agent-sdk/package-lock.json` exist and are the targeted directories.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
