### PR TITLE
fix(runtime): prevent notice and terminal row range panics

### DIFF
--- a/src/app/events/notices.rs
+++ b/src/app/events/notices.rs
@@ -28,14 +28,13 @@ pub(super) fn upsert_turn_notice(
     message: &str,
 ) {
     prune_invalid_turn_notice_refs(app);
-    let Some(existing_ref_idx) =
-        app.turn_notice_refs.iter().position(|notice_ref| notice_ref.dedup_key == dedup_key)
+    let Some(existing) =
+        app.turn_notice_refs.iter().find(|notice_ref| notice_ref.dedup_key == dedup_key).cloned()
     else {
         insert_new_notice(app, dedup_key, stage, severity, message);
         return;
     };
 
-    let existing = app.turn_notice_refs[existing_ref_idx].clone();
     if stage < existing.stage {
         return;
     }
@@ -43,10 +42,10 @@ pub(super) fn upsert_turn_notice(
     match existing.location {
         TurnNoticeLocation::Inline { msg_idx, block_idx } => {
             if update_inline_notice(app, msg_idx, block_idx, &dedup_key, severity, message) {
-                app.turn_notice_refs[existing_ref_idx].stage = stage;
+                update_turn_notice_ref_stage(app, &dedup_key, stage);
                 return;
             }
-            app.turn_notice_refs.remove(existing_ref_idx);
+            remove_turn_notice_refs(app, &dedup_key);
             insert_new_notice(app, dedup_key, stage, severity, message);
         }
         TurnNoticeLocation::Standalone { msg_idx } => {
@@ -54,7 +53,7 @@ pub(super) fn upsert_turn_notice(
                 && remove_standalone_notice(app, msg_idx)
                 && let Some(owner_idx) = app.active_turn_assistant_idx()
             {
-                app.turn_notice_refs.remove(existing_ref_idx);
+                remove_turn_notice_refs(app, &dedup_key);
                 insert_inline_notice(
                     app,
                     owner_idx,
@@ -66,14 +65,26 @@ pub(super) fn upsert_turn_notice(
             }
 
             if update_standalone_notice(app, msg_idx, &dedup_key, severity, message) {
-                app.turn_notice_refs[existing_ref_idx].stage = stage;
+                update_turn_notice_ref_stage(app, &dedup_key, stage);
                 return;
             }
 
-            app.turn_notice_refs.remove(existing_ref_idx);
+            remove_turn_notice_refs(app, &dedup_key);
             insert_new_notice(app, dedup_key, stage, severity, message);
         }
     }
+}
+
+fn update_turn_notice_ref_stage(app: &mut App, dedup_key: &NoticeDedupKey, stage: NoticeStage) {
+    if let Some(notice_ref) =
+        app.turn_notice_refs.iter_mut().find(|notice_ref| &notice_ref.dedup_key == dedup_key)
+    {
+        notice_ref.stage = stage;
+    }
+}
+
+fn remove_turn_notice_refs(app: &mut App, dedup_key: &NoticeDedupKey) {
+    app.turn_notice_refs.retain(|notice_ref| &notice_ref.dedup_key != dedup_key);
 }
 
 fn insert_new_notice(
@@ -245,7 +256,10 @@ fn prune_invalid_turn_notice_refs(app: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::{update_inline_notice, upsert_turn_notice};
-    use crate::app::{App, ChatMessage, MessageBlock, MessageRole, NoticeStage, SystemSeverity};
+    use crate::app::{
+        App, ChatMessage, MessageBlock, MessageRole, NoticeDedupKey, NoticeStage, SystemSeverity,
+        TurnNoticeLocation,
+    };
 
     #[test]
     fn inline_notice_insert_updates_canonical_assistant_message() {
@@ -296,5 +310,43 @@ mod tests {
         };
         assert_eq!(notice.severity, SystemSeverity::Error);
         assert_eq!(notice.text.text, "failed");
+    }
+
+    #[test]
+    fn standalone_notice_migrates_inline_without_double_removing_tracking() {
+        let mut app = App::test_default();
+
+        upsert_turn_notice(
+            &mut app,
+            NoticeDedupKey::ApiRetry,
+            NoticeStage::Warning,
+            SystemSeverity::Warning,
+            "retrying before assistant",
+        );
+        assert_eq!(app.messages.len(), 1);
+        assert_eq!(app.turn_notice_refs.len(), 1);
+
+        app.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+        app.bind_active_turn_assistant(1);
+
+        upsert_turn_notice(
+            &mut app,
+            NoticeDedupKey::ApiRetry,
+            NoticeStage::Warning,
+            SystemSeverity::Warning,
+            "retrying with assistant",
+        );
+
+        assert_eq!(app.messages.len(), 1);
+        assert!(matches!(app.messages[0].role, MessageRole::Assistant));
+        let Some(MessageBlock::Notice(notice)) = app.messages[0].blocks.first() else {
+            panic!("expected migrated inline notice");
+        };
+        assert_eq!(notice.text.text, "retrying with assistant");
+        assert_eq!(app.turn_notice_refs.len(), 1);
+        assert!(matches!(
+            app.turn_notice_refs[0].location,
+            TurnNoticeLocation::Inline { msg_idx: 0, block_idx: 0 }
+        ));
     }
 }

--- a/src/app/terminal_runtime/chat_session.rs
+++ b/src/app/terminal_runtime/chat_session.rs
@@ -153,6 +153,7 @@ impl ChatTerminalSession {
         serialized_rows: &SerializedLiveRows,
         base_excluded_ids: BTreeSet<HistoryOutputId>,
     ) -> anyhow::Result<()> {
+        app.surface_dirty.chat.take_repaint();
         let composer = Self::build_composer_surface(app, width);
         let mut history_plan = self.prepare_history_flush(
             serialized_rows,
@@ -241,8 +242,6 @@ impl ChatTerminalSession {
                 scrollback_inserted_rows: outcome.flushed_history.flushed_rows,
             },
         );
-
-        app.surface_dirty.chat.take_repaint();
         Ok(())
     }
 
@@ -692,7 +691,10 @@ fn build_static_history_batches(
             push_history_batch(&mut batches, HistoryBatchKind::Normal, width, &mut rows, &mut ids);
         }
 
-        rows.extend(serialized_rows.rows()[segment.start_row..segment.end_row].iter().cloned());
+        let Some(segment_rows) = serialized_rows.segment_rows(segment) else {
+            continue;
+        };
+        rows.extend(segment_rows.iter().cloned());
         ids.extend(segment_ids);
         expected_start = Some(segment.end_row);
     }
@@ -711,6 +713,7 @@ fn build_replay_history_batches(
         .segments()
         .iter()
         .filter(|segment| segment.commit_ready && segment.start_row < stable_row_count)
+        .filter(|segment| serialized_rows.segment_rows(segment).is_some())
         .collect::<Vec<_>>();
     let confirm_ids = unique_ids(stable_segments.iter().flat_map(|segment| segment.ids.iter()));
 
@@ -718,7 +721,10 @@ fn build_replay_history_batches(
         let mut rows = 0usize;
         let mut start = stable_segments.len();
         for (idx, segment) in stable_segments.iter().enumerate().rev() {
-            let segment_rows = segment.end_row.saturating_sub(segment.start_row);
+            let segment_rows = match serialized_rows.segment_rows(segment) {
+                Some(segment_rows) => segment_rows.len(),
+                None => 0,
+            };
             if rows > 0 && rows.saturating_add(segment_rows) > cap {
                 break;
             }
@@ -745,7 +751,10 @@ fn build_replay_history_batches(
             queued_rows = queued_rows.saturating_add(rows.len());
             push_history_batch(&mut batches, HistoryBatchKind::Replay, width, &mut rows, &mut ids);
         }
-        rows.extend(serialized_rows.rows()[segment.start_row..segment.end_row].iter().cloned());
+        let Some(segment_rows) = serialized_rows.segment_rows(segment) else {
+            continue;
+        };
+        rows.extend(segment_rows.iter().cloned());
         ids.extend(segment_ids);
         expected_start = Some(segment.end_row);
     }
@@ -800,7 +809,10 @@ fn excluded_row_count(
         .segments()
         .iter()
         .filter(|segment| segment.ids.iter().all(|id| excluded_ids.contains(id)))
-        .map(|segment| segment.end_row.saturating_sub(segment.start_row))
+        .map(|segment| match serialized_rows.segment_rows(segment) {
+            Some(rows) => rows.len(),
+            None => 0,
+        })
         .sum()
 }
 
@@ -896,7 +908,9 @@ impl RowWindow {
     }
 
     fn slice<T>(self, rows: &[T]) -> &[T] {
-        &rows[self.start..self.end()]
+        let start = self.start.min(rows.len());
+        let end = self.end().min(rows.len());
+        if start > end { &[] } else { &rows[start..end] }
     }
 }
 
@@ -1154,7 +1168,8 @@ fn preview_rows(rows: &[Line<'static>], limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        ChatTerminalSession, ComposerEditor, ComposerSurface, HistoryCommitState, MutableLayoutPlan,
+        ChatTerminalSession, ComposerEditor, ComposerSurface, HistoryCommitState,
+        MutableLayoutPlan, RowWindow,
     };
     use crate::app::terminal_runtime::chat_terminal::ChatTerminal;
     use crate::app::terminal_runtime::chat_terminal::plan_inline_geometry;
@@ -1162,7 +1177,10 @@ mod tests {
         App, ChatMessage, ChatMessageId, HistoryOutputId, MessageBlock, MessageRole, TextBlock,
         TextBlockSpacing,
     };
-    use crate::ui::inline_chat_rows::serialize_live_rows_with_boundaries_excluding;
+    use crate::ui::inline_chat_rows::{
+        LiveRowBoundaryKind, LiveRowSegment, SerializedLiveRows,
+        serialize_live_rows_with_boundaries_excluding,
+    };
     use ratatui::layout::Rect;
     use ratatui::text::Line;
     use std::collections::BTreeSet;
@@ -1189,6 +1207,18 @@ mod tests {
 
     fn line_text(line: &Line<'_>) -> String {
         line.spans.iter().map(|span| span.content.as_ref()).collect::<String>().trim_end().into()
+    }
+
+    fn live_segment(start_row: usize, end_row: usize, id: HistoryOutputId) -> LiveRowSegment {
+        LiveRowSegment {
+            ids: vec![id],
+            msg_idx: 0,
+            block_idx: None,
+            kind: LiveRowBoundaryKind::AssistantLabel,
+            start_row,
+            end_row,
+            commit_ready: true,
+        }
     }
 
     fn session_with_history(history: HistoryCommitState) -> ChatTerminalSession {
@@ -1236,6 +1266,28 @@ mod tests {
     }
 
     #[test]
+    fn incomplete_replay_requests_follow_up_repaint() {
+        let mut app = App::test_default();
+        let mut session = session_with_history(HistoryCommitState::default());
+
+        app.surface_dirty.chat.take_repaint();
+        session.complete_history_flush(
+            &mut app,
+            120,
+            &super::super::chat_terminal::ChatDrawOutcome {
+                viewport_area: Rect::new(0, 27, 120, 3),
+                flushed_history: super::super::chat_terminal::FlushedHistory {
+                    flushed_rows: 160,
+                    replay_incomplete: true,
+                    ..Default::default()
+                },
+            },
+        );
+
+        assert!(app.surface_dirty.chat.repaint);
+    }
+
+    #[test]
     fn static_history_batches_do_not_reinsert_confirmed_text_blocks() {
         let first = TextBlock::from_complete("first paragraph\n\n")
             .with_trailing_spacing(TextBlockSpacing::ParagraphBreak);
@@ -1271,6 +1323,34 @@ mod tests {
                 .any(|batch| batch.confirm_ids.contains(&HistoryOutputId::Block(second_id)))
         );
         assert_eq!(inserted_text, vec!["second paragraph"]);
+    }
+
+    #[test]
+    fn history_batches_skip_invalid_live_row_segments() {
+        let invalid_id = output_id();
+        let serialized = SerializedLiveRows::from_parts_for_test(
+            rows(2),
+            vec![live_segment(0, 3, invalid_id.clone())],
+        );
+
+        let static_batches =
+            super::build_static_history_batches(&serialized, 120, &BTreeSet::new());
+        let replay = super::build_replay_history_batches(&serialized, 120, None);
+        let excluded_rows = super::excluded_row_count(&serialized, &BTreeSet::from([invalid_id]));
+
+        assert!(static_batches.is_empty());
+        assert!(replay.batches.is_empty());
+        assert!(replay.confirm_ids.is_empty());
+        assert_eq!(replay.rows, 0);
+        assert_eq!(excluded_rows, 0);
+    }
+
+    #[test]
+    fn row_window_slice_returns_empty_for_stale_ranges() {
+        let rows = rows(2);
+        let stale = RowWindow { start: 4, visible_len: 2 };
+
+        assert!(stale.slice(&rows).is_empty());
     }
 
     #[test]
@@ -1387,7 +1467,7 @@ mod tests {
 
         let plan = plan_inline_geometry(Some(old_area), 4, 120, 37);
 
-        assert_eq!(plan.target_area, Some(Rect::new(0, 34, 120, 4)));
+        assert_eq!(plan.target_area, Some(Rect::new(0, 33, 120, 4)));
         assert_eq!(plan.height, 4);
     }
 

--- a/src/app/terminal_runtime/chat_terminal.rs
+++ b/src/app/terminal_runtime/chat_terminal.rs
@@ -1015,7 +1015,8 @@ pub(crate) fn plan_inline_geometry(
     let height = desired_height.max(1).min(screen_height);
     let old_area = last_frame_area.filter(|area| !area.is_empty());
     let target_area = old_area.map(|area| {
-        Rect::new(0, area.y.min(screen_height.saturating_sub(1)), terminal_width.max(1), height)
+        let max_top = screen_height.saturating_sub(height);
+        Rect::new(0, area.y.min(max_top), terminal_width.max(1), height)
     });
     InlineGeometryPlan { old_area, target_area, height }
 }
@@ -1424,6 +1425,14 @@ mod tests {
 
         assert_eq!(plan.target_area, Some(Rect::new(0, 17, 120, 11)));
         assert_eq!(inline_viewport_top_after_create(17, plan.height, 37), 17);
+    }
+
+    #[test]
+    fn geometry_plan_clamps_shrink_target_inside_terminal() {
+        let plan = plan_inline_geometry(Some(Rect::new(0, 34, 120, 6)), 11, 80, 20);
+
+        assert_eq!(plan.height, 11);
+        assert_eq!(plan.target_area, Some(Rect::new(0, 9, 80, 11)));
     }
 
     #[test]

--- a/src/app/terminal_runtime/history_insert.rs
+++ b/src/app/terminal_runtime/history_insert.rs
@@ -27,6 +27,30 @@ impl RenderedHistoryRows {
     }
 
     pub(super) fn slice(&self, range: std::ops::Range<usize>) -> &[Line<'static>] {
-        &self.rows[range]
+        let start = range.start.min(self.rows.len());
+        let end = range.end.min(self.rows.len());
+        if start > end { &[] } else { &self.rows[start..end] }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RenderedHistoryRows;
+    use ratatui::text::Line;
+
+    #[test]
+    fn slice_returns_empty_for_invalid_range_order() {
+        let rows = RenderedHistoryRows::new(80, vec![Line::from("first"), Line::from("second")]);
+        let start = 2;
+        let end = 1;
+
+        assert!(rows.slice(start..end).is_empty());
+    }
+
+    #[test]
+    fn slice_clamps_range_end_to_available_rows() {
+        let rows = RenderedHistoryRows::new(80, vec![Line::from("first"), Line::from("second")]);
+
+        assert_eq!(rows.slice(1..5).len(), 1);
     }
 }

--- a/src/ui/inline_chat_rows.rs
+++ b/src/ui/inline_chat_rows.rs
@@ -44,12 +44,27 @@ pub(crate) struct SerializedLiveRows {
 }
 
 impl SerializedLiveRows {
+    #[cfg(test)]
+    pub(crate) fn from_parts_for_test(
+        rows: Vec<Line<'static>>,
+        segments: Vec<LiveRowSegment>,
+    ) -> Self {
+        Self { rows, segments }
+    }
+
     pub(crate) fn rows(&self) -> &[Line<'static>] {
         &self.rows
     }
 
     pub(crate) fn segments(&self) -> &[LiveRowSegment] {
         &self.segments
+    }
+
+    pub(crate) fn segment_rows(&self, segment: &LiveRowSegment) -> Option<&[Line<'static>]> {
+        if segment.start_row > segment.end_row || segment.end_row > self.rows.len() {
+            return None;
+        }
+        Some(&self.rows[segment.start_row..segment.end_row])
     }
 
     pub(crate) fn rows_excluding_ids(
@@ -61,7 +76,10 @@ impl SerializedLiveRows {
             if segment.ids.iter().all(|id| excluded_ids.contains(id)) {
                 continue;
             }
-            rows.extend(self.rows[segment.start_row..segment.end_row].iter().cloned());
+            let Some(segment_rows) = self.segment_rows(segment) else {
+                continue;
+            };
+            rows.extend(segment_rows.iter().cloned());
         }
         rows
     }
@@ -70,7 +88,7 @@ impl SerializedLiveRows {
         self.segments
             .iter()
             .find(|segment| !segment.commit_ready)
-            .map_or(self.rows.len(), |segment| segment.start_row)
+            .map_or(self.rows.len(), |segment| segment.start_row.min(self.rows.len()))
     }
 
     pub(crate) fn first_mutable_boundary_kind(&self) -> Option<LiveRowBoundaryKind> {
@@ -78,7 +96,10 @@ impl SerializedLiveRows {
     }
 
     pub(crate) fn first_mutable_boundary_start(&self) -> Option<usize> {
-        self.segments.iter().find(|segment| !segment.commit_ready).map(|segment| segment.start_row)
+        self.segments
+            .iter()
+            .find(|segment| !segment.commit_ready)
+            .map(|segment| segment.start_row.min(self.rows.len()))
     }
 
     pub(crate) fn first_mutable_boundary_msg_idx(&self) -> Option<usize> {
@@ -1202,13 +1223,13 @@ fn preview_rows(rows: &[Line<'static>], limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        LiveRowBoundaryKind, SerializedLiveRows, serialize_live_rows_with_boundaries_excluding,
-        thinking_line,
+        LiveRowBoundaryKind, LiveRowSegment, SerializedLiveRows,
+        serialize_live_rows_with_boundaries_excluding, thinking_line,
     };
     use crate::agent::model;
     use crate::app::{
-        App, AppStatus, BlockCache, ChatMessage, HistoryOutputId, MessageBlock, MessageRole,
-        NoticeBlock, TerminalSnapshotMode, TextBlock, TextBlockSpacing, ToolCallInfo,
+        App, AppStatus, BlockCache, ChatMessage, ChatMessageId, HistoryOutputId, MessageBlock,
+        MessageRole, NoticeBlock, TerminalSnapshotMode, TextBlock, TextBlockSpacing, ToolCallInfo,
     };
     use ratatui::text::Line;
     use std::collections::BTreeSet;
@@ -1238,12 +1259,47 @@ mod tests {
         serialize_live_rows_with_boundaries_excluding(app, width, &BTreeSet::new())
     }
 
+    fn live_segment(start_row: usize, end_row: usize, commit_ready: bool) -> LiveRowSegment {
+        LiveRowSegment {
+            ids: vec![HistoryOutputId::AssistantLabel(ChatMessageId::new())],
+            msg_idx: 0,
+            block_idx: None,
+            kind: LiveRowBoundaryKind::AssistantLabel,
+            start_row,
+            end_row,
+            commit_ready,
+        }
+    }
+
     #[test]
     fn thinking_line_uses_selected_verb() {
         let text = line_text(&thinking_line(0, "Pondering"));
 
         assert!(text.contains("Pondering..."));
         assert!(!text.contains("Thinking..."));
+    }
+
+    #[test]
+    fn serialized_live_rows_skip_invalid_segment_ranges() {
+        let rows = vec![Line::from("first"), Line::from("second")];
+        let serialized = SerializedLiveRows::from_parts_for_test(
+            rows,
+            vec![live_segment(0, 1, true), live_segment(1, 3, true)],
+        );
+
+        assert_eq!(line_texts(&serialized.rows_excluding_ids(&BTreeSet::new())), vec!["first"]);
+        assert!(serialized.segment_rows(&serialized.segments()[1]).is_none());
+    }
+
+    #[test]
+    fn serialized_live_rows_clamp_stable_boundary_to_rows_len() {
+        let serialized = SerializedLiveRows::from_parts_for_test(
+            vec![Line::from("only")],
+            vec![live_segment(4, 5, false)],
+        );
+
+        assert_eq!(serialized.stable_row_count(), 1);
+        assert_eq!(serialized.first_mutable_boundary_start(), Some(1));
     }
 
     fn user_text_message(text: &str) -> ChatMessage {


### PR DESCRIPTION
## Summary

- Fix standalone-to-inline notice migration so notice tracking is not removed twice.
- Harden terminal history replay and row-range handling against stale internal ranges.
- Preserve follow-up repaint requests during resize purge replay so long resumed sessions finish replaying after a resize.
- Clamp inline viewport geometry to stay inside the current terminal after shrink resizes.

## Why

The deployed app could panic when a turn notice migrated from a standalone message into an assistant message, because the message removal path already pruned the matching notice ref and the caller removed the same index again.

Long resumed sessions also exposed terminal resize/replay fragility: stale row ranges could panic, and resize purge replay could insert only the first capped replay batch while clearing the repaint request needed to continue replaying the remaining transcript.

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
- Manual:
  - Resumed large Claude JSONL session `423f6448-ef0d-41fc-b56e-e0b649f5106c` with `--diagnostics-preset full`.
  - Repeated terminal shrink/grow resize testing on the resumed long session; transcript replay remained consistent after the repaint preservation fix.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
