### PR TITLE
chore(deps): tidy Dependabot for agent SDK, bump toolchain, fix hono advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,10 @@ updates:
   # npm dependencies (root package)
   - package-ecosystem: "npm"
     directory: "/"
+    # The Agent SDK is tracked by the Agent SDK Update Monitor workflow
+    # (issue-based), so exclude it here to avoid duplicate PRs.
+    ignore:
+      - dependency-name: "@anthropic-ai/claude-agent-sdk"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -48,6 +52,10 @@ updates:
   # npm dependencies (agent-sdk bridge)
   - package-ecosystem: "npm"
     directory: "/agent-sdk"
+    # The Agent SDK is tracked by the Agent SDK Update Monitor workflow
+    # (issue-based), so exclude it here to avoid duplicate PRs.
+    ignore:
+      - dependency-name: "@anthropic-ai/claude-agent-sdk"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/agent-sdk-update-monitor.yml
+++ b/.github/workflows/agent-sdk-update-monitor.yml
@@ -53,11 +53,11 @@ jobs:
           | Bridge package | \`${bridge_version}\` |
           | Latest npm | \`${latest_version}\` |
 
-          Suggested next step:
+          Suggested next steps:
 
-          - Recreate the SDK migration scratch workspace under \`tmp/\`.
-          - Follow \`notes/sdk-version-migration.md\`.
+          - Review the upstream release notes between \`${root_version}\`/\`${bridge_version}\` and \`${latest_version}\`.
           - Compare release notes and tarball diffs before changing package pins.
+          - Update the pins in \`package.json\` and \`agent-sdk/package.json\`, then rebuild the bridge.
 
           This issue was opened or refreshed by \`${GITHUB_WORKFLOW}\`.
           EOF

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -1783,9 +1783,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -16,9 +16,9 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.12",
-        "@types/node": "25.3.3",
+        "@types/node": "26.0.0",
         "knip": "6.4.1",
-        "typescript": "5.9.3"
+        "typescript": "6.0.3"
       }
     },
     "..": {
@@ -1158,13 +1158,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
-      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/accepts": {
@@ -2673,9 +2673,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2697,9 +2697,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -24,8 +24,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.12",
-    "@types/node": "25.3.3",
+    "@types/node": "26.0.0",
     "knip": "6.4.1",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }


### PR DESCRIPTION
## Summary

- **Dependabot:** ignore `@anthropic-ai/claude-agent-sdk` in both npm blocks (root + `/agent-sdk`). The Agent SDK is already tracked by the **Agent SDK Update Monitor** workflow (issue-based), so Dependabot PRs for it were redundant duplicates.
- **Monitor workflow:** drop the private `tmp/` and `notes/` references from the auto-generated issue body in favor of generic next steps.
- **Toolchain bumps (agent-sdk dev deps):** `typescript` 5.9.3 → 6.0.3, `@types/node` 25.3.3 → 26.0.0.
- **Security:** bump transitive `hono` 4.12.21 → 4.12.27, resolving 5 Dependabot advisories (1 high, 4 moderate) via `@modelcontextprotocol/sdk`.

## Why

Dependabot and the monitor workflow were both surfacing the same Agent SDK updates (PRs *and* an issue). Ignoring the SDK in Dependabot makes the monitor the single source of truth, while the rest of the npm groups keep flowing. The major toolchain bumps were verified locally, and the `hono` bump clears the open security advisories on the bridge.

Note: this PR leaves the Agent SDK tracker issue (#206) open on purpose — the SDK pins are unchanged here, and that update is handled separately via the monitor workflow.

## Validation

- Automated: `tsc` build (confirmed 6.0.3), `biome lint` (26 files, clean), `knip` (no findings), `node --test` (**226/226 pass**) — all green against TS 6.0.3 + @types/node 26.
- Manual: verified lockfile diffs are scoped per commit (toolchain vs. hono); confirmed `hono` 4.12.27 satisfies all 5 advisory patched ranges (≥ 4.12.25).
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A — dev-only toolchain bumps; SDK pins unchanged.
- Docs updated: N/A
