### PR TITLE
chore(release): prepare 0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.12.4] - 2026-06-26 [Changes][v0.12.4]
 
 ### Features
 
@@ -627,7 +627,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
-[Unreleased]: https://github.com/srothgan/claude-code-rust/compare/v0.12.3...main
+[v0.12.4]: https://github.com/srothgan/claude-code-rust/compare/v0.12.3...v0.12.4
 [v0.12.3]: https://github.com/srothgan/claude-code-rust/compare/v0.12.2...v0.12.3
 [v0.12.2]: https://github.com/srothgan/claude-code-rust/compare/v0.12.1...v0.12.2
 [v0.12.1]: https://github.com/srothgan/claude-code-rust/compare/v0.12.0...v0.12.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump the crate package version and lockfile metadata to `0.12.4`.
- Promote the changelog `Unreleased` entries to the `0.12.4` release dated `2026-06-26`.

## Why

Prepare the `0.12.4` release branch with the version metadata and changelog state expected for tagging.

Closes #

## Validation

- Automated:
  - [x] `cargo check --offline`
  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test`
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: CHANGELOG only
