### PR TITLE
feat(agent-sdk): migrate to 0.3.193 and add rewind support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- **Claude Agent SDK 0.3.193 migration** (#212, @srothgan): Refresh the bridge for the current SDK, add `/rewind` with conversation and code restore modes, render MCP resource directory listings, and surface new SDK system notices, rate-limit credit metadata, and SDK-created resume sessions.
+- **Deterministic Read syntax highlighting** (#210, @srothgan): Preserve tool locations for Read output, add broader syntax coverage, and render a brighter dark-terminal theme with a dim line-number gutter.
+
+### Fixes
+
+- **Runtime resize and notice hardening** (#211, @srothgan): Prevent notice migration and terminal row-range panics, preserve resize replay repaint requests, and clamp inline geometry after terminal shrinks.
+
+### CI and Dependencies
+
+- **Dependabot and Agent SDK monitor cleanup** (#201, #207, @srothgan): Add npm version updates for root and bridge packages, make the SDK monitor the single Agent SDK update path, bump the bridge TypeScript toolchain, and clear Hono advisories.
+- **Dependency updates** (#196, #197, #198, #199, #200): Bump `which` to `8.0.4`, `ratatui` to `0.30.2`, `time` to `0.3.51`, `hono` through `4.12.27`, and `rand` to `0.8.6`.
+- **Workflow action bump** (#195): Bump `actions/checkout` to `7`.
+
 ## [0.12.3] - 2026-06-16 [Changes][v0.12.3]
 
 ### Documentation
@@ -605,6 +622,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[Unreleased]: https://github.com/srothgan/claude-code-rust/compare/v0.12.3...main
 [v0.12.3]: https://github.com/srothgan/claude-code-rust/compare/v0.12.2...v0.12.3
 [v0.12.2]: https://github.com/srothgan/claude-code-rust/compare/v0.12.1...v0.12.2
 [v0.12.1]: https://github.com/srothgan/claude-code-rust/compare/v0.12.0...v0.12.1

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -9,9 +9,10 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk": "0.3.190",
         "@anthropic-ai/sdk": "0.97.1",
         "@modelcontextprotocol/sdk": "1.29.0",
+        "claude-code-rust": "file:..",
         "zod": "4.4.3"
       },
       "devDependencies": {
@@ -24,11 +25,10 @@
     "..": {
       "name": "claude-code-rust",
       "version": "0.10.0",
-      "extraneous": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk": "0.3.190",
         "@anthropic-ai/sdk": "0.97.1",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "4.4.3"
@@ -36,27 +36,30 @@
       "bin": {
         "claude-rs": "bin/claude-rs.js"
       },
+      "devDependencies": {
+        "jscpd": "5.0.9"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.177.tgz",
-      "integrity": "sha512-CBzXnzR661q3AlfZzBjmIFQx0cxr36iJV3PExTYmPyGQX32qxtiFQgnxTcF8wB4hcSVf2hnoy/gprVJdkNx7cw==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.190.tgz",
+      "integrity": "sha512-d4morVtH9eBUsk5BXmhcX2tnEums/RwbM9LrhZB3VCDAYNiDTEW4IejY5o572//7/0qN111l6fmPr5b5cmrjsQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.177"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.190"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -65,9 +68,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.177.tgz",
-      "integrity": "sha512-u9Ty+KPllm2nw0RatdPF0zcPRquNZjVptmyLG0DqduGbgZDLQpfPFMF5hffFIRnVaXhx7+jkUmEdw0jrda0UcA==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.190.tgz",
+      "integrity": "sha512-131dhlg7qGXgVsnKi0pTPMK4lQOunF4Ewx9AT4sP24LXc0vxYZ8r7d6Vy5ba/jCp6NqkJUNsMNYwNfvIaGdv4Q==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +81,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.177.tgz",
-      "integrity": "sha512-ona6Jv54XFwBTqOj3MzLWfKtc2m7Rdh58wOAX9Hnue/6FcWfyeuz/UDcidVTXQ7Xytz//Tb0JJgFtiQjO7FbIA==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.190.tgz",
+      "integrity": "sha512-IU8RDROU69Hd81TgH8VAjXMq/pvTreuT0Fqtjut2u5p9zYB7m0q1uWZyEWJfte6aCTA6aQLcFp2l1RRpRfOYxg==",
       "cpu": [
         "x64"
       ],
@@ -91,9 +94,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.177.tgz",
-      "integrity": "sha512-wBCbklkaDb483Ab4DUFfmJjZJKXz58YXPv+CiGsyjq1St19mbKEma5KKz3Ya9mlV8aLyh4zmLK2mEHPnF//Ipg==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.190.tgz",
+      "integrity": "sha512-MhBNdygHatPnfw2zpfx70A535pDk2mZQwkFeL0kSfiF0pAgJWyuyYCAI7NUH61NtT3R2kO1kxGGWxgAuh0Ncag==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +107,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.177.tgz",
-      "integrity": "sha512-v6PMDD3h2erLuTK5S2ZvExqdL3v44OyC70XpKhyqIUnyPaGR9YAMjh//EKdWC+mNvt6mIbRZpaDcHtbASVW8Rw==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.190.tgz",
+      "integrity": "sha512-/fHLhroUkjgqjbU4vQtql9nVNf9qyYLDuXAUViA3VCCYY78mgfQPj0k3p0dVre38Cr5AuzWVS8tLxJm3Yg1o4g==",
       "cpu": [
         "arm64"
       ],
@@ -117,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.177.tgz",
-      "integrity": "sha512-WDP6puwPHscggNAfvIxyUSHSAjfUEkGRfnMXEPBHOqO+qjX2KGxeE13/ih3EVioeBVOUIqPui6VB05vXLa6T9Q==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.190.tgz",
+      "integrity": "sha512-iLT6Z2ivtCSu722H51wBwEjTfRrymrVZjV6puhkBHAFQsW7U8ya0gKzELlun/nj8gYLT38eoUanIhdSDdyWoAA==",
       "cpu": [
         "x64"
       ],
@@ -130,9 +133,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.177.tgz",
-      "integrity": "sha512-1cdEO06WoEsl1JnnLCPIlg/8x37GtBsTuj65gIpSjdrImNBjgIuMWVyceP4qaXhFjtQgYK1nx3TpaxEFVDOrDg==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.190.tgz",
+      "integrity": "sha512-ixcKEYuAaK6Fx2a9hjNRlCqTu9uc2SgZZr/f5Uzy4xFSHZNVyc+xn0c+JlCV6ZwiVs8FRlxGuFGoOD0yN3X6Zg==",
       "cpu": [
         "x64"
       ],
@@ -143,9 +146,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.177.tgz",
-      "integrity": "sha512-xLgDWnZaYohtFrkgEIkGZdP+rp4sXxAMbbpEvEp0LK1vAYmJam/ztT2yoK6gfI58IbToJq1WGUEX2HVnE65yOg==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.190.tgz",
+      "integrity": "sha512-CcMt72vqTWBV3y+E0szfcOcUHcY8qAG+SnjUwYMHNMlzBrUL4cpiiGO6qKYxo4kkdoSWaHZVxVkPtOldrPiz4A==",
       "cpu": [
         "arm64"
       ],
@@ -156,9 +159,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.177.tgz",
-      "integrity": "sha512-SIdQLbtF//rYK4KDBNpUPyjyui7NwCFPZ2/3vyW3TR8R8xynkNq3cLis90FnPSgxaSshi38vkJYWh+9kGDB7zg==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.190.tgz",
+      "integrity": "sha512-3tkc+zizxgl+q+keZ52OJ3flUq2i4TUUgfkXJaozbylHglW94qW/j0axmEp+cREGiiV5jtJGxLMziHpr/dS6TQ==",
       "cpu": [
         "x64"
       ],
@@ -1287,6 +1290,10 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/claude-code-rust": {
+      "resolved": "..",
+      "link": true
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk": "0.3.193",
         "@anthropic-ai/sdk": "0.97.1",
         "@modelcontextprotocol/sdk": "1.29.0",
         "claude-code-rust": "file:..",
@@ -28,7 +28,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk": "0.3.193",
         "@anthropic-ai/sdk": "0.97.1",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "4.4.3"
@@ -44,22 +44,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.190.tgz",
-      "integrity": "sha512-d4morVtH9eBUsk5BXmhcX2tnEums/RwbM9LrhZB3VCDAYNiDTEW4IejY5o572//7/0qN111l6fmPr5b5cmrjsQ==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.193.tgz",
+      "integrity": "sha512-WzL03VJE1sT0Nz3rEpsYMYR+9n6iyQtLVt7ghMWnYC9pvDsiy6kwcMplZniWSjH8Dm6CfkUBN5t6KB4i/JfouA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.190"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.193"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.190.tgz",
-      "integrity": "sha512-131dhlg7qGXgVsnKi0pTPMK4lQOunF4Ewx9AT4sP24LXc0vxYZ8r7d6Vy5ba/jCp6NqkJUNsMNYwNfvIaGdv4Q==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.193.tgz",
+      "integrity": "sha512-1hT7b+KIm/3E1OSJofr7PF21Xq2zT1ccnjzuVcWQ5LYXJ09lgCMvA/ZfcDBKuoyCZ4lSnuicKXZ/h5vRbWfqrA==",
       "cpu": [
         "arm64"
       ],
@@ -81,9 +81,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.190.tgz",
-      "integrity": "sha512-IU8RDROU69Hd81TgH8VAjXMq/pvTreuT0Fqtjut2u5p9zYB7m0q1uWZyEWJfte6aCTA6aQLcFp2l1RRpRfOYxg==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.193.tgz",
+      "integrity": "sha512-9x5Y/L6iwETwEJFmPaYXfsE8q0cVgx75V7nL60HvSzi8K1XQNcG5u53jOzRvqDNah8mvGYOb+9AWrMCSJvmFyA==",
       "cpu": [
         "x64"
       ],
@@ -94,9 +94,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.190.tgz",
-      "integrity": "sha512-MhBNdygHatPnfw2zpfx70A535pDk2mZQwkFeL0kSfiF0pAgJWyuyYCAI7NUH61NtT3R2kO1kxGGWxgAuh0Ncag==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.193.tgz",
+      "integrity": "sha512-gvfD9pKHXWxCkkIX6bC4/FOALTxqHYjAu83iT1bzn5mCv6QWSZRl6WLRRtvKpWtWuY1jpML1lL3YfKADsAX/rA==",
       "cpu": [
         "arm64"
       ],
@@ -107,9 +107,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.190.tgz",
-      "integrity": "sha512-/fHLhroUkjgqjbU4vQtql9nVNf9qyYLDuXAUViA3VCCYY78mgfQPj0k3p0dVre38Cr5AuzWVS8tLxJm3Yg1o4g==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.193.tgz",
+      "integrity": "sha512-a3qsVTBe4G6ndsVavfIXEVAXLVXM8uvBUNYpm4jKqk2+ovWZQe/96CXOwmerg9U+/bllg4QJ9lSyYCsdtVIr6w==",
       "cpu": [
         "arm64"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.190.tgz",
-      "integrity": "sha512-iLT6Z2ivtCSu722H51wBwEjTfRrymrVZjV6puhkBHAFQsW7U8ya0gKzELlun/nj8gYLT38eoUanIhdSDdyWoAA==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.193.tgz",
+      "integrity": "sha512-1sz+7cn0iuh0ThInuAYF1jpFvLyOaZ0PZYQIF7eb9JDZbBohUf6INeTCwjAwUL0ASCq2xS7Odu/qDVuTtLTeDA==",
       "cpu": [
         "x64"
       ],
@@ -133,9 +133,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.190.tgz",
-      "integrity": "sha512-ixcKEYuAaK6Fx2a9hjNRlCqTu9uc2SgZZr/f5Uzy4xFSHZNVyc+xn0c+JlCV6ZwiVs8FRlxGuFGoOD0yN3X6Zg==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.193.tgz",
+      "integrity": "sha512-DLXlO4tlcWygz0Ft4nu6ai5KssByYt2tOeWdc4dFXKt6uBKXpbZVziUUq3ePO5zuAFyU6w7EjYLv8MMPURbAiQ==",
       "cpu": [
         "x64"
       ],
@@ -146,9 +146,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.190.tgz",
-      "integrity": "sha512-CcMt72vqTWBV3y+E0szfcOcUHcY8qAG+SnjUwYMHNMlzBrUL4cpiiGO6qKYxo4kkdoSWaHZVxVkPtOldrPiz4A==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.193.tgz",
+      "integrity": "sha512-36LJKiGuKusgaPTVeh9QanL00UcaE0RcC4pgK800/0SenApbh979ndxI0XKUVfLHzlGkqlhkhT3foMdqS+zx1w==",
       "cpu": [
         "arm64"
       ],
@@ -159,9 +159,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.190.tgz",
-      "integrity": "sha512-3tkc+zizxgl+q+keZ52OJ3flUq2i4TUUgfkXJaozbylHglW94qW/j0axmEp+cREGiiV5jtJGxLMziHpr/dS6TQ==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.193.tgz",
+      "integrity": "sha512-VyyKZlWQpbD6nkUTeNvgmLvpqt1QaPQQBOC30tbEYwYsV5MC1I35Li0H7nWwngGqPSTtMvHpjpz6Eb2FSTn7/A==",
       "cpu": [
         "x64"
       ],

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -12,7 +12,6 @@
         "@anthropic-ai/claude-agent-sdk": "0.3.193",
         "@anthropic-ai/sdk": "0.97.1",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "claude-code-rust": "file:..",
         "zod": "4.4.3"
       },
       "devDependencies": {
@@ -20,27 +19,6 @@
         "@types/node": "26.0.0",
         "knip": "6.4.1",
         "typescript": "6.0.3"
-      }
-    },
-    "..": {
-      "name": "claude-code-rust",
-      "version": "0.10.0",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.193",
-        "@anthropic-ai/sdk": "0.97.1",
-        "@modelcontextprotocol/sdk": "1.29.0",
-        "zod": "4.4.3"
-      },
-      "bin": {
-        "claude-rs": "bin/claude-rs.js"
-      },
-      "devDependencies": {
-        "jscpd": "5.0.9"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -1290,10 +1268,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/claude-code-rust": {
-      "resolved": "..",
-      "link": true
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -20,7 +20,6 @@
     "@anthropic-ai/claude-agent-sdk": "0.3.193",
     "@anthropic-ai/sdk": "0.97.1",
     "@modelcontextprotocol/sdk": "1.29.0",
-    "claude-code-rust": "file:..",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -17,9 +17,10 @@
     "test": "npm run build && node --test dist/**/*.test.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.177",
+    "@anthropic-ai/claude-agent-sdk": "0.3.190",
     "@anthropic-ai/sdk": "0.97.1",
     "@modelcontextprotocol/sdk": "1.29.0",
+    "claude-code-rust": "file:..",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -17,7 +17,7 @@
     "test": "npm run build && node --test dist/**/*.test.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.190",
+    "@anthropic-ai/claude-agent-sdk": "0.3.193",
     "@anthropic-ai/sdk": "0.97.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "claude-code-rust": "file:..",

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -6395,13 +6395,15 @@ test("mapSdkSessions normalizes and sorts sessions", () => {
   ]);
 });
 
-test("buildSessionListOptions scopes repo-local listings to worktrees", () => {
+test("buildSessionListOptions includes SDK-created sessions for resume listings", () => {
   assert.deepEqual(buildSessionListOptions("C:/repo"), {
     dir: "C:/repo",
+    includeProgrammatic: true,
     includeWorktrees: true,
     limit: 50,
   });
   assert.deepEqual(buildSessionListOptions(undefined), {
+    includeProgrammatic: true,
     limit: 50,
   });
 });

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -5196,7 +5196,7 @@ test("looksLikeAuthRequired detects login hints", () => {
 });
 
 test("agent sdk version compatibility check matches pinned version", () => {
-  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.177");
+  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.190");
   assert.equal(agentSdkVersionCompatibilityError(), undefined);
 });
 

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -1922,6 +1922,112 @@ test("handleSdkMessage emits transcript retraction for model_refusal_fallback", 
   );
 });
 
+test("handleSdkMessage emits warning notice for model_refusal_no_fallback with explanation", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "model_refusal_no_fallback",
+      original_model: "claude-opus-4-1",
+      request_id: "req-1",
+      api_refusal_category: "cyber",
+      api_refusal_explanation: "policy text",
+      refused_user_message_uuid: "user-1",
+      content: "raw content",
+      uuid: "refusal-notice",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    {
+      type: "system_notice_update",
+      severity: "warning",
+      message:
+        "Could not continue with claude-opus-4-1: model refused the request and no fallback model is configured. Reason: policy text.",
+    },
+  ]);
+});
+
+test("handleSdkMessage emits warning notice for model_refusal_no_fallback with category only", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "model_refusal_no_fallback",
+      original_model: "claude-opus-4-1",
+      request_id: "req-1",
+      api_refusal_category: "cyber",
+      uuid: "refusal-notice",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    {
+      type: "system_notice_update",
+      severity: "warning",
+      message:
+        "Could not continue with claude-opus-4-1: model refused the request and no fallback model is configured. Refusal category: cyber.",
+    },
+  ]);
+});
+
+test("handleSdkMessage emits warning notice for model_refusal_no_fallback with content detail", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "model_refusal_no_fallback",
+      original_model: "claude-opus-4-1",
+      request_id: "req-1",
+      content: "Refused by policy!",
+      uuid: "refusal-notice",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    {
+      type: "system_notice_update",
+      severity: "warning",
+      message:
+        "Could not continue with claude-opus-4-1: model refused the request and no fallback model is configured. Refused by policy!",
+    },
+  ]);
+});
+
+test("handleSdkMessage emits readable model_refusal_no_fallback notice for empty metadata", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "model_refusal_no_fallback",
+      original_model: " ",
+      request_id: null,
+      api_refusal_category: " ",
+      api_refusal_explanation: null,
+      refused_user_message_uuid: null,
+      content: " ",
+      uuid: "refusal-notice",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    {
+      type: "system_notice_update",
+      severity: "warning",
+      message:
+        "Could not continue with the selected model: model refused the request and no fallback model is configured.",
+    },
+  ]);
+});
+
 test("handleSdkMessage emits tolerant transcript retraction for model_fallback", () => {
   const session = makeSessionState();
 

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -3432,11 +3432,15 @@ test("buildRateLimitUpdate maps SDK fields to wire shape", () => {
     overageDisabledReason: "out_of_credits",
     isUsingOverage: false,
     surpassedThreshold: 0.9,
+    errorCode: "credits_required",
+    canUserPurchaseCredits: true,
+    hasChargeableSavedPaymentMethod: false,
   });
 
   assert.deepEqual(update, {
     type: "rate_limit_update",
     status: "allowed_warning",
+    error_code: "credits_required",
     resets_at: 1_741_280_000,
     utilization: 0.92,
     rate_limit_type: "five_hour",
@@ -3445,6 +3449,8 @@ test("buildRateLimitUpdate maps SDK fields to wire shape", () => {
     overage_disabled_reason: "out_of_credits",
     is_using_overage: false,
     surpassed_threshold: 0.9,
+    can_user_purchase_credits: true,
+    has_chargeable_saved_payment_method: false,
   });
 });
 
@@ -3480,6 +3486,10 @@ test("buildRateLimitUpdate rejects invalid payloads", () => {
     }),
     { type: "rate_limit_update", status: "rejected" },
   );
+  assert.deepEqual(buildRateLimitUpdate({ status: "rejected", errorCode: "other" }), {
+    type: "rate_limit_update",
+    status: "rejected",
+  });
 });
 
 test("buildApiRetryUpdate maps SDK api_retry messages to wire shape", () => {

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -3374,6 +3374,7 @@ test("normalizeToolKind maps known tool names", () => {
   assert.equal(normalizeToolKind("ShowOnboardingRolePicker"), "other");
   assert.equal(normalizeToolKind("TaskOutput"), "other");
   assert.equal(normalizeToolKind("TaskStop"), "other");
+  assert.equal(normalizeToolKind("ReadMcpResourceDir"), "read");
   assert.equal(normalizeToolKind("Task"), "think");
   assert.equal(normalizeToolKind("Agent"), "think");
   assert.equal(normalizeToolKind("EnterPlanMode"), "switch_mode");
@@ -3395,6 +3396,26 @@ test("shell tool titles use input command", () => {
     "Get-ChildItem",
   );
   assert.equal(createToolCall("tc-powershell-empty", "PowerShell", {}).title, "Terminal");
+});
+
+test("ReadMcpResourceDir titles include server and URI context", () => {
+  assert.equal(
+    createToolCall("tc-mcp-dir-title", "ReadMcpResourceDir", {
+      server: "docs",
+      uri: "file://manuals/",
+    }).title,
+    "ReadMcpResourceDir docs file://manuals/",
+  );
+  assert.equal(
+    createToolCall("tc-mcp-dir-uri-title", "ReadMcpResourceDir", {
+      uri: "file://manuals/",
+    }).title,
+    "ReadMcpResourceDir file://manuals/",
+  );
+  assert.equal(
+    createToolCall("tc-mcp-dir-fallback-title", "ReadMcpResourceDir", {}).title,
+    "ReadMcpResourceDir",
+  );
 });
 
 test("parseFastModeState accepts known values and rejects unknown values", () => {
@@ -4912,6 +4933,156 @@ test("buildToolResultFields marks ReadMcpResource error output as failed", () =>
     {
       type: "content",
       content: { type: "text", text: "Error: resource not found" },
+    },
+  ]);
+});
+
+test("buildToolResultFields renders structured ReadMcpResourceDir listings", () => {
+  const base = createToolCall("tc-mcp-dir", "ReadMcpResourceDir", {
+    server: "docs",
+    uri: "file://manuals/",
+  });
+  const fields = buildToolResultFields(
+    false,
+    {
+      resources: [
+        {
+          name: "guide.md",
+          uri: "file://manuals/guide.md",
+          mimeType: "text/markdown",
+        },
+        {
+          name: "images",
+          uri: "file://manuals/images",
+          mimeType: "inode/directory",
+        },
+        {
+          name: "readme",
+          uri: "file://manuals/readme",
+        },
+      ],
+    },
+    base,
+  );
+
+  const expected =
+    "guide.md - file://manuals/guide.md (text/markdown)\n" +
+    "images - file://manuals/images (directory)\n" +
+    "readme - file://manuals/readme";
+  assert.equal(fields.status, "completed");
+  assert.equal(fields.raw_output, expected);
+  assert.deepEqual(fields.content, [
+    {
+      type: "content",
+      content: { type: "text", text: expected },
+    },
+  ]);
+});
+
+test("buildToolResultFields renders empty ReadMcpResourceDir listings", () => {
+  const base = createToolCall("tc-mcp-dir-empty", "ReadMcpResourceDir", {
+    server: "docs",
+    uri: "file://empty/",
+  });
+  const fields = buildToolResultFields(false, { resources: [] }, base);
+
+  assert.equal(fields.status, "completed");
+  assert.equal(fields.raw_output, "No resources found.");
+  assert.deepEqual(fields.content, [
+    {
+      type: "content",
+      content: { type: "text", text: "No resources found." },
+    },
+  ]);
+});
+
+test("buildToolResultFields marks ReadMcpResourceDir error output as failed", () => {
+  const base = createToolCall("tc-mcp-dir-error", "ReadMcpResourceDir", {
+    server: "docs",
+    uri: "file://missing/",
+  });
+  const fields = buildToolResultFields(
+    false,
+    {
+      resources: [],
+      error: "directory not found",
+    },
+    base,
+  );
+
+  assert.equal(fields.status, "failed");
+  assert.equal(fields.raw_output, "Error: directory not found");
+  assert.deepEqual(fields.content, [
+    {
+      type: "content",
+      content: { type: "text", text: "Error: directory not found" },
+    },
+  ]);
+});
+
+test("buildToolResultFields parses ReadMcpResourceDir transcript JSON", () => {
+  const base = createToolCall("tc-mcp-dir-history", "ReadMcpResourceDir", {
+    server: "docs",
+    uri: "file://manuals/",
+  });
+  const transcriptJson = JSON.stringify({
+    resources: [
+      {
+        name: "api.json",
+        uri: "file://manuals/api.json",
+        mimeType: "application/json",
+      },
+    ],
+  });
+  const fields = buildToolResultFields(false, transcriptJson, base, {
+    type: "tool_result",
+    tool_use_id: "tc-mcp-dir-history",
+    content: transcriptJson,
+  });
+
+  assert.equal(fields.raw_output, "api.json - file://manuals/api.json (application/json)");
+  assert.deepEqual(fields.content, [
+    {
+      type: "content",
+      content: {
+        type: "text",
+        text: "api.json - file://manuals/api.json (application/json)",
+      },
+    },
+  ]);
+});
+
+test("buildToolResultFields skips invalid ReadMcpResourceDir entries", () => {
+  const base = createToolCall("tc-mcp-dir-invalid", "ReadMcpResourceDir", {
+    server: "docs",
+    uri: "file://manuals/",
+  });
+  const fields = buildToolResultFields(
+    false,
+    {
+      resources: [
+        { name: "missing-uri" },
+        { uri: "file://manuals/missing-name" },
+        null,
+        {
+          name: "valid.txt",
+          uri: "file://manuals/valid.txt",
+          mimeType: "text/plain",
+        },
+      ],
+    },
+    base,
+  );
+
+  assert.equal(fields.status, "completed");
+  assert.equal(fields.raw_output, "valid.txt - file://manuals/valid.txt (text/plain)");
+  assert.deepEqual(fields.content, [
+    {
+      type: "content",
+      content: {
+        type: "text",
+        text: "valid.txt - file://manuals/valid.txt (text/plain)",
+      },
     },
   ]);
 });

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -68,7 +68,7 @@ import { classifyTurnErrorKind } from "./bridge/error_classification.js";
 import { emitToolCall, emitToolProgressUpdate, emitToolResultUpdate } from "./bridge/tool_calls.js";
 import { linkTaskToolUse } from "./bridge/task_links.js";
 import { requestAskUserQuestionAnswers } from "./bridge/user_interaction.js";
-import { handleResultMessage } from "./bridge/message_handlers.js";
+import { flushPendingWorkerShutdown, handleResultMessage } from "./bridge/message_handlers.js";
 
 const BRIDGE_RUNTIME_PROCESS_NAME =
   process.platform === "win32" ? "claude-rs-bridge-node.exe" : "claude-rs-bridge-node";
@@ -104,6 +104,7 @@ function makeSessionState(): SessionState {
     pendingQuestions: new Map(),
     pendingUserDialogs: new Map(),
     pendingElicitations: new Map(),
+    informationalDedupKeys: new Set(),
     mcpStatusRevalidatedAt: new Map(),
     hiddenToolUseIds: new Set(),
     authHintSent: false,
@@ -3850,6 +3851,213 @@ test("handleSdkMessage emits system notices for notifications and plugin failure
     { type: "system_notice_update", severity: "info", message: "Sync completed" },
     { type: "system_notice_update", severity: "warning", message: "Plugin install failed acme: download failed" },
   ]);
+});
+
+test("handleSdkMessage maps informational system messages to notices by level", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "informational",
+      content: "  Sync ready  ",
+      level: "notice",
+      uuid: "message-info-notice",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "informational",
+      content: "Try /compact",
+      level: "suggestion",
+      uuid: "message-info-suggestion",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "informational",
+      content: "Hook blocked continuation",
+      level: "warning",
+      uuid: "message-info-warning",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    { type: "system_notice_update", severity: "info", message: "Sync ready" },
+    { type: "system_notice_update", severity: "info", message: "Suggestion: Try /compact" },
+    { type: "system_notice_update", severity: "warning", message: "Hook blocked continuation" },
+  ]);
+});
+
+test("handleSdkMessage keeps informational info log-only unless continuation is prevented", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "informational",
+      content: "Transcript-only progress",
+      level: "info",
+      uuid: "message-info-log-only",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "informational",
+      content: "Stop hook denied continuation",
+      level: "info",
+      prevent_continuation: true,
+      uuid: "message-info-prevented",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    {
+      type: "system_notice_update",
+      severity: "warning",
+      message: "Stop hook denied continuation",
+    },
+  ]);
+});
+
+test("handleSdkMessage deduplicates informational messages by tool use, level, and content", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "informational",
+      content: "Progress",
+      level: "notice",
+      tool_use_id: "tool-1",
+      uuid: "message-info-1",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "informational",
+      content: " Progress ",
+      level: "notice",
+      tool_use_id: "tool-1",
+      uuid: "message-info-2",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "informational",
+      content: "Progress updated",
+      level: "notice",
+      tool_use_id: "tool-1",
+      uuid: "message-info-3",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    { type: "system_notice_update", severity: "info", message: "Progress" },
+    { type: "system_notice_update", severity: "info", message: "Progress updated" },
+  ]);
+});
+
+test("handleSdkMessage does not deduplicate informational messages without a tool use id", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    for (const uuid of ["message-info-1", "message-info-2"]) {
+      handleSdkMessage(session, {
+        type: "system",
+        subtype: "informational",
+        content: "Repeated global notice",
+        level: "notice",
+        uuid,
+        session_id: "session-1",
+      } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    }
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    { type: "system_notice_update", severity: "info", message: "Repeated global notice" },
+    { type: "system_notice_update", severity: "info", message: "Repeated global notice" },
+  ]);
+});
+
+test("handleSdkMessage treats worker shutdown before connect as log-only", () => {
+  const session = makeSessionState();
+  session.connected = false;
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "worker_shutting_down",
+      reason: "host_exit",
+      uuid: "message-worker-shutdown",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    flushPendingWorkerShutdown(session);
+  });
+
+  assert.deepEqual(events, []);
+  assert.equal(session.pendingWorkerShutdown, undefined);
+});
+
+test("handleSdkMessage flushes connected worker shutdown only when stream ends", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "worker_shutting_down",
+      reason: "host_exit",
+      uuid: "message-worker-shutdown",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    flushPendingWorkerShutdown(session);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    {
+      type: "system_notice_update",
+      severity: "warning",
+      message: "Claude worker is shutting down: host_exit",
+    },
+  ]);
+});
+
+test("handleSdkMessage cancels pending worker shutdown after later SDK activity", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "worker_shutting_down",
+      reason: "host_exit",
+      uuid: "message-worker-shutdown",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "notification",
+      text: "Still running",
+      priority: "low",
+      uuid: "message-notification",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    flushPendingWorkerShutdown(session);
+  });
+
+  assert.deepEqual(events.map((event) => event.update), [
+    { type: "system_notice_update", severity: "info", message: "Still running" },
+  ]);
+});
+
+test("handleSdkMessage ignores unknown future system subtypes", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "future_subtype",
+      content: "Unknown",
+      uuid: "message-future",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events, []);
 });
 
 test("handleSdkMessage treats mirror errors as log-only diagnostics", () => {

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -5808,7 +5808,7 @@ test("looksLikeAuthRequired detects login hints", () => {
 });
 
 test("agent sdk version compatibility check matches pinned version", () => {
-  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.190");
+  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.193");
   assert.equal(agentSdkVersionCompatibilityError(), undefined);
 });
 

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -5,6 +5,7 @@ import {
   CACHE_SPLIT_POLICY,
   buildApiRetryUpdate,
   buildRateLimitUpdate,
+  buildRewindConversationPlan,
   buildQueryOptions,
   canGenerateSessionTitle,
   generatePersistedSessionTitle,
@@ -41,12 +42,13 @@ import {
   previewKilobyteLabel,
   staleMcpAuthCandidates,
   resolveInstalledAgentSdkVersion,
+  rewindTargetsFromSessionMessages,
   unwrapToolUseResult,
   updateAvailableCommands,
   handleReloadPluginsCommand,
 } from "./bridge.js";
 import type { SessionState } from "./bridge.js";
-import type { Options } from "@anthropic-ai/claude-agent-sdk";
+import type { Options, SessionMessage } from "@anthropic-ai/claude-agent-sdk";
 import {
   availableModesForSession,
   buildModeState,
@@ -58,6 +60,7 @@ import { handleMcpSetServersCommand } from "./bridge/mcp.js";
 import {
   emitCurrentModelUpdate,
   handleUserDialogResponse,
+  closeSessionsBeforeRegister,
   refreshCurrentModel,
   resolveCurrentModel,
   sessions,
@@ -110,6 +113,33 @@ function makeSessionState(): SessionState {
     authHintSent: false,
   };
 }
+
+test("closeSessionsBeforeRegister closes same-key stale session before replacement registration", async () => {
+  sessions.clear();
+  let staleClosed = 0;
+  const stale = makeSessionState();
+  stale.sessionId = "session-1";
+  stale.query = {
+    close: () => {
+      staleClosed += 1;
+    },
+  } as import("@anthropic-ai/claude-agent-sdk").Query;
+  const replacement = makeSessionState();
+  replacement.sessionId = "session-1";
+
+  sessions.set(stale.sessionId, stale);
+  await closeSessionsBeforeRegister(replacement, [stale], "req-1");
+
+  assert.equal(staleClosed, 1);
+  assert.equal(sessions.has("session-1"), false);
+
+  sessions.set(replacement.sessionId, replacement);
+  await closeSessionsBeforeRegister(replacement, [stale], "req-2");
+
+  assert.equal(staleClosed, 2);
+  assert.equal(sessions.get("session-1"), replacement);
+  sessions.clear();
+});
 
 test("availableModesForSession omits conditional modes when unsupported", () => {
   const session = makeSessionState();
@@ -932,6 +962,178 @@ test("parseCommandEnvelope validates get_context_usage command", () => {
   });
 });
 
+test("parseCommandEnvelope validates get_rewind_targets command", () => {
+  const parsed = parseCommandEnvelope(
+    JSON.stringify({
+      request_id: "req-rewind-targets",
+      command: "get_rewind_targets",
+      session_id: "session-123",
+    }),
+  );
+
+  assert.equal(parsed.requestId, "req-rewind-targets");
+  assert.deepEqual(parsed.command, {
+    command: "get_rewind_targets",
+    session_id: "session-123",
+  });
+});
+
+test("parseCommandEnvelope validates rewind command modes", () => {
+  for (const restoreMode of ["both", "conversation", "code"] as const) {
+    const parsed = parseCommandEnvelope(
+      JSON.stringify({
+        request_id: "req-rewind",
+        command: "rewind",
+        session_id: "session-123",
+        target_user_message_id: "user-1",
+        restore_mode: restoreMode,
+        launch_settings: {
+          language: "German",
+        },
+      }),
+    );
+
+    assert.equal(parsed.requestId, "req-rewind");
+    assert.deepEqual(parsed.command, {
+      command: "rewind",
+      session_id: "session-123",
+      target_user_message_id: "user-1",
+      restore_mode: restoreMode,
+      launch_settings: { language: "German" },
+    });
+  }
+});
+
+test("parseCommandEnvelope rejects invalid rewind mode", () => {
+  assert.throws(
+    () =>
+      parseCommandEnvelope(
+        JSON.stringify({
+          command: "rewind",
+          session_id: "session-123",
+          target_user_message_id: "user-1",
+          restore_mode: "files",
+        }),
+      ),
+    /rewind\.restore_mode must be one of both, conversation, code/,
+  );
+});
+
+test("rewindTargetsFromSessionMessages filters user text messages with UUIDs", () => {
+  const messages = [
+    {
+      type: "user",
+      uuid: "user-1",
+      message: { role: "user", content: [{ type: "text", text: " first prompt\nline " }] },
+    },
+    {
+      type: "assistant",
+      uuid: "assistant-1",
+      message: { role: "assistant", content: [{ type: "text", text: "ignored" }] },
+    },
+    {
+      type: "user",
+      uuid: "tool-result",
+      message: { role: "user", content: [{ type: "tool_result", content: "ignored" }] },
+    },
+    {
+      type: "user",
+      uuid: "user-2",
+      message: { role: "user", content: [{ type: "text", text: "second prompt" }] },
+    },
+  ] as unknown as SessionMessage[];
+
+  assert.deepEqual(rewindTargetsFromSessionMessages(messages), [
+    {
+      uuid: "user-2",
+      first_text: "second prompt",
+      input_text: "second prompt",
+      index: 3,
+      previous_assistant_uuid: "assistant-1",
+    },
+    {
+      uuid: "user-1",
+      first_text: "first prompt line",
+      input_text: "first prompt\nline",
+      index: 0,
+    },
+  ]);
+});
+
+test("buildRewindConversationPlan anchors at previous assistant message", () => {
+  const messages = [
+    {
+      type: "user",
+      uuid: "user-1",
+      message: { role: "user", content: "first prompt" },
+    },
+    {
+      type: "assistant",
+      uuid: "assistant-1",
+      message: { role: "assistant", content: [{ type: "text", text: "reply" }] },
+    },
+    {
+      type: "user",
+      uuid: "user-2",
+      message: { role: "user", content: "second prompt" },
+    },
+  ] as unknown as SessionMessage[];
+
+  const plan = buildRewindConversationPlan(messages, "user-2");
+
+  assert.ok(plan);
+  assert.equal(plan.inputText, "second prompt");
+  assert.equal(plan.previousAssistantUuid, "assistant-1");
+  assert.equal(plan.targetIndex, 2);
+  assert.deepEqual(
+    plan.retainedMessages.map((message) => message.uuid),
+    ["user-1", "assistant-1"],
+  );
+  assert.ok(plan.resumeUpdates.length > 0);
+});
+
+test("buildRewindConversationPlan treats first user message as fresh replacement", () => {
+  const messages = [
+    {
+      type: "user",
+      uuid: "user-1",
+      message: { role: "user", content: " first prompt\nline " },
+    },
+    {
+      type: "assistant",
+      uuid: "assistant-1",
+      message: { role: "assistant", content: [{ type: "text", text: "reply" }] },
+    },
+  ] as unknown as SessionMessage[];
+
+  const plan = buildRewindConversationPlan(messages, "user-1");
+
+  assert.ok(plan);
+  assert.equal(plan.inputText, " first prompt\nline ");
+  assert.equal(plan.previousAssistantUuid, undefined);
+  assert.equal(plan.targetIndex, 0);
+  assert.deepEqual(plan.retainedMessages, []);
+  assert.deepEqual(plan.resumeUpdates, []);
+});
+
+test("buildRewindConversationPlan rejects stale or inconsistent targets", () => {
+  const messages = [
+    {
+      type: "user",
+      uuid: "user-1",
+      message: { role: "user", content: "first prompt" },
+    },
+    {
+      type: "user",
+      uuid: "user-2",
+      message: { role: "user", content: "second prompt" },
+    },
+  ] as unknown as SessionMessage[];
+
+  assert.equal(buildRewindConversationPlan(messages, "missing-user"), null);
+  assert.equal(buildRewindConversationPlan(messages, "user-2"), null);
+});
+
 test("staleMcpAuthCandidates selects previously connected servers that regressed to needs-auth", () => {
   const candidates = staleMcpAuthCandidates(
     [
@@ -1069,11 +1271,32 @@ test("buildQueryOptions maps launch settings into sdk query options", () => {
   assert.equal("effort" in options, false);
   assert.equal(options.agentProgressSummaries, true);
   assert.equal(options.promptSuggestions, true);
+  assert.equal(options.enableFileCheckpointing, true);
   assert.equal(options.sessionId, "session-1");
   assert.deepEqual(options.settingSources, ["user", "project", "local"]);
   assert.deepEqual(options.toolConfig, {
     askUserQuestion: { previewFormat: "markdown" },
   });
+});
+
+test("buildQueryOptions includes resumeSessionAt when provided", () => {
+  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const options = buildQueryOptions({
+    cwd: "C:/work",
+    resume: "session-1",
+    resumeSessionAt: "assistant-1",
+    launchSettings: {},
+    provisionalSessionId: "session-1",
+    input,
+    canUseTool: async () => ({ behavior: "deny", message: "not used" }),
+    enableSdkDebug: false,
+    enableSpawnDebug: false,
+    sessionIdForLogs: () => "session-1",
+  });
+
+  assert.equal(options.resume, "session-1");
+  assert.equal(options.resumeSessionAt, "assistant-1");
+  assert.equal("sessionId" in options, false);
 });
 
 test("buildQueryOptions forwards settings and maps startup model and permission mode", () => {

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -8,7 +8,17 @@ import {
   listSessions,
   renameSession,
 } from "@anthropic-ai/claude-agent-sdk";
-import type { BridgeCommand } from "./types.js";
+import type {
+  RewindFilesResult as SdkRewindFilesResult,
+  SessionMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import type {
+  BridgeCommand,
+  BridgeEvent,
+  RewindFilesResult,
+  RewindRestoreMode,
+  RewindTarget,
+} from "./types.js";
 import type { EffortLevel } from "./types.js";
 import {
   buildModeState,
@@ -42,6 +52,7 @@ import {
   emitCurrentModelUpdate,
   refreshCurrentModel,
   shouldInvalidateResolvedRuntimeModel,
+  type PendingRewindResult,
   type SessionState,
 } from "./bridge/session_lifecycle.js";
 import { mapSessionMessagesToUpdates } from "./bridge/history.js";
@@ -127,6 +138,73 @@ export function buildSessionMutationOptions(
   cwd?: string,
 ): import("@anthropic-ai/claude-agent-sdk").SessionMutationOptions | undefined {
   return cwd ? { dir: cwd } : undefined;
+}
+
+function normalizeRewindTargetText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+type UserTextParts = {
+  firstText: string;
+  inputText: string;
+};
+
+function userTextPartsFromSessionMessage(message: SessionMessage): UserTextParts | undefined {
+  const record = message as unknown as Record<string, unknown>;
+  if (record.type !== "user") {
+    return undefined;
+  }
+  const payload = record.message;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return undefined;
+  }
+  const content = (payload as Record<string, unknown>).content;
+  if (typeof content === "string") {
+    const firstText = normalizeRewindTargetText(content);
+    return firstText ? { firstText, inputText: content } : undefined;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const textBlocks: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object" || Array.isArray(block)) {
+      continue;
+    }
+    const blockRecord = block as Record<string, unknown>;
+    if (blockRecord.type === "text" && typeof blockRecord.text === "string") {
+      textBlocks.push(blockRecord.text);
+    }
+  }
+  const firstText = textBlocks.map(normalizeRewindTargetText).find((text) => text.length > 0);
+  return firstText ? { firstText, inputText: textBlocks.join("\n").trim() } : undefined;
+}
+
+export function rewindTargetsFromSessionMessages(messages: SessionMessage[]): RewindTarget[] {
+  const targets: RewindTarget[] = [];
+  let previousAssistantUuid: string | undefined;
+
+  messages.forEach((message, index) => {
+    const record = message as unknown as Record<string, unknown>;
+    const uuid = typeof record.uuid === "string" ? record.uuid.trim() : "";
+    if (record.type === "assistant" && uuid) {
+      previousAssistantUuid = uuid;
+      return;
+    }
+    const textParts = userTextPartsFromSessionMessage(message);
+    if (!uuid || !textParts) {
+      return;
+    }
+    targets.push({
+      uuid,
+      first_text: textParts.firstText,
+      input_text: textParts.inputText,
+      index,
+      ...(previousAssistantUuid ? { previous_assistant_uuid: previousAssistantUuid } : {}),
+    });
+  });
+
+  return targets.reverse();
 }
 
 type SessionTitleGeneratingQuery = import("@anthropic-ai/claude-agent-sdk").Query & {
@@ -247,6 +325,381 @@ export async function handleReloadPluginsCommand(
       fields: { error_message: message },
     });
     emitRuntimeReloadFailed(session.sessionId, message, requestId);
+  }
+}
+
+type ResolvedRewindTarget = {
+  inputText: string;
+  previousAssistantUuid?: string;
+  targetIndex: number;
+  retainedMessages: SessionMessage[];
+};
+
+export type RewindConversationPlan = ResolvedRewindTarget & {
+  resumeUpdates: ReturnType<typeof mapSessionMessagesToUpdates>;
+};
+
+function resolveRewindTarget(
+  messages: SessionMessage[],
+  targetUserMessageId: string,
+): ResolvedRewindTarget | null {
+  let previousAssistantUuid: string | undefined;
+  let textUserCountBeforeTarget = 0;
+
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    const record = message as unknown as Record<string, unknown>;
+    const uuid = typeof record.uuid === "string" ? record.uuid.trim() : "";
+    if (record.type === "assistant" && uuid) {
+      previousAssistantUuid = uuid;
+      continue;
+    }
+
+    const textParts = userTextPartsFromSessionMessage(message);
+    if (!textParts) {
+      continue;
+    }
+    if (uuid === targetUserMessageId) {
+      if (!previousAssistantUuid && textUserCountBeforeTarget > 0) {
+        return null;
+      }
+      if (previousAssistantUuid) {
+        const anchorIndex = messages.findIndex((candidate) => {
+          const candidateRecord = candidate as unknown as Record<string, unknown>;
+          return candidateRecord.uuid === previousAssistantUuid;
+        });
+        if (anchorIndex < 0) {
+          return null;
+        }
+        return {
+          inputText: textParts.inputText,
+          previousAssistantUuid,
+          targetIndex: index,
+          retainedMessages: messages.slice(0, anchorIndex + 1),
+        };
+      }
+      return {
+        inputText: textParts.inputText,
+        targetIndex: index,
+        retainedMessages: [],
+      };
+    }
+    if (uuid) {
+      textUserCountBeforeTarget += 1;
+    }
+  }
+
+  return null;
+}
+
+export function buildRewindConversationPlan(
+  messages: SessionMessage[],
+  targetUserMessageId: string,
+): RewindConversationPlan | null {
+  const resolved = resolveRewindTarget(messages, targetUserMessageId);
+  if (!resolved) {
+    return null;
+  }
+  return {
+    ...resolved,
+    resumeUpdates: mapSessionMessagesToUpdates(resolved.retainedMessages),
+  };
+}
+
+function mapRewindFilesResult(result: SdkRewindFilesResult): RewindFilesResult {
+  return {
+    can_rewind: result.canRewind,
+    ...(result.error ? { error: result.error } : {}),
+    files_changed: result.filesChanged ?? [],
+    ...(result.insertions !== undefined ? { insertions: result.insertions } : {}),
+    ...(result.deletions !== undefined ? { deletions: result.deletions } : {}),
+  };
+}
+
+async function rewindFiles(
+  session: SessionState,
+  targetUserMessageId: string,
+  dryRun: boolean,
+): Promise<RewindFilesResult> {
+  if (typeof session.query.rewindFiles !== "function") {
+    return {
+      can_rewind: false,
+      error: "file rewind is not supported by this SDK runtime",
+      files_changed: [],
+    };
+  }
+  return mapRewindFilesResult(await session.query.rewindFiles(targetUserMessageId, { dryRun }));
+}
+
+function emitRewindResult(
+  sessionId: string,
+  restoreMode: RewindRestoreMode,
+  status: Extract<BridgeEvent, { event: "rewind_result" }>["status"],
+  requestId: string | undefined,
+  fileResult?: RewindFilesResult,
+  message?: string,
+): void {
+  writeEvent(
+    {
+      event: "rewind_result",
+      session_id: sessionId,
+      restore_mode: restoreMode,
+      status,
+      ...(fileResult ? { file_result: fileResult } : {}),
+      ...(message ? { message } : {}),
+    },
+    requestId,
+  );
+}
+
+async function replaceConversationForRewind(
+  command: Extract<BridgeCommand, { command: "rewind" }>,
+  session: SessionState,
+  targetUserMessageId: string,
+  requestId: string | undefined,
+  pendingRewindResult?: PendingRewindResult,
+): Promise<void> {
+  const historyMessages = await getSessionMessages(command.session_id, {
+    dir: session.cwd,
+    includeSystemMessages: true,
+  });
+  const resolved = buildRewindConversationPlan(historyMessages, targetUserMessageId);
+  if (!resolved) {
+    bridgeLogger.warn({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "rewind_failed",
+      message: "conversation rewind target was stale or inconsistent",
+      outcome: "failure",
+      ...(requestId ? { requestId } : {}),
+      sessionId: session.sessionId,
+      fields: {
+        target_user_message_id: targetUserMessageId,
+        history_message_count: historyMessages.length,
+        reason: "target_not_found_or_inconsistent",
+      },
+    });
+    throw new Error(`unknown rewind target: ${targetUserMessageId}`);
+  }
+
+  const resumeUpdates = resolved.resumeUpdates;
+  const staleSessions = Array.from(sessions.values());
+  setSessionListingDir(session.cwd);
+  bridgeLogger.info({
+    target: LOG_TARGETS.APP_SESSION,
+    eventName: "rewind_target_resolved",
+    message: "conversation rewind target resolved",
+    outcome: "success",
+    ...(requestId ? { requestId } : {}),
+    sessionId: session.sessionId,
+    fields: {
+      target_user_message_id: targetUserMessageId,
+      target_index: resolved.targetIndex,
+      previous_assistant_uuid: resolved.previousAssistantUuid ?? "<none>",
+      history_message_count: historyMessages.length,
+      retained_message_count: resolved.retainedMessages.length,
+      retained_update_count: resumeUpdates.length,
+      stale_session_count: staleSessions.length,
+    },
+  });
+
+  if (!resolved.previousAssistantUuid) {
+    bridgeLogger.info({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "rewind_first_message_branch",
+      message: "conversation rewind target is first user message; creating fresh replacement",
+      outcome: "start",
+      ...(requestId ? { requestId } : {}),
+      sessionId: session.sessionId,
+      fields: {
+        target_user_message_id: targetUserMessageId,
+        history_message_count: historyMessages.length,
+        stale_session_count: staleSessions.length,
+      },
+    });
+    await createSession({
+      cwd: session.cwd,
+      launchSettings: command.launch_settings,
+      connectEvent: "session_replaced",
+      requestId,
+      restoredInput: resolved.inputText,
+      ...(pendingRewindResult ? { pendingRewindResult } : {}),
+      ...(staleSessions.length > 0 ? { sessionsToCloseAfterConnect: staleSessions } : {}),
+    });
+    bridgeLogger.info({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "rewind_replacement_created",
+      message: "conversation rewind replacement session created",
+      outcome: "success",
+      ...(requestId ? { requestId } : {}),
+      fields: {
+        target_user_message_id: targetUserMessageId,
+        resume_session_at: "<none>",
+        retained_message_count: 0,
+        retained_update_count: 0,
+        stale_session_count: staleSessions.length,
+      },
+    });
+    return;
+  }
+
+  const sessionsToCloseAfterConnect = staleSessions.filter((stale) => stale !== session);
+  await createSession({
+    cwd: session.cwd,
+    resume: command.session_id,
+    resumeSessionAt: resolved.previousAssistantUuid,
+    launchSettings: command.launch_settings,
+    connectEvent: "session_replaced",
+    requestId,
+    sessionsToCloseBeforeRegister: [session],
+    ...(resumeUpdates.length > 0 ? { resumeUpdates } : {}),
+    restoredInput: resolved.inputText,
+    ...(pendingRewindResult ? { pendingRewindResult } : {}),
+    ...(sessionsToCloseAfterConnect.length > 0 ? { sessionsToCloseAfterConnect } : {}),
+  });
+  bridgeLogger.info({
+    target: LOG_TARGETS.APP_SESSION,
+    eventName: "rewind_replacement_created",
+    message: "conversation rewind replacement session created",
+    outcome: "success",
+    ...(requestId ? { requestId } : {}),
+    sessionId: command.session_id,
+    fields: {
+      target_user_message_id: targetUserMessageId,
+      resume_session_at: resolved.previousAssistantUuid,
+      retained_message_count: resolved.retainedMessages.length,
+      retained_update_count: resumeUpdates.length,
+      stale_session_count: staleSessions.length,
+    },
+  });
+}
+
+async function handleRewind(
+  command: Extract<BridgeCommand, { command: "rewind" }>,
+  requestId?: string,
+): Promise<void> {
+  const session = sessionById(command.session_id);
+  if (!session) {
+    slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
+    return;
+  }
+  const targetUserMessageId = command.target_user_message_id.trim();
+  if (!targetUserMessageId) {
+    slashError(command.session_id, "rewind target cannot be empty", requestId);
+    return;
+  }
+
+  bridgeLogger.info({
+    target: LOG_TARGETS.APP_SESSION,
+    eventName: "rewind_requested",
+    message: "rewind requested",
+    outcome: "start",
+    ...(requestId ? { requestId } : {}),
+    sessionId: session.sessionId,
+    fields: {
+      target_user_message_id: targetUserMessageId,
+      restore_mode: command.restore_mode,
+    },
+  });
+
+  if (command.restore_mode === "conversation") {
+    try {
+      await replaceConversationForRewind(command, session, targetUserMessageId, requestId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      bridgeLogger.error({
+        target: LOG_TARGETS.APP_SESSION,
+        eventName: "rewind_failed",
+        message: "conversation rewind failed",
+        outcome: "failure",
+        ...(requestId ? { requestId } : {}),
+        sessionId: session.sessionId,
+        fields: {
+          target_user_message_id: targetUserMessageId,
+          restore_mode: command.restore_mode,
+          error_message: message,
+        },
+      });
+      slashError(command.session_id, `failed to rewind conversation: ${message}`, requestId);
+    }
+    return;
+  }
+
+  let appliedFileResult: RewindFilesResult;
+  try {
+    const dryRunResult = await rewindFiles(session, targetUserMessageId, true);
+    if (!dryRunResult.can_rewind) {
+      slashError(
+        command.session_id,
+        dryRunResult.error ?? "failed to dry-run file rewind",
+        requestId,
+      );
+      return;
+    }
+    appliedFileResult = await rewindFiles(session, targetUserMessageId, false);
+    if (!appliedFileResult.can_rewind) {
+      slashError(command.session_id, appliedFileResult.error ?? "failed to restore code", requestId);
+      return;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    bridgeLogger.error({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "rewind_failed",
+      message: "file rewind failed",
+      outcome: "failure",
+      ...(requestId ? { requestId } : {}),
+      sessionId: session.sessionId,
+      fields: {
+        target_user_message_id: targetUserMessageId,
+        restore_mode: command.restore_mode,
+        error_message: message,
+      },
+    });
+    slashError(command.session_id, `failed to restore code: ${message}`, requestId);
+    return;
+  }
+
+  if (command.restore_mode === "code") {
+    emitRewindResult(
+      session.sessionId,
+      command.restore_mode,
+      "success",
+      requestId,
+      appliedFileResult,
+    );
+    return;
+  }
+
+  try {
+    await replaceConversationForRewind(command, session, targetUserMessageId, requestId, {
+      event: "rewind_result",
+      restore_mode: command.restore_mode,
+      status: "success",
+      file_result: appliedFileResult,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    bridgeLogger.error({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "rewind_failed",
+      message: "conversation rewind failed after file restore",
+      outcome: "partial_failure",
+      ...(requestId ? { requestId } : {}),
+      sessionId: session.sessionId,
+      fields: {
+        target_user_message_id: targetUserMessageId,
+        restore_mode: command.restore_mode,
+        error_message: message,
+      },
+    });
+    emitRewindResult(
+      session.sessionId,
+      command.restore_mode,
+      "partial_failure",
+      requestId,
+      appliedFileResult,
+      `Code was restored, but the conversation could not be rewound: ${message}`,
+    );
   }
 }
 
@@ -757,6 +1210,58 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
       }
       return;
     }
+
+    case "get_rewind_targets": {
+      const session = sessionById(command.session_id);
+      if (!session) {
+        slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
+        return;
+      }
+      try {
+        const historyMessages = await getSessionMessages(command.session_id, {
+          dir: session.cwd,
+          includeSystemMessages: true,
+        });
+        const targets = rewindTargetsFromSessionMessages(historyMessages);
+        bridgeLogger.info({
+          target: LOG_TARGETS.APP_SESSION,
+          eventName: "rewind_targets_loaded",
+          message: "rewind targets loaded from session history",
+          outcome: "success",
+          ...(requestId ? { requestId } : {}),
+          sessionId: session.sessionId,
+          fields: {
+            history_message_count: historyMessages.length,
+            target_count: targets.length,
+          },
+        });
+        writeEvent(
+          {
+            event: "rewind_targets",
+            session_id: session.sessionId,
+            targets,
+          },
+          requestId,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        bridgeLogger.warn({
+          target: LOG_TARGETS.APP_SESSION,
+          eventName: "rewind_targets_failed",
+          message: "failed to load rewind targets",
+          outcome: "failure",
+          ...(requestId ? { requestId } : {}),
+          sessionId: session.sessionId,
+          fields: { error_message: message },
+        });
+        slashError(command.session_id, `failed to load rewind targets: ${message}`, requestId);
+      }
+      return;
+    }
+
+    case "rewind":
+      await handleRewind(command, requestId);
+      return;
 
     case "reload_plugins": {
       const session = sessionById(command.session_id);

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -267,7 +267,7 @@ export function emitAgentConfigOptionUpdate(sessionId: string, agent: string | n
   });
 }
 
-const EXPECTED_AGENT_SDK_VERSION = "0.3.190";
+const EXPECTED_AGENT_SDK_VERSION = "0.3.193";
 const require = createRequire(import.meta.url);
 
 export function resolveInstalledAgentSdkVersion(): string | undefined {

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -189,7 +189,7 @@ export function emitAgentConfigOptionUpdate(sessionId: string, agent: string | n
   });
 }
 
-const EXPECTED_AGENT_SDK_VERSION = "0.3.177";
+const EXPECTED_AGENT_SDK_VERSION = "0.3.190";
 const require = createRequire(import.meta.url);
 
 export function resolveInstalledAgentSdkVersion(): string | undefined {

--- a/agent-sdk/src/bridge/commands.ts
+++ b/agent-sdk/src/bridge/commands.ts
@@ -10,6 +10,7 @@ import type {
   PermissionOutcome,
   QuestionOutcome,
   RefusalFallbackPromptChoice,
+  RewindRestoreMode,
   SessionLaunchSettings,
   UserDialogOutcome,
 } from "../types.js";
@@ -142,6 +143,18 @@ function expectEffortLevel(
     throw new Error(`${context}.${key} must be one of low, medium, high, xhigh, max`);
   }
   return value;
+}
+
+function expectRewindRestoreMode(
+  record: Record<string, unknown>,
+  key: string,
+  context: string,
+): RewindRestoreMode {
+  const value = expectString(record, key, context);
+  if (value === "both" || value === "conversation" || value === "code") {
+    return value;
+  }
+  throw new Error(`${context}.${key} must be one of both, conversation, code`);
 }
 
 function expectNonEmptyStringOrNull(
@@ -379,6 +392,23 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
         return {
           command: "get_context_usage",
           session_id: expectString(raw, "session_id", "get_context_usage"),
+        };
+      case "get_rewind_targets":
+        return {
+          command: "get_rewind_targets",
+          session_id: expectString(raw, "session_id", "get_rewind_targets"),
+        };
+      case "rewind":
+        return {
+          command: "rewind",
+          session_id: expectString(raw, "session_id", "rewind"),
+          target_user_message_id: expectString(
+            raw,
+            "target_user_message_id",
+            "rewind",
+          ),
+          restore_mode: expectRewindRestoreMode(raw, "restore_mode", "rewind"),
+          launch_settings: optionalLaunchSettings(raw, "launch_settings", "rewind"),
         };
       case "reload_plugins":
         return {

--- a/agent-sdk/src/bridge/events.ts
+++ b/agent-sdk/src/bridge/events.ts
@@ -164,6 +164,7 @@ function buildConnectBridgeEvent(
         available_models: session.availableModels,
         mode: session.mode ? buildModeState(session, session.mode) : null,
         ...(historyUpdates && historyUpdates.length > 0 ? { history_updates: historyUpdates } : {}),
+        ...(session.restoredInput !== undefined ? { restored_input: session.restoredInput } : {}),
       }
     : {
         event: "connected",
@@ -192,6 +193,7 @@ function logConnectEventEmission(
       history_update_count: session.resumeUpdates?.length ?? 0,
       available_model_count: session.availableModels.length,
       stale_session_count: session.sessionsToCloseAfterConnect?.length ?? 0,
+      has_restored_input: session.restoredInput !== undefined,
     },
   });
 }
@@ -200,10 +202,18 @@ export function emitConnectEvent(session: SessionState): void {
   const bridgeEvent = buildConnectBridgeEvent(session, session.connectEvent);
   logConnectEventEmission(session, session.connectEvent, session.connectRequestId);
   writeEvent(bridgeEvent, session.connectRequestId);
+  if (session.pendingRewindResult) {
+    writeEvent(
+      { ...session.pendingRewindResult, session_id: session.sessionId },
+      session.connectRequestId,
+    );
+    session.pendingRewindResult = undefined;
+  }
   session.connectRequestId = undefined;
   session.connected = true;
   session.authHintSent = false;
   session.resumeUpdates = undefined;
+  session.restoredInput = undefined;
 
   const staleSessions = session.sessionsToCloseAfterConnect;
   session.sessionsToCloseAfterConnect = undefined;
@@ -231,7 +241,12 @@ export function emitSessionReplacedEvent(session: SessionState, requestId?: stri
   const bridgeEvent = buildConnectBridgeEvent(session, "session_replaced");
   logConnectEventEmission(session, "session_replaced", requestId);
   writeEvent(bridgeEvent, requestId);
+  if (session.pendingRewindResult) {
+    writeEvent({ ...session.pendingRewindResult, session_id: session.sessionId }, requestId);
+    session.pendingRewindResult = undefined;
+  }
   session.resumeUpdates = undefined;
+  session.restoredInput = undefined;
   refreshSessionsList();
 }
 

--- a/agent-sdk/src/bridge/events.ts
+++ b/agent-sdk/src/bridge/events.ts
@@ -12,7 +12,9 @@ export function buildSessionListOptions(
   dir: string | undefined,
   limit = SESSION_LIST_LIMIT,
 ): ListSessionsOptions {
-  return dir ? { dir, includeWorktrees: true, limit } : { limit };
+  return dir
+    ? { dir, includeProgrammatic: true, includeWorktrees: true, limit }
+    : { includeProgrammatic: true, limit };
 }
 
 export function setSessionListingDir(dir: string | undefined): void {

--- a/agent-sdk/src/bridge/logger.ts
+++ b/agent-sdk/src/bridge/logger.ts
@@ -102,6 +102,10 @@ function commandSessionId(command: BridgeCommand): string | undefined {
     case "question_response":
     case "elicitation_response":
     case "get_status_snapshot":
+    case "get_context_usage":
+    case "get_rewind_targets":
+    case "rewind":
+    case "reload_plugins":
     case "mcp_status":
     case "mcp_reconnect":
     case "mcp_toggle":
@@ -137,6 +141,8 @@ function commandToolCallId(command: BridgeCommand): string | undefined {
     case "elicitation_response":
     case "get_status_snapshot":
     case "get_context_usage":
+    case "get_rewind_targets":
+    case "rewind":
     case "reload_plugins":
     case "mcp_status":
     case "mcp_reconnect":
@@ -174,6 +180,8 @@ function eventToolCallId(event: BridgeEvent): string | undefined {
     case "sessions_listed":
     case "status_snapshot":
     case "context_usage":
+    case "rewind_targets":
+    case "rewind_result":
     case "mcp_snapshot":
       return undefined;
   }
@@ -218,6 +226,8 @@ function protocolEventLevel(event: BridgeEvent): LogLevel {
     case "sessions_listed":
     case "status_snapshot":
     case "context_usage":
+    case "rewind_targets":
+    case "rewind_result":
     case "runtime_reload_completed":
     case "mcp_set_servers_result":
     case "mcp_snapshot":

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -152,6 +152,128 @@ function emitSystemNoticeUpdate(
   emitSessionUpdate(session.sessionId, { type: "system_notice_update", severity, message: trimmed });
 }
 
+const MAX_INFORMATIONAL_DEDUP_KEYS = 256;
+
+function shouldEmitInformationalMessage(
+  session: SessionState,
+  level: string,
+  content: string,
+  toolUseId: string,
+): boolean {
+  if (!toolUseId) {
+    return true;
+  }
+  const key = `${toolUseId}\u0000${level}\u0000${content}`;
+  if (session.informationalDedupKeys.has(key)) {
+    return false;
+  }
+  session.informationalDedupKeys.add(key);
+  while (session.informationalDedupKeys.size > MAX_INFORMATIONAL_DEDUP_KEYS) {
+    const first = session.informationalDedupKeys.values().next().value;
+    if (typeof first !== "string") {
+      break;
+    }
+    session.informationalDedupKeys.delete(first);
+  }
+  return true;
+}
+
+function handleInformationalSystemMessage(session: SessionState, msg: Record<string, unknown>): void {
+  const content = typeof msg.content === "string" ? msg.content.trim() : "";
+  if (!content) {
+    return;
+  }
+  const level = typeof msg.level === "string" ? msg.level : "info";
+  const toolUseId = typeof msg.tool_use_id === "string" ? msg.tool_use_id : "";
+  if (!shouldEmitInformationalMessage(session, level, content, toolUseId)) {
+    return;
+  }
+
+  switch (level) {
+    case "notice":
+      emitSystemNoticeUpdate(session, "info", content);
+      return;
+    case "suggestion":
+      emitSystemNoticeUpdate(session, "info", `Suggestion: ${content}`);
+      return;
+    case "warning":
+      emitSystemNoticeUpdate(session, "warning", content);
+      return;
+    case "info":
+      if (msg.prevent_continuation === true) {
+        emitSystemNoticeUpdate(session, "warning", content);
+      }
+      return;
+    default:
+      bridgeLogger.debug({
+        target: LOG_TARGETS.BRIDGE_SDK,
+        eventName: "sdk_informational_level_unhandled",
+        message: "SDK informational message ignored for unknown level",
+        outcome: "ignored",
+        sessionId: session.sessionId,
+        toolCallId: toolUseId || undefined,
+        fields: {
+          informational_level: level,
+        },
+      });
+  }
+}
+
+function workerShutdownMessage(reason: string): string {
+  const trimmed = reason.trim();
+  return trimmed ? `Claude worker is shutting down: ${trimmed}` : "Claude worker is shutting down.";
+}
+
+function handleWorkerShuttingDownSystemMessage(
+  session: SessionState,
+  msg: Record<string, unknown>,
+): void {
+  const reason = typeof msg.reason === "string" ? msg.reason.trim() : "";
+  if (!session.connected) {
+    bridgeLogger.debug({
+      target: LOG_TARGETS.BRIDGE_SDK,
+      eventName: "sdk_worker_shutdown_preconnect_ignored",
+      message: "SDK worker shutdown ignored before session connect",
+      outcome: "ignored",
+      sessionId: session.sessionId,
+      fields: {
+        reason: reason || undefined,
+      },
+    });
+    return;
+  }
+  session.pendingWorkerShutdown = { reason };
+}
+
+function cancelPendingWorkerShutdown(session: SessionState): void {
+  if (!session.pendingWorkerShutdown) {
+    return;
+  }
+  bridgeLogger.debug({
+    target: LOG_TARGETS.BRIDGE_SDK,
+    eventName: "sdk_worker_shutdown_cancelled",
+    message: "SDK worker shutdown ignored after later stream activity",
+    outcome: "ignored",
+    sessionId: session.sessionId,
+    fields: {
+      reason: session.pendingWorkerShutdown.reason || undefined,
+    },
+  });
+  session.pendingWorkerShutdown = undefined;
+}
+
+export function flushPendingWorkerShutdown(session: SessionState): void {
+  const pending = session.pendingWorkerShutdown;
+  if (!pending) {
+    return;
+  }
+  session.pendingWorkerShutdown = undefined;
+  if (!session.connected) {
+    return;
+  }
+  emitSystemNoticeUpdate(session, "warning", workerShutdownMessage(pending.reason));
+}
+
 function notificationSeverity(priority: unknown): SystemNoticeSeverity {
   return priority === "high" || priority === "immediate" ? "warning" : "info";
 }
@@ -850,10 +972,13 @@ function terminalReasonFromValue(value: unknown): TerminalReason | undefined {
 export function handleSdkMessage(session: SessionState, message: SDKMessage): void {
   const msg = message as unknown as Record<string, unknown>;
   const type = typeof msg.type === "string" ? msg.type : "";
+  const subtype = type === "system" && typeof msg.subtype === "string" ? msg.subtype : "";
+  if (subtype !== "worker_shutting_down") {
+    cancelPendingWorkerShutdown(session);
+  }
   logSdkMessageOrigin(session, msg);
 
   if (type === "system") {
-    const subtype = typeof msg.subtype === "string" ? msg.subtype : "";
     if (handleFallbackRetractionMessage(session, subtype, msg)) {
       return;
     }
@@ -866,6 +991,16 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
     if (subtype === "notification") {
       const text = typeof msg.text === "string" ? msg.text : "";
       emitSystemNoticeUpdate(session, notificationSeverity(msg.priority), text);
+      return;
+    }
+
+    if (subtype === "informational") {
+      handleInformationalSystemMessage(session, msg);
+      return;
+    }
+
+    if (subtype === "worker_shutting_down") {
+      handleWorkerShuttingDownSystemMessage(session, msg);
       return;
     }
 

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -219,6 +219,60 @@ function handleInformationalSystemMessage(session: SessionState, msg: Record<str
   }
 }
 
+function trimmedStringField(msg: Record<string, unknown>, field: string): string | undefined {
+  const value = msg[field];
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function ensureSentencePunctuation(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+function modelRefusalNoFallbackMessage(msg: Record<string, unknown>): string {
+  const model = trimmedStringField(msg, "original_model") ?? "the selected model";
+  const base = `Could not continue with ${model}: model refused the request and no fallback model is configured.`;
+  const explanation = trimmedStringField(msg, "api_refusal_explanation");
+  const category = trimmedStringField(msg, "api_refusal_category");
+  const content = trimmedStringField(msg, "content");
+  const detail = explanation
+    ? `Reason: ${explanation}`
+    : category
+      ? `Refusal category: ${category}`
+      : content;
+  const detailSentence = detail ? ensureSentencePunctuation(detail) : "";
+  return detailSentence ? `${base} ${detailSentence}` : base;
+}
+
+function handleModelRefusalNoFallbackMessage(session: SessionState, msg: Record<string, unknown>): void {
+  const message = modelRefusalNoFallbackMessage(msg);
+  emitSystemNoticeUpdate(session, "warning", message);
+  bridgeLogger.info({
+    target: LOG_TARGETS.APP_SESSION,
+    eventName: "sdk_model_refusal_no_fallback_received",
+    message: "SDK model refusal without fallback received",
+    outcome: "success",
+    sessionId: session.sessionId,
+    requestId: trimmedStringField(msg, "request_id"),
+    fields: {
+      original_model: trimmedStringField(msg, "original_model"),
+      api_refusal_category: trimmedStringField(msg, "api_refusal_category"),
+      refused_user_message_uuid: trimmedStringField(msg, "refused_user_message_uuid"),
+      sdk_message_uuid: trimmedStringField(msg, "uuid"),
+      sdk_message_session_id: trimmedStringField(msg, "session_id"),
+      has_api_refusal_explanation: trimmedStringField(msg, "api_refusal_explanation") !== undefined,
+      has_content: trimmedStringField(msg, "content") !== undefined,
+    },
+  });
+}
+
 function workerShutdownMessage(reason: string): string {
   const trimmed = reason.trim();
   return trimmed ? `Claude worker is shutting down: ${trimmed}` : "Claude worker is shutting down.";
@@ -980,6 +1034,11 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
 
   if (type === "system") {
     if (handleFallbackRetractionMessage(session, subtype, msg)) {
+      return;
+    }
+
+    if (subtype === "model_refusal_no_fallback") {
+      handleModelRefusalNoFallbackMessage(session, msg);
       return;
     }
 

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -18,6 +18,7 @@ import type {
   CurrentModel,
   AvailableModel,
   BridgeCommand,
+  BridgeEvent,
   ElicitationAction,
   ElicitationRequest,
   FastModeState,
@@ -78,6 +79,11 @@ export { mapAvailableModels, resolveCurrentModel } from "./model_metadata.js";
 export { shouldEmitStartupAuthRequiredForAccount } from "./account_metadata.js";
 
 export type ConnectEventKind = "connected" | "session_replaced";
+
+export type PendingRewindResult = Omit<
+  Extract<BridgeEvent, { event: "rewind_result" }>,
+  "session_id"
+>;
 
 const BRIDGE_RUNTIME_PROCESS_NAME =
   process.platform === "win32" ? "claude-rs-bridge-node.exe" : "claude-rs-bridge-node";
@@ -170,6 +176,8 @@ export type SessionState = {
   lastAssistantError?: ApiRetryError;
   sessionsToCloseAfterConnect?: SessionState[];
   resumeUpdates?: SessionUpdate[];
+  restoredInput?: string;
+  pendingRewindResult?: PendingRewindResult;
 };
 
 export const sessions = new Map<string, SessionState>();
@@ -337,6 +345,29 @@ export async function closeSessionWithLogging(
   });
 }
 
+export async function closeSessionsBeforeRegister(
+  replacementSession: SessionState,
+  staleSessions: SessionState[] | undefined,
+  requestId?: string,
+): Promise<void> {
+  if (!staleSessions || staleSessions.length === 0) {
+    return;
+  }
+
+  for (const stale of staleSessions) {
+    if (stale === replacementSession) {
+      continue;
+    }
+    if (sessions.get(stale.sessionId) === stale) {
+      sessions.delete(stale.sessionId);
+    }
+    await closeSessionWithLogging(stale, {
+      reason: "stale_before_register",
+      requestId,
+    });
+  }
+}
+
 export async function closeAllSessions(options: CloseSessionOptions = {}): Promise<void> {
   const active = Array.from(sessions.values());
   sessions.clear();
@@ -362,12 +393,16 @@ export async function closeAllSessions(options: CloseSessionOptions = {}): Promi
 export async function createSession(params: {
   cwd: string;
   resume?: string;
+  resumeSessionAt?: string;
   launchSettings: SessionLaunchSettings;
   connectEvent: ConnectEventKind;
   requestId?: string;
+  sessionsToCloseBeforeRegister?: SessionState[];
   sessionsToCloseAfterConnect?: SessionState[];
   resumeUpdates?: SessionUpdate[];
-}): Promise<void> {
+  restoredInput?: string;
+  pendingRewindResult?: PendingRewindResult;
+}): Promise<SessionState> {
   const input = new AsyncQueue<SDKUserMessage>();
   const provisionalSessionId = params.resume ?? randomUUID();
   const initialModel = initialSessionModel(params.launchSettings);
@@ -376,6 +411,7 @@ export async function createSession(params: {
     startupPermissionModeOptions(params.launchSettings).allowDangerouslySkipPermissions === true;
   const historyUpdateCount = params.resumeUpdates?.length ?? 0;
   const staleSessionCount = params.sessionsToCloseAfterConnect?.length ?? 0;
+  const staleSessionBeforeRegisterCount = params.sessionsToCloseBeforeRegister?.length ?? 0;
 
   let session!: SessionState;
   const sessionIdForLogs = () => session?.sessionId ?? provisionalSessionId;
@@ -453,8 +489,10 @@ export async function createSession(params: {
       cwd: params.cwd,
       connect_event: params.connectEvent,
       resume_requested: params.resume !== undefined,
+      resume_session_at: params.resumeSessionAt ?? "<none>",
       history_update_count: historyUpdateCount,
       stale_session_count: staleSessionCount,
+      stale_session_before_register_count: staleSessionBeforeRegisterCount,
     },
   });
   try {
@@ -463,6 +501,7 @@ export async function createSession(params: {
       options: buildQueryOptions({
         cwd: params.cwd,
         resume: params.resume,
+        resumeSessionAt: params.resumeSessionAt,
         launchSettings: params.launchSettings,
         provisionalSessionId,
         input,
@@ -486,6 +525,7 @@ export async function createSession(params: {
       fields: {
         cwd: params.cwd,
         resume_requested: params.resume !== undefined,
+        resume_session_at: params.resumeSessionAt ?? "<none>",
         error_message: message,
       },
     });
@@ -528,6 +568,10 @@ export async function createSession(params: {
     ...(params.resumeUpdates && params.resumeUpdates.length > 0
       ? { resumeUpdates: params.resumeUpdates }
       : {}),
+    ...(params.restoredInput !== undefined ? { restoredInput: params.restoredInput } : {}),
+    ...(params.pendingRewindResult !== undefined
+      ? { pendingRewindResult: params.pendingRewindResult }
+      : {}),
     ...(params.sessionsToCloseAfterConnect
       ? { sessionsToCloseAfterConnect: params.sessionsToCloseAfterConnect }
       : {}),
@@ -535,6 +579,7 @@ export async function createSession(params: {
   refreshCurrentModel(session);
   const { refreshSupportedModesForSession } = await import("./commands.js");
   refreshSupportedModesForSession(session);
+  await closeSessionsBeforeRegister(session, params.sessionsToCloseBeforeRegister, params.requestId);
   sessions.set(provisionalSessionId, session);
   bridgeLogger.info({
     target: LOG_TARGETS.APP_SESSION,
@@ -547,6 +592,7 @@ export async function createSession(params: {
       cwd: session.cwd,
       connect_event: session.connectEvent,
       resume_requested: params.resume !== undefined,
+      resume_session_at: params.resumeSessionAt ?? "<none>",
     },
   });
   bridgeLogger.info({
@@ -669,11 +715,14 @@ export async function createSession(params: {
       failConnection(`agent stream failed: ${message}`, params.requestId);
     }
   })();
+
+  return session;
 }
 
 type QueryOptionsBuilderParams = {
   cwd: string;
   resume?: string;
+  resumeSessionAt?: string;
   launchSettings: SessionLaunchSettings;
   provisionalSessionId: string;
   input: AsyncQueue<SDKUserMessage>;
@@ -839,6 +888,7 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
     cwd: params.cwd,
     includePartialMessages: true,
     promptSuggestions: true,
+    enableFileCheckpointing: true,
     executable: "node" as const,
     ...(params.resume ? {} : { sessionId: params.provisionalSessionId }),
     ...(settings ? { settings } : {}),
@@ -896,6 +946,7 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
     // --setting-sources argument.
     settingSources: DEFAULT_SETTING_SOURCES,
     resume: params.resume,
+    ...(params.resumeSessionAt ? { resumeSessionAt: params.resumeSessionAt } : {}),
     canUseTool: params.canUseTool,
     onElicitation: async (request: {
       mode?: string;

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -129,6 +129,10 @@ export type PendingElicitation = {
   elicitationId?: string;
 };
 
+export type PendingWorkerShutdown = {
+  reason: string;
+};
+
 export type SessionState = {
   sessionId: string;
   cwd: string;
@@ -156,6 +160,8 @@ export type SessionState = {
   pendingQuestions: Map<string, PendingQuestion>;
   pendingUserDialogs: Map<string, PendingUserDialog>;
   pendingElicitations: Map<string, PendingElicitation>;
+  informationalDedupKeys: Set<string>;
+  pendingWorkerShutdown?: PendingWorkerShutdown;
   mcpStatusRevalidatedAt: Map<string, number>;
   hiddenToolUseIds: Set<string>;
   authHintSent: boolean;
@@ -515,6 +521,7 @@ export async function createSession(params: {
     pendingQuestions: new Map<string, PendingQuestion>(),
     pendingUserDialogs: new Map<string, PendingUserDialog>(),
     pendingElicitations: new Map<string, PendingElicitation>(),
+    informationalDedupKeys: new Set<string>(),
     mcpStatusRevalidatedAt: new Map<string, number>(),
     hiddenToolUseIds: new Set<string>(),
     authHintSent: false,
@@ -631,6 +638,11 @@ export async function createSession(params: {
         // Lazy import to break circular dependency at module-evaluation time.
         const { handleSdkMessage } = await import("./message_handlers.js");
         handleSdkMessage(session, message);
+      }
+      {
+        // Lazy import to break circular dependency at module-evaluation time.
+        const { flushPendingWorkerShutdown } = await import("./message_handlers.js");
+        flushPendingWorkerShutdown(session);
       }
       if (!session.connected) {
         bridgeLogger.error({

--- a/agent-sdk/src/bridge/state_parsing.ts
+++ b/agent-sdk/src/bridge/state_parsing.ts
@@ -82,6 +82,10 @@ export function buildRateLimitUpdate(
     status,
   };
 
+  if (info.errorCode === "credits_required") {
+    update.error_code = "credits_required";
+  }
+
   const resetsAt = numberField(info, "resetsAt");
   if (resetsAt !== undefined) {
     update.resets_at = resetsAt;
@@ -119,6 +123,14 @@ export function buildRateLimitUpdate(
   const surpassedThreshold = numberField(info, "surpassedThreshold");
   if (surpassedThreshold !== undefined) {
     update.surpassed_threshold = surpassedThreshold;
+  }
+
+  if (typeof info.canUserPurchaseCredits === "boolean") {
+    update.can_user_purchase_credits = info.canUserPurchaseCredits;
+  }
+
+  if (typeof info.hasChargeableSavedPaymentMethod === "boolean") {
+    update.has_chargeable_saved_payment_method = info.hasChargeableSavedPaymentMethod;
   }
 
   return update;

--- a/agent-sdk/src/bridge/tooling.ts
+++ b/agent-sdk/src/bridge/tooling.ts
@@ -32,6 +32,8 @@ const WORKFLOW_TOOL_NAME = "Workflow";
 const PROJECTS_TOOL_NAME = "Projects";
 const ARTIFACT_TOOL_NAME = "Artifact";
 const SHOW_ONBOARDING_ROLE_PICKER_TOOL_NAME = "ShowOnboardingRolePicker";
+const READ_MCP_RESOURCE_TOOL_NAME = "ReadMcpResource";
+const READ_MCP_RESOURCE_DIR_TOOL_NAME = "ReadMcpResourceDir";
 const SEARCH_OUTPUT_MODES = new Set(["content", "files_with_matches", "count"]);
 
 function isCronToolName(name: string): boolean {
@@ -70,6 +72,10 @@ function isAgentLikeToolName(name: string): boolean {
 
 export function isShellToolName(name: string): boolean {
   return name === "Bash" || name === "PowerShell";
+}
+
+function isMcpResourceReadToolName(name: string): boolean {
+  return name === READ_MCP_RESOURCE_TOOL_NAME || name === READ_MCP_RESOURCE_DIR_TOOL_NAME;
 }
 
 function agentInputTitle(name: string, input: Record<string, unknown>): string | undefined {
@@ -171,7 +177,8 @@ export function normalizeToolKind(name: string): string {
   }
   switch (name) {
     case "Read":
-    case "ReadMcpResource":
+    case READ_MCP_RESOURCE_TOOL_NAME:
+    case READ_MCP_RESOURCE_DIR_TOOL_NAME:
       return "read";
     case "Write":
     case "Edit":
@@ -301,14 +308,14 @@ export function toolTitle(
   if ((name === "Read" || name === "Write" || name === "Edit") && typeof input.file_path === "string") {
     return `${name} ${input.file_path}`;
   }
-  if (name === "ReadMcpResource") {
+  if (isMcpResourceReadToolName(name)) {
     const uri = typeof input.uri === "string" ? input.uri : "";
     const server = typeof input.server === "string" ? input.server : "";
     if (server && uri) {
-      return `ReadMcpResource ${server} ${uri}`;
+      return `${name} ${server} ${uri}`;
     }
     if (uri) {
-      return `ReadMcpResource ${uri}`;
+      return `${name} ${uri}`;
     }
   }
   return name;
@@ -503,6 +510,47 @@ function mcpResourceContentFromResult(rawResult: unknown, rawContent: unknown): 
   }
 
   return [];
+}
+
+function mcpResourceDirTextFromResult(
+  toolName: string,
+  rawResult: unknown,
+  rawContent: unknown,
+): string | undefined {
+  if (toolName !== READ_MCP_RESOURCE_DIR_TOOL_NAME) {
+    return undefined;
+  }
+
+  for (const candidate of collectResultCandidates(rawResult, rawContent)) {
+    if (!Array.isArray(candidate.resources)) {
+      continue;
+    }
+
+    const lines: string[] = [];
+    for (const entry of candidate.resources) {
+      const record = asRecordOrNull(entry);
+      if (!record) {
+        continue;
+      }
+      const name = nonEmptyString(record.name);
+      const uri = nonEmptyString(record.uri);
+      if (!name || !uri) {
+        continue;
+      }
+
+      const mimeType = nonEmptyString(record.mimeType);
+      const suffix = mimeType
+        ? mimeType === "inode/directory"
+          ? " (directory)"
+          : ` (${mimeType})`
+        : "";
+      lines.push(`${name} - ${uri}${suffix}`);
+    }
+
+    return lines.length > 0 ? lines.join("\n") : "No resources found.";
+  }
+
+  return undefined;
 }
 
 function extractToolOutputMetadata(
@@ -1932,12 +1980,12 @@ function enterPlanModeStructuredOutputHandled(
   return false;
 }
 
-function readMcpResourceErrorText(
+function mcpResourceReadErrorText(
   toolName: string,
   rawResult: unknown,
   rawContent: unknown,
 ): string | undefined {
-  if (toolName !== "ReadMcpResource") {
+  if (!isMcpResourceReadToolName(toolName)) {
     return undefined;
   }
 
@@ -2026,11 +2074,21 @@ export function buildToolResultFields(
   if (agentTitle) {
     fields.title = agentTitle;
   }
-  const readMcpResourceError = readMcpResourceErrorText(toolName, rawResult, rawContent);
+  const readMcpResourceError = mcpResourceReadErrorText(toolName, rawResult, rawContent);
   if (readMcpResourceError) {
     fields.status = "failed";
     fields.raw_output = readMcpResourceError;
     fields.content = [{ type: "content", content: { type: "text", text: readMcpResourceError } }];
+    return fields;
+  }
+  const readMcpResourceDirOutput = !isError
+    ? mcpResourceDirTextFromResult(toolName, rawResult, rawContent)
+    : undefined;
+  if (readMcpResourceDirOutput !== undefined) {
+    fields.raw_output = readMcpResourceDirOutput;
+    fields.content = [
+      { type: "content", content: { type: "text", text: readMcpResourceDirOutput } },
+    ];
     return fields;
   }
   const searchOutput = !isError ? searchResultText(toolName, rawResult, rawContent) : undefined;
@@ -2182,7 +2240,7 @@ export function buildToolResultFields(
     }
   }
 
-  if (!isError && toolName === "ReadMcpResource") {
+  if (!isError && toolName === READ_MCP_RESOURCE_TOOL_NAME) {
     const structuredResourceContent = mcpResourceContentFromResult(rawResult, rawContent);
     if (structuredResourceContent.length > 0) {
       fields.content = structuredResourceContent;

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -553,6 +553,25 @@ export interface SessionLaunchSettings {
   agent_progress_summaries?: boolean;
 }
 
+export interface RewindTarget {
+  uuid: string;
+  first_text: string;
+  input_text: string;
+  index: number;
+  previous_assistant_uuid?: string;
+}
+
+export type RewindRestoreMode = "both" | "conversation" | "code";
+export type RewindResultStatus = "success" | "failure" | "partial_failure";
+
+export interface RewindFilesResult {
+  can_rewind: boolean;
+  error?: string;
+  files_changed: string[];
+  insertions?: number;
+  deletions?: number;
+}
+
 export interface BridgeCommandEnvelope {
   request_id?: string;
   command: string;
@@ -654,6 +673,17 @@ export type BridgeCommand =
   | {
       command: "get_context_usage";
       session_id: string;
+    }
+  | {
+      command: "get_rewind_targets";
+      session_id: string;
+    }
+  | {
+      command: "rewind";
+      session_id: string;
+      target_user_message_id: string;
+      restore_mode: RewindRestoreMode;
+      launch_settings: SessionLaunchSettings;
     }
   | {
       command: "reload_plugins";
@@ -769,6 +799,7 @@ export type BridgeEvent =
       available_models: AvailableModel[];
       mode: ModeState | null;
       history_updates?: SessionUpdate[];
+      restored_input?: string;
     }
   | { event: "initialized"; result: InitializeResult }
   | { event: "sessions_listed"; sessions: SessionListEntry[] }
@@ -777,6 +808,19 @@ export type BridgeEvent =
       event: "context_usage";
       session_id: string;
       percentage?: number;
+    }
+  | {
+      event: "rewind_targets";
+      session_id: string;
+      targets: RewindTarget[];
+    }
+  | {
+      event: "rewind_result";
+      session_id: string;
+      restore_mode: RewindRestoreMode;
+      status: RewindResultStatus;
+      file_result?: RewindFilesResult;
+      message?: string;
     }
   | {
       event: "mcp_snapshot";

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -81,6 +81,7 @@ export type TerminalReason =
 
 export interface RateLimitUpdate {
   status: RateLimitStatus;
+  error_code?: "credits_required";
   resets_at?: number;
   utilization?: number;
   rate_limit_type?: string;
@@ -89,6 +90,8 @@ export interface RateLimitUpdate {
   overage_disabled_reason?: string;
   is_using_overage?: boolean;
   surpassed_threshold?: number;
+  can_user_purchase_credits?: boolean;
+  has_chargeable_saved_payment_method?: boolean;
 }
 
 export type ApiRetryError =

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -26,6 +26,7 @@ Use `/docs commands` in the app to render the live merged command list into chat
 | `/model` | `/model <id>` | Switch to a model advertised by the active session. |
 | `/new-session` | `/new-session` | Start a fresh bridge session in the current folder. |
 | `/resume` | `/resume <session_id>` | Resume a recent or manually supplied session id. |
+| `/rewind` | `/rewind <user_message_uuid> <both\|conversation\|code>` | Restore conversation, code, or both to a previous user message. |
 
 ## SDK-Advertised Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.177",
+        "@anthropic-ai/claude-agent-sdk": "0.3.190",
         "@anthropic-ai/sdk": "0.97.1",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "4.4.3"
@@ -26,22 +26,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.177.tgz",
-      "integrity": "sha512-CBzXnzR661q3AlfZzBjmIFQx0cxr36iJV3PExTYmPyGQX32qxtiFQgnxTcF8wB4hcSVf2hnoy/gprVJdkNx7cw==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.190.tgz",
+      "integrity": "sha512-d4morVtH9eBUsk5BXmhcX2tnEums/RwbM9LrhZB3VCDAYNiDTEW4IejY5o572//7/0qN111l6fmPr5b5cmrjsQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.177"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.190"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.177.tgz",
-      "integrity": "sha512-u9Ty+KPllm2nw0RatdPF0zcPRquNZjVptmyLG0DqduGbgZDLQpfPFMF5hffFIRnVaXhx7+jkUmEdw0jrda0UcA==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.190.tgz",
+      "integrity": "sha512-131dhlg7qGXgVsnKi0pTPMK4lQOunF4Ewx9AT4sP24LXc0vxYZ8r7d6Vy5ba/jCp6NqkJUNsMNYwNfvIaGdv4Q==",
       "cpu": [
         "arm64"
       ],
@@ -63,9 +63,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.177.tgz",
-      "integrity": "sha512-ona6Jv54XFwBTqOj3MzLWfKtc2m7Rdh58wOAX9Hnue/6FcWfyeuz/UDcidVTXQ7Xytz//Tb0JJgFtiQjO7FbIA==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.190.tgz",
+      "integrity": "sha512-IU8RDROU69Hd81TgH8VAjXMq/pvTreuT0Fqtjut2u5p9zYB7m0q1uWZyEWJfte6aCTA6aQLcFp2l1RRpRfOYxg==",
       "cpu": [
         "x64"
       ],
@@ -76,9 +76,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.177.tgz",
-      "integrity": "sha512-wBCbklkaDb483Ab4DUFfmJjZJKXz58YXPv+CiGsyjq1St19mbKEma5KKz3Ya9mlV8aLyh4zmLK2mEHPnF//Ipg==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.190.tgz",
+      "integrity": "sha512-MhBNdygHatPnfw2zpfx70A535pDk2mZQwkFeL0kSfiF0pAgJWyuyYCAI7NUH61NtT3R2kO1kxGGWxgAuh0Ncag==",
       "cpu": [
         "arm64"
       ],
@@ -89,9 +89,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.177.tgz",
-      "integrity": "sha512-v6PMDD3h2erLuTK5S2ZvExqdL3v44OyC70XpKhyqIUnyPaGR9YAMjh//EKdWC+mNvt6mIbRZpaDcHtbASVW8Rw==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.190.tgz",
+      "integrity": "sha512-/fHLhroUkjgqjbU4vQtql9nVNf9qyYLDuXAUViA3VCCYY78mgfQPj0k3p0dVre38Cr5AuzWVS8tLxJm3Yg1o4g==",
       "cpu": [
         "arm64"
       ],
@@ -102,9 +102,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.177.tgz",
-      "integrity": "sha512-WDP6puwPHscggNAfvIxyUSHSAjfUEkGRfnMXEPBHOqO+qjX2KGxeE13/ih3EVioeBVOUIqPui6VB05vXLa6T9Q==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.190.tgz",
+      "integrity": "sha512-iLT6Z2ivtCSu722H51wBwEjTfRrymrVZjV6puhkBHAFQsW7U8ya0gKzELlun/nj8gYLT38eoUanIhdSDdyWoAA==",
       "cpu": [
         "x64"
       ],
@@ -115,9 +115,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.177.tgz",
-      "integrity": "sha512-1cdEO06WoEsl1JnnLCPIlg/8x37GtBsTuj65gIpSjdrImNBjgIuMWVyceP4qaXhFjtQgYK1nx3TpaxEFVDOrDg==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.190.tgz",
+      "integrity": "sha512-ixcKEYuAaK6Fx2a9hjNRlCqTu9uc2SgZZr/f5Uzy4xFSHZNVyc+xn0c+JlCV6ZwiVs8FRlxGuFGoOD0yN3X6Zg==",
       "cpu": [
         "x64"
       ],
@@ -128,9 +128,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.177.tgz",
-      "integrity": "sha512-xLgDWnZaYohtFrkgEIkGZdP+rp4sXxAMbbpEvEp0LK1vAYmJam/ztT2yoK6gfI58IbToJq1WGUEX2HVnE65yOg==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.190.tgz",
+      "integrity": "sha512-CcMt72vqTWBV3y+E0szfcOcUHcY8qAG+SnjUwYMHNMlzBrUL4cpiiGO6qKYxo4kkdoSWaHZVxVkPtOldrPiz4A==",
       "cpu": [
         "arm64"
       ],
@@ -141,9 +141,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.177.tgz",
-      "integrity": "sha512-SIdQLbtF//rYK4KDBNpUPyjyui7NwCFPZ2/3vyW3TR8R8xynkNq3cLis90FnPSgxaSshi38vkJYWh+9kGDB7zg==",
+      "version": "0.3.190",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.190.tgz",
+      "integrity": "sha512-3tkc+zizxgl+q+keZ52OJ3flUq2i4TUUgfkXJaozbylHglW94qW/j0axmEp+cREGiiV5jtJGxLMziHpr/dS6TQ==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.190",
+        "@anthropic-ai/claude-agent-sdk": "0.3.193",
         "@anthropic-ai/sdk": "0.97.1",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "4.4.3"
@@ -26,22 +26,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.190.tgz",
-      "integrity": "sha512-d4morVtH9eBUsk5BXmhcX2tnEums/RwbM9LrhZB3VCDAYNiDTEW4IejY5o572//7/0qN111l6fmPr5b5cmrjsQ==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.193.tgz",
+      "integrity": "sha512-WzL03VJE1sT0Nz3rEpsYMYR+9n6iyQtLVt7ghMWnYC9pvDsiy6kwcMplZniWSjH8Dm6CfkUBN5t6KB4i/JfouA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.190",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.190"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.193"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.190.tgz",
-      "integrity": "sha512-131dhlg7qGXgVsnKi0pTPMK4lQOunF4Ewx9AT4sP24LXc0vxYZ8r7d6Vy5ba/jCp6NqkJUNsMNYwNfvIaGdv4Q==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.193.tgz",
+      "integrity": "sha512-1hT7b+KIm/3E1OSJofr7PF21Xq2zT1ccnjzuVcWQ5LYXJ09lgCMvA/ZfcDBKuoyCZ4lSnuicKXZ/h5vRbWfqrA==",
       "cpu": [
         "arm64"
       ],
@@ -63,9 +63,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.190.tgz",
-      "integrity": "sha512-IU8RDROU69Hd81TgH8VAjXMq/pvTreuT0Fqtjut2u5p9zYB7m0q1uWZyEWJfte6aCTA6aQLcFp2l1RRpRfOYxg==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.193.tgz",
+      "integrity": "sha512-9x5Y/L6iwETwEJFmPaYXfsE8q0cVgx75V7nL60HvSzi8K1XQNcG5u53jOzRvqDNah8mvGYOb+9AWrMCSJvmFyA==",
       "cpu": [
         "x64"
       ],
@@ -76,9 +76,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.190.tgz",
-      "integrity": "sha512-MhBNdygHatPnfw2zpfx70A535pDk2mZQwkFeL0kSfiF0pAgJWyuyYCAI7NUH61NtT3R2kO1kxGGWxgAuh0Ncag==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.193.tgz",
+      "integrity": "sha512-gvfD9pKHXWxCkkIX6bC4/FOALTxqHYjAu83iT1bzn5mCv6QWSZRl6WLRRtvKpWtWuY1jpML1lL3YfKADsAX/rA==",
       "cpu": [
         "arm64"
       ],
@@ -89,9 +89,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.190.tgz",
-      "integrity": "sha512-/fHLhroUkjgqjbU4vQtql9nVNf9qyYLDuXAUViA3VCCYY78mgfQPj0k3p0dVre38Cr5AuzWVS8tLxJm3Yg1o4g==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.193.tgz",
+      "integrity": "sha512-a3qsVTBe4G6ndsVavfIXEVAXLVXM8uvBUNYpm4jKqk2+ovWZQe/96CXOwmerg9U+/bllg4QJ9lSyYCsdtVIr6w==",
       "cpu": [
         "arm64"
       ],
@@ -102,9 +102,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.190.tgz",
-      "integrity": "sha512-iLT6Z2ivtCSu722H51wBwEjTfRrymrVZjV6puhkBHAFQsW7U8ya0gKzELlun/nj8gYLT38eoUanIhdSDdyWoAA==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.193.tgz",
+      "integrity": "sha512-1sz+7cn0iuh0ThInuAYF1jpFvLyOaZ0PZYQIF7eb9JDZbBohUf6INeTCwjAwUL0ASCq2xS7Odu/qDVuTtLTeDA==",
       "cpu": [
         "x64"
       ],
@@ -115,9 +115,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.190.tgz",
-      "integrity": "sha512-ixcKEYuAaK6Fx2a9hjNRlCqTu9uc2SgZZr/f5Uzy4xFSHZNVyc+xn0c+JlCV6ZwiVs8FRlxGuFGoOD0yN3X6Zg==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.193.tgz",
+      "integrity": "sha512-DLXlO4tlcWygz0Ft4nu6ai5KssByYt2tOeWdc4dFXKt6uBKXpbZVziUUq3ePO5zuAFyU6w7EjYLv8MMPURbAiQ==",
       "cpu": [
         "x64"
       ],
@@ -128,9 +128,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.190.tgz",
-      "integrity": "sha512-CcMt72vqTWBV3y+E0szfcOcUHcY8qAG+SnjUwYMHNMlzBrUL4cpiiGO6qKYxo4kkdoSWaHZVxVkPtOldrPiz4A==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.193.tgz",
+      "integrity": "sha512-36LJKiGuKusgaPTVeh9QanL00UcaE0RcC4pgK800/0SenApbh979ndxI0XKUVfLHzlGkqlhkhT3foMdqS+zx1w==",
       "cpu": [
         "arm64"
       ],
@@ -141,9 +141,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.190",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.190.tgz",
-      "integrity": "sha512-3tkc+zizxgl+q+keZ52OJ3flUq2i4TUUgfkXJaozbylHglW94qW/j0axmEp+cREGiiV5jtJGxLMziHpr/dS6TQ==",
+      "version": "0.3.193",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.193.tgz",
+      "integrity": "sha512-VyyKZlWQpbD6nkUTeNvgmLvpqt1QaPQQBOC30tbEYwYsV5MC1I35Li0H7nWwngGqPSTtMvHpjpz6Eb2FSTn7/A==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.177",
+    "@anthropic-ai/claude-agent-sdk": "0.3.190",
     "@anthropic-ai/sdk": "0.97.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "zod": "4.4.3"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.190",
+    "@anthropic-ai/claude-agent-sdk": "0.3.193",
     "@anthropic-ai/sdk": "0.97.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "zod": "4.4.3"

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -442,6 +442,31 @@ impl AgentConnection {
         })
     }
 
+    pub fn get_rewind_targets(&self, session_id: String) -> anyhow::Result<()> {
+        self.send(CommandEnvelope {
+            request_id: None,
+            command: BridgeCommand::GetRewindTargets { session_id },
+        })
+    }
+
+    pub fn rewind(
+        &self,
+        session_id: String,
+        target_user_message_id: String,
+        restore_mode: crate::agent::types::RewindRestoreMode,
+        launch_settings: SessionLaunchSettings,
+    ) -> anyhow::Result<()> {
+        self.send(CommandEnvelope {
+            request_id: None,
+            command: BridgeCommand::Rewind {
+                session_id,
+                target_user_message_id,
+                restore_mode,
+                launch_settings,
+            },
+        })
+    }
+
     pub fn reload_plugins(&self, session_id: String) -> anyhow::Result<()> {
         self.send(CommandEnvelope {
             request_id: None,
@@ -698,6 +723,45 @@ mod tests {
         assert_eq!(
             envelope.command,
             BridgeCommand::ReloadPlugins { session_id: "session-1".to_owned() }
+        );
+    }
+
+    #[test]
+    fn get_rewind_targets_sends_bridge_command() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let conn = AgentConnection::new(tx);
+
+        conn.get_rewind_targets("session-1".to_owned()).expect("rewind targets");
+
+        let envelope = rx.try_recv().expect("command");
+        assert_eq!(
+            envelope.command,
+            BridgeCommand::GetRewindTargets { session_id: "session-1".to_owned() }
+        );
+    }
+
+    #[test]
+    fn rewind_sends_bridge_command() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let conn = AgentConnection::new(tx);
+
+        conn.rewind(
+            "session-1".to_owned(),
+            "user-1".to_owned(),
+            crate::agent::types::RewindRestoreMode::Code,
+            crate::agent::wire::SessionLaunchSettings::default(),
+        )
+        .expect("rewind");
+
+        let envelope = rx.try_recv().expect("command");
+        assert_eq!(
+            envelope.command,
+            BridgeCommand::Rewind {
+                session_id: "session-1".to_owned(),
+                target_user_message_id: "user-1".to_owned(),
+                restore_mode: crate::agent::types::RewindRestoreMode::Code,
+                launch_settings: crate::agent::wire::SessionLaunchSettings::default(),
+            }
         );
     }
 

--- a/src/agent/events.rs
+++ b/src/agent/events.rs
@@ -99,6 +99,7 @@ pub enum ClientEvent {
         available_models: Vec<model::AvailableModel>,
         mode: Option<crate::app::ModeState>,
         history_updates: Vec<model::SessionUpdate>,
+        restored_input: Option<String>,
     },
     /// Recent sessions discovered via SDK session listing.
     SessionsListed { sessions: Vec<crate::agent::types::SessionListEntry> },
@@ -114,6 +115,10 @@ pub enum ClientEvent {
     StatusSnapshotReceived { session_id: String, account: model::AccountInfo },
     /// Session context window usage received from bridge.
     ContextUsageReceived { session_id: String, percentage: Option<u8> },
+    /// Rewind target candidates loaded from persisted SDK session history.
+    RewindTargetsReceived { session_id: String, targets: Vec<model::RewindTarget> },
+    /// Result of a rewind operation that touched files.
+    RewindResultReceived { result: model::RewindResult },
     /// MCP server snapshot received from bridge.
     McpSnapshotReceived {
         session_id: String,

--- a/src/agent/model.rs
+++ b/src/agent/model.rs
@@ -1360,6 +1360,7 @@ pub enum SystemNoticeSeverity {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RateLimitUpdate {
     pub status: RateLimitStatus,
+    pub error_code: Option<String>,
     pub resets_at: Option<f64>,
     pub utilization: Option<f64>,
     pub rate_limit_type: Option<String>,
@@ -1368,6 +1369,8 @@ pub struct RateLimitUpdate {
     pub overage_disabled_reason: Option<String>,
     pub is_using_overage: Option<bool>,
     pub surpassed_threshold: Option<f64>,
+    pub can_user_purchase_credits: Option<bool>,
+    pub has_chargeable_saved_payment_method: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/agent/model.rs
+++ b/src/agent/model.rs
@@ -126,6 +126,69 @@ impl ContentChunk {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RewindTarget {
+    pub uuid: String,
+    pub first_text: String,
+    pub input_text: String,
+    pub index: u64,
+    pub previous_assistant_uuid: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RewindRestoreMode {
+    Both,
+    Conversation,
+    Code,
+}
+
+impl RewindRestoreMode {
+    #[must_use]
+    pub const fn as_stored(self) -> &'static str {
+        match self {
+            Self::Both => "both",
+            Self::Conversation => "conversation",
+            Self::Code => "code",
+        }
+    }
+
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Both => "code and conversation",
+            Self::Conversation => "conversation",
+            Self::Code => "code",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RewindResultStatus {
+    Success,
+    Failure,
+    PartialFailure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RewindFilesResult {
+    pub can_rewind: bool,
+    pub error: Option<String>,
+    pub files_changed: Vec<String>,
+    pub insertions: Option<u64>,
+    pub deletions: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RewindResult {
+    pub session_id: String,
+    pub restore_mode: RewindRestoreMode,
+    pub status: RewindResultStatus,
+    pub file_result: Option<RewindFilesResult>,
+    pub message: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolKind {

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -130,6 +130,7 @@ pub struct SettingsParseErrorUpdate {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RateLimitUpdate {
     pub status: RateLimitStatus,
+    pub error_code: Option<String>,
     pub resets_at: Option<f64>,
     pub utilization: Option<f64>,
     pub rate_limit_type: Option<String>,
@@ -138,6 +139,8 @@ pub struct RateLimitUpdate {
     pub overage_disabled_reason: Option<String>,
     pub is_using_overage: Option<bool>,
     pub surpassed_threshold: Option<f64>,
+    pub can_user_purchase_credits: Option<bool>,
+    pub has_chargeable_saved_payment_method: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -393,6 +396,7 @@ pub enum SessionUpdate {
     },
     RateLimitUpdate {
         status: RateLimitStatus,
+        error_code: Option<String>,
         resets_at: Option<f64>,
         utilization: Option<f64>,
         rate_limit_type: Option<String>,
@@ -401,6 +405,8 @@ pub enum SessionUpdate {
         overage_disabled_reason: Option<String>,
         is_using_overage: Option<bool>,
         surpassed_threshold: Option<f64>,
+        can_user_purchase_credits: Option<bool>,
+        has_chargeable_saved_payment_method: Option<bool>,
     },
     ApiRetryUpdate {
         attempt: u64,
@@ -868,8 +874,8 @@ pub enum McpSnapshotSource {
 mod tests {
     use super::{
         AccountInfo, ApiRetryError, AvailableModel, EffortLevel, McpServerOrgMaxPermission,
-        McpServerStatus, McpServerStatusConfig, McpServerToolPermissionPolicy, SessionStatus,
-        SessionUpdate, SystemNoticeSeverity, TranscriptRetractionReason,
+        McpServerStatus, McpServerStatusConfig, McpServerToolPermissionPolicy, RateLimitStatus,
+        SessionStatus, SessionUpdate, SystemNoticeSeverity, TranscriptRetractionReason,
     };
 
     #[test]
@@ -953,6 +959,29 @@ mod tests {
                 SessionUpdate::ApiRetryUpdate { error, .. } if error == expected
             ));
         }
+    }
+
+    #[test]
+    fn rate_limit_update_deserializes_credits_metadata() {
+        let update: SessionUpdate = serde_json::from_value(serde_json::json!({
+            "type": "rate_limit_update",
+            "status": "rejected",
+            "error_code": "credits_required",
+            "can_user_purchase_credits": true,
+            "has_chargeable_saved_payment_method": false
+        }))
+        .expect("deserialize rate limit update");
+
+        assert!(matches!(
+            update,
+            SessionUpdate::RateLimitUpdate {
+                status: RateLimitStatus::Rejected,
+                ref error_code,
+                can_user_purchase_credits: Some(true),
+                has_chargeable_saved_payment_method: Some(false),
+                ..
+            } if error_code.as_deref() == Some("credits_required")
+        ));
     }
 
     #[test]

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -26,6 +26,62 @@ pub struct AvailableCommand {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RewindTarget {
+    pub uuid: String,
+    pub first_text: String,
+    pub input_text: String,
+    pub index: u64,
+    pub previous_assistant_uuid: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RewindRestoreMode {
+    Both,
+    Conversation,
+    Code,
+}
+
+impl RewindRestoreMode {
+    #[must_use]
+    pub const fn as_stored(self) -> &'static str {
+        match self {
+            Self::Both => "both",
+            Self::Conversation => "conversation",
+            Self::Code => "code",
+        }
+    }
+
+    #[must_use]
+    pub fn from_stored(value: &str) -> Option<Self> {
+        match value {
+            "both" => Some(Self::Both),
+            "conversation" => Some(Self::Conversation),
+            "code" => Some(Self::Code),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RewindResultStatus {
+    Success,
+    Failure,
+    PartialFailure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RewindFilesResult {
+    pub can_rewind: bool,
+    pub error: Option<String>,
+    #[serde(default)]
+    pub files_changed: Vec<String>,
+    pub insertions: Option<u64>,
+    pub deletions: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AvailableAgent {
     pub name: String,
     pub description: String,

--- a/src/agent/wire.rs
+++ b/src/agent/wire.rs
@@ -119,6 +119,16 @@ pub enum BridgeCommand {
     GetContextUsage {
         session_id: String,
     },
+    GetRewindTargets {
+        session_id: String,
+    },
+    Rewind {
+        session_id: String,
+        target_user_message_id: String,
+        restore_mode: types::RewindRestoreMode,
+        #[serde(default, skip_serializing_if = "SessionLaunchSettings::is_empty")]
+        launch_settings: SessionLaunchSettings,
+    },
     ReloadPlugins {
         session_id: String,
     },
@@ -177,6 +187,8 @@ impl BridgeCommand {
             Self::ElicitationResponse { .. } => "elicitation_response",
             Self::GetStatusSnapshot { .. } => "get_status_snapshot",
             Self::GetContextUsage { .. } => "get_context_usage",
+            Self::GetRewindTargets { .. } => "get_rewind_targets",
+            Self::Rewind { .. } => "rewind",
             Self::ReloadPlugins { .. } => "reload_plugins",
             Self::GetMcpSnapshot { .. } => "get_mcp_snapshot",
             Self::McpReconnect { .. } => "mcp_reconnect",
@@ -207,6 +219,8 @@ impl BridgeCommand {
             | Self::ElicitationResponse { session_id, .. }
             | Self::GetStatusSnapshot { session_id }
             | Self::GetContextUsage { session_id }
+            | Self::GetRewindTargets { session_id }
+            | Self::Rewind { session_id, .. }
             | Self::ReloadPlugins { session_id }
             | Self::GetMcpSnapshot { session_id }
             | Self::McpReconnect { session_id, .. }
@@ -241,6 +255,8 @@ impl BridgeCommand {
             | Self::ElicitationResponse { .. }
             | Self::GetStatusSnapshot { .. }
             | Self::GetContextUsage { .. }
+            | Self::GetRewindTargets { .. }
+            | Self::Rewind { .. }
             | Self::ReloadPlugins { .. }
             | Self::GetMcpSnapshot { .. }
             | Self::McpReconnect { .. }
@@ -353,6 +369,7 @@ pub enum BridgeEvent {
         available_models: Vec<types::AvailableModel>,
         mode: Option<types::ModeState>,
         history_updates: Option<Vec<types::SessionUpdate>>,
+        restored_input: Option<String>,
     },
     Initialized {
         result: types::InitializeResult,
@@ -367,6 +384,19 @@ pub enum BridgeEvent {
     ContextUsage {
         session_id: String,
         percentage: Option<u8>,
+    },
+    RewindTargets {
+        session_id: String,
+        targets: Vec<types::RewindTarget>,
+    },
+    RewindResult {
+        session_id: String,
+        restore_mode: types::RewindRestoreMode,
+        status: types::RewindResultStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        file_result: Option<types::RewindFilesResult>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
     },
     McpSnapshot {
         session_id: String,
@@ -403,6 +433,8 @@ impl BridgeEvent {
             Self::SessionsListed { .. } => "sessions_listed",
             Self::StatusSnapshot { .. } => "status_snapshot",
             Self::ContextUsage { .. } => "context_usage",
+            Self::RewindTargets { .. } => "rewind_targets",
+            Self::RewindResult { .. } => "rewind_result",
             Self::McpSnapshot { .. } => "mcp_snapshot",
         }
     }
@@ -428,6 +460,8 @@ impl BridgeEvent {
             | Self::SessionReplaced { session_id, .. }
             | Self::StatusSnapshot { session_id, .. }
             | Self::ContextUsage { session_id, .. }
+            | Self::RewindTargets { session_id, .. }
+            | Self::RewindResult { session_id, .. }
             | Self::McpSnapshot { session_id, .. } => Some(session_id.as_str()),
             Self::AuthRequired { .. }
             | Self::ConnectionFailed { .. }
@@ -463,6 +497,8 @@ impl BridgeEvent {
             | Self::SessionsListed { .. }
             | Self::StatusSnapshot { .. }
             | Self::ContextUsage { .. }
+            | Self::RewindTargets { .. }
+            | Self::RewindResult { .. }
             | Self::McpSnapshot { .. } => None,
         }
     }
@@ -554,6 +590,89 @@ mod tests {
     }
 
     #[test]
+    fn get_rewind_targets_command_serializes_snake_case() {
+        let env = CommandEnvelope {
+            request_id: None,
+            command: BridgeCommand::GetRewindTargets { session_id: "s1".to_owned() },
+        };
+
+        let json = serde_json::to_value(&env).expect("serialize");
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "command": "get_rewind_targets",
+                "session_id": "s1"
+            })
+        );
+    }
+
+    #[test]
+    fn rewind_command_serializes_snake_case() {
+        let env = CommandEnvelope {
+            request_id: None,
+            command: BridgeCommand::Rewind {
+                session_id: "s1".to_owned(),
+                target_user_message_id: "user-1".to_owned(),
+                restore_mode: types::RewindRestoreMode::Both,
+                launch_settings: SessionLaunchSettings {
+                    language: Some("German".to_owned()),
+                    ..SessionLaunchSettings::default()
+                },
+            },
+        };
+
+        let json = serde_json::to_value(&env).expect("serialize");
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "command": "rewind",
+                "session_id": "s1",
+                "target_user_message_id": "user-1",
+                "restore_mode": "both",
+                "launch_settings": {
+                    "language": "German"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn rewind_result_event_deserializes() {
+        let decoded: EventEnvelope = serde_json::from_value(serde_json::json!({
+            "event": "rewind_result",
+            "session_id": "session-1",
+            "restore_mode": "code",
+            "status": "success",
+            "file_result": {
+                "can_rewind": true,
+                "files_changed": ["src/main.rs"],
+                "insertions": 2,
+                "deletions": 1
+            }
+        }))
+        .expect("deserialize rewind result");
+
+        assert_eq!(
+            decoded.event,
+            BridgeEvent::RewindResult {
+                session_id: "session-1".to_owned(),
+                restore_mode: types::RewindRestoreMode::Code,
+                status: types::RewindResultStatus::Success,
+                file_result: Some(types::RewindFilesResult {
+                    can_rewind: true,
+                    error: None,
+                    files_changed: vec!["src/main.rs".to_owned()],
+                    insertions: Some(2),
+                    deletions: Some(1),
+                }),
+                message: None,
+            }
+        );
+    }
+
+    #[test]
     fn mcp_set_servers_command_serializes_latest_fields_as_snake_case() {
         let env = CommandEnvelope {
             request_id: None,
@@ -631,6 +750,38 @@ mod tests {
     }
 
     #[test]
+    fn session_replaced_event_deserializes_restored_input() {
+        let decoded: EventEnvelope = serde_json::from_value(serde_json::json!({
+            "event": "session_replaced",
+            "session_id": "session-2",
+            "cwd": "C:/work",
+            "current_model": {
+                "requested_id": null,
+                "resolved_id": "opus",
+                "display_name_short": "Opus",
+                "display_name_long": "Claude Opus",
+                "catalog_id": null,
+                "supports_effort": false,
+                "supported_effort_levels": [],
+                "supports_fast_mode": false,
+                "supports_auto_mode": false,
+                "supports_adaptive_thinking": false,
+                "is_authoritative": true
+            },
+            "available_models": [],
+            "mode": null,
+            "history_updates": [],
+            "restored_input": "selected prompt"
+        }))
+        .expect("deserialize session replaced");
+
+        let BridgeEvent::SessionReplaced { restored_input, .. } = decoded.event else {
+            panic!("expected session_replaced");
+        };
+        assert_eq!(restored_input.as_deref(), Some("selected prompt"));
+    }
+
+    #[test]
     fn mcp_set_servers_result_event_deserializes() {
         let json = serde_json::json!({
             "request_id": "req-mcp-set",
@@ -688,6 +839,53 @@ mod tests {
                     source: Some(types::McpSnapshotSource::ReloadPlugins),
                     error: None,
                 },
+            }
+        );
+    }
+
+    #[test]
+    fn rewind_targets_event_deserializes() {
+        let decoded: EventEnvelope = serde_json::from_value(serde_json::json!({
+            "event": "rewind_targets",
+            "session_id": "session-1",
+            "targets": [
+                {
+                    "uuid": "user-2",
+                    "first_text": "second prompt",
+                    "input_text": "second prompt",
+                    "previous_assistant_uuid": "assistant-1",
+                    "index": 3
+                },
+                {
+                    "uuid": "user-1",
+                    "first_text": "first prompt",
+                    "input_text": "first prompt",
+                    "index": 0
+                }
+            ]
+        }))
+        .expect("deserialize rewind targets");
+
+        assert_eq!(
+            decoded.event,
+            BridgeEvent::RewindTargets {
+                session_id: "session-1".to_owned(),
+                targets: vec![
+                    types::RewindTarget {
+                        uuid: "user-2".to_owned(),
+                        first_text: "second prompt".to_owned(),
+                        input_text: "second prompt".to_owned(),
+                        index: 3,
+                        previous_assistant_uuid: Some("assistant-1".to_owned()),
+                    },
+                    types::RewindTarget {
+                        uuid: "user-1".to_owned(),
+                        first_text: "first prompt".to_owned(),
+                        input_text: "first prompt".to_owned(),
+                        index: 0,
+                        previous_assistant_uuid: None,
+                    },
+                ],
             }
         );
     }

--- a/src/app/connect/event_dispatch.rs
+++ b/src/app/connect/event_dispatch.rs
@@ -15,8 +15,8 @@ use tokio::sync::mpsc;
 use super::bridge_lifecycle::emit_connection_failed;
 use super::type_converters::{
     convert_account_info, convert_current_model, convert_mode_state, map_available_models,
-    map_mcp_server_status, map_permission_request, map_question_request, map_session_update,
-    map_user_dialog_request,
+    map_mcp_server_status, map_permission_request, map_question_request, map_rewind_result,
+    map_rewind_targets, map_session_update, map_user_dialog_request,
 };
 
 struct ConnectedEventData {
@@ -146,6 +146,7 @@ pub(super) fn handle_bridge_event(
             available_models,
             mode,
             history_updates,
+            restored_input,
         } => {
             let history_updates = history_updates
                 .unwrap_or_default()
@@ -159,6 +160,7 @@ pub(super) fn handle_bridge_event(
                 available_models: map_available_models(available_models),
                 mode: mode.map(convert_mode_state),
                 history_updates,
+                restored_input,
             });
         }
         crate::agent::wire::BridgeEvent::SessionsListed { sessions } => {
@@ -173,6 +175,23 @@ pub(super) fn handle_bridge_event(
         }
         crate::agent::wire::BridgeEvent::ContextUsage { session_id, percentage } => {
             let _ = event_tx.send(ClientEvent::ContextUsageReceived { session_id, percentage });
+        }
+        crate::agent::wire::BridgeEvent::RewindTargets { session_id, targets } => {
+            let _ = event_tx.send(ClientEvent::RewindTargetsReceived {
+                session_id,
+                targets: map_rewind_targets(targets),
+            });
+        }
+        crate::agent::wire::BridgeEvent::RewindResult {
+            session_id,
+            restore_mode,
+            status,
+            file_result,
+            message,
+        } => {
+            let _ = event_tx.send(ClientEvent::RewindResultReceived {
+                result: map_rewind_result(session_id, restore_mode, status, file_result, message),
+            });
         }
         crate::agent::wire::BridgeEvent::McpSnapshot { session_id, servers, source, error } => {
             let _ = event_tx.send(ClientEvent::McpSnapshotReceived {
@@ -205,6 +224,7 @@ fn handle_connected_event(
             available_models: map_available_models(event.available_models),
             mode,
             history_updates,
+            restored_input: None,
         });
     } else {
         *connected_once = true;

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -65,7 +65,9 @@ struct StartConnectionParams {
     session_launch_settings: SessionLaunchSettings,
 }
 
-pub(crate) use session_start::{SessionStartReason, begin_resume_session, start_new_session};
+pub(crate) use session_start::{
+    SessionStartReason, begin_resume_session, begin_rewind, start_new_session,
+};
 
 /// Create the `App` struct in `Connecting` state and load shared settings state.
 #[allow(clippy::too_many_lines)]
@@ -177,6 +179,9 @@ pub fn create_app(cli: &Cli) -> App {
         focus: FocusManager::default(),
         keymap: super::keymap::ResolvedKeymap::defaults(),
         available_commands: Vec::new(),
+        rewind_targets: Vec::new(),
+        rewind_targets_session_id: None,
+        rewind_targets_in_flight: false,
         plugins: PluginsState::default(),
         available_agents: Vec::new(),
         available_models: Vec::new(),

--- a/src/app/connect/session_start.rs
+++ b/src/app/connect/session_start.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::agent::client::AgentConnection;
+use crate::agent::types::RewindRestoreMode;
 use crate::agent::wire::SessionLaunchSettings;
 use crate::app::App;
 use crate::app::config::{language_input_validation_message, store};
@@ -12,6 +13,7 @@ pub(crate) enum SessionStartReason {
     Startup,
     NewSession,
     Resume,
+    Rewind,
     Login,
     Logout,
 }
@@ -22,6 +24,7 @@ impl SessionStartReason {
             Self::Startup => "startup",
             Self::NewSession => "new_session",
             Self::Resume => "resume",
+            Self::Rewind => "rewind",
             Self::Login => "login",
             Self::Logout => "logout",
         }
@@ -30,7 +33,7 @@ impl SessionStartReason {
     fn event_name(self) -> &'static str {
         match self {
             Self::Startup => "session_start_requested",
-            Self::Resume => "session_resume_requested",
+            Self::Resume | Self::Rewind => "session_resume_requested",
             Self::NewSession | Self::Login | Self::Logout => "session_restart_requested",
         }
     }
@@ -45,6 +48,7 @@ pub(crate) fn session_launch_settings_for_reason(
         SessionStartReason::Startup
         | SessionStartReason::NewSession
         | SessionStartReason::Resume
+        | SessionStartReason::Rewind
         | SessionStartReason::Login => {
             let language = store::language(&app.config.committed_settings_document)
                 .ok()
@@ -187,6 +191,18 @@ pub(crate) fn begin_resume_session(
     app.resuming_session_id = Some(session_id.clone());
     app.show_session_overview = false;
     resume_session(app, conn, session_id)
+}
+
+pub(crate) fn begin_rewind(
+    app: &App,
+    conn: &AgentConnection,
+    session_id: String,
+    target_user_message_id: String,
+    restore_mode: RewindRestoreMode,
+) -> anyhow::Result<()> {
+    let launch_settings = session_launch_settings_for_reason(app, SessionStartReason::Rewind);
+    log_session_request(app, SessionStartReason::Rewind, &launch_settings, Some(&session_id));
+    conn.rewind(session_id, target_user_message_id, restore_mode, launch_settings)
 }
 
 #[cfg(test)]

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -213,6 +213,61 @@ pub(super) fn map_available_agents_update(
     )
 }
 
+pub(super) fn map_rewind_targets(targets: Vec<types::RewindTarget>) -> Vec<model::RewindTarget> {
+    targets
+        .into_iter()
+        .map(|target| model::RewindTarget {
+            uuid: target.uuid,
+            first_text: target.first_text,
+            input_text: target.input_text,
+            index: target.index,
+            previous_assistant_uuid: target.previous_assistant_uuid,
+        })
+        .collect()
+}
+
+fn map_rewind_restore_mode(mode: types::RewindRestoreMode) -> model::RewindRestoreMode {
+    match mode {
+        types::RewindRestoreMode::Both => model::RewindRestoreMode::Both,
+        types::RewindRestoreMode::Conversation => model::RewindRestoreMode::Conversation,
+        types::RewindRestoreMode::Code => model::RewindRestoreMode::Code,
+    }
+}
+
+fn map_rewind_result_status(status: types::RewindResultStatus) -> model::RewindResultStatus {
+    match status {
+        types::RewindResultStatus::Success => model::RewindResultStatus::Success,
+        types::RewindResultStatus::Failure => model::RewindResultStatus::Failure,
+        types::RewindResultStatus::PartialFailure => model::RewindResultStatus::PartialFailure,
+    }
+}
+
+fn map_rewind_files_result(result: types::RewindFilesResult) -> model::RewindFilesResult {
+    model::RewindFilesResult {
+        can_rewind: result.can_rewind,
+        error: result.error,
+        files_changed: result.files_changed,
+        insertions: result.insertions,
+        deletions: result.deletions,
+    }
+}
+
+pub(super) fn map_rewind_result(
+    session_id: String,
+    restore_mode: types::RewindRestoreMode,
+    status: types::RewindResultStatus,
+    file_result: Option<types::RewindFilesResult>,
+    message: Option<String>,
+) -> model::RewindResult {
+    model::RewindResult {
+        session_id,
+        restore_mode: map_rewind_restore_mode(restore_mode),
+        status: map_rewind_result_status(status),
+        file_result: file_result.map(map_rewind_files_result),
+        message,
+    }
+}
+
 pub(super) fn map_available_models(
     models: Vec<types::AvailableModel>,
 ) -> Vec<model::AvailableModel> {

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -18,6 +18,7 @@ pub(super) fn map_rate_limit_status(status: types::RateLimitStatus) -> model::Ra
 pub(super) fn map_rate_limit_update(update: types::RateLimitUpdate) -> model::RateLimitUpdate {
     model::RateLimitUpdate {
         status: map_rate_limit_status(update.status),
+        error_code: update.error_code,
         resets_at: update.resets_at,
         utilization: update.utilization,
         rate_limit_type: update.rate_limit_type,
@@ -26,6 +27,8 @@ pub(super) fn map_rate_limit_update(update: types::RateLimitUpdate) -> model::Ra
         overage_disabled_reason: update.overage_disabled_reason,
         is_using_overage: update.is_using_overage,
         surpassed_threshold: update.surpassed_threshold,
+        can_user_purchase_credits: update.can_user_purchase_credits,
+        has_chargeable_saved_payment_method: update.has_chargeable_saved_payment_method,
     }
 }
 
@@ -342,6 +345,7 @@ pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::
         }
         types::SessionUpdate::RateLimitUpdate {
             status,
+            error_code,
             resets_at,
             utilization,
             rate_limit_type,
@@ -350,9 +354,12 @@ pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::
             overage_disabled_reason,
             is_using_overage,
             surpassed_threshold,
+            can_user_purchase_credits,
+            has_chargeable_saved_payment_method,
         } => Some(model::SessionUpdate::RateLimitUpdate(map_rate_limit_update(
             types::RateLimitUpdate {
                 status,
+                error_code,
                 resets_at,
                 utilization,
                 rate_limit_type,
@@ -361,6 +368,8 @@ pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::
                 overage_disabled_reason,
                 is_using_overage,
                 surpassed_threshold,
+                can_user_purchase_credits,
+                has_chargeable_saved_payment_method,
             },
         ))),
         types::SessionUpdate::ApiRetryUpdate {
@@ -1131,6 +1140,33 @@ mod tests {
             panic!("expected agent message chunk");
         };
         assert_eq!(chunk.source_message_uuid.as_deref(), Some("assistant-1"));
+    }
+
+    #[test]
+    fn map_session_update_preserves_rate_limit_credits_metadata() {
+        let mapped = map_session_update(types::SessionUpdate::RateLimitUpdate {
+            status: types::RateLimitStatus::Rejected,
+            error_code: Some("credits_required".to_owned()),
+            resets_at: None,
+            utilization: None,
+            rate_limit_type: None,
+            overage_status: None,
+            overage_resets_at: None,
+            overage_disabled_reason: None,
+            is_using_overage: None,
+            surpassed_threshold: None,
+            can_user_purchase_credits: Some(true),
+            has_chargeable_saved_payment_method: Some(false),
+        })
+        .expect("rate limit update should map");
+
+        let model::SessionUpdate::RateLimitUpdate(update) = mapped else {
+            panic!("expected rate limit update");
+        };
+        assert_eq!(update.status, model::RateLimitStatus::Rejected);
+        assert_eq!(update.error_code.as_deref(), Some("credits_required"));
+        assert_eq!(update.can_user_purchase_credits, Some(true));
+        assert_eq!(update.has_chargeable_saved_payment_method, Some(false));
     }
 
     #[test]

--- a/src/app/events/client.rs
+++ b/src/app/events/client.rs
@@ -203,15 +203,19 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             available_models,
             mode,
             history_updates,
+            restored_input,
         } => {
             session::handle_session_replaced_event(
                 app,
-                session_id,
-                cwd,
-                current_model,
-                available_models,
-                mode,
-                &history_updates,
+                session::SessionReplacedEventData {
+                    session_id,
+                    cwd,
+                    current_model,
+                    available_models,
+                    mode,
+                    history_updates,
+                    restored_input,
+                },
             );
             crate::app::config::refresh_mcp_snapshot(app);
             crate::app::session_runtime::request_status_snapshot_refresh(app);
@@ -281,6 +285,28 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                 return;
             }
             crate::app::session_runtime::apply_context_usage_snapshot(app, percentage);
+        }
+        ClientEvent::RewindTargetsReceived { session_id, targets } => {
+            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+                != Some(session_id.as_str())
+            {
+                tracing::debug!(
+                    target: crate::logging::targets::APP_SESSION,
+                    event_name = "rewind_targets_dropped",
+                    message = "rewind targets dropped for a stale session",
+                    outcome = "dropped",
+                    session_id = %session_id,
+                    reason = "stale_session",
+                );
+                return;
+            }
+            app.rewind_targets = targets;
+            app.rewind_targets_session_id = Some(crate::agent::model::SessionId::new(session_id));
+            app.rewind_targets_in_flight = false;
+            crate::app::slash::sync_with_cursor(app);
+        }
+        ClientEvent::RewindResultReceived { result } => {
+            session::handle_rewind_result_event(app, &result);
         }
         ClientEvent::McpSnapshotReceived { session_id, mut servers, source, error } => {
             if app.session_id.as_ref().map(ToString::to_string).as_deref()

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -124,12 +124,12 @@ fn handle_resize(app: &mut App, width: u16, height: u16) -> bool {
             app.chat_render.invalidate_live_anchor();
             match app.terminal_lifecycle {
                 super::TerminalLifecycleState::Running(super::SurfaceMode::Chat) => {
-                    app.request_chat_resize_purge_replay_rebuild();
+                    app.request_chat_purge_replay_rebuild(super::ChatPurgeReplayOptions::resize());
                     if matches!(app.status, AppStatus::Thinking | AppStatus::Running) {
                         app.chat_render.mark_resize_purge_replay_during_turn();
                     }
                     active_surface_repaint = true;
-                    "request_chat_resize_purge_replay"
+                    "request_chat_purge_replay"
                 }
                 super::TerminalLifecycleState::Running(super::SurfaceMode::Fullscreen(_)) => {
                     app.request_fullscreen_repaint();
@@ -1679,7 +1679,10 @@ mod tests {
         handle_terminal_event(&mut app, Event::Resize(120, 40));
 
         assert!(!app.surface_dirty.fullscreen.redraw);
-        assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::ResizePurgeReplay);
+        assert_eq!(
+            app.surface_dirty.chat.rebuild,
+            ChatRebuildKind::PurgeReplay(crate::app::ChatPurgeReplayOptions::resize())
+        );
         assert!(app.surface_dirty.chat.repaint);
         assert_resize_measurements_cleared(&app, 120, 40);
     }
@@ -1792,7 +1795,10 @@ mod tests {
 
         handle_terminal_event(&mut app, Event::Resize(120, 40));
 
-        assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::ResizePurgeReplay);
+        assert_eq!(
+            app.surface_dirty.chat.rebuild,
+            ChatRebuildKind::PurgeReplay(crate::app::ChatPurgeReplayOptions::resize())
+        );
         assert!(app.chat_render.resize_purge_replay_after_turn);
     }
 
@@ -2258,6 +2264,7 @@ mod tests {
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: Vec::new(),
+                restored_input: None,
             },
         );
 
@@ -2285,7 +2292,10 @@ mod tests {
         };
         assert_eq!(welcome.cwd, "/replacement");
         assert_ne!(welcome.tip_seed, 5);
-        assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::SessionBoundary);
+        assert_eq!(
+            app.surface_dirty.chat.rebuild,
+            ChatRebuildKind::PurgeReplay(crate::app::ChatPurgeReplayOptions::session_replacement())
+        );
     }
 
     #[test]
@@ -2311,6 +2321,7 @@ mod tests {
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: Vec::new(),
+                restored_input: None,
             },
         );
 
@@ -2665,6 +2676,28 @@ mod tests {
 
         assert!(matches!(app.status, AppStatus::Ready));
         assert!(app.resuming_session_id.is_none());
+    }
+
+    #[test]
+    fn slash_command_error_clears_rewind_target_loading_state() {
+        let mut app = make_test_app();
+        app.rewind_targets_in_flight = true;
+        app.rewind_targets_session_id = Some(model::SessionId::new("session-1"));
+        app.rewind_targets = vec![model::RewindTarget {
+            uuid: "user-1".into(),
+            first_text: "hello".into(),
+            input_text: "hello".into(),
+            index: 0,
+            previous_assistant_uuid: None,
+        }];
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::SlashCommandError("failed to load rewind targets".into()),
+        );
+
+        assert!(!app.rewind_targets_in_flight);
+        assert!(app.rewind_targets_session_id.is_none());
     }
 
     #[test]
@@ -3083,6 +3116,7 @@ mod tests {
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: Vec::new(),
+                restored_input: None,
             },
         );
 
@@ -3113,6 +3147,7 @@ mod tests {
                 available_models: Vec::new(),
                 mode: None,
                 history_updates,
+                restored_input: None,
             },
         );
 
@@ -3148,6 +3183,35 @@ mod tests {
         );
 
         assert!(!session_overview_has_welcome(&app));
+    }
+
+    #[test]
+    fn session_replaced_restores_input_after_loading_history() {
+        let mut app = make_test_app();
+        app.pending_command_label = Some("Rewinding conversation...".to_owned());
+        app.status = AppStatus::CommandPending;
+        let history_updates =
+            vec![model::SessionUpdate::AgentMessageChunk(model::ContentChunk::new(
+                model::ContentBlock::Text(model::TextContent::new("assistant reply")),
+            ))];
+
+        handle_client_event(
+            &mut app,
+            ClientEvent::SessionReplaced {
+                session_id: model::SessionId::new("rewound"),
+                cwd: "/replacement".into(),
+                current_model: test_current_model("new-model"),
+                available_models: Vec::new(),
+                mode: None,
+                history_updates,
+                restored_input: Some("selected prompt".to_owned()),
+            },
+        );
+
+        assert_eq!(app.input.text(), "selected prompt");
+        assert!(app.pending_command_label.is_none());
+        assert!(matches!(app.status, AppStatus::Ready));
+        assert!(canonical_messages_contain_text(&app, "assistant reply"));
     }
 
     #[test]
@@ -3268,6 +3332,7 @@ mod tests {
                 available_models: Vec::new(),
                 mode: None,
                 history_updates,
+                restored_input: None,
             },
         );
 
@@ -3310,6 +3375,7 @@ mod tests {
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: vec![model::SessionUpdate::ToolCall(open_tool)],
+                restored_input: None,
             },
         );
 
@@ -3340,6 +3406,7 @@ mod tests {
                         "assistant reply",
                     ))),
                 )],
+                restored_input: None,
             },
         );
 
@@ -3363,6 +3430,7 @@ mod tests {
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: vec![model::SessionUpdate::ToolCall(task_tool)],
+                restored_input: None,
             },
         );
 
@@ -4795,6 +4863,7 @@ mod tests {
                 available_models: Vec::new(),
                 mode: None,
                 history_updates: Vec::new(),
+                restored_input: None,
             },
         );
 
@@ -4989,6 +5058,7 @@ mod tests {
                 primary: "/config".into(),
                 secondary: Some("Open settings".into()),
             }],
+            placeholder: None,
             dialog: crate::app::dialog::DialogState::default(),
         });
         app.claim_focus_target(FocusTarget::Mention);
@@ -5272,6 +5342,7 @@ mod tests {
                 primary: "/config".into(),
                 secondary: Some("Open settings".into()),
             }],
+            placeholder: None,
             dialog: crate::app::dialog::DialogState::default(),
         });
         app.claim_focus_target(FocusTarget::Mention);

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -3882,6 +3882,7 @@ mod tests {
 
         let warning_update = model::RateLimitUpdate {
             status: model::RateLimitStatus::AllowedWarning,
+            error_code: None,
             resets_at: Some(123.0),
             utilization: Some(0.92),
             rate_limit_type: Some("five_hour".to_owned()),
@@ -3890,6 +3891,8 @@ mod tests {
             overage_disabled_reason: None,
             is_using_overage: None,
             surpassed_threshold: None,
+            can_user_purchase_credits: None,
+            has_chargeable_saved_payment_method: None,
         };
 
         handle_client_event(
@@ -3942,6 +3945,7 @@ mod tests {
             ClientEvent::SessionUpdate(model::SessionUpdate::RateLimitUpdate(
                 model::RateLimitUpdate {
                     status: model::RateLimitStatus::AllowedWarning,
+                    error_code: None,
                     resets_at: Some(1_741_280_000.0),
                     utilization: Some(0.95),
                     rate_limit_type: Some("five_hour".to_owned()),
@@ -3950,6 +3954,8 @@ mod tests {
                     overage_disabled_reason: None,
                     is_using_overage: None,
                     surpassed_threshold: None,
+                    can_user_purchase_credits: None,
+                    has_chargeable_saved_payment_method: None,
                 },
             )),
         );
@@ -3985,6 +3991,7 @@ mod tests {
         let mut app = make_test_app();
         app.last_rate_limit_update = Some(model::RateLimitUpdate {
             status: model::RateLimitStatus::AllowedWarning,
+            error_code: None,
             resets_at: Some(1_741_280_000.0),
             utilization: Some(0.95),
             rate_limit_type: Some("five_hour".to_owned()),
@@ -3993,6 +4000,8 @@ mod tests {
             overage_disabled_reason: None,
             is_using_overage: None,
             surpassed_threshold: None,
+            can_user_purchase_credits: None,
+            has_chargeable_saved_payment_method: None,
         });
         app.status = AppStatus::Thinking;
         app.messages.push(user_msg("first"));
@@ -4024,6 +4033,7 @@ mod tests {
             ClientEvent::SessionUpdate(model::SessionUpdate::RateLimitUpdate(
                 model::RateLimitUpdate {
                     status: model::RateLimitStatus::Rejected,
+                    error_code: None,
                     resets_at: Some(1_741_290_000.0),
                     utilization: None,
                     rate_limit_type: Some("daily".to_owned()),
@@ -4032,6 +4042,8 @@ mod tests {
                     overage_disabled_reason: None,
                     is_using_overage: None,
                     surpassed_threshold: None,
+                    can_user_purchase_credits: None,
+                    has_chargeable_saved_payment_method: None,
                 },
             )),
         );
@@ -4061,6 +4073,7 @@ mod tests {
             ClientEvent::SessionUpdate(model::SessionUpdate::RateLimitUpdate(
                 model::RateLimitUpdate {
                     status: model::RateLimitStatus::AllowedWarning,
+                    error_code: None,
                     resets_at: Some(123.0),
                     utilization: Some(0.91),
                     rate_limit_type: Some("five_hour".to_owned()),
@@ -4069,6 +4082,8 @@ mod tests {
                     overage_disabled_reason: None,
                     is_using_overage: None,
                     surpassed_threshold: None,
+                    can_user_purchase_credits: None,
+                    has_chargeable_saved_payment_method: None,
                 },
             )),
         );
@@ -4086,6 +4101,7 @@ mod tests {
             ClientEvent::SessionUpdate(model::SessionUpdate::RateLimitUpdate(
                 model::RateLimitUpdate {
                     status: model::RateLimitStatus::AllowedWarning,
+                    error_code: None,
                     resets_at: Some(456.0),
                     utilization: Some(0.92),
                     rate_limit_type: Some("daily".to_owned()),
@@ -4094,6 +4110,8 @@ mod tests {
                     overage_disabled_reason: None,
                     is_using_overage: None,
                     surpassed_threshold: None,
+                    can_user_purchase_credits: None,
+                    has_chargeable_saved_payment_method: None,
                 },
             )),
         );

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -4828,6 +4828,7 @@ mod tests {
         tc.pending_permission = Some(InlinePermission {
             options,
             display: None,
+            subagent_context: None,
             response_tx,
             selected_index: 0,
             focused,

--- a/src/app/events/rate_limit.rs
+++ b/src/app/events/rate_limit.rs
@@ -192,6 +192,7 @@ mod tests {
     fn org_level_disabled_without_primary_context_uses_extra_usage_message() {
         let update = RateLimitUpdate {
             status: RateLimitStatus::Rejected,
+            error_code: None,
             resets_at: None,
             utilization: None,
             rate_limit_type: None,
@@ -200,6 +201,8 @@ mod tests {
             overage_disabled_reason: Some("org_level_disabled".to_owned()),
             is_using_overage: Some(false),
             surpassed_threshold: None,
+            can_user_purchase_credits: None,
+            has_chargeable_saved_payment_method: None,
         };
 
         assert_eq!(
@@ -212,6 +215,7 @@ mod tests {
     fn org_level_disabled_with_primary_context_keeps_normal_rate_limit_message() {
         let update = RateLimitUpdate {
             status: RateLimitStatus::Rejected,
+            error_code: None,
             resets_at: Some(1_741_280_000.0),
             utilization: None,
             rate_limit_type: Some("five_hour".to_owned()),
@@ -220,6 +224,8 @@ mod tests {
             overage_disabled_reason: Some("org_level_disabled".to_owned()),
             is_using_overage: Some(false),
             surpassed_threshold: None,
+            can_user_purchase_credits: None,
+            has_chargeable_saved_payment_method: None,
         };
 
         let summary = format_rate_limit_summary(&update);

--- a/src/app/events/rate_limit.rs
+++ b/src/app/events/rate_limit.rs
@@ -15,6 +15,7 @@ fn format_rate_limit_type(raw: &str) -> &str {
         "seven_day" => "7-day",
         "seven_day_opus" => "7-day Opus",
         "seven_day_sonnet" => "7-day Sonnet",
+        "seven_day_overage_included" => "7-day overage-included",
         "overage" => "overage",
         other => other,
     }
@@ -232,5 +233,27 @@ mod tests {
         assert!(summary.contains("Rate limit reached"));
         assert!(summary.contains("5-hour rate limit"));
         assert!(!summary.contains("Extra usage is required for 1M context"));
+    }
+
+    #[test]
+    fn seven_day_overage_included_rate_limit_type_renders_readable_label() {
+        let update = RateLimitUpdate {
+            status: RateLimitStatus::AllowedWarning,
+            error_code: None,
+            resets_at: None,
+            utilization: Some(0.92),
+            rate_limit_type: Some("seven_day_overage_included".to_owned()),
+            overage_status: None,
+            overage_resets_at: None,
+            overage_disabled_reason: None,
+            is_using_overage: None,
+            surpassed_threshold: None,
+            can_user_purchase_credits: None,
+            has_chargeable_saved_payment_method: None,
+        };
+
+        let summary = format_rate_limit_summary(&update);
+        assert!(summary.contains("7-day overage-included rate limit"));
+        assert!(!summary.contains("seven_day_overage_included"));
     }
 }

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -18,6 +18,16 @@ const TURN_ERROR_INPUT_LOCK_HINT: &str =
     "Input disabled after an error. Press Ctrl+Q to quit and try again.";
 const UPDATE_INSTALL_COMMAND: &str = "npm install -g claude-code-rust";
 
+pub(super) struct SessionReplacedEventData {
+    pub session_id: model::SessionId,
+    pub cwd: String,
+    pub current_model: model::CurrentModel,
+    pub available_models: Vec<model::AvailableModel>,
+    pub mode: Option<super::super::ModeState>,
+    pub history_updates: Vec<model::SessionUpdate>,
+    pub restored_input: Option<String>,
+}
+
 pub(super) fn handle_connected_client_event(
     app: &mut App,
     session_id: model::SessionId,
@@ -192,6 +202,8 @@ pub(super) fn handle_connection_failed_event(app: &mut App, msg: &str) {
 }
 
 pub(super) fn handle_slash_command_error_event(app: &mut App, msg: &str) {
+    app.rewind_targets_in_flight = false;
+    app.rewind_targets_session_id = None;
     if app.config.pending_session_title_change.take().is_some() {
         app.config.last_error = Some(msg.to_owned());
         app.config.status_message = None;
@@ -289,15 +301,16 @@ pub(super) fn handle_logout_completed_event(app: &mut App) {
     }
 }
 
-pub(super) fn handle_session_replaced_event(
-    app: &mut App,
-    session_id: model::SessionId,
-    cwd: String,
-    current_model: model::CurrentModel,
-    available_models: Vec<model::AvailableModel>,
-    mode: Option<super::super::ModeState>,
-    history_updates: &[model::SessionUpdate],
-) {
+pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplacedEventData) {
+    let SessionReplacedEventData {
+        session_id,
+        cwd,
+        current_model,
+        available_models,
+        mode,
+        history_updates,
+        restored_input,
+    } = event;
     let session_id_for_log = session_id.to_string();
     let history_update_count = history_updates.len();
     let available_model_count = available_models.len();
@@ -312,18 +325,23 @@ pub(super) fn handle_session_replaced_event(
         current_model,
         mode,
         false,
-        ChatResetRenderMode::ClearVisibleTranscript,
+        ChatResetRenderMode::DeferTranscriptRender,
     );
-    app.request_chat_session_boundary_rebuild();
     app.sync_welcome_snapshot();
     if !history_updates.is_empty() {
-        load_resume_history(app, history_updates);
+        load_resume_history(app, &history_updates);
     }
     ensure_update_notice_message(app);
     clear_pending_command(app);
+    if let Some(restored_input) = restored_input.as_deref() {
+        app.input.set_text(restored_input);
+    }
     app.resuming_session_id = None;
     crate::app::file_index::restart(app);
     crate::app::config::refresh_runtime_tabs_for_session_change(app);
+    // After session replacement, terminal scrollback is stale. Rebuild from
+    // app.messages, which was rebuilt only from bridge-reported session history.
+    app.request_chat_purge_replay_rebuild(crate::app::ChatPurgeReplayOptions::session_replacement());
     tracing::info!(
         target: crate::logging::targets::APP_SESSION,
         event_name = "session_replaced",
@@ -334,7 +352,67 @@ pub(super) fn handle_session_replaced_event(
         current_model = ?app.current_model.as_ref().map(|model| model.resolved_id.clone()),
         history_update_count,
         available_model_count,
+        restored_input = restored_input.is_some(),
     );
+}
+
+pub(super) fn handle_rewind_result_event(app: &mut App, result: &model::RewindResult) {
+    if app.session_id.as_ref().map(ToString::to_string).as_deref()
+        != Some(result.session_id.as_str())
+    {
+        tracing::debug!(
+            target: crate::logging::targets::APP_SESSION,
+            event_name = "rewind_result_dropped",
+            message = "rewind result dropped for a stale session",
+            outcome = "dropped",
+            session_id = %result.session_id,
+            reason = "stale_session",
+        );
+        return;
+    }
+
+    let severity = match result.status {
+        model::RewindResultStatus::Success => SystemSeverity::Info,
+        model::RewindResultStatus::Failure | model::RewindResultStatus::PartialFailure => {
+            SystemSeverity::Error
+        }
+    };
+    let message = rewind_result_message(result);
+    super::notices::emit_system_notice(app, severity, &message);
+    clear_pending_command(app);
+}
+
+fn rewind_result_message(result: &model::RewindResult) -> String {
+    if let Some(message) = result.message.as_deref()
+        && !message.trim().is_empty()
+        && !matches!(result.status, model::RewindResultStatus::Success)
+    {
+        return message.to_owned();
+    }
+
+    let Some(file_result) = result.file_result.as_ref() else {
+        return result
+            .message
+            .clone()
+            .unwrap_or_else(|| format!("Rewind {} completed.", result.restore_mode.label()));
+    };
+    let file_count = file_result.files_changed.len();
+    let insertions = file_result.insertions.unwrap_or(0);
+    let deletions = file_result.deletions.unwrap_or(0);
+    let file_word = if file_count == 1 { "file" } else { "files" };
+    match result.status {
+        model::RewindResultStatus::Success => format!(
+            "Restored code for {file_count} {file_word} ({insertions} insertions, {deletions} deletions)."
+        ),
+        model::RewindResultStatus::Failure => file_result
+            .error
+            .clone()
+            .or_else(|| result.message.clone())
+            .unwrap_or_else(|| "Failed to restore code.".to_owned()),
+        model::RewindResultStatus::PartialFailure => result.message.clone().unwrap_or_else(|| {
+            "Code was restored, but the conversation could not be rewound.".to_owned()
+        }),
+    }
 }
 
 pub(super) fn handle_update_available_event(
@@ -578,12 +656,16 @@ mod tests {
 
         handle_session_replaced_event(
             &mut app,
-            model::SessionId::new("session-2"),
-            dir.path().to_string_lossy().into_owned(),
-            model::CurrentModel::new("model", "model", "model").authoritative(true),
-            Vec::new(),
-            None,
-            &[],
+            SessionReplacedEventData {
+                session_id: model::SessionId::new("session-2"),
+                cwd: dir.path().to_string_lossy().into_owned(),
+                current_model: model::CurrentModel::new("model", "model", "model")
+                    .authoritative(true),
+                available_models: Vec::new(),
+                mode: None,
+                history_updates: Vec::new(),
+                restored_input: None,
+            },
         );
 
         assert_eq!(app.file_index.root.as_deref(), Some(dir.path()));

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -7,7 +7,7 @@ use crate::agent::model;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ChatResetRenderMode {
     PreserveInlineViewport,
-    ClearVisibleTranscript,
+    DeferTranscriptRender,
 }
 
 pub(super) fn reset_for_new_session(
@@ -46,6 +46,9 @@ fn reset_session_identity_state(
     app.login_hint = None;
     super::clear_compaction_state(app, false);
     app.session_usage = super::super::SessionUsageState::default();
+    app.rewind_targets.clear();
+    app.rewind_targets_session_id = None;
+    app.rewind_targets_in_flight = false;
     app.status = super::super::AppStatus::Ready;
     app.fast_mode_state = model::FastModeState::Off;
     app.runtime_session_state = None;
@@ -108,7 +111,7 @@ fn reset_cache_and_footer_state_for_new_session(app: &mut App, render_mode: Chat
     crate::app::plugins::reset_for_session_change(app);
     match render_mode {
         ChatResetRenderMode::PreserveInlineViewport => app.request_chat_repaint(),
-        ChatResetRenderMode::ClearVisibleTranscript => app.request_chat_visible_rebuild(),
+        ChatResetRenderMode::DeferTranscriptRender => {}
     }
 }
 
@@ -201,7 +204,7 @@ mod tests {
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
             false,
-            ChatResetRenderMode::ClearVisibleTranscript,
+            ChatResetRenderMode::DeferTranscriptRender,
         );
 
         assert_eq!(app.chat_render.terminal_width, 0);
@@ -232,7 +235,7 @@ mod tests {
     }
 
     #[test]
-    fn replacement_session_reset_requests_visible_transcript_clear() {
+    fn replacement_session_reset_defers_transcript_render() {
         let mut app = App::test_default();
         app.messages.push(ChatMessage::welcome("1.2.3", "Pro", "/workspace/demo", "session-1"));
         app.surface_dirty.chat.rebuild = ChatRebuildKind::None;
@@ -244,10 +247,36 @@ mod tests {
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
             false,
-            ChatResetRenderMode::ClearVisibleTranscript,
+            ChatResetRenderMode::DeferTranscriptRender,
         );
 
-        assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::VisibleScreen);
-        assert!(app.surface_dirty.chat.repaint);
+        assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::None);
+    }
+
+    #[test]
+    fn session_reset_clears_rewind_target_state() {
+        let mut app = App::test_default();
+        app.rewind_targets = vec![model::RewindTarget {
+            uuid: "user-1".to_owned(),
+            first_text: "prompt".to_owned(),
+            input_text: "prompt".to_owned(),
+            index: 0,
+            previous_assistant_uuid: None,
+        }];
+        app.rewind_targets_session_id = Some(model::SessionId::new("session-1"));
+        app.rewind_targets_in_flight = true;
+
+        reset_for_new_session(
+            &mut app,
+            model::SessionId::new("session-2"),
+            model::CurrentModel::new("test", "test", "test").authoritative(true),
+            None,
+            false,
+            ChatResetRenderMode::DeferTranscriptRender,
+        );
+
+        assert!(app.rewind_targets.is_empty());
+        assert!(app.rewind_targets_session_id.is_none());
+        assert!(!app.rewind_targets_in_flight);
     }
 }

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -3,8 +3,8 @@
 
 use super::super::{
     App, AppStatus, CancelOrigin, ChatMessage, FocusTarget, InlinePermission, InlineQuestion,
-    InvalidationLevel, MessageBlock, MessageRole, NoticeStage, SystemSeverity, TextBlock,
-    UserDialogBlock,
+    InvalidationLevel, MessageBlock, MessageRole, NoticeStage, SubagentPermissionContext,
+    SystemSeverity, TextBlock, ToolCallInfo, ToolCallScope, UserDialogBlock,
 };
 use super::clear_compaction_state;
 use super::rate_limit::{format_rate_limit_summary, rate_limit_notice_key};
@@ -38,6 +38,15 @@ pub(super) fn handle_permission_request_event(
     let session_id = request.session_id.to_string();
     let tool_id = request.tool_call.tool_call_id.clone();
     let options = request.options.clone();
+    let permission_context = resolve_permission_context(app, &tool_id);
+    let display_title =
+        permission_display_field(request.display.as_ref(), |display| display.title.as_deref());
+    let display_name = permission_display_field(request.display.as_ref(), |display| {
+        display.display_name.as_deref()
+    });
+    let display_description = permission_display_field(request.display.as_ref(), |display| {
+        display.description.as_deref()
+    });
 
     let Some((mi, bi)) = app.lookup_tool_call(&tool_id) else {
         tracing::warn!(
@@ -76,6 +85,7 @@ pub(super) fn handle_permission_request_event(
         tc.pending_permission = Some(InlinePermission {
             options: request.options,
             display: request.display,
+            subagent_context: permission_context.clone(),
             response_tx,
             selected_index: 0,
             focused: auto_focus,
@@ -90,15 +100,17 @@ pub(super) fn handle_permission_request_event(
             app.config.preferred_notification_channel_effective(),
             super::super::notify::NotifyEvent::PermissionRequired,
         );
-        tracing::info!(
-            target: crate::logging::targets::APP_PERMISSION,
-            event_name = "permission_request_applied",
-            message = "permission request applied to inline tool call",
-            outcome = "success",
-            session_id = %session_id,
-            tool_call_id = %tool_id,
-            option_count = options.len(),
-            focused = auto_focus,
+        log_permission_request_applied(
+            &session_id,
+            &tool_id,
+            options.len(),
+            auto_focus,
+            permission_context.as_ref(),
+            PermissionDisplayLogFields {
+                title: &display_title,
+                name: &display_name,
+                description: &display_description,
+            },
         );
     } else {
         tracing::warn!(
@@ -119,6 +131,115 @@ pub(super) fn handle_permission_request_event(
         app.invalidate_layout(InvalidationLevel::MessageChanged(mi));
         app.request_chat_mutable_rebuild();
     }
+}
+
+#[derive(Clone, Copy)]
+struct PermissionDisplayLogFields<'a> {
+    title: &'a str,
+    name: &'a str,
+    description: &'a str,
+}
+
+fn log_permission_request_applied(
+    session_id: &str,
+    tool_id: &str,
+    option_count: usize,
+    focused: bool,
+    permission_context: Option<&SubagentPermissionContext>,
+    display_fields: PermissionDisplayLogFields<'_>,
+) {
+    tracing::info!(
+        target: crate::logging::targets::APP_PERMISSION,
+        event_name = "permission_request_applied",
+        message = "permission request applied to inline tool call",
+        outcome = "success",
+        session_id = %session_id,
+        tool_call_id = %tool_id,
+        option_count,
+        focused,
+        subagent_label = %permission_context.map_or("", |context| context.subagent_label.as_str()),
+        subagent_parent_tool_call_id = %permission_context
+            .map_or("", |context| context.parent_tool_call_id.as_str()),
+        subagent_parent_tool_title = %permission_context
+            .and_then(|context| context.parent_tool_title.as_deref())
+            .unwrap_or(""),
+        subagent_parent_model = %permission_context
+            .and_then(|context| context.parent_model.as_deref())
+            .unwrap_or(""),
+        subagent_child_tool_name = %permission_context
+            .map_or("", |context| context.child_tool_name.as_str()),
+        subagent_child_tool_title = %permission_context
+            .map_or("", |context| context.child_tool_title.as_str()),
+        permission_display_title = %display_fields.title,
+        permission_display_name = %display_fields.name,
+        permission_display_description = %display_fields.description,
+    );
+}
+
+fn permission_display_field(
+    display: Option<&model::PermissionDisplay>,
+    field: impl FnOnce(&model::PermissionDisplay) -> Option<&str>,
+) -> String {
+    display
+        .and_then(field)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("")
+        .to_owned()
+}
+
+fn resolve_permission_context(app: &App, tool_call_id: &str) -> Option<SubagentPermissionContext> {
+    let ToolCallScope::SubagentChild { parent_tool_use_id } = app.tool_call_scope(tool_call_id)?
+    else {
+        return None;
+    };
+    let child = indexed_tool_call(app, tool_call_id)?;
+    let parent = indexed_tool_call(app, &parent_tool_use_id);
+    let parent_raw_input = parent.and_then(|tool| tool.raw_input.clone());
+    let parent_model = parent_raw_input
+        .as_ref()
+        .and_then(|raw_input| raw_input_string(raw_input, "model"))
+        .map(str::to_owned);
+    let parent_tool_title =
+        parent.map(|tool| tool.title.trim()).filter(|title| !title.is_empty()).map(str::to_owned);
+    let subagent_label = parent_raw_input
+        .as_ref()
+        .and_then(|raw_input| raw_input_string(raw_input, "name"))
+        .or_else(|| {
+            parent_raw_input
+                .as_ref()
+                .and_then(|raw_input| raw_input_string(raw_input, "subagent_type"))
+        })
+        .or(parent_tool_title.as_deref())
+        .unwrap_or("Subagent")
+        .to_owned();
+
+    Some(SubagentPermissionContext {
+        subagent_label,
+        child_tool_name: child.sdk_tool_name.clone(),
+        child_tool_title: child.title.clone(),
+        parent_tool_call_id: parent_tool_use_id,
+        parent_tool_title,
+        parent_model,
+        parent_raw_input,
+    })
+}
+
+fn indexed_tool_call<'a>(app: &'a App, tool_call_id: &str) -> Option<&'a ToolCallInfo> {
+    let (mi, bi) = app.lookup_tool_call(tool_call_id)?;
+    let MessageBlock::ToolCall(tc) = app.messages.get(mi)?.blocks.get(bi)? else {
+        return None;
+    };
+    Some(tc.as_ref())
+}
+
+fn raw_input_string<'a>(raw_input: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    raw_input
+        .as_object()
+        .and_then(|input| input.get(key))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
 }
 
 pub(super) fn handle_question_request_event(
@@ -653,6 +774,99 @@ mod tests {
         )
     }
 
+    fn tool_call_info(
+        id: &str,
+        title: &str,
+        sdk_tool_name: &str,
+        raw_input: Option<serde_json::Value>,
+        hidden: bool,
+    ) -> crate::app::ToolCallInfo {
+        crate::app::ToolCallInfo {
+            id: id.to_owned(),
+            source_message_uuids: Vec::new(),
+            title: title.to_owned(),
+            sdk_tool_name: sdk_tool_name.to_owned(),
+            raw_input,
+            raw_input_bytes: 0,
+            locations: Vec::new(),
+            output_metadata: None,
+            task_metadata: None,
+            status: model::ToolCallStatus::InProgress,
+            content: Vec::new(),
+            hidden,
+            terminal_id: None,
+            terminal_command: None,
+            terminal_output: None,
+            terminal_output_len: 0,
+            terminal_bytes_seen: 0,
+            terminal_snapshot_mode: crate::app::TerminalSnapshotMode::AppendOnly,
+            cache: crate::app::BlockCache::default(),
+            pending_permission: None,
+            pending_question: None,
+        }
+    }
+
+    fn push_tool(app: &mut App, tool: crate::app::ToolCallInfo) {
+        let msg_idx = app.messages.len();
+        let tool_id = tool.id.clone();
+        app.messages.push(ChatMessage::new(
+            MessageRole::Assistant,
+            vec![MessageBlock::ToolCall(Box::new(tool))],
+            None,
+        ));
+        app.index_tool_call(tool_id, msg_idx, 0);
+    }
+
+    fn permission_request(tool_id: &str) -> model::RequestPermissionRequest {
+        model::RequestPermissionRequest::new(
+            "session-1",
+            model::ToolCallUpdate::new(tool_id, model::ToolCallUpdateFields::new()),
+            vec![model::PermissionOption::new(
+                "allow",
+                "Allow",
+                model::PermissionOptionKind::AllowOnce,
+            )],
+            None,
+        )
+    }
+
+    fn pending_permission_context(
+        app: &App,
+        tool_id: &str,
+    ) -> Option<crate::app::SubagentPermissionContext> {
+        let (mi, bi) = app.lookup_tool_call(tool_id)?;
+        let Some(MessageBlock::ToolCall(tool)) =
+            app.messages.get(mi).and_then(|msg| msg.blocks.get(bi))
+        else {
+            return None;
+        };
+        tool.pending_permission.as_ref().and_then(|permission| permission.subagent_context.clone())
+    }
+
+    #[derive(Clone)]
+    struct SharedLogWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    struct LogWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedLogWriter {
+        type Writer = LogWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            LogWriter(std::sync::Arc::clone(&self.0))
+        }
+    }
+
+    impl std::io::Write for LogWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("log buffer lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
     #[test]
     fn turn_complete_removes_empty_tail_assistant() {
         let mut app = App::test_default();
@@ -791,5 +1005,146 @@ mod tests {
             panic!("expected tool call block");
         };
         assert!(tool.pending_permission.is_some());
+    }
+
+    #[test]
+    fn permission_request_applied_log_includes_subagent_and_display_fields() {
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_writer(SharedLogWriter(std::sync::Arc::clone(&buffer)))
+            .finish();
+        let context = SubagentPermissionContext {
+            subagent_label: "reviewer".to_owned(),
+            child_tool_name: "Bash".to_owned(),
+            child_tool_title: "Bash".to_owned(),
+            parent_tool_call_id: "agent-1".to_owned(),
+            parent_tool_title: Some("Agent: reviewer".to_owned()),
+            parent_model: Some("claude-opus-4-8".to_owned()),
+            parent_raw_input: None,
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            log_permission_request_applied(
+                "session-1",
+                "bash-1",
+                2,
+                true,
+                Some(&context),
+                PermissionDisplayLogFields {
+                    title: "Allow command?",
+                    name: "Bash",
+                    description: "Runs a command",
+                },
+            );
+        });
+
+        let output =
+            String::from_utf8(buffer.lock().expect("log buffer lock").clone()).expect("utf8 log");
+        assert!(output.contains(r#""subagent_label":"reviewer""#));
+        assert!(output.contains(r#""subagent_parent_tool_call_id":"agent-1""#));
+        assert!(output.contains(r#""subagent_parent_model":"claude-opus-4-8""#));
+        assert!(output.contains(r#""subagent_child_tool_name":"Bash""#));
+        assert!(output.contains(r#""permission_display_title":"Allow command?""#));
+        assert!(output.contains(r#""permission_display_name":"Bash""#));
+        assert!(output.contains(r#""permission_display_description":"Runs a command""#));
+    }
+
+    #[test]
+    fn main_agent_permission_gets_no_subagent_context() {
+        let mut app = App::test_default();
+        push_tool(&mut app, tool_call_info("bash-1", "Bash", "Bash", None, false));
+        app.register_tool_call_scope("bash-1".to_owned(), ToolCallScope::MainAgent);
+        let (tx, _rx) = tokio::sync::oneshot::channel();
+
+        handle_permission_request_event(&mut app, permission_request("bash-1"), tx);
+
+        assert!(pending_permission_context(&app, "bash-1").is_none());
+    }
+
+    #[test]
+    fn subagent_child_permission_resolves_parent_and_child_context() {
+        let mut app = App::test_default();
+        push_tool(
+            &mut app,
+            tool_call_info(
+                "agent-1",
+                "Agent: reviewer",
+                "Agent",
+                Some(serde_json::json!({
+                    "name": "reviewer",
+                    "subagent_type": "general-purpose",
+                    "model": "claude-opus-4-8"
+                })),
+                false,
+            ),
+        );
+        push_tool(&mut app, tool_call_info("bash-1", "Bash", "Bash", None, true));
+        app.register_tool_call_scope("agent-1".to_owned(), ToolCallScope::SubagentRoot);
+        app.register_tool_call_scope(
+            "bash-1".to_owned(),
+            ToolCallScope::SubagentChild { parent_tool_use_id: "agent-1".to_owned() },
+        );
+        let (tx, _rx) = tokio::sync::oneshot::channel();
+
+        handle_permission_request_event(&mut app, permission_request("bash-1"), tx);
+
+        let context = pending_permission_context(&app, "bash-1").expect("subagent context");
+        assert_eq!(context.subagent_label, "reviewer");
+        assert_eq!(context.child_tool_name, "Bash");
+        assert_eq!(context.child_tool_title, "Bash");
+        assert_eq!(context.parent_tool_call_id, "agent-1");
+        assert_eq!(context.parent_tool_title.as_deref(), Some("Agent: reviewer"));
+        assert_eq!(context.parent_model.as_deref(), Some("claude-opus-4-8"));
+        assert!(context.parent_raw_input.is_some());
+    }
+
+    #[test]
+    fn subagent_child_permission_missing_parent_falls_back_cleanly() {
+        let mut app = App::test_default();
+        push_tool(&mut app, tool_call_info("bash-1", "Bash", "Bash", None, true));
+        app.register_tool_call_scope(
+            "bash-1".to_owned(),
+            ToolCallScope::SubagentChild { parent_tool_use_id: "missing-parent".to_owned() },
+        );
+        let (tx, _rx) = tokio::sync::oneshot::channel();
+
+        handle_permission_request_event(&mut app, permission_request("bash-1"), tx);
+
+        let context = pending_permission_context(&app, "bash-1").expect("subagent context");
+        assert_eq!(context.subagent_label, "Subagent");
+        assert_eq!(context.parent_tool_call_id, "missing-parent");
+        assert_eq!(context.parent_tool_title, None);
+        assert_eq!(context.parent_model, None);
+        assert_eq!(context.parent_raw_input, None);
+    }
+
+    #[test]
+    fn subagent_label_prefers_name_over_subagent_type() {
+        let mut app = App::test_default();
+        push_tool(
+            &mut app,
+            tool_call_info(
+                "agent-1",
+                "Agent: reviewer",
+                "Agent",
+                Some(serde_json::json!({
+                    "name": "reviewer",
+                    "subagent_type": "tester"
+                })),
+                false,
+            ),
+        );
+        push_tool(&mut app, tool_call_info("bash-1", "Bash", "Bash", None, true));
+        app.register_tool_call_scope(
+            "bash-1".to_owned(),
+            ToolCallScope::SubagentChild { parent_tool_use_id: "agent-1".to_owned() },
+        );
+        let (tx, _rx) = tokio::sync::oneshot::channel();
+
+        handle_permission_request_event(&mut app, permission_request("bash-1"), tx);
+
+        let context = pending_permission_context(&app, "bash-1").expect("subagent context");
+        assert_eq!(context.subagent_label, "reviewer");
     }
 }

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -449,6 +449,8 @@ fn finish_ready_turn_exit(app: &mut App, exit: TurnExitState, tool_status: model
     app.finalize_turn_runtime_artifacts(tool_status);
     app.status = AppStatus::Ready;
     app.files_accessed = 0;
+    app.rewind_targets_session_id = None;
+    app.rewind_targets_in_flight = false;
     app.sync_git_context();
 
     let removed_tail_assistant = remove_empty_tail_assistant(app, exit.tail_assistant_idx);
@@ -648,7 +650,9 @@ fn request_post_turn_resize_purge_replay_if_needed(app: &mut App) {
         app.terminal_lifecycle,
         super::super::TerminalLifecycleState::Running(super::super::SurfaceMode::Chat)
     ) {
-        app.request_chat_resize_purge_replay_rebuild();
+        app.request_chat_purge_replay_rebuild(
+            super::super::ChatPurgeReplayOptions::post_turn_resize(),
+        );
     }
 }
 
@@ -760,7 +764,9 @@ fn push_turn_error_message(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{App, ChatRebuildKind, SurfaceMode, TerminalLifecycleState};
+    use crate::app::{
+        App, ChatPurgeReplayOptions, ChatRebuildKind, SurfaceMode, TerminalLifecycleState,
+    };
 
     fn empty_assistant_message() -> ChatMessage {
         ChatMessage::new(MessageRole::Assistant, Vec::new(), None)
@@ -949,7 +955,10 @@ mod tests {
 
         handle_turn_complete_event(&mut app, None);
 
-        assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::ResizePurgeReplay);
+        assert_eq!(
+            app.surface_dirty.chat.rebuild,
+            ChatRebuildKind::PurgeReplay(ChatPurgeReplayOptions::post_turn_resize())
+        );
         assert!(app.surface_dirty.chat.repaint);
         assert!(!app.chat_render.resize_purge_replay_after_turn);
     }

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -982,6 +982,7 @@ mod tests {
                     secondary: None,
                 },
             ],
+            placeholder: None,
             dialog: crate::app::dialog::DialogState::default(),
         });
         app.claim_focus_target(FocusTarget::Mention);

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -24,15 +24,74 @@ pub struct FullscreenSurfaceDirtyState {
     pub redraw: bool,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub const RESIZE_PURGE_REPLAY_MAX_ROWS: usize = 9_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChatPurgeReplayReason {
+    Resize,
+    ChatReturnAfterResize,
+    PostTurnResize,
+    SessionReplacement,
+    TerminalHistoryOutOfSync,
+}
+
+impl ChatPurgeReplayReason {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Resize => "resize",
+            Self::ChatReturnAfterResize => "chat_return_after_resize",
+            Self::PostTurnResize => "post_turn_resize",
+            Self::SessionReplacement => "session_replacement",
+            Self::TerminalHistoryOutOfSync => "terminal_history_out_of_sync",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChatPurgeReplayOptions {
+    pub reason: ChatPurgeReplayReason,
+    pub max_replay_rows: Option<usize>,
+}
+
+impl ChatPurgeReplayOptions {
+    pub const fn resize() -> Self {
+        Self {
+            reason: ChatPurgeReplayReason::Resize,
+            max_replay_rows: Some(RESIZE_PURGE_REPLAY_MAX_ROWS),
+        }
+    }
+
+    pub const fn chat_return_after_resize() -> Self {
+        Self {
+            reason: ChatPurgeReplayReason::ChatReturnAfterResize,
+            max_replay_rows: Some(RESIZE_PURGE_REPLAY_MAX_ROWS),
+        }
+    }
+
+    pub const fn post_turn_resize() -> Self {
+        Self {
+            reason: ChatPurgeReplayReason::PostTurnResize,
+            max_replay_rows: Some(RESIZE_PURGE_REPLAY_MAX_ROWS),
+        }
+    }
+
+    pub const fn session_replacement() -> Self {
+        Self { reason: ChatPurgeReplayReason::SessionReplacement, max_replay_rows: None }
+    }
+
+    pub const fn terminal_history_out_of_sync() -> Self {
+        Self { reason: ChatPurgeReplayReason::TerminalHistoryOutOfSync, max_replay_rows: None }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ChatRebuildKind {
     #[default]
     None,
     MutableViewport,
     FullscreenReturn,
     VisibleScreen,
-    ResizePurgeReplay,
-    SessionBoundary,
+    PurgeReplay(ChatPurgeReplayOptions),
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -47,28 +106,29 @@ impl ChatSurfaceDirtyState {
     }
 
     pub fn request_mutable_rebuild(&mut self) {
-        self.rebuild = self.rebuild.max(ChatRebuildKind::MutableViewport);
+        self.request_rebuild(ChatRebuildKind::MutableViewport);
         self.repaint = true;
     }
 
     pub fn request_visible_screen_rebuild(&mut self) {
-        self.rebuild = self.rebuild.max(ChatRebuildKind::VisibleScreen);
+        self.request_rebuild(ChatRebuildKind::VisibleScreen);
         self.repaint = true;
     }
 
     pub fn request_fullscreen_return_rebuild(&mut self) {
-        self.rebuild = self.rebuild.max(ChatRebuildKind::FullscreenReturn);
+        self.request_rebuild(ChatRebuildKind::FullscreenReturn);
         self.repaint = true;
     }
 
-    pub fn request_resize_purge_replay_rebuild(&mut self) {
-        self.rebuild = self.rebuild.max(ChatRebuildKind::ResizePurgeReplay);
+    pub fn request_purge_replay_rebuild(&mut self, options: ChatPurgeReplayOptions) {
+        self.request_rebuild(ChatRebuildKind::PurgeReplay(options));
         self.repaint = true;
     }
 
-    pub fn request_session_boundary_rebuild(&mut self) {
-        self.rebuild = self.rebuild.max(ChatRebuildKind::SessionBoundary);
-        self.repaint = true;
+    fn request_rebuild(&mut self, next: ChatRebuildKind) {
+        if should_replace_rebuild(self.rebuild, next) {
+            self.rebuild = next;
+        }
     }
 
     pub fn take_rebuild(&mut self) -> ChatRebuildKind {
@@ -82,6 +142,38 @@ impl ChatSurfaceDirtyState {
         self.repaint = false;
         repaint
     }
+}
+
+const fn rebuild_priority(kind: ChatRebuildKind) -> u8 {
+    match kind {
+        ChatRebuildKind::None => 0,
+        ChatRebuildKind::MutableViewport | ChatRebuildKind::FullscreenReturn => 1,
+        ChatRebuildKind::VisibleScreen => 2,
+        ChatRebuildKind::PurgeReplay(_) => 3,
+    }
+}
+
+fn should_replace_rebuild(current: ChatRebuildKind, next: ChatRebuildKind) -> bool {
+    let current_priority = rebuild_priority(current);
+    let next_priority = rebuild_priority(next);
+
+    if next_priority != current_priority {
+        return next_priority > current_priority;
+    }
+
+    match (current, next) {
+        (ChatRebuildKind::PurgeReplay(current), ChatRebuildKind::PurgeReplay(next)) => {
+            should_replace_purge_replay(current, next)
+        }
+        _ => true,
+    }
+}
+
+fn should_replace_purge_replay(
+    current: ChatPurgeReplayOptions,
+    next: ChatPurgeReplayOptions,
+) -> bool {
+    !matches!((current.max_replay_rows, next.max_replay_rows), (None, Some(_)))
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -216,30 +308,58 @@ mod tests {
     }
 
     #[test]
-    fn chat_resize_purge_replay_rebuild_dominates_visible_rebuild() {
+    fn chat_purge_replay_rebuild_dominates_visible_rebuild() {
         let mut dirty = ChatSurfaceDirtyState::default();
+        let options = ChatPurgeReplayOptions::resize();
 
         dirty.request_visible_screen_rebuild();
-        dirty.request_resize_purge_replay_rebuild();
+        dirty.request_purge_replay_rebuild(options);
         dirty.request_mutable_rebuild();
         dirty.request_visible_screen_rebuild();
 
-        assert_eq!(dirty.rebuild, ChatRebuildKind::ResizePurgeReplay);
+        assert_eq!(dirty.rebuild, ChatRebuildKind::PurgeReplay(options));
         assert!(dirty.repaint);
     }
 
     #[test]
-    fn chat_session_boundary_rebuild_dominates_visible_rebuild() {
+    fn later_chat_purge_replay_request_replaces_options() {
         let mut dirty = ChatSurfaceDirtyState::default();
+        let resize_options = ChatPurgeReplayOptions::resize();
+        let replacement_options = ChatPurgeReplayOptions::session_replacement();
 
         dirty.request_visible_screen_rebuild();
-        dirty.request_resize_purge_replay_rebuild();
-        dirty.request_session_boundary_rebuild();
+        dirty.request_purge_replay_rebuild(resize_options);
         dirty.request_mutable_rebuild();
         dirty.request_visible_screen_rebuild();
-        dirty.request_resize_purge_replay_rebuild();
+        dirty.request_purge_replay_rebuild(replacement_options);
 
-        assert_eq!(dirty.rebuild, ChatRebuildKind::SessionBoundary);
+        assert_eq!(dirty.rebuild, ChatRebuildKind::PurgeReplay(replacement_options));
+        assert!(dirty.repaint);
+    }
+
+    #[test]
+    fn session_replacement_purge_replay_survives_later_resize_request() {
+        let mut dirty = ChatSurfaceDirtyState::default();
+        let replacement_options = ChatPurgeReplayOptions::session_replacement();
+
+        dirty.request_purge_replay_rebuild(replacement_options);
+        dirty.request_mutable_rebuild();
+        dirty.request_visible_screen_rebuild();
+        dirty.request_purge_replay_rebuild(ChatPurgeReplayOptions::resize());
+
+        assert_eq!(dirty.rebuild, ChatRebuildKind::PurgeReplay(replacement_options));
+        assert!(dirty.repaint);
+    }
+
+    #[test]
+    fn terminal_history_out_of_sync_purge_replay_survives_later_post_turn_resize_request() {
+        let mut dirty = ChatSurfaceDirtyState::default();
+        let out_of_sync_options = ChatPurgeReplayOptions::terminal_history_out_of_sync();
+
+        dirty.request_purge_replay_rebuild(out_of_sync_options);
+        dirty.request_purge_replay_rebuild(ChatPurgeReplayOptions::post_turn_resize());
+
+        assert_eq!(dirty.rebuild, ChatRebuildKind::PurgeReplay(out_of_sync_options));
         assert!(dirty.repaint);
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -54,8 +54,9 @@ pub use events::{handle_client_event, handle_terminal_event};
 pub use focus::{FocusManager, FocusOwner, FocusTarget};
 pub use input::InputState;
 pub use lifecycle::{
-    ChatRebuildKind, ChatSurfaceDirtyState, FullscreenSurfaceDirtyState, ReleaseReason,
-    SurfaceDirtyState, TerminalLifecycleState,
+    ChatPurgeReplayOptions, ChatPurgeReplayReason, ChatRebuildKind, ChatSurfaceDirtyState,
+    FullscreenSurfaceDirtyState, RESIZE_PURGE_REPLAY_MAX_ROWS, ReleaseReason, SurfaceDirtyState,
+    TerminalLifecycleState,
 };
 pub use service_status_check::start_service_status_check;
 pub(crate) use state::MarkdownRenderKey;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -66,11 +66,12 @@ pub use state::{
     InvalidationLevel, LayoutInvalidation, LiveRegionRenderState, LoginHint, McpState,
     MessageBlock, MessageBlockId, MessageRole, MessageUsage, ModeInfo, ModeState, NoticeBlock,
     NoticeDedupKey, NoticeStage, PasteSessionState, PendingCommandAck, RateLimitIncidentKey,
-    RecentSessionInfo, SelectionPoint, SessionPickerState, SessionUsageState, SystemSeverity,
-    TerminalSize, TerminalSizeChange, TerminalSnapshotMode, TextBlock, TextBlockSpacing,
-    ToolCallInfo, ToolCallScope, TurnNoticeLocation, TurnNoticeRef, UpdateNoticeState,
-    UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow, UserDialogBlock,
-    WelcomeBlock, hash_text_block_content, hash_welcome_block_content, is_execute_tool_name,
+    RecentSessionInfo, SelectionPoint, SessionPickerState, SessionUsageState,
+    SubagentPermissionContext, SystemSeverity, TerminalSize, TerminalSizeChange,
+    TerminalSnapshotMode, TextBlock, TextBlockSpacing, ToolCallInfo, ToolCallScope,
+    TurnNoticeLocation, TurnNoticeRef, UpdateNoticeState, UsageSnapshot, UsageSourceKind,
+    UsageSourceMode, UsageState, UsageWindow, UserDialogBlock, WelcomeBlock,
+    hash_text_block_content, hash_welcome_block_content, is_execute_tool_name,
 };
 pub use trust::TrustSelection;
 pub use update_check::start_update_check;

--- a/src/app/permissions.rs
+++ b/src/app/permissions.rs
@@ -343,6 +343,7 @@ mod tests {
             tc.pending_permission = Some(InlinePermission {
                 options,
                 display: None,
+                subagent_context: None,
                 response_tx: tx,
                 selected_index: 0,
                 focused,
@@ -350,6 +351,12 @@ mod tests {
         }
         app.pending_interaction_ids.push(tool_id.to_owned());
         rx
+    }
+
+    fn add_tool_without_permission(app: &mut App, tool_id: &str) {
+        let msg_idx = app.messages.len();
+        app.messages.push(assistant_tool_msg(test_tool_call(tool_id)));
+        app.index_tool_call(tool_id.to_owned(), msg_idx, 0);
     }
 
     fn permission_focused(app: &App, tool_id: &str) -> bool {
@@ -468,5 +475,31 @@ mod tests {
 
         let resp = rx.try_recv().expect("permission should be cancelled");
         assert!(matches!(resp.outcome, model::RequestPermissionOutcome::Cancelled));
+    }
+
+    #[test]
+    fn permission_response_for_subagent_child_uses_child_tool_id() {
+        let mut app = App::test_default();
+        add_tool_without_permission(&mut app, "agent-1");
+        let mut child_rx = add_permission(&mut app, "bash-1", allow_options(), true);
+        app.register_tool_call_scope("agent-1".to_owned(), crate::app::ToolCallScope::SubagentRoot);
+        app.register_tool_call_scope(
+            "bash-1".to_owned(),
+            crate::app::ToolCallScope::SubagentChild { parent_tool_use_id: "agent-1".to_owned() },
+        );
+
+        let consumed = execute_permission_action(
+            &mut app,
+            InteractionAction::Confirm,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        assert_eq!(consumed, KeyOutcome::Handled(true));
+        let response = child_rx.try_recv().expect("child permission should receive response");
+        let model::RequestPermissionOutcome::Selected(selected) = response.outcome else {
+            panic!("expected selected permission response");
+        };
+        assert_eq!(selected.option_id, "allow-once");
+        assert_eq!(app.pending_interaction_ids, Vec::<String>::new());
     }
 }

--- a/src/app/slash/candidates.rs
+++ b/src/app/slash/candidates.rs
@@ -168,11 +168,15 @@ fn is_builtin_variable_input_command(command_name: &str) -> bool {
                     | AppSlashCommand::Mode
                     | AppSlashCommand::Model
                     | AppSlashCommand::Resume
+                    | AppSlashCommand::Rewind
             )
     })
 }
 
 pub(super) fn builtin_argument_confirmation_closes(command_name: &str, arg_index: usize) -> bool {
+    if command_name == "/rewind" {
+        return arg_index == 1;
+    }
     arg_index == 0 && is_builtin_variable_input_command(command_name)
 }
 
@@ -358,7 +362,7 @@ pub(super) fn argument_candidates(
     command_name: &str,
     arg_index: usize,
 ) -> Vec<SlashCandidate> {
-    if arg_index > 0 {
+    if arg_index > 0 && !(command_name == "/rewind" && arg_index == 1) {
         return Vec::new();
     }
 
@@ -380,6 +384,23 @@ pub(super) fn argument_candidates(
                 }
             })
             .collect(),
+        "/rewind" => {
+            if arg_index == 1 {
+                return rewind_restore_mode_candidates();
+            }
+            if app.session_id.as_ref() == app.rewind_targets_session_id.as_ref() {
+                app.rewind_targets
+                    .iter()
+                    .map(|target| SlashCandidate {
+                        insert_value: target.uuid.clone(),
+                        primary: truncate_rewind_label(&target.first_text),
+                        secondary: Some(target.uuid.clone()),
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            }
+        }
         "/mode" => app
             .mode
             .as_ref()
@@ -407,6 +428,84 @@ pub(super) fn argument_candidates(
     }
 }
 
+fn rewind_restore_mode_candidates() -> Vec<SlashCandidate> {
+    vec![
+        SlashCandidate {
+            insert_value: "both".to_owned(),
+            primary: "Restore code and conversation".to_owned(),
+            secondary: Some("revert both code and conversation to that point".to_owned()),
+        },
+        SlashCandidate {
+            insert_value: "conversation".to_owned(),
+            primary: "Restore conversation".to_owned(),
+            secondary: Some("rewind to that message while keeping current code".to_owned()),
+        },
+        SlashCandidate {
+            insert_value: "code".to_owned(),
+            primary: "Restore code".to_owned(),
+            secondary: Some("revert file changes while keeping the conversation".to_owned()),
+        },
+    ]
+}
+
+fn rewind_placeholder(app: &App, query: &str) -> String {
+    if app.rewind_targets_in_flight {
+        return "Loading messages".to_owned();
+    }
+
+    let Some(session_id) = app.session_id.as_ref() else {
+        return "Connect to load messages".to_owned();
+    };
+
+    if app.rewind_targets_session_id.as_ref() != Some(session_id) {
+        if app.conn.is_none() {
+            return "Connect to load messages".to_owned();
+        }
+        return "Loading messages".to_owned();
+    }
+
+    if app.rewind_targets.is_empty() || query.trim().is_empty() {
+        "No previous user messages".to_owned()
+    } else {
+        "No matching messages".to_owned()
+    }
+}
+
+fn placeholder_for_empty_candidates(
+    app: &App,
+    detection: &SlashDetection,
+    candidates: &[SlashCandidate],
+) -> Option<String> {
+    if !candidates.is_empty() {
+        return None;
+    }
+
+    match &detection.context {
+        SlashContext::Argument { command, arg_index, .. }
+            if command == "/rewind" && *arg_index == 0 =>
+        {
+            Some(rewind_placeholder(app, &detection.query))
+        }
+        SlashContext::Argument { command, arg_index, .. }
+            if command == "/rewind" && *arg_index == 1 =>
+        {
+            Some("Select restore mode".to_owned())
+        }
+        _ => None,
+    }
+}
+
+fn truncate_rewind_label(text: &str) -> String {
+    const MAX_CHARS: usize = 80;
+    let text = text.trim();
+    let mut chars = text.chars();
+    let mut label: String = chars.by_ref().take(MAX_CHARS).collect();
+    if chars.next().is_some() {
+        label.push_str("...");
+    }
+    if label.is_empty() { "(empty user message)".to_owned() } else { label }
+}
+
 pub(super) fn build_slash_state(app: &App) -> Option<SlashState> {
     let detection =
         detect_slash_at_cursor(app.input.lines(), app.input.cursor_row(), app.input.cursor_col())?;
@@ -425,12 +524,14 @@ pub(super) fn build_slash_state(app: &App) -> Option<SlashState> {
             )
         }
     };
+    let placeholder = placeholder_for_empty_candidates(app, &detection, &candidates);
     Some(SlashState {
         trigger_row: detection.trigger_row,
         trigger_col: detection.trigger_col,
         query: detection.query,
         context: detection.context,
         candidates,
+        placeholder,
         dialog: DialogState::default(),
     })
 }

--- a/src/app/slash/catalog.rs
+++ b/src/app/slash/catalog.rs
@@ -24,6 +24,7 @@ pub(crate) enum AppSlashCommand {
     Model,
     NewSession,
     Resume,
+    Rewind,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -232,6 +233,14 @@ pub(crate) const APP_SLASH_COMMANDS: &[AppSlashCommandSpec] = &[
         long_description: "Resume a recent or manually supplied session ID.",
         args: NO_ARGS,
     },
+    AppSlashCommandSpec {
+        command: AppSlashCommand::Rewind,
+        name: "/rewind",
+        usage: "Usage: /rewind <user_message_uuid> <both|conversation|code>",
+        short_description: "Restore conversation or code",
+        long_description: "Restore conversation, code, or both to a previous user message.",
+        args: NO_ARGS,
+    },
 ];
 
 impl AppSlashCommand {
@@ -260,6 +269,7 @@ impl AppSlashCommand {
             Self::Model => "/model",
             Self::NewSession => "/new-session",
             Self::Resume => "/resume",
+            Self::Rewind => "/rewind",
         }
     }
 

--- a/src/app/slash/executors.rs
+++ b/src/app/slash/executors.rs
@@ -8,8 +8,11 @@ use super::{
     require_connection, set_command_pending,
 };
 use crate::agent::events::ClientEvent;
+use crate::agent::types::RewindRestoreMode;
 use crate::app::config::{self, SettingFile, store};
-use crate::app::connect::{SessionStartReason, begin_resume_session, start_new_session};
+use crate::app::connect::{
+    SessionStartReason, begin_resume_session, begin_rewind, start_new_session,
+};
 use crate::app::events::push_system_message_with_severity;
 use crate::app::{App, AppStatus, CancelOrigin, ReleaseReason, SystemSeverity};
 use std::fmt::Write as _;
@@ -55,6 +58,7 @@ pub fn try_handle_submit(app: &mut App, text: &str) -> bool {
         AppSlashCommand::Model => handle_model_submit(app, &parsed.args),
         AppSlashCommand::NewSession => handle_new_session_submit(app, &parsed.args),
         AppSlashCommand::Resume => handle_resume_submit(app, &parsed.args),
+        AppSlashCommand::Rewind => handle_rewind_submit(app, &parsed.args),
     }
 }
 
@@ -875,6 +879,48 @@ fn handle_resume_submit(app: &mut App, args: &[&str]) -> bool {
         let _ = app
             .event_tx
             .send(ClientEvent::SlashCommandError(format!("Failed to run /resume: {e}")));
+    }
+    true
+}
+
+fn handle_rewind_submit(app: &mut App, args: &[&str]) -> bool {
+    let [target_uuid, restore_mode_arg] = args else {
+        push_system_message(app, usage(AppSlashCommand::Rewind));
+        return true;
+    };
+    let target_uuid = target_uuid.trim();
+    let restore_mode_arg = restore_mode_arg.trim();
+    if target_uuid.is_empty() || restore_mode_arg.is_empty() || args.len() != 2 {
+        push_system_message(app, usage(AppSlashCommand::Rewind));
+        return true;
+    }
+    let Some(restore_mode) = RewindRestoreMode::from_stored(restore_mode_arg) else {
+        push_system_message(app, usage(AppSlashCommand::Rewind));
+        return true;
+    };
+    let Some(target) = app.rewind_targets.iter().find(|target| target.uuid == target_uuid) else {
+        push_system_message(app, format!("Unknown rewind target: {target_uuid}"));
+        return true;
+    };
+    let target_uuid = target.uuid.clone();
+    let Some((conn, session_id)) = require_active_session(
+        app,
+        "Cannot rewind: not connected yet.",
+        "Cannot rewind: no active session.",
+    ) else {
+        return true;
+    };
+
+    let pending_label = match restore_mode {
+        RewindRestoreMode::Conversation => "Rewinding conversation...",
+        RewindRestoreMode::Code => "Restoring code...",
+        RewindRestoreMode::Both => "Restoring code and conversation...",
+    };
+    set_command_pending(app, pending_label, None);
+    if let Err(e) = begin_rewind(app, &conn, session_id.to_string(), target_uuid, restore_mode) {
+        let _ = app
+            .event_tx
+            .send(ClientEvent::SlashCommandError(format!("Failed to run /rewind: {e}")));
     }
     true
 }

--- a/src/app/slash/mod.rs
+++ b/src/app/slash/mod.rs
@@ -54,6 +54,8 @@ pub struct SlashState {
     pub context: SlashContext,
     /// Filtered list of supported candidates.
     pub candidates: Vec<SlashCandidate>,
+    /// Non-selectable line rendered when no candidates are available.
+    pub placeholder: Option<String>,
     /// Shared autocomplete dialog navigation state.
     pub dialog: DialogState,
 }
@@ -193,6 +195,7 @@ mod tests {
         assert!(names.iter().any(|n| n == "/mcp"), "missing /mcp");
         assert!(names.iter().any(|n| n == "/opus-version"), "missing /opus-version");
         assert!(names.iter().any(|n| n == "/plugins"), "missing /plugins");
+        assert!(names.iter().any(|n| n == "/rewind"), "missing /rewind");
         assert!(names.iter().any(|n| n == "/usage"), "missing /usage");
     }
 
@@ -834,6 +837,139 @@ mod tests {
     }
 
     #[test]
+    fn rewind_argument_candidates_use_cached_targets() {
+        let mut app = App::test_default();
+        let session_id = model::SessionId::new("session-1");
+        app.session_id = Some(session_id.clone());
+        app.rewind_targets_session_id = Some(session_id);
+        app.rewind_targets = vec![
+            model::RewindTarget {
+                uuid: "user-1".to_owned(),
+                first_text: "first prompt".to_owned(),
+                input_text: "first prompt".to_owned(),
+                index: 0,
+                previous_assistant_uuid: None,
+            },
+            model::RewindTarget {
+                uuid: "user-2".to_owned(),
+                first_text: "second prompt".to_owned(),
+                input_text: "second prompt".to_owned(),
+                index: 3,
+                previous_assistant_uuid: Some("assistant-1".to_owned()),
+            },
+        ];
+        app.input.set_text("/rewind second");
+        let _ = app.input.set_cursor(0, "/rewind second".chars().count());
+
+        let slash = super::candidates::build_slash_state(&app).expect("slash state");
+
+        assert!(matches!(slash.context, SlashContext::Argument { .. }));
+        assert_eq!(
+            slash
+                .candidates
+                .iter()
+                .map(|candidate| (
+                    candidate.insert_value.as_str(),
+                    candidate.primary.as_str(),
+                    candidate.secondary.as_deref()
+                ))
+                .collect::<Vec<_>>(),
+            vec![("user-2", "second prompt", Some("user-2"))]
+        );
+    }
+
+    #[test]
+    fn rewind_argument_candidates_hide_stale_targets() {
+        let mut app = App::test_default();
+        app.session_id = Some(model::SessionId::new("session-1"));
+        app.rewind_targets_session_id = Some(model::SessionId::new("old-session"));
+        app.rewind_targets = vec![model::RewindTarget {
+            uuid: "user-1".to_owned(),
+            first_text: "first prompt".to_owned(),
+            input_text: "first prompt".to_owned(),
+            index: 0,
+            previous_assistant_uuid: None,
+        }];
+
+        let candidates = argument_candidates(&app, "/rewind", 0);
+
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn rewind_argument_context_requests_targets_when_cache_is_stale() {
+        let mut app = App::test_default();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+        app.session_id = Some(model::SessionId::new("session-1"));
+        app.input.set_text("/rewind ");
+        let _ = app.input.set_cursor(0, "/rewind ".chars().count());
+
+        sync_with_cursor(&mut app);
+
+        assert!(app.rewind_targets_in_flight);
+        let envelope = rx.try_recv().expect("rewind target request");
+        assert!(matches!(
+            envelope.command,
+            crate::agent::wire::BridgeCommand::GetRewindTargets { session_id }
+                if session_id == "session-1"
+        ));
+    }
+
+    #[test]
+    fn rewind_argument_context_shows_loading_while_request_is_in_flight() {
+        let mut app = App::test_default();
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+        app.session_id = Some(model::SessionId::new("session-1"));
+        app.input.set_text("/rewind ");
+        let _ = app.input.set_cursor(0, "/rewind ".chars().count());
+
+        sync_with_cursor(&mut app);
+
+        let slash = app.slash.as_ref().expect("slash state");
+        assert!(slash.candidates.is_empty());
+        assert_eq!(slash.placeholder.as_deref(), Some("Loading messages"));
+    }
+
+    #[test]
+    fn rewind_argument_context_shows_no_previous_messages_when_loaded_empty() {
+        let mut app = App::test_default();
+        let session_id = model::SessionId::new("session-1");
+        app.session_id = Some(session_id.clone());
+        app.rewind_targets_session_id = Some(session_id);
+        app.input.set_text("/rewind ");
+        let _ = app.input.set_cursor(0, "/rewind ".chars().count());
+
+        let slash = super::candidates::build_slash_state(&app).expect("slash state");
+
+        assert!(slash.candidates.is_empty());
+        assert_eq!(slash.placeholder.as_deref(), Some("No previous user messages"));
+    }
+
+    #[test]
+    fn rewind_argument_context_shows_no_matching_messages_for_filtered_empty_result() {
+        let mut app = App::test_default();
+        let session_id = model::SessionId::new("session-1");
+        app.session_id = Some(session_id.clone());
+        app.rewind_targets_session_id = Some(session_id);
+        app.rewind_targets = vec![model::RewindTarget {
+            uuid: "user-1".to_owned(),
+            first_text: "first prompt".to_owned(),
+            input_text: "first prompt".to_owned(),
+            index: 0,
+            previous_assistant_uuid: None,
+        }];
+        app.input.set_text("/rewind missing");
+        let _ = app.input.set_cursor(0, "/rewind missing".chars().count());
+
+        let slash = super::candidates::build_slash_state(&app).expect("slash state");
+
+        assert!(slash.candidates.is_empty());
+        assert_eq!(slash.placeholder.as_deref(), Some("No matching messages"));
+    }
+
+    #[test]
     fn effort_argument_candidates_include_session_only_max() {
         let mut app = App::test_default();
         app.current_model = Some(
@@ -962,6 +1098,7 @@ mod tests {
         assert!(block.text.contains("/model"));
         assert!(block.text.contains("/new-session"));
         assert!(block.text.contains("/resume"));
+        assert!(block.text.contains("/rewind"));
     }
 
     #[test]
@@ -1056,6 +1193,7 @@ mod tests {
                 primary: "New".to_owned(),
                 secondary: None,
             }],
+            placeholder: None,
             dialog: DialogState::default(),
         });
 
@@ -1121,6 +1259,79 @@ mod tests {
             panic!("expected text block");
         };
         assert_eq!(block.text, "Usage: /resume <session_id>");
+    }
+
+    #[test]
+    fn rewind_with_missing_target_returns_usage() {
+        let mut app = App::test_default();
+
+        let consumed = try_handle_submit(&mut app, "/rewind");
+
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected usage message");
+        };
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "Usage: /rewind <user_message_uuid> <both|conversation|code>");
+    }
+
+    #[test]
+    fn rewind_with_cached_target_requires_connection() {
+        let mut app = App::test_default();
+        app.rewind_targets = vec![model::RewindTarget {
+            uuid: "user-1".to_owned(),
+            first_text: "first prompt".to_owned(),
+            input_text: "first prompt".to_owned(),
+            index: 0,
+            previous_assistant_uuid: None,
+        }];
+
+        let consumed = try_handle_submit(&mut app, "/rewind user-1 conversation");
+
+        assert!(consumed);
+        let Some(last) = app.messages.last() else {
+            panic!("expected selection message");
+        };
+        assert!(matches!(last.role, MessageRole::System(Some(SystemSeverity::Error))));
+        let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+            panic!("expected text block");
+        };
+        assert_eq!(block.text, "Cannot rewind: not connected yet.");
+    }
+
+    #[test]
+    fn rewind_with_cached_target_sends_bridge_command() {
+        let mut app = App::test_default();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+        app.session_id = Some(model::SessionId::new("session-1"));
+        app.rewind_targets = vec![model::RewindTarget {
+            uuid: "user-1".to_owned(),
+            first_text: "first prompt".to_owned(),
+            input_text: "first prompt".to_owned(),
+            index: 0,
+            previous_assistant_uuid: None,
+        }];
+
+        let consumed = try_handle_submit(&mut app, "/rewind user-1 conversation");
+
+        assert!(consumed);
+        assert_eq!(app.pending_command_label.as_deref(), Some("Rewinding conversation..."));
+        let envelope = rx.try_recv().expect("rewind command");
+        let crate::agent::wire::BridgeCommand::Rewind {
+            session_id,
+            target_user_message_id,
+            restore_mode,
+            ..
+        } = envelope.command
+        else {
+            panic!("expected rewind command");
+        };
+        assert_eq!(session_id, "session-1");
+        assert_eq!(target_user_message_id, "user-1");
+        assert_eq!(restore_mode, crate::agent::types::RewindRestoreMode::Conversation);
     }
 
     #[test]
@@ -1665,6 +1876,7 @@ mod tests {
                 primary: "/mode".into(),
                 secondary: None,
             }],
+            placeholder: None,
             dialog: DialogState::default(),
         });
 
@@ -1688,6 +1900,7 @@ mod tests {
                 primary: "/docs".into(),
                 secondary: Some("Show in-chat help topics".into()),
             }],
+            placeholder: None,
             dialog: DialogState::default(),
         });
 
@@ -1734,6 +1947,7 @@ mod tests {
                     primary: value.to_owned(),
                     secondary: None,
                 }],
+                placeholder: None,
                 dialog: DialogState::default(),
             });
 

--- a/src/app/slash/navigation.rs
+++ b/src/app/slash/navigation.rs
@@ -4,7 +4,9 @@
 //! Slash command autocomplete navigation: activate, deactivate, sync,
 //! move selection, and confirm.
 
-use super::candidates::{build_slash_state, builtin_argument_confirmation_closes};
+use super::candidates::{
+    build_slash_state, builtin_argument_confirmation_closes, detect_slash_at_cursor,
+};
 use super::{SlashContext, SlashState};
 use crate::app::{AUTOCOMPLETE_VISIBLE_ROWS, App, FocusTarget};
 
@@ -55,7 +57,46 @@ fn replacement_range(slash: &SlashState, chars: &[char]) -> Option<(usize, usize
     }
 }
 
+fn request_rewind_targets_for_active_argument(app: &mut App) {
+    let Some(detection) =
+        detect_slash_at_cursor(app.input.lines(), app.input.cursor_row(), app.input.cursor_col())
+    else {
+        return;
+    };
+    let SlashContext::Argument { command, arg_index, .. } = detection.context else {
+        return;
+    };
+    if command != "/rewind" || arg_index != 0 || app.rewind_targets_in_flight {
+        return;
+    }
+    let Some(session_id) = app.session_id.clone() else {
+        return;
+    };
+    if app.rewind_targets_session_id.as_ref() == Some(&session_id) {
+        return;
+    }
+    let Some(conn) = app.conn.clone() else {
+        return;
+    };
+    let session_id_text = session_id.to_string();
+    app.rewind_targets_in_flight = true;
+    app.rewind_targets.clear();
+    app.rewind_targets_session_id = None;
+    if let Err(err) = conn.get_rewind_targets(session_id_text.clone()) {
+        app.rewind_targets_in_flight = false;
+        tracing::warn!(
+            target: crate::logging::targets::APP_SESSION,
+            event_name = "rewind_targets_request_failed",
+            message = "failed to request rewind targets",
+            outcome = "failure",
+            session_id = %session_id_text,
+            error_message = %err,
+        );
+    }
+}
+
 pub fn activate(app: &mut App) {
+    request_rewind_targets_for_active_argument(app);
     let Some(state) = build_slash_state(app) else {
         return;
     };
@@ -67,6 +108,7 @@ pub fn activate(app: &mut App) {
 }
 
 pub fn update_query(app: &mut App) {
+    request_rewind_targets_for_active_argument(app);
     let Some(next_state) = build_slash_state(app) else {
         deactivate(app);
         return;
@@ -80,6 +122,7 @@ pub fn update_query(app: &mut App) {
         slash.query = next_state.query;
         slash.context = next_state.context;
         slash.candidates = next_state.candidates;
+        slash.placeholder = next_state.placeholder;
         slash.dialog = dialog;
         slash.dialog.clamp(slash.candidates.len(), AUTOCOMPLETE_VISIBLE_ROWS);
     } else {
@@ -89,6 +132,7 @@ pub fn update_query(app: &mut App) {
 }
 
 pub fn sync_with_cursor(app: &mut App) {
+    request_rewind_targets_for_active_argument(app);
     match (build_slash_state(app), app.slash.is_some()) {
         (Some(_), true) => update_query(app),
         (Some(_), false) => activate(app),

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -211,6 +211,12 @@ pub struct App {
     pub keymap: ResolvedKeymap,
     /// Commands advertised by the agent via `AvailableCommandsUpdate`.
     pub available_commands: Vec<model::AvailableCommand>,
+    /// Rewind candidates loaded from persisted SDK session history.
+    pub rewind_targets: Vec<model::RewindTarget>,
+    /// Session id that owns `rewind_targets`.
+    pub rewind_targets_session_id: Option<model::SessionId>,
+    /// True while a rewind target refresh request is in flight.
+    pub rewind_targets_in_flight: bool,
     /// Plugin inventory and UI state for the Config > Plugins view.
     pub plugins: PluginsState,
     /// Subagents advertised by the agent via `AvailableAgentsUpdate`.
@@ -408,12 +414,11 @@ impl App {
         self.surface_dirty.chat.request_fullscreen_return_rebuild();
     }
 
-    pub(crate) fn request_chat_resize_purge_replay_rebuild(&mut self) {
-        self.surface_dirty.chat.request_resize_purge_replay_rebuild();
-    }
-
-    pub(crate) fn request_chat_session_boundary_rebuild(&mut self) {
-        self.surface_dirty.chat.request_session_boundary_rebuild();
+    pub(crate) fn request_chat_purge_replay_rebuild(
+        &mut self,
+        options: super::ChatPurgeReplayOptions,
+    ) {
+        self.surface_dirty.chat.request_purge_replay_rebuild(options);
     }
 
     pub(crate) fn request_fullscreen_repaint(&mut self) {
@@ -866,6 +871,9 @@ impl App {
             focus: FocusManager::default(),
             keymap: ResolvedKeymap::defaults(),
             available_commands: Vec::new(),
+            rewind_targets: Vec::new(),
+            rewind_targets_session_id: None,
+            rewind_targets_in_flight: false,
             plugins: PluginsState::default(),
             available_agents: Vec::new(),
             available_models: Vec::new(),
@@ -1035,6 +1043,9 @@ impl App {
         self.mode = None;
         self.fast_mode_state = model::FastModeState::Off;
         self.session_usage = SessionUsageState::default();
+        self.rewind_targets.clear();
+        self.rewind_targets_session_id = None;
+        self.rewind_targets_in_flight = false;
     }
 
     pub fn reconcile_trust_state_from_preferences_and_cwd(&mut self) {
@@ -2496,6 +2507,7 @@ mod tests {
                 primary: "/config".into(),
                 secondary: Some("Open settings".into()),
             }],
+            placeholder: None,
             dialog: crate::app::dialog::DialogState::default(),
         });
         app

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -24,7 +24,8 @@ pub use messages::{
     hash_text_block_content, hash_welcome_block_content,
 };
 pub use tool_call_info::{
-    InlinePermission, InlineQuestion, TerminalSnapshotMode, ToolCallInfo, is_execute_tool_name,
+    InlinePermission, InlineQuestion, SubagentPermissionContext, TerminalSnapshotMode,
+    ToolCallInfo, is_execute_tool_name,
 };
 pub use types::{
     AppStatus, CancelOrigin, ExtraUsage, HistoryRetentionPolicy, HistoryRetentionStats, LoginHint,
@@ -1659,6 +1660,7 @@ mod tests {
                         model::PermissionOptionKind::AllowOnce,
                     )],
                     display: None,
+                    subagent_context: None,
                     response_tx: tx,
                     selected_index: 0,
                     focused: false,

--- a/src/app/state/tool_call_info.rs
+++ b/src/app/state/tool_call_info.rs
@@ -41,6 +41,17 @@ pub struct ToolCallInfo {
     pub pending_question: Option<InlineQuestion>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubagentPermissionContext {
+    pub subagent_label: String,
+    pub child_tool_name: String,
+    pub child_tool_title: String,
+    pub parent_tool_call_id: String,
+    pub parent_tool_title: Option<String>,
+    pub parent_model: Option<String>,
+    pub parent_raw_input: Option<serde_json::Value>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TerminalSnapshotMode {
     AppendOnly,
@@ -101,16 +112,12 @@ impl ToolCallInfo {
 
     #[must_use]
     pub fn hidden_unless_focused_interaction(&self) -> bool {
-        self.hidden
-            && !self.pending_permission.as_ref().is_some_and(|permission| permission.focused)
-            && !self.pending_question.as_ref().is_some_and(|question| question.focused)
+        self.hidden && self.pending_permission.is_none() && self.pending_question.is_none()
     }
 
     #[must_use]
     pub fn is_hidden_focused_interaction(&self) -> bool {
-        self.hidden
-            && (self.pending_permission.as_ref().is_some_and(|permission| permission.focused)
-                || self.pending_question.as_ref().is_some_and(|question| question.focused))
+        self.hidden && (self.pending_permission.is_some() || self.pending_question.is_some())
     }
 
     #[must_use]
@@ -163,6 +170,7 @@ pub fn is_exit_plan_mode_tool_name(tool_name: &str) -> bool {
 pub struct InlinePermission {
     pub options: Vec<model::PermissionOption>,
     pub display: Option<model::PermissionDisplay>,
+    pub subagent_context: Option<SubagentPermissionContext>,
     pub response_tx: tokio::sync::oneshot::Sender<model::RequestPermissionResponse>,
     pub selected_index: usize,
     /// Whether this permission currently has keyboard focus.

--- a/src/app/terminal_runtime/chat_session.rs
+++ b/src/app/terminal_runtime/chat_session.rs
@@ -3,7 +3,7 @@
 
 use super::chat_terminal::{ChatDrawRequest, ChatTerminal, HistoryBatchKind, PendingHistoryBatch};
 use super::history_insert::RenderedHistoryRows;
-use crate::app::{App, HistoryOutputId};
+use crate::app::{App, ChatPurgeReplayOptions, HistoryOutputId};
 use crate::ui::footer_rows::serialize_footer_rows;
 use crate::ui::inline_chat_rows::LiveRowBoundaryKind;
 use crate::ui::inline_chat_rows::{
@@ -59,32 +59,23 @@ impl ChatTerminalSession {
         self.history.reset();
     }
 
-    pub(super) fn clear_session_boundary(&mut self, app: &mut App) {
-        if let Err(err) = self.terminal.reset_session_boundary() {
+    pub(super) fn clear_for_purge_replay(
+        &mut self,
+        app: &mut App,
+        options: ChatPurgeReplayOptions,
+    ) {
+        if let Err(err) = self.terminal.reset_purge_replay(options.reason.label()) {
             tracing::warn!(
                 target: crate::logging::targets::APP_RENDER,
-                event_name = "inline_chat_session_boundary_clear_failed",
-                message = "failed to clear inline terminal for session boundary",
+                event_name = "inline_chat_purge_replay_failed",
+                message = "failed to purge terminal before transcript replay",
                 outcome = "failure",
+                reason = %options.reason.label(),
                 error_message = %err,
             );
         }
         app.chat_render.invalidate_live_anchor();
-        self.history.reset();
-    }
-
-    pub(super) fn clear_for_resize_purge_replay(&mut self, app: &mut App) {
-        if let Err(err) = self.terminal.reset_resize_purge_replay() {
-            tracing::warn!(
-                target: crate::logging::targets::APP_RENDER,
-                event_name = "inline_chat_resize_purge_replay_failed",
-                message = "failed to purge terminal before resize replay",
-                outcome = "failure",
-                error_message = %err,
-            );
-        }
-        app.chat_render.invalidate_live_anchor();
-        self.history.reset_for_resize_purge_replay();
+        self.history.reset_for_purge_replay(options.max_replay_rows);
     }
 
     pub(super) fn clear_mutable_viewport(&mut self, app: &mut App) {
@@ -453,7 +444,7 @@ impl ChatTerminalSession {
 }
 
 fn mark_chat_terminal_history_out_of_sync(app: &mut App) {
-    app.request_chat_resize_purge_replay_rebuild();
+    app.request_chat_purge_replay_rebuild(ChatPurgeReplayOptions::terminal_history_out_of_sync());
 }
 
 fn log_prepared_draw(prepared: &PreparedDrawLog<'_>) {
@@ -549,19 +540,12 @@ struct HistoryCommitState {
     width: u16,
     confirmed: BTreeSet<HistoryOutputId>,
     history_in_sync: bool,
-    cap_next_purge_replay: bool,
+    replay_row_cap: Option<usize>,
 }
-
-const RESIZE_PURGE_REPLAY_MAX_ROWS: usize = 9_000;
 
 impl Default for HistoryCommitState {
     fn default() -> Self {
-        Self {
-            width: 0,
-            confirmed: BTreeSet::new(),
-            history_in_sync: true,
-            cap_next_purge_replay: false,
-        }
+        Self { width: 0, confirmed: BTreeSet::new(), history_in_sync: true, replay_row_cap: None }
     }
 }
 
@@ -570,8 +554,8 @@ impl HistoryCommitState {
         *self = Self::default();
     }
 
-    fn reset_for_resize_purge_replay(&mut self) {
-        *self = Self { history_in_sync: false, cap_next_purge_replay: true, ..Self::default() };
+    fn reset_for_purge_replay(&mut self, max_replay_rows: Option<usize>) {
+        *self = Self { history_in_sync: false, replay_row_cap: max_replay_rows, ..Self::default() };
     }
 
     fn confirmed_ids(&self) -> &BTreeSet<HistoryOutputId> {
@@ -587,21 +571,21 @@ impl HistoryCommitState {
     }
 
     fn cap_replay_rows(&self) -> Option<usize> {
-        self.cap_next_purge_replay.then_some(RESIZE_PURGE_REPLAY_MAX_ROWS)
+        self.replay_row_cap
     }
 
     fn confirm(&mut self, width: u16, ids: Vec<HistoryOutputId>) {
         self.width = width.max(1);
         self.confirmed.extend(ids);
         self.history_in_sync = true;
-        self.cap_next_purge_replay = false;
+        self.replay_row_cap = None;
     }
 
     fn mark_terminal_history_synced(&mut self, width: u16, ids: Vec<HistoryOutputId>) {
         self.width = width.max(1);
         self.confirmed.extend(ids);
         self.history_in_sync = true;
-        self.cap_next_purge_replay = false;
+        self.replay_row_cap = None;
     }
 
     fn mark_out_of_sync(&mut self) {
@@ -1245,11 +1229,23 @@ mod tests {
         let mut state = HistoryCommitState::default();
         state.confirm(80, vec![output_id()]);
 
-        state.reset_for_resize_purge_replay();
+        state.reset_for_purge_replay(Some(crate::app::RESIZE_PURGE_REPLAY_MAX_ROWS));
 
         assert!(!state.is_synced());
         assert_eq!(state.confirmed_len(), 0);
-        assert_eq!(state.cap_replay_rows(), Some(super::RESIZE_PURGE_REPLAY_MAX_ROWS));
+        assert_eq!(state.cap_replay_rows(), Some(crate::app::RESIZE_PURGE_REPLAY_MAX_ROWS));
+    }
+
+    #[test]
+    fn session_replacement_purge_replay_marks_history_unsynced_without_cap() {
+        let mut state = HistoryCommitState::default();
+        state.confirm(80, vec![output_id()]);
+
+        state.reset_for_purge_replay(None);
+
+        assert!(!state.is_synced());
+        assert_eq!(state.confirmed_len(), 0);
+        assert_eq!(state.cap_replay_rows(), None);
     }
 
     #[test]
@@ -1257,7 +1253,7 @@ mod tests {
         let mut state = HistoryCommitState::default();
         let id = output_id();
 
-        state.reset_for_resize_purge_replay();
+        state.reset_for_purge_replay(Some(crate::app::RESIZE_PURGE_REPLAY_MAX_ROWS));
         state.mark_terminal_history_synced(80, vec![id.clone()]);
 
         assert!(state.is_synced());

--- a/src/app/terminal_runtime/chat_terminal.rs
+++ b/src/app/terminal_runtime/chat_terminal.rs
@@ -19,7 +19,7 @@ use std::io::{Stdout, Write};
 
 type StdoutBackend = CrosstermBackend<Stdout>;
 type StdoutTerminal = Terminal<StdoutBackend>;
-pub(super) const RESIZE_PURGE_REPLAY_CLEAR_ANSI: &str = "\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H";
+pub(super) const PURGE_REPLAY_CLEAR_ANSI: &str = "\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H";
 const MIN_REPLAY_BATCH_ROWS: usize = 32;
 const MAX_REPLAY_BATCH_ROWS: usize = 160;
 
@@ -153,27 +153,22 @@ impl ChatTerminal {
         self.reset_visible_with_reason("visible_reset")
     }
 
-    pub(super) fn reset_session_boundary(&mut self) -> anyhow::Result<()> {
-        let cleared_area = self.clear_owned_region("session_boundary_reset")?;
-        self.reset_after_owned_region_clear(cleared_area);
-        Ok(())
-    }
-
-    pub(super) fn reset_resize_purge_replay(&mut self) -> anyhow::Result<()> {
+    pub(super) fn reset_purge_replay(&mut self, reason: &'static str) -> anyhow::Result<()> {
         let (terminal_width, terminal_height) = crossterm::terminal::size()
-            .context("failed to read terminal size before resize purge")?;
+            .context("failed to read terminal size before purge replay")?;
         let mut stdout = std::io::stdout();
         stdout
-            .write_all(RESIZE_PURGE_REPLAY_CLEAR_ANSI.as_bytes())
-            .context("failed to queue resize purge replay clear")?;
-        stdout.flush().context("failed to flush resize purge replay clear")?;
+            .write_all(PURGE_REPLAY_CLEAR_ANSI.as_bytes())
+            .context("failed to queue purge replay clear")?;
+        stdout.flush().context("failed to flush purge replay clear")?;
 
-        self.reset_after_resize_purge_replay_clear(terminal_width, terminal_height);
+        self.reset_after_purge_replay_clear(terminal_width, terminal_height);
         tracing::debug!(
             target: crate::logging::targets::APP_RENDER,
-            event_name = "inline_chat_resize_purge_replay_cleared",
-            message = "terminal scrollback and visible screen cleared before resize replay",
+            event_name = "inline_chat_purge_replay_cleared",
+            message = "terminal scrollback and visible screen cleared before transcript replay",
             outcome = "success",
+            reason,
             terminal_width = terminal_width.max(1),
             terminal_height = terminal_height.max(1),
             owned_top = self.state.owned_top,
@@ -204,7 +199,7 @@ impl ChatTerminal {
         }
     }
 
-    fn reset_after_resize_purge_replay_clear(&mut self, terminal_width: u16, terminal_height: u16) {
+    fn reset_after_purge_replay_clear(&mut self, terminal_width: u16, terminal_height: u16) {
         let screen_height = terminal_height.max(1);
         self.terminal = None;
         self.pending_history.clear();
@@ -1436,20 +1431,17 @@ mod tests {
     }
 
     #[test]
-    fn resize_purge_replay_uses_codex_clear_sequence() {
-        assert_eq!(
-            super::RESIZE_PURGE_REPLAY_CLEAR_ANSI,
-            "\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H"
-        );
+    fn purge_replay_uses_codex_clear_sequence() {
+        assert_eq!(super::PURGE_REPLAY_CLEAR_ANSI, "\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H");
     }
 
     #[test]
-    fn resize_purge_replay_reset_anchors_viewport_at_top() {
+    fn purge_replay_reset_anchors_viewport_at_top() {
         let mut terminal = ChatTerminal::new(12);
         terminal.state.owned_bottom = 29;
         terminal.state.area = Some(Rect::new(0, 17, 120, 6));
 
-        terminal.reset_after_resize_purge_replay_clear(120, 39);
+        terminal.reset_after_purge_replay_clear(120, 39);
 
         assert!(terminal.terminal.is_none());
         assert_eq!(terminal.state.owned_top, 0);
@@ -1460,7 +1452,7 @@ mod tests {
     #[test]
     fn scrollback_preflight_rejects_full_height_resize_replay_insert() {
         let mut terminal = ChatTerminal::new(0);
-        terminal.reset_after_resize_purge_replay_clear(124, 32);
+        terminal.reset_after_purge_replay_clear(124, 32);
 
         let can_insert = terminal.can_insert_scrollback_rows(
             ChatDrawRequest {

--- a/src/app/terminal_runtime/mod.rs
+++ b/src/app/terminal_runtime/mod.rs
@@ -196,12 +196,8 @@ impl TerminalRuntime {
                     session.clear(app);
                     Ok(())
                 }
-                ChatRebuildKind::ResizePurgeReplay => {
-                    session.clear_for_resize_purge_replay(app);
-                    Ok(())
-                }
-                ChatRebuildKind::SessionBoundary => {
-                    session.clear_session_boundary(app);
+                ChatRebuildKind::PurgeReplay(options) => {
+                    session.clear_for_purge_replay(app, options);
                     Ok(())
                 }
             },
@@ -311,7 +307,9 @@ fn plan_surface_transition(from: SurfaceMode, to: SurfaceMode) -> SurfaceTransit
 
 fn request_chat_rebuild_after_fullscreen_exit(app: &mut App, reused_chat_session: bool) {
     if app.chat_render.take_resize_purge_replay_on_chat_return() {
-        app.request_chat_resize_purge_replay_rebuild();
+        app.request_chat_purge_replay_rebuild(
+            crate::app::ChatPurgeReplayOptions::chat_return_after_resize(),
+        );
     } else if reused_chat_session {
         app.request_chat_fullscreen_return_rebuild();
     } else {
@@ -424,7 +422,12 @@ mod tests {
 
         request_chat_rebuild_after_fullscreen_exit(&mut app, true);
 
-        assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::ResizePurgeReplay);
+        assert_eq!(
+            app.surface_dirty.chat.rebuild,
+            ChatRebuildKind::PurgeReplay(
+                crate::app::ChatPurgeReplayOptions::chat_return_after_resize()
+            )
+        );
         assert!(app.surface_dirty.chat.repaint);
         assert!(!app.chat_render.resize_purge_replay_on_chat_return);
     }

--- a/src/app/view/tests.rs
+++ b/src/app/view/tests.rs
@@ -30,6 +30,7 @@ fn busy_view_test_app() -> App {
         query: "/co".to_owned(),
         context: SlashContext::CommandName,
         candidates: vec![],
+        placeholder: None,
         dialog: DialogState::default(),
     });
     app.subagent = Some(SubagentState {

--- a/src/ui/autocomplete.rs
+++ b/src/ui/autocomplete.rs
@@ -107,7 +107,7 @@ fn dropdown_lines(dropdown: &Dropdown<'_>, meta: &DropdownMeta) -> Vec<Line<'sta
         }
         Dropdown::Slash(s) => {
             if s.candidates.is_empty() {
-                lines.push(hint_line("Type a command name after /"));
+                lines.push(slash_placeholder_line(s));
             } else {
                 for (i, candidate) in s.candidates[meta.start..meta.end].iter().enumerate() {
                     lines.push(slash_candidate_line(s, candidate, meta.start + i));
@@ -130,6 +130,11 @@ fn dropdown_lines(dropdown: &Dropdown<'_>, meta: &DropdownMeta) -> Vec<Line<'sta
 fn mention_placeholder_line(mention: &mention::MentionState) -> Line<'static> {
     let message = mention.placeholder_message().unwrap_or_default();
     hint_line(&message)
+}
+
+fn slash_placeholder_line(slash: &slash::SlashState) -> Line<'static> {
+    let message = slash.placeholder.as_deref().unwrap_or("Type a command name after /");
+    hint_line(message)
 }
 
 fn hint_line(message: &str) -> Line<'static> {
@@ -189,7 +194,7 @@ fn slash_candidate_line(
     }
 
     if let Some(secondary) = &candidate.secondary {
-        spans.push(Span::styled("  ", Style::default().fg(theme::DIM)));
+        spans.push(Span::styled("  | ", Style::default().fg(theme::DIM)));
         spans.push(Span::styled(secondary.clone(), Style::default().fg(theme::DIM)));
     }
 
@@ -382,6 +387,23 @@ mod tests {
         assert_eq!(composer_hint_height(&app), 5);
         assert_eq!(rows.len(), 5);
         assert!(line_text(&rows[0]).contains("/1m-context"));
+    }
+
+    #[test]
+    fn slash_empty_state_renders_command_placeholder() {
+        let mut app = App::test_default();
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+        app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+        app.input.set_text("/rewind ");
+        let _ = app.input.set_cursor(0, "/rewind ".chars().count());
+        slash::sync_with_cursor(&mut app);
+
+        let rows = composer_hint_rows(&app);
+
+        assert_eq!(composer_hint_height(&app), 1);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(line_text(&rows[0]), "  [ Loading messages");
     }
 
     #[test]

--- a/src/ui/footer_rows.rs
+++ b/src/ui/footer_rows.rs
@@ -570,6 +570,7 @@ mod tests {
                 pending_permission: Some(InlinePermission {
                     options: vec![],
                     display: None,
+                    subagent_context: None,
                     response_tx,
                     selected_index: 0,
                     focused: true,

--- a/src/ui/inline_chat_rows.rs
+++ b/src/ui/inline_chat_rows.rs
@@ -1401,6 +1401,7 @@ mod tests {
             tool.pending_permission = Some(crate::app::InlinePermission {
                 options: Vec::new(),
                 display: None,
+                subagent_context: None,
                 response_tx,
                 selected_index: 0,
                 focused: true,
@@ -1429,6 +1430,53 @@ mod tests {
         }
 
         MessageBlock::ToolCall(Box::new(tool))
+    }
+
+    fn tool_call_block_with_pending_permission(
+        id: &str,
+        hidden: bool,
+        focused: bool,
+    ) -> MessageBlock {
+        let mut block = tool_call_block(id, hidden);
+        let MessageBlock::ToolCall(tool) = &mut block else {
+            unreachable!("tool_call_block always returns a tool call");
+        };
+        let (response_tx, _response_rx) = tokio::sync::oneshot::channel();
+        tool.pending_permission = Some(crate::app::InlinePermission {
+            options: Vec::new(),
+            display: None,
+            subagent_context: None,
+            response_tx,
+            selected_index: 0,
+            focused,
+        });
+        block
+    }
+
+    fn tool_call_block_with_subagent_pending_permission(id: &str) -> MessageBlock {
+        let mut block = tool_call_block_with_pending_permission(id, true, true);
+        let MessageBlock::ToolCall(tool) = &mut block else {
+            unreachable!("tool_call_block_with_pending_permission returns a tool call");
+        };
+        let permission = tool.pending_permission.as_mut().expect("pending permission");
+        permission.options = vec![
+            model::PermissionOption::new(
+                "allow",
+                "Allow once",
+                model::PermissionOptionKind::AllowOnce,
+            ),
+            model::PermissionOption::new("deny", "Deny", model::PermissionOptionKind::RejectOnce),
+        ];
+        permission.subagent_context = Some(crate::app::SubagentPermissionContext {
+            subagent_label: "general-purpose".to_owned(),
+            child_tool_name: "Bash".to_owned(),
+            child_tool_title: "Child Tool".to_owned(),
+            parent_tool_call_id: "agent-1".to_owned(),
+            parent_tool_title: Some("Agent: general-purpose".to_owned()),
+            parent_model: Some("claude-opus-4-8".to_owned()),
+            parent_raw_input: None,
+        });
+        block
     }
 
     #[test]
@@ -1882,7 +1930,7 @@ mod tests {
     }
 
     #[test]
-    fn hidden_canonical_tool_with_focused_permission_renders_interaction_rows() {
+    fn hidden_canonical_tool_with_focused_permission_without_subagent_context_has_no_header() {
         let mut app = App::test_default();
         app.messages.push(assistant_blocks_message(vec![tool_call_block_with_interaction(
             "child-1", true, true, false,
@@ -1897,6 +1945,82 @@ mod tests {
                 text.iter().any(|line| line.contains("Child Tool")),
                 "missing tool title at width {width}: {text:?}"
             );
+            assert!(
+                !text.iter().any(|line| line.contains("Subagent:")),
+                "unexpected subagent header at width {width}: {text:?}"
+            );
+            assert!(
+                !text.iter().any(|line| line.contains("Subagent ·")),
+                "unexpected subagent title prefix at width {width}: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn hidden_canonical_tool_with_unfocused_permission_renders_interaction_rows() {
+        let mut app = App::test_default();
+        app.messages.push(assistant_blocks_message(vec![tool_call_block_with_pending_permission(
+            "child-1", true, false,
+        )]));
+
+        for width in [32, 120, 32] {
+            let rows = serialize_live_rows(&mut app, width);
+            let text = line_texts(&rows);
+
+            assert!(text.iter().any(|line| line == "Claude"), "missing label at width {width}");
+            assert!(
+                text.iter().any(|line| line.contains("Child Tool")),
+                "missing tool title at width {width}: {text:?}"
+            );
+            assert!(
+                text.iter().any(|line| line.contains("Waiting for input")),
+                "missing waiting row at width {width}: {text:?}"
+            );
+            assert!(
+                !text.iter().any(|line| line.contains("Subagent:")),
+                "unexpected subagent header at width {width}: {text:?}"
+            );
+            assert!(
+                !text.iter().any(|line| line.contains("Subagent ·")),
+                "unexpected subagent title prefix at width {width}: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn hidden_canonical_tool_with_subagent_permission_prefixes_child_tool_title() {
+        let mut app = App::test_default();
+        app.messages.push(assistant_blocks_message(vec![
+            tool_call_block_with_subagent_pending_permission("child-1"),
+        ]));
+
+        for width in [80, 120, 80] {
+            let rows = serialize_live_rows(&mut app, width);
+            let text = line_texts(&rows);
+
+            let child_idx = text
+                .iter()
+                .position(|line| line.contains("Subagent ·") && line.contains("Child Tool"))
+                .expect("missing prefixed child tool line");
+            assert!(
+                !text[child_idx].contains("general-purpose"),
+                "subagent label should not render at width {width}: {text:?}"
+            );
+            let permission_idx = text
+                .iter()
+                .position(|line| line.contains("Allow once"))
+                .expect("missing permission options");
+
+            assert!(child_idx < permission_idx, "permission rendered before child: {text:?}");
+            assert_eq!(
+                text.iter().filter(|line| line.contains("Subagent ·")).count(),
+                1,
+                "expected one prefixed subagent title at width {width}: {text:?}"
+            );
+            assert!(!text.iter().any(|line| line.contains("Subagent:")));
+            assert!(!text.iter().any(|line| line.contains("[model:")));
+            assert!(!text.iter().any(|line| line.contains("Agent:")));
+            assert!(!text.iter().any(|line| line.contains("general-purpose")));
         }
     }
 

--- a/src/ui/tool_call/interactions.rs
+++ b/src/ui/tool_call/interactions.rs
@@ -23,19 +23,19 @@ pub(super) fn render_permission_lines(
         return render_plan_approval_lines(tc, perm);
     }
 
-    // Unfocused permissions: show a dimmed "waiting for focus" line
+    let mut lines = vec![Line::default()];
+    // Unfocused permissions: show a dimmed "waiting for focus" line.
     if !perm.focused {
-        return vec![
-            Line::default(),
-            Line::from(Span::styled(
-                "  \u{25cb} Waiting for input... (Tab to focus)",
-                Style::default().fg(theme::DIM),
-            )),
-        ];
+        lines.push(Line::from(Span::styled(
+            "  \u{25cb} Waiting for input... (Tab to focus)",
+            Style::default().fg(theme::DIM),
+        )));
+        return lines;
     }
 
-    let mut lines = vec![Line::default()];
-    if let Some(display) = permission_display_lines(tc, perm) {
+    if perm.subagent_context.is_none()
+        && let Some(display) = permission_display_lines(tc, perm)
+    {
         lines.extend(display);
     }
 
@@ -474,6 +474,7 @@ mod tests {
                 PermissionOption::new("deny", "Deny", reject_kind),
             ],
             display: None,
+            subagent_context: None,
             response_tx,
             selected_index: 0,
             focused: true,
@@ -586,6 +587,91 @@ mod tests {
 
         assert!(!rendered.contains("\n  Strava: List activities\n"));
         assert!(rendered.contains("This action reads activity metadata"));
+    }
+
+    #[test]
+    fn subagent_permission_context_does_not_render_metadata_rows() {
+        let tc = test_tool_call("Bash");
+        let mut perm = test_permission(PermissionOptionKind::AllowOnce);
+        perm.subagent_context = Some(crate::app::SubagentPermissionContext {
+            subagent_label: "reviewer".to_owned(),
+            child_tool_name: "Bash".to_owned(),
+            child_tool_title: "Bash".to_owned(),
+            parent_tool_call_id: "agent-1".to_owned(),
+            parent_tool_title: Some("Agent: reviewer".to_owned()),
+            parent_model: None,
+            parent_raw_input: None,
+        });
+
+        let rendered = render_permission_lines(&tc, &perm)
+            .into_iter()
+            .map(|line| {
+                line.spans.into_iter().map(|span| span.content.into_owned()).collect::<String>()
+            })
+            .collect::<Vec<_>>();
+
+        assert!(!rendered.iter().any(|line| line.contains("Subagent:")));
+        assert!(!rendered.iter().any(|line| line.contains("Tool:")));
+        assert!(rendered.iter().any(|line| line.contains("Allow")));
+    }
+
+    #[test]
+    fn unfocused_subagent_permission_keeps_normal_waiting_row() {
+        let tc = test_tool_call("Bash");
+        let mut perm = test_permission(PermissionOptionKind::AllowOnce);
+        perm.focused = false;
+        perm.subagent_context = Some(crate::app::SubagentPermissionContext {
+            subagent_label: "reviewer".to_owned(),
+            child_tool_name: "Bash".to_owned(),
+            child_tool_title: "Bash".to_owned(),
+            parent_tool_call_id: "agent-1".to_owned(),
+            parent_tool_title: Some("Agent: reviewer".to_owned()),
+            parent_model: None,
+            parent_raw_input: None,
+        });
+
+        let rendered = render_permission_lines(&tc, &perm)
+            .into_iter()
+            .map(|line| {
+                line.spans.into_iter().map(|span| span.content.into_owned()).collect::<String>()
+            })
+            .collect::<Vec<_>>();
+
+        assert!(!rendered.iter().any(|line| line.contains("Subagent:")));
+        assert!(!rendered.iter().any(|line| line.contains("Tool:")));
+        assert!(rendered.iter().any(|line| line.contains("Waiting for input")));
+    }
+
+    #[test]
+    fn subagent_permission_suppresses_sdk_display_metadata() {
+        let tc = test_tool_call("Write");
+        let mut perm = test_permission(PermissionOptionKind::AllowOnce);
+        perm.display = Some(
+            PermissionDisplay::new()
+                .display_name(Some("Write".to_owned()))
+                .description(Some("subagent_one_probe.txt".to_owned())),
+        );
+        perm.subagent_context = Some(crate::app::SubagentPermissionContext {
+            subagent_label: "general-purpose".to_owned(),
+            child_tool_name: "Write".to_owned(),
+            child_tool_title: "Write subagent_one_probe.txt".to_owned(),
+            parent_tool_call_id: "agent-1".to_owned(),
+            parent_tool_title: Some("Agent: general-purpose".to_owned()),
+            parent_model: None,
+            parent_raw_input: None,
+        });
+
+        let rendered = render_permission_lines(&tc, &perm)
+            .into_iter()
+            .map(|line| {
+                line.spans.into_iter().map(|span| span.content.into_owned()).collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(!rendered.contains("subagent_one_probe.txt"));
+        assert!(!rendered.contains("\n  Write\n"));
+        assert!(rendered.contains("Allow"));
     }
 
     #[test]

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -800,6 +800,7 @@ mod tests {
                 ),
             ],
             display: None,
+            subagent_context: None,
             response_tx,
             selected_index: 0,
             focused: true,
@@ -810,6 +811,81 @@ mod tests {
 
         assert!(rendered.iter().any(|line| line.contains("wrapped")));
         assert!(rendered.iter().any(|line| line.contains("Allow")));
+    }
+
+    #[test]
+    fn render_tool_call_cached_prefixes_hidden_subagent_child_permission_title() {
+        let mut tc = test_tool_call(
+            "Write probe text to result file",
+            "Write",
+            model::ToolCallStatus::InProgress,
+        );
+        tc.hidden = true;
+        tc.content = vec![model::ToolCallContent::from("running...".to_owned())];
+        let (response_tx, _response_rx) = tokio::sync::oneshot::channel();
+        tc.pending_permission = Some(crate::app::InlinePermission {
+            options: vec![
+                model::PermissionOption::new(
+                    "allow_once",
+                    "Allow once",
+                    model::PermissionOptionKind::AllowOnce,
+                ),
+                model::PermissionOption::new(
+                    "allow_always",
+                    "Always allow",
+                    model::PermissionOptionKind::AllowAlways,
+                ),
+                model::PermissionOption::new(
+                    "deny",
+                    "Deny",
+                    model::PermissionOptionKind::RejectOnce,
+                ),
+            ],
+            display: Some(
+                model::PermissionDisplay::new()
+                    .display_name(Some("Write".to_owned()))
+                    .description(Some("probe file".to_owned())),
+            ),
+            subagent_context: Some(crate::app::SubagentPermissionContext {
+                subagent_label: "general-purpose".to_owned(),
+                child_tool_name: "Write".to_owned(),
+                child_tool_title: "Write probe text to result file".to_owned(),
+                parent_tool_call_id: "agent-1".to_owned(),
+                parent_tool_title: Some("Agent: general-purpose".to_owned()),
+                parent_model: Some("claude-opus-4-8".to_owned()),
+                parent_raw_input: None,
+            }),
+            response_tx,
+            selected_index: 0,
+            focused: true,
+        });
+
+        let mut rendered = Vec::new();
+        render_tool_call_cached(&mut tc, ToolCallRenderContext::default(), 100, 0, &mut rendered);
+        let text = rendered_line_texts_trimmed(&rendered);
+
+        let first = text.first().expect("missing tool title row");
+        assert!(first.contains("Subagent ·"), "missing inline subagent marker: {text:?}");
+        assert!(
+            first.contains("Write probe text to result file"),
+            "first row should be the child tool title: {text:?}"
+        );
+        let child_idx = text
+            .iter()
+            .position(|line| line.contains("Write probe text to result file"))
+            .expect("missing child tool title");
+        let content_idx =
+            text.iter().position(|line| line.contains("running...")).expect("missing content");
+        let permission_idx =
+            text.iter().position(|line| line.contains("Allow once")).expect("missing permission");
+
+        assert_eq!(child_idx, 0, "child title should be the first row: {text:?}");
+        assert!(child_idx < content_idx, "content should follow child title: {text:?}");
+        assert!(content_idx < permission_idx, "permission should follow child content: {text:?}");
+        assert!(!text.iter().any(|line| line.contains("general-purpose")));
+        assert!(!text.iter().any(|line| line.contains("[model:")));
+        assert!(!text.iter().any(|line| line.contains("Agent:")));
+        assert!(!text.iter().any(|line| line.contains("probe file")));
     }
 
     #[test]

--- a/src/ui/tool_call/standard.rs
+++ b/src/ui/tool_call/standard.rs
@@ -68,11 +68,25 @@ pub(super) fn render_tool_call_title(
         ));
     }
 
+    if let Some(prefix) = hidden_subagent_permission_title_prefix(tc) {
+        title_spans.push(prefix);
+    }
+
     let display_title = tool_display_title(tc, render_context);
     title_spans.extend(markdown_inline_spans(display_title.as_ref()));
     title_spans.extend(tool_output_badge_spans(tc));
 
     Line::from(truncate_spans_to_width(title_spans, usize::from(width)))
+}
+
+fn hidden_subagent_permission_title_prefix(tc: &ToolCallInfo) -> Option<Span<'static>> {
+    let has_subagent_permission = tc
+        .pending_permission
+        .as_ref()
+        .is_some_and(|permission| permission.subagent_context.is_some());
+    (tc.hidden && has_subagent_permission).then(|| {
+        Span::styled("Subagent · ", Style::default().fg(theme::DIM).add_modifier(Modifier::BOLD))
+    })
 }
 
 /// Render the body lines (everything after the title) for a tool call.


### PR DESCRIPTION
## Summary

- Update the Claude Agent SDK integration to `0.3.193`, including bridge/root package pins, lockfiles, and the runtime compatibility guard.
- Add `/rewind` support with target discovery, autocomplete placeholders, conversation restore, code restore, combined restore mode, session replacement, and restored input handling.
- Preserve and render newer SDK outputs, including MCP resource directory listings, SDK-created resume sessions, rate-limit credit metadata, new informational/system message subtypes, worker shutdown notices, and model-refusal-without-fallback notices.
- Refine UI behavior for subagent permission prompts and rate-limit bucket labels while expanding Rust and bridge coverage for the new event and wire shapes.

## Why

This keeps the Rust TUI bridge compatible with the current Claude Agent SDK surface and exposes the new recovery and runtime metadata that the SDK now provides. The branch also makes newer SDK messages user-readable instead of leaking raw SDK fields or silently dropping important state.

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `npm --prefix agent-sdk test`
- Manual:
  - Reviewed branch history and diff against `main` for the Agent SDK migration, `/rewind` flow, MCP resource directory rendering, rate-limit metadata, resume listing behavior, and system notice handling.
- Screenshot/video (if UI changed): Not captured.

## Notes

- Breaking changes: N/A
- Docs updated: Yes, `/rewind` is added to `docs/src/commands.md`.
