### PR TITLE
feat: improve @ mention autocomplete and streamed table rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **Mention file autocomplete** (#226, @srothgan): Move `@` file matching off the UI path, support raw indexed file and folder mentions with spaces, and keep suggestions stable while refreshed queries are pending.
+
 ### Documentation
 
 - **README banner** (#217, @srothgan): Add a project screenshot banner to the README.
@@ -11,6 +15,8 @@ All notable changes to this project will be documented in this file.
 ### Fixes
 
 - **Inline chat resize transactions** (#217, @srothgan): Treat terminal size as a draw-transaction snapshot, recover from mid-draw resizes with purge/replay, and clip stale inline viewport geometry before owned-region clears.
+- **Mention autocomplete ranking and replacement** (#226, @srothgan): Resolve spaced `@` mention spans from active state and indexed paths, preserve whole-mention replacement boundaries, and rank shallow project paths ahead of deep dependency matches unless the query explicitly targets the deep path.
+- **Streaming markdown tables** (#226, @srothgan): Preserve table rendering across streamed cache splits so partial assistant updates do not corrupt table layout.
 
 ### Maintenance
 
@@ -20,6 +26,7 @@ All notable changes to this project will be documented in this file.
 
 - **quinn-proto advisory fix** (#220, @srothgan): Bump `quinn-proto` to `0.11.15` for `RUSTSEC-2026-0185` (remote memory exhaustion from unbounded out-of-order stream reassembly).
 - **Security Audit workflow resilience** (#220, @srothgan): Mark the `cargo audit` step `continue-on-error` so newly published advisories still report and file a tracking issue without failing the scheduled Security Audit run.
+- **Dependency updates** (#221, #222, #224, #223): Bump `uuid` to `1.23.4`, `anyhow` to `1.0.103`, `tui-markdown` to `0.3.8`, and `knip` to `6.23.0` in `agent-sdk`.
 
 ## [0.12.4] - 2026-06-26 [Changes][v0.12.4]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "libc",
  "notify",
  "notify-rust",
+ "nucleo",
  "pretty_assertions",
  "pulldown-cmark",
  "ratatui",
@@ -2079,6 +2080,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleo"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4"
+dependencies = [
+ "nucleo-matcher",
+ "parking_lot",
+ "rayon",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +2847,26 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ ignore = "0.4.25"
 libc = "0.2"
 notify = "8.2.0"
 notify-rust = "4.17.0"
+nucleo = "0.5.0"
 pulldown-cmark = "0.13.4"
 ratatui = { version = "0.30.1", features = ["unstable-rendered-line-info", "scrolling-regions"] }
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls"] }

--- a/README.md
+++ b/README.md
@@ -47,15 +47,17 @@ Full documentation is available at [srothgan.github.io/claude-code-rust](https:/
 
 ## Why
 
-The stock Claude Code TUI runs on Node.js with React Ink. This causes real problems:
+The stock Claude Code TUI runs on Node.js with React Ink, which renders by redrawing full frames over raw ANSI escape codes. This causes real, widely-reported problems:
 
-- **Memory**: 200-400MB baseline vs ~20-50MB for a native binary
-- **Startup**: 2-5 seconds vs under 100ms
-- **Scrollback**: Broken virtual scrolling that loses history
-- **Input latency**: Event queue delays on keystroke handling
-- **Copy/paste**: Custom implementation instead of native terminal support
+- **Flickering**: The whole view is redrawn on every status update, causing constant flicker — bad enough to crash editors' integrated terminals during long sessions
+- **CPU**: Sustained high CPU even when idle, and runaway loops that spawn multiple background processes
+- **Memory**: 200-400MB baseline (and climbing with conversation length) vs ~20-50MB for a native binary
+- **Resize**: Window resizing leaves duplicated frames in scrollback, loses lines when shrinking, and can garble the display
+- **Input latency**: Keystrokes echo with visible delay as context fills up, and noticeably worse on Windows
+- **Scrollback**: Hijacks the terminal's native scrollback, erasing history you can no longer scroll back to
+- **Paste**: Large pastes can flood stdout and freeze the terminal
 
-Claude Code Rust fixes all of these by compiling to a single native binary with direct terminal control via Crossterm.
+Claude Code Rust addresses these by compiling to a single native binary with diffed, direct terminal control via Crossterm and Ratatui — no full-frame redraws, no Node runtime overhead.
 
 ## Documentation
 

--- a/src/app/cache_policy.rs
+++ b/src/app/cache_policy.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Simon Peter Rothgang
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Range;
+
 pub const DEFAULT_CACHE_SPLIT_SOFT_LIMIT_BYTES: usize = 1536;
 pub const DEFAULT_CACHE_SPLIT_HARD_LIMIT_BYTES: usize = 4096;
 pub const DEFAULT_TOOL_PREVIEW_LIMIT_BYTES: usize = 2048;
@@ -49,6 +51,7 @@ pub struct TextSplitDecision {
 #[must_use]
 pub fn find_text_split(text: &str, policy: CacheSplitPolicy) -> Option<TextSplitDecision> {
     let bytes = text.as_bytes();
+    let table_ranges = markdown_table_ranges(text);
     let mut in_fence = false;
     let mut i = 0usize;
 
@@ -67,6 +70,10 @@ pub fn find_text_split(text: &str, policy: CacheSplitPolicy) -> Option<TextSplit
         if !in_fence {
             if i + 1 < bytes.len() && bytes[i] == b'\n' && bytes[i + 1] == b'\n' {
                 let split_at = i + 2;
+                if split_inside_markdown_table(split_at, &table_ranges) {
+                    i += 1;
+                    continue;
+                }
                 if split_at < bytes.len() {
                     return Some(TextSplitDecision {
                         split_at,
@@ -76,7 +83,7 @@ pub fn find_text_split(text: &str, policy: CacheSplitPolicy) -> Option<TextSplit
                 return None;
             }
 
-            if bytes[i] == b'\n' {
+            if bytes[i] == b'\n' && !split_inside_markdown_table(i + 1, &table_ranges) {
                 track_text_split_candidate(
                     i + 1,
                     &policy,
@@ -86,7 +93,8 @@ pub fn find_text_split(text: &str, policy: CacheSplitPolicy) -> Option<TextSplit
                 );
             }
 
-            if is_sentence_boundary(bytes, i) {
+            if is_sentence_boundary(bytes, i) && !split_inside_markdown_table(i + 1, &table_ranges)
+            {
                 track_text_split_candidate(
                     i + 1,
                     &policy,
@@ -122,6 +130,17 @@ pub fn find_text_split_index(text: &str, policy: CacheSplitPolicy) -> Option<usi
     find_text_split(text, policy).map(|decision| decision.split_at)
 }
 
+#[must_use]
+pub(crate) fn markdown_table_tail_is_open(text: &str) -> bool {
+    markdown_table_ranges(text).last().is_some_and(|range| range.end == text.len())
+}
+
+#[must_use]
+pub(crate) fn starts_with_markdown_table_row(text: &str) -> bool {
+    let first_line = text.split_inclusive('\n').next().unwrap_or(text);
+    markdown_table_row_cells(line_content(first_line)).is_some()
+}
+
 fn track_text_split_candidate(
     split_at: usize,
     policy: &CacheSplitPolicy,
@@ -148,9 +167,113 @@ fn is_sentence_boundary(bytes: &[u8], i: usize) -> bool {
         && (i + 1 == bytes.len() || matches!(bytes[i + 1], b' ' | b'\t' | b'\r' | b'\n'))
 }
 
+fn split_inside_markdown_table(split_at: usize, ranges: &[Range<usize>]) -> bool {
+    ranges.iter().any(|range| split_at > range.start && split_at < range.end)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MarkdownLine<'a> {
+    start: usize,
+    end: usize,
+    content: &'a str,
+}
+
+fn markdown_table_ranges(text: &str) -> Vec<Range<usize>> {
+    let lines = markdown_lines(text);
+    let mut ranges = Vec::new();
+    let mut in_fence = false;
+    let mut idx = 0usize;
+
+    while idx < lines.len() {
+        let line = lines[idx];
+        let trimmed = line.content.trim();
+        if markdown_fence_line(trimmed) {
+            in_fence = !in_fence;
+            idx += 1;
+            continue;
+        }
+
+        if !in_fence
+            && idx + 1 < lines.len()
+            && markdown_table_row_cells(line.content).is_some()
+            && markdown_table_delimiter_cells(lines[idx + 1].content).is_some()
+        {
+            let start = line.start;
+            let mut end = lines[idx + 1].end;
+            let mut next_idx = idx + 2;
+            while next_idx < lines.len() {
+                let next = lines[next_idx];
+                let next_trimmed = next.content.trim();
+                if next_trimmed.is_empty() || markdown_fence_line(next_trimmed) {
+                    break;
+                }
+                if markdown_table_row_cells(next.content).is_none() {
+                    break;
+                }
+                end = next.end;
+                next_idx += 1;
+            }
+            ranges.push(start..end);
+            idx = next_idx;
+            continue;
+        }
+
+        idx += 1;
+    }
+
+    ranges
+}
+
+fn markdown_lines(text: &str) -> Vec<MarkdownLine<'_>> {
+    let mut lines = Vec::new();
+    let mut start = 0usize;
+    for raw in text.split_inclusive('\n') {
+        let end = start + raw.len();
+        lines.push(MarkdownLine { start, end, content: line_content(raw) });
+        start = end;
+    }
+    if start < text.len() {
+        lines.push(MarkdownLine { start, end: text.len(), content: line_content(&text[start..]) });
+    }
+    lines
+}
+
+fn line_content(line: &str) -> &str {
+    line.trim_end_matches('\n').trim_end_matches('\r')
+}
+
+fn markdown_fence_line(trimmed: &str) -> bool {
+    trimmed.starts_with("```") || trimmed.starts_with("~~~")
+}
+
+fn markdown_table_row_cells(line: &str) -> Option<Vec<&str>> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || !trimmed.contains('|') {
+        return None;
+    }
+
+    let without_leading = trimmed.strip_prefix('|').unwrap_or(trimmed);
+    let without_outer = without_leading.strip_suffix('|').unwrap_or(without_leading);
+    Some(without_outer.split('|').map(str::trim).collect())
+}
+
+fn markdown_table_delimiter_cells(line: &str) -> Option<Vec<&str>> {
+    let cells = markdown_table_row_cells(line)?;
+    (!cells.is_empty() && cells.iter().all(|cell| markdown_table_delimiter_cell(cell)))
+        .then_some(cells)
+}
+
+fn markdown_table_delimiter_cell(cell: &str) -> bool {
+    let trimmed = cell.trim();
+    let without_leading_align = trimmed.strip_prefix(':').unwrap_or(trimmed);
+    let core = without_leading_align.strip_suffix(':').unwrap_or(without_leading_align);
+    core.len() >= 3 && core.bytes().all(|byte| byte == b'-')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt::Write as _;
 
     #[test]
     fn split_prefers_double_newline() {
@@ -172,5 +295,70 @@ mod tests {
     fn split_ignores_double_newline_inside_fence() {
         let text = "```rust\nfirst\n\nsecond\n```";
         assert!(find_text_split_index(text, *default_cache_split_policy()).is_none());
+    }
+
+    #[test]
+    fn split_does_not_cut_inside_long_markdown_table() {
+        let policy = *default_cache_split_policy();
+        let mut rows = String::new();
+        for idx in 0..80 {
+            let _ = writeln!(
+                rows,
+                "| Slow startup {idx} | Users report delayed echo once context is large. | https://example.com/issues/{idx}?query=very-long-value |"
+            );
+        }
+        let text = format!("| Hassle | Report | Ref |\n| --- | --- | --- |\n{rows}");
+
+        assert!(text.len() > policy.hard_limit_bytes);
+        assert!(find_text_split_index(&text, policy).is_none());
+    }
+
+    #[test]
+    fn split_allows_boundary_after_table_closing_blank_line() {
+        let policy = CacheSplitPolicy {
+            soft_limit_bytes: 32,
+            hard_limit_bytes: 256,
+            preview_limit_bytes: DEFAULT_TOOL_PREVIEW_LIMIT_BYTES,
+        };
+        let text = "| Hassle | Report |\n| --- | --- |\n| Slow startup | Delayed echo. |\n\nNext paragraph.";
+
+        let split_at = find_text_split_index(text, policy);
+
+        assert_eq!(
+            split_at,
+            Some("| Hassle | Report |\n| --- | --- |\n| Slow startup | Delayed echo. |\n\n".len())
+        );
+    }
+
+    #[test]
+    fn ordinary_paragraphs_still_split_at_soft_newline() {
+        let policy = CacheSplitPolicy {
+            soft_limit_bytes: 32,
+            hard_limit_bytes: 256,
+            preview_limit_bytes: DEFAULT_TOOL_PREVIEW_LIMIT_BYTES,
+        };
+        let prefix = "ordinary paragraph line";
+        let text = format!("{prefix}\nnext line keeps streaming");
+
+        let split_at = find_text_split_index(&text, policy).expect("expected soft split");
+
+        assert_eq!(&text[..split_at], format!("{prefix}\n"));
+    }
+
+    #[test]
+    fn table_detection_supports_empty_cells_and_long_url_cells() {
+        let policy = *default_cache_split_policy();
+        let mut rows = String::new();
+        for idx in 0..60 {
+            let _ = writeln!(
+                rows,
+                "| Row {idx} |  | https://example.com/articles/{idx}/with/a/very/long/path?alpha=beta&gamma=delta |"
+            );
+        }
+        let text = format!("| Name | Empty | URL |\n| --- | --- | --- |\n{rows}");
+
+        assert!(text.len() > policy.hard_limit_bytes);
+        assert!(markdown_table_tail_is_open(&text));
+        assert!(find_text_split_index(&text, policy).is_none());
     }
 }

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -19,6 +19,7 @@ use crate::app::{
 };
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use pretty_assertions::assert_eq;
+use std::fmt::Write as _;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -657,6 +658,59 @@ fn agent_message_chunk_splits_into_frozen_text_blocks() {
     assert_eq!(b1.trailing_spacing, TextBlockSpacing::ParagraphBreak);
     assert_eq!(b2.trailing_spacing, TextBlockSpacing::ParagraphBreak);
     assert_eq!(b3.trailing_spacing, TextBlockSpacing::None);
+}
+
+#[test]
+fn streaming_long_markdown_table_does_not_leave_raw_pipe_row_tail() {
+    let mut rows = String::new();
+    for idx in 0..70 {
+        let _ = writeln!(
+            rows,
+            "| Slow startup {idx} | Startup output lands after a long delay once context is large. | https://example.com/issues/{idx}/very/long/reference |"
+        );
+    }
+    let table = format!("| Hassle | What users report | Refs |\n| --- | --- | --- |\n{rows}");
+    assert!(table.len() > crate::app::DEFAULT_CACHE_SPLIT_SOFT_LIMIT_BYTES);
+    let mut app = make_test_app();
+
+    handle_client_event(
+        &mut app,
+        ClientEvent::SessionUpdate(model::SessionUpdate::AgentMessageChunk(
+            model::ContentChunk::new(model::ContentBlock::Text(model::TextContent::new(&table))),
+        )),
+    );
+
+    assert!(matches!(app.status, AppStatus::Running));
+    let serialized = crate::ui::inline_chat_rows::serialize_live_rows_with_boundaries_excluding(
+        &mut app,
+        180,
+        &std::collections::BTreeSet::new(),
+    );
+    let committed_ids = serialized
+        .segments()
+        .iter()
+        .filter(|segment| segment.commit_ready)
+        .flat_map(|segment| segment.ids.iter().cloned())
+        .collect::<std::collections::BTreeSet<_>>();
+    let remaining = crate::ui::inline_chat_rows::serialize_live_rows_with_boundaries_excluding(
+        &mut app,
+        180,
+        &committed_ids,
+    );
+    let remaining_text = remaining
+        .rows()
+        .iter()
+        .map(|row| row.spans.iter().map(|span| span.content.as_ref()).collect::<String>())
+        .collect::<Vec<_>>();
+
+    assert!(
+        remaining_text.iter().any(|line| line.contains("Slow startup")),
+        "expected table rows to remain visible: {remaining_text:?}"
+    );
+    assert!(
+        !remaining_text.iter().any(|line| line.trim_start().starts_with("| Slow startup |")),
+        "live tail must not render raw Markdown table rows: {remaining_text:?}"
+    );
 }
 
 // has_in_progress_tool_calls

--- a/src/app/file_index.rs
+++ b/src/app/file_index.rs
@@ -2,17 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::App;
-use std::collections::{BTreeMap, BTreeSet};
+use nucleo::pattern::{CaseMatching, Normalization};
+use nucleo::{Config as NucleoConfig, Injector, Nucleo, Utf32String};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
-use std::sync::mpsc::{self, RecvTimeoutError, Sender, TryRecvError};
-use std::time::{Duration, SystemTime};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, TryRecvError};
+use std::time::{Duration, Instant, SystemTime};
 
 const SCAN_BATCH_SIZE: usize = 256;
 const EVENT_DRAIN_BUDGET: usize = 64;
 const WATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const WATCH_DEBOUNCE_INTERVAL: Duration = Duration::from_millis(50);
 const MAX_CANDIDATES: usize = 50;
+const NUCLEO_COLUMNS: u32 = 1;
+const NUCLEO_QUERY_TICK_MS: u64 = 10;
+const MATCHER_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 #[derive(Clone, Debug)]
 pub struct FileCandidate {
@@ -29,12 +35,14 @@ pub struct FileIndexState {
     pub root: Option<PathBuf>,
     pub respect_gitignore: bool,
     pub generation: u64,
+    pub index_version: u64,
     pub entries: BTreeMap<String, FileCandidate>,
     pub scan_finished: bool,
     pub rebuild_pending: bool,
     scan_overrides: ScanOverrides,
     pub scan: Option<FileIndexScanHandle>,
     pub watch: Option<FileIndexWatchHandle>,
+    pub matcher: Option<FileIndexMatcherHandle>,
 }
 
 pub struct FileIndexScanHandle {
@@ -45,6 +53,39 @@ pub struct FileIndexWatchHandle {
     cancel: Arc<AtomicBool>,
 }
 
+pub struct FileIndexMatcherHandle {
+    index_tx: Sender<FileIndexMatcherCommand>,
+    query_tx: Sender<MentionMatchRequest>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct EventApplyStats {
+    index_changed: bool,
+    mention_changed: bool,
+    scan_entries: usize,
+    fs_changes: usize,
+    rebuilds: usize,
+    scan_finished: bool,
+    match_results: usize,
+}
+
+impl EventApplyStats {
+    fn merge(&mut self, other: Self) {
+        self.index_changed |= other.index_changed;
+        self.mention_changed |= other.mention_changed;
+        self.scan_entries += other.scan_entries;
+        self.fs_changes += other.fs_changes;
+        self.rebuilds += other.rebuilds;
+        self.scan_finished |= other.scan_finished;
+        self.match_results += other.match_results;
+    }
+}
+
+fn elapsed_ms(started_at: Instant) -> u128 {
+    started_at.elapsed().as_millis()
+}
+
+#[derive(Clone)]
 pub enum FileIndexChange {
     Upsert(FileCandidate),
     RemoveExact { rel_path: String },
@@ -57,6 +98,32 @@ pub enum FileIndexEvent {
     ScanFinished { generation: u64 },
     FsBatch { generation: u64, changes: Vec<FileIndexChange> },
     RebuildRequested { generation: u64 },
+    MatchResult(MentionMatchResult),
+}
+
+#[derive(Clone, Debug)]
+pub struct MentionMatchRequest {
+    pub generation: u64,
+    pub index_version: u64,
+    pub sequence: u64,
+    pub query: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct MentionMatchResult {
+    pub generation: u64,
+    pub index_version: u64,
+    pub sequence: u64,
+    pub query: String,
+    pub candidates: Vec<FileCandidate>,
+    pub scan_finished: bool,
+}
+
+enum FileIndexMatcherCommand {
+    Reset { generation: u64, index_version: u64, entries: Vec<FileCandidate>, scan_finished: bool },
+    ScanBatch { generation: u64, index_version: u64, entries: Vec<FileCandidate> },
+    ScanFinished { generation: u64, index_version: u64 },
+    FsBatch { generation: u64, index_version: u64, changes: Vec<FileIndexChange> },
 }
 
 #[derive(Default)]
@@ -79,6 +146,7 @@ impl Drop for FileIndexWatchHandle {
 
 pub fn reset(app: &mut App) {
     app.file_index.generation = app.file_index.generation.saturating_add(1);
+    app.file_index.index_version = 0;
     app.file_index.root = None;
     app.file_index.respect_gitignore = app.config.respect_gitignore_effective();
     app.file_index.entries.clear();
@@ -87,18 +155,45 @@ pub fn reset(app: &mut App) {
     app.file_index.scan_overrides = ScanOverrides::default();
     app.file_index.scan = None;
     app.file_index.watch = None;
+    app.file_index.matcher = None;
 }
 
 pub fn restart(app: &mut App) {
+    let previous_root = app.file_index.root.clone();
+    let previous_entries = app.file_index.entries.len();
+    let previous_generation = app.file_index.generation;
     reset(app);
     let root = PathBuf::from(&app.cwd_raw);
     let generation = app.file_index.generation;
     let respect_gitignore = app.config.respect_gitignore_effective();
+    tracing::info!(
+        target: crate::logging::targets::APP_FILE_INDEX,
+        event_name = "file_index_restart",
+        message = "file index restart requested",
+        previous_generation,
+        generation,
+        previous_root = %previous_root
+            .as_ref()
+            .map_or_else(|| "<none>".to_owned(), |root| root.display().to_string()),
+        root = %root.display(),
+        previous_entries,
+        respect_gitignore,
+    );
     app.file_index.root = Some(root.clone());
     app.file_index.respect_gitignore = respect_gitignore;
     app.file_index.scan_finished = false;
     app.file_index.rebuild_pending = false;
     app.file_index.scan_overrides = ScanOverrides::default();
+    app.file_index.matcher = Some(spawn_matcher(generation, app.file_index_event_tx.clone()));
+    send_matcher_command(
+        app,
+        FileIndexMatcherCommand::Reset {
+            generation,
+            index_version: app.file_index.index_version,
+            entries: Vec::new(),
+            scan_finished: false,
+        },
+    );
     app.file_index.scan = Some(spawn_scan(
         root.clone(),
         generation,
@@ -112,17 +207,52 @@ pub fn restart(app: &mut App) {
 pub fn ensure_started(app: &mut App) {
     let respect_gitignore = app.config.respect_gitignore_effective();
     let current_root = PathBuf::from(&app.cwd_raw);
-    let needs_restart = app.file_index.root.as_ref() != Some(&current_root)
-        || app.file_index.respect_gitignore != respect_gitignore
-        || (app.file_index.root.is_none())
-        || (!app.file_index.scan_finished && app.file_index.scan.is_none());
+    let root_changed = app.file_index.root.as_ref() != Some(&current_root);
+    let respect_gitignore_changed = app.file_index.respect_gitignore != respect_gitignore;
+    let missing_root = app.file_index.root.is_none();
+    let scan_missing_while_unfinished =
+        !app.file_index.scan_finished && app.file_index.scan.is_none();
+    let needs_restart =
+        root_changed || respect_gitignore_changed || missing_root || scan_missing_while_unfinished;
     if needs_restart {
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_ensure_restart",
+            message = "file index ensure_started requested restart",
+            root_changed,
+            respect_gitignore_changed,
+            missing_root,
+            scan_missing_while_unfinished,
+            current_root = %current_root.display(),
+            indexed_root = %app.file_index.root
+                .as_ref()
+                .map_or_else(|| "<none>".to_owned(), |root| root.display().to_string()),
+            generation = app.file_index.generation,
+            entries = app.file_index.entries.len(),
+            scan_finished = app.file_index.scan_finished,
+        );
         restart(app);
     }
 }
 
+pub fn request_match(app: &mut App, request: MentionMatchRequest) {
+    ensure_matcher(app);
+    if let Some(matcher) = app.file_index.matcher.as_ref()
+        && matcher.query_tx.send(request).is_err()
+    {
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_matcher_send_failed",
+            message = "file index matcher query send failed",
+            generation = app.file_index.generation,
+        );
+    }
+}
+
 pub fn drain_events(app: &mut App) {
+    let started_at = Instant::now();
     let mut handled = 0;
+    let mut stats = EventApplyStats::default();
     loop {
         if handled >= EVENT_DRAIN_BUDGET {
             break;
@@ -131,107 +261,370 @@ pub fn drain_events(app: &mut App) {
             Ok(event) => event,
             Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
         };
-        apply_event(app, event);
+        stats.merge(apply_event(app, event));
         handled += 1;
     }
-}
-
-pub fn visible_candidates(
-    entries: &BTreeMap<String, FileCandidate>,
-    query: &str,
-) -> Vec<FileCandidate> {
-    let query_lower = query.to_lowercase();
-    let mut filtered: Vec<FileCandidate> = entries
-        .values()
-        .filter(|candidate| match_tier(candidate, &query_lower).is_some())
-        .cloned()
-        .collect();
-    rank_and_truncate_candidates(&mut filtered, &query_lower);
-    filtered
-}
-
-pub fn rank_and_truncate_candidates(candidates: &mut Vec<FileCandidate>, query_lower: &str) {
-    let tiers: Vec<Option<u8>> = candidates.iter().map(|c| match_tier(c, query_lower)).collect();
-    let mut indices: Vec<usize> = (0..candidates.len()).collect();
-    indices.sort_by(|&i, &j| {
-        tiers[i]
-            .cmp(&tiers[j])
-            .then_with(|| candidates[i].depth.cmp(&candidates[j].depth))
-            .then_with(|| candidates[i].rel_path.cmp(&candidates[j].rel_path))
-    });
-
-    indices.truncate(MAX_CANDIDATES);
-    *candidates = indices.into_iter().map(|i| candidates[i].clone()).collect();
-}
-
-fn match_tier(candidate: &FileCandidate, query_lower: &str) -> Option<u8> {
-    if query_lower.is_empty() {
-        return Some(0);
+    if stats.index_changed {
+        refresh_after_mutation(app, &stats);
     }
-
-    if candidate.basename_lower.starts_with(query_lower) {
-        Some(0)
-    } else if candidate.rel_path_lower.starts_with(query_lower) {
-        Some(1)
-    } else if candidate.basename_lower.contains(query_lower) {
-        Some(2)
-    } else if candidate.rel_path_lower.contains(query_lower) {
-        Some(3)
-    } else {
-        None
+    if stats.index_changed || stats.mention_changed {
+        app.request_chat_repaint();
+    }
+    if handled > 0 {
+        let duration_ms = elapsed_ms(started_at);
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_events_drained",
+            message = "file index events drained on app thread",
+            duration_ms,
+            handled,
+            index_changed = stats.index_changed,
+            mention_changed = stats.mention_changed,
+            scan_entries = stats.scan_entries,
+            fs_changes = stats.fs_changes,
+            rebuilds = stats.rebuilds,
+            scan_finished_event = stats.scan_finished,
+            match_results = stats.match_results,
+            budget_hit = handled >= EVENT_DRAIN_BUDGET,
+            total_entries = app.file_index.entries.len(),
+            index_version = app.file_index.index_version,
+            generation = app.file_index.generation,
+            scan_finished = app.file_index.scan_finished,
+            mention_active = app.mention.is_some(),
+        );
     }
 }
 
-fn apply_event(app: &mut App, event: FileIndexEvent) {
+#[derive(Clone, Copy, Debug, Default)]
+struct MatcherUpsertStats {
+    inserted: usize,
+    replaced: usize,
+}
+
+#[derive(Default)]
+struct MatcherEntries {
+    entries: Vec<FileCandidate>,
+    indices: HashMap<String, usize>,
+}
+
+impl MatcherEntries {
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &FileCandidate> {
+        self.entries.iter()
+    }
+
+    fn reset(&mut self, entries: Vec<FileCandidate>) -> MatcherUpsertStats {
+        self.entries.clear();
+        self.indices.clear();
+        self.entries.reserve(entries.len());
+        self.indices.reserve(entries.len());
+
+        let mut stats = MatcherUpsertStats::default();
+        for entry in entries {
+            let upsert_stats = self.upsert(entry);
+            stats.inserted += upsert_stats.inserted;
+            stats.replaced += upsert_stats.replaced;
+        }
+        stats
+    }
+
+    fn upsert(&mut self, candidate: FileCandidate) -> MatcherUpsertStats {
+        if let Some(index) = self.indices.get(&candidate.rel_path).copied() {
+            self.entries[index] = candidate;
+            MatcherUpsertStats { replaced: 1, ..MatcherUpsertStats::default() }
+        } else {
+            let index = self.entries.len();
+            self.indices.insert(candidate.rel_path.clone(), index);
+            self.entries.push(candidate);
+            MatcherUpsertStats { inserted: 1, ..MatcherUpsertStats::default() }
+        }
+    }
+
+    fn remove_exact(&mut self, rel_path: &str) -> bool {
+        let Some(index) = self.indices.remove(rel_path) else {
+            return false;
+        };
+
+        self.entries.swap_remove(index);
+        if index < self.entries.len() {
+            self.indices.insert(self.entries[index].rel_path.clone(), index);
+        }
+        true
+    }
+
+    fn remove_prefix(&mut self, rel_prefix: &str) -> usize {
+        let before = self.entries.len();
+        self.entries.retain(|candidate| !candidate.rel_path.starts_with(rel_prefix));
+        if self.entries.len() != before {
+            self.rebuild_indices();
+        }
+        before - self.entries.len()
+    }
+
+    fn replace_prefix(
+        &mut self,
+        rel_prefix: &str,
+        entries: Vec<FileCandidate>,
+    ) -> (usize, MatcherUpsertStats) {
+        let removed = self.remove_prefix(rel_prefix);
+        let mut stats = MatcherUpsertStats::default();
+        for entry in entries {
+            let upsert_stats = self.upsert(entry);
+            stats.inserted += upsert_stats.inserted;
+            stats.replaced += upsert_stats.replaced;
+        }
+        (removed, stats)
+    }
+
+    fn apply_change(&mut self, change: FileIndexChange) -> MatcherChangeStats {
+        match change {
+            FileIndexChange::Upsert(candidate) => {
+                let stats = self.upsert(candidate);
+                MatcherChangeStats {
+                    inserted: stats.inserted,
+                    replaced: stats.replaced,
+                    ..MatcherChangeStats::default()
+                }
+            }
+            FileIndexChange::RemoveExact { rel_path } => MatcherChangeStats {
+                removed: usize::from(self.remove_exact(&rel_path)),
+                ..MatcherChangeStats::default()
+            },
+            FileIndexChange::RemovePrefix { rel_prefix } => MatcherChangeStats {
+                removed: self.remove_prefix(&rel_prefix),
+                ..MatcherChangeStats::default()
+            },
+            FileIndexChange::ReplacePrefix { rel_prefix, entries } => {
+                let (removed, stats) = self.replace_prefix(&rel_prefix, entries);
+                MatcherChangeStats { inserted: stats.inserted, replaced: stats.replaced, removed }
+            }
+        }
+    }
+
+    fn rebuild_indices(&mut self) {
+        self.indices.clear();
+        self.indices.reserve(self.entries.len());
+        for (index, entry) in self.entries.iter().enumerate() {
+            self.indices.insert(entry.rel_path.clone(), index);
+        }
+    }
+}
+
+struct MentionMatcher {
+    entries: MatcherEntries,
+    engine: Nucleo<FileCandidate>,
+    injector: Injector<FileCandidate>,
+    last_query: String,
+}
+
+impl Default for MentionMatcher {
+    fn default() -> Self {
+        let mut config = NucleoConfig::DEFAULT.match_paths();
+        config.prefer_prefix = true;
+        let notify = Arc::new(|| {});
+        let engine = Nucleo::new(config, notify, None, NUCLEO_COLUMNS);
+        let injector = engine.injector();
+        Self { entries: MatcherEntries::default(), engine, injector, last_query: String::new() }
+    }
+}
+
+impl MentionMatcher {
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn reset(&mut self, entries: Vec<FileCandidate>) -> MatcherUpsertStats {
+        let stats = self.entries.reset(entries);
+        self.rebuild_stream(true);
+        stats
+    }
+
+    fn upsert_scan_batch(&mut self, batch: Vec<FileCandidate>) -> MatcherUpsertStats {
+        let mut stats = MatcherUpsertStats::default();
+        let mut needs_rebuild = false;
+        for entry in batch {
+            let upsert_stats = self.entries.upsert(entry.clone());
+            stats.inserted += upsert_stats.inserted;
+            stats.replaced += upsert_stats.replaced;
+            if upsert_stats.inserted > 0 {
+                self.inject(entry);
+            }
+            needs_rebuild |= upsert_stats.replaced > 0;
+        }
+        if needs_rebuild {
+            self.rebuild_stream(false);
+        }
+        stats
+    }
+
+    fn apply_change_batch(&mut self, changes: Vec<FileIndexChange>) -> MatcherChangeStats {
+        let mut stats = MatcherChangeStats::default();
+        for change in changes {
+            stats.merge(self.entries.apply_change(change));
+        }
+        if stats.inserted > 0 || stats.replaced > 0 || stats.removed > 0 {
+            self.rebuild_stream(false);
+        }
+        stats
+    }
+
+    fn set_query(&mut self, query: &str) {
+        let append = query.starts_with(&self.last_query);
+        self.last_query.clear();
+        self.last_query.push_str(query);
+        self.engine.pattern.reparse(0, query, CaseMatching::Smart, Normalization::Smart, append);
+    }
+
+    fn tick(&mut self, timeout_ms: u64) -> nucleo::Status {
+        self.engine.tick(timeout_ms)
+    }
+
+    fn candidates(&self, limit: usize) -> Vec<FileCandidate> {
+        let snapshot = self.engine.snapshot();
+        let limit = u32::try_from(limit).unwrap_or(u32::MAX);
+        let end = snapshot.matched_item_count().min(limit);
+        snapshot.matched_items(0..end).map(|item| item.data.clone()).collect()
+    }
+
+    fn matched_item_count(&self) -> u32 {
+        self.engine.snapshot().matched_item_count()
+    }
+
+    fn injected_items(&self) -> u32 {
+        self.injector.injected_items()
+    }
+
+    fn rebuild_stream(&mut self, clear_snapshot: bool) {
+        self.engine.restart(clear_snapshot);
+        self.injector = self.engine.injector();
+        let entries = self.entries.iter().cloned().collect::<Vec<_>>();
+        for entry in entries {
+            self.inject(entry);
+        }
+    }
+
+    fn inject(&self, candidate: FileCandidate) {
+        self.injector.push(candidate, |candidate, columns| {
+            columns[0] = Utf32String::from(candidate.rel_path.as_str());
+        });
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct MatcherChangeStats {
+    inserted: usize,
+    replaced: usize,
+    removed: usize,
+}
+
+impl MatcherChangeStats {
+    fn merge(&mut self, other: Self) {
+        self.inserted += other.inserted;
+        self.replaced += other.replaced;
+        self.removed += other.removed;
+    }
+}
+
+fn apply_event(app: &mut App, event: FileIndexEvent) -> EventApplyStats {
     match event {
         FileIndexEvent::ScanBatch { generation, entries } => {
             if generation != app.file_index.generation {
-                return;
+                return EventApplyStats::default();
             }
+            let scan_entries = entries.len();
+            let mut matcher_entries = Vec::with_capacity(entries.len());
             for entry in entries {
                 if app.file_index.scan_overrides.blocks(&entry.rel_path) {
                     continue;
                 }
+                matcher_entries.push(entry.clone());
                 app.file_index.entries.insert(entry.rel_path.clone(), entry);
             }
-            refresh_after_mutation(app);
+            if matcher_entries.is_empty() {
+                return EventApplyStats { scan_entries, ..EventApplyStats::default() };
+            }
+            let index_version = bump_index_version(app);
+            send_matcher_command(
+                app,
+                FileIndexMatcherCommand::ScanBatch {
+                    generation,
+                    index_version,
+                    entries: matcher_entries,
+                },
+            );
+            EventApplyStats { index_changed: true, scan_entries, ..EventApplyStats::default() }
         }
         FileIndexEvent::ScanFinished { generation } => {
             if generation != app.file_index.generation {
-                return;
+                return EventApplyStats::default();
             }
             app.file_index.scan_finished = true;
             app.file_index.scan_overrides = ScanOverrides::default();
             app.file_index.scan = None;
-            refresh_after_mutation(app);
+            let index_version = bump_index_version(app);
+            send_matcher_command(
+                app,
+                FileIndexMatcherCommand::ScanFinished { generation, index_version },
+            );
+            EventApplyStats {
+                index_changed: true,
+                scan_finished: true,
+                ..EventApplyStats::default()
+            }
         }
         FileIndexEvent::FsBatch { generation, changes } => {
             if generation != app.file_index.generation {
-                return;
+                return EventApplyStats::default();
             }
+            let fs_changes = changes.len();
+            let matcher_changes = changes.clone();
             for change in changes {
                 if !app.file_index.scan_finished {
                     app.file_index.scan_overrides.record_change(&change);
                 }
                 apply_change(&mut app.file_index.entries, change);
             }
-            refresh_after_mutation(app);
+            let index_version = bump_index_version(app);
+            send_matcher_command(
+                app,
+                FileIndexMatcherCommand::FsBatch {
+                    generation,
+                    index_version,
+                    changes: matcher_changes,
+                },
+            );
+            EventApplyStats { index_changed: true, fs_changes, ..EventApplyStats::default() }
         }
         FileIndexEvent::RebuildRequested { generation } => {
             if generation != app.file_index.generation {
-                return;
+                return EventApplyStats::default();
             }
             restart(app);
-            refresh_after_mutation(app);
+            EventApplyStats { index_changed: true, rebuilds: 1, ..EventApplyStats::default() }
+        }
+        FileIndexEvent::MatchResult(result) => {
+            let mention_changed = super::mention::apply_match_result(app, result);
+            EventApplyStats { mention_changed, match_results: 1, ..EventApplyStats::default() }
         }
     }
 }
 
-fn refresh_after_mutation(app: &mut App) {
+fn refresh_after_mutation(app: &mut App, stats: &EventApplyStats) {
     if app.mention.is_some() {
-        super::mention::refresh_from_file_index(app);
+        if stats.scan_finished || stats.fs_changes > 0 || stats.rebuilds > 0 {
+            super::mention::refresh_from_file_index(app);
+        } else {
+            super::mention::refresh_from_file_index_after_scan_batch(app);
+        }
     }
-    app.request_chat_repaint();
+}
+
+fn bump_index_version(app: &mut App) -> u64 {
+    app.file_index.index_version = app.file_index.index_version.saturating_add(1);
+    app.file_index.index_version
 }
 
 fn apply_change(entries: &mut BTreeMap<String, FileCandidate>, change: FileIndexChange) {
@@ -254,6 +647,387 @@ fn apply_change(entries: &mut BTreeMap<String, FileCandidate>, change: FileIndex
     }
 }
 
+fn ensure_matcher(app: &mut App) {
+    if app.file_index.matcher.is_some() {
+        return;
+    }
+    let generation = app.file_index.generation;
+    let index_version = app.file_index.index_version;
+    let entries = app.file_index.entries.values().cloned().collect();
+    let scan_finished = app.file_index.scan_finished;
+    app.file_index.matcher = Some(spawn_matcher(generation, app.file_index_event_tx.clone()));
+    send_matcher_command(
+        app,
+        FileIndexMatcherCommand::Reset { generation, index_version, entries, scan_finished },
+    );
+}
+
+fn send_matcher_command(app: &mut App, command: FileIndexMatcherCommand) {
+    let Some(matcher) = app.file_index.matcher.as_ref() else {
+        return;
+    };
+    if matcher.index_tx.send(command).is_err() {
+        app.file_index.matcher = None;
+        tracing::warn!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_matcher_send_failed",
+            message = "file index matcher command channel is closed",
+            generation = app.file_index.generation,
+            index_version = app.file_index.index_version,
+        );
+    }
+}
+
+fn spawn_matcher(generation: u64, event_tx: Sender<FileIndexEvent>) -> FileIndexMatcherHandle {
+    let (index_tx, index_rx) = mpsc::channel();
+    let (query_tx, query_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        FileIndexMatcherRuntime::new(generation, index_rx, query_rx, event_tx).run();
+    });
+    FileIndexMatcherHandle { index_tx, query_tx }
+}
+
+struct FileIndexMatcherRuntime {
+    generation: u64,
+    index_version: u64,
+    matcher: MentionMatcher,
+    scan_finished: bool,
+    index_rx: Receiver<FileIndexMatcherCommand>,
+    query_rx: Receiver<MentionMatchRequest>,
+    event_tx: Sender<FileIndexEvent>,
+}
+
+struct CoalescedQuery {
+    request: MentionMatchRequest,
+    replaced_queries: usize,
+}
+
+impl FileIndexMatcherRuntime {
+    fn new(
+        generation: u64,
+        index_rx: Receiver<FileIndexMatcherCommand>,
+        query_rx: Receiver<MentionMatchRequest>,
+        event_tx: Sender<FileIndexEvent>,
+    ) -> Self {
+        Self {
+            generation,
+            index_version: 0,
+            matcher: MentionMatcher::default(),
+            scan_finished: false,
+            index_rx,
+            query_rx,
+            event_tx,
+        }
+    }
+
+    fn run(mut self) {
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_matcher_started",
+            message = "file index matcher thread started",
+            generation = self.generation,
+        );
+
+        loop {
+            if !self.handle_next_command() {
+                break;
+            }
+        }
+
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_matcher_stopped",
+            message = "file index matcher thread stopped",
+            generation = self.generation,
+            index_version = self.index_version,
+        );
+    }
+
+    fn handle_next_command(&mut self) -> bool {
+        if let Ok(request) = self.query_rx.try_recv() {
+            return self.handle_query(request);
+        }
+
+        match self.index_rx.recv_timeout(MATCHER_IDLE_POLL_INTERVAL) {
+            Ok(command) => {
+                self.apply_index_command(command);
+                true
+            }
+            Err(RecvTimeoutError::Timeout) => true,
+            Err(RecvTimeoutError::Disconnected) => {
+                self.query_rx.try_recv().is_ok_and(|request| self.handle_query(request))
+            }
+        }
+    }
+
+    fn handle_query(&mut self, request: MentionMatchRequest) -> bool {
+        let coalesced = self.coalesce_query(request);
+        if coalesced.request.generation != self.generation {
+            tracing::debug!(
+                target: crate::logging::targets::APP_FILE_INDEX,
+                event_name = "file_index_matcher_query_rejected",
+                message = "file index matcher rejected stale mention query",
+                matcher_generation = self.generation,
+                request_generation = coalesced.request.generation,
+                sequence = coalesced.request.sequence,
+                query_chars = coalesced.request.query.chars().count(),
+                replaced_queries = coalesced.replaced_queries,
+            );
+            return true;
+        }
+        self.complete_query(coalesced)
+    }
+
+    fn coalesce_query(&mut self, mut latest: MentionMatchRequest) -> CoalescedQuery {
+        let mut replaced_queries = 0;
+        loop {
+            match self.query_rx.try_recv() {
+                Ok(request) => {
+                    latest = request;
+                    replaced_queries += 1;
+                }
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => {
+                    return CoalescedQuery { request: latest, replaced_queries };
+                }
+            }
+        }
+    }
+
+    fn apply_index_command(&mut self, command: FileIndexMatcherCommand) {
+        match command {
+            FileIndexMatcherCommand::Reset {
+                generation,
+                index_version,
+                entries,
+                scan_finished,
+            } => {
+                self.reset(generation, index_version, entries, scan_finished);
+            }
+            FileIndexMatcherCommand::ScanBatch { generation, index_version, entries: batch } => {
+                self.apply_scan_batch(generation, index_version, batch);
+            }
+            FileIndexMatcherCommand::ScanFinished { generation, index_version } => {
+                self.apply_scan_finished(generation, index_version);
+            }
+            FileIndexMatcherCommand::FsBatch { generation, index_version, changes } => {
+                self.apply_fs_batch(generation, index_version, changes);
+            }
+        }
+    }
+
+    fn apply_scan_batch(&mut self, generation: u64, index_version: u64, batch: Vec<FileCandidate>) {
+        if generation != self.generation {
+            self.log_ignored_index_command(
+                "file index matcher ignored stale scan batch",
+                generation,
+                index_version,
+                Some(batch.len()),
+                None,
+            );
+            return;
+        }
+
+        let entries_before = self.matcher.len();
+        let batch_len = batch.len();
+        let upserts = self.matcher.upsert_scan_batch(batch);
+        self.index_version = index_version;
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_matcher_scan_batch_applied",
+            message = "file index matcher applied scan batch",
+            generation = self.generation,
+            index_version = self.index_version,
+            batch_entries = batch_len,
+            inserted = upserts.inserted,
+            replaced = upserts.replaced,
+            entries_before,
+            entries_after = self.matcher.len(),
+            injected_items = self.matcher.injected_items(),
+        );
+    }
+
+    fn apply_scan_finished(&mut self, generation: u64, index_version: u64) {
+        if generation != self.generation {
+            self.log_ignored_index_command(
+                "file index matcher ignored stale scan finished",
+                generation,
+                index_version,
+                None,
+                None,
+            );
+            return;
+        }
+
+        self.scan_finished = true;
+        self.index_version = index_version;
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_matcher_scan_finished_applied",
+            message = "file index matcher applied scan finished",
+            generation = self.generation,
+            index_version = self.index_version,
+            entries = self.matcher.len(),
+            injected_items = self.matcher.injected_items(),
+        );
+    }
+
+    fn apply_fs_batch(
+        &mut self,
+        generation: u64,
+        index_version: u64,
+        changes: Vec<FileIndexChange>,
+    ) {
+        if generation != self.generation {
+            self.log_ignored_index_command(
+                "file index matcher ignored stale filesystem batch",
+                generation,
+                index_version,
+                None,
+                Some(changes.len()),
+            );
+            return;
+        }
+
+        let entries_before = self.matcher.len();
+        let changes_len = changes.len();
+        let change_stats = self.matcher.apply_change_batch(changes);
+        self.index_version = index_version;
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_matcher_fs_batch_applied",
+            message = "file index matcher applied filesystem batch",
+            generation = self.generation,
+            index_version = self.index_version,
+            changes = changes_len,
+            inserted = change_stats.inserted,
+            replaced = change_stats.replaced,
+            removed = change_stats.removed,
+            entries_before,
+            entries_after = self.matcher.len(),
+            injected_items = self.matcher.injected_items(),
+        );
+    }
+
+    fn log_ignored_index_command(
+        &self,
+        message: &'static str,
+        generation: u64,
+        index_version: u64,
+        batch_entries: Option<usize>,
+        changes: Option<usize>,
+    ) {
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_matcher_index_command_ignored",
+            message,
+            matcher_generation = self.generation,
+            command_generation = generation,
+            index_version,
+            batch_entries,
+            changes,
+        );
+    }
+
+    fn reset(
+        &mut self,
+        generation: u64,
+        index_version: u64,
+        entries: Vec<FileCandidate>,
+        scan_finished: bool,
+    ) {
+        let entries_before = self.matcher.len();
+        let incoming_entries = entries.len();
+        self.generation = generation;
+        self.index_version = index_version;
+        let upserts = self.matcher.reset(entries);
+        self.scan_finished = scan_finished;
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_matcher_reset",
+            message = "file index matcher state reset",
+            generation = self.generation,
+            index_version = self.index_version,
+            entries_before,
+            incoming_entries,
+            entries = self.matcher.len(),
+            injected_items = self.matcher.injected_items(),
+            inserted = upserts.inserted,
+            replaced = upserts.replaced,
+            scan_finished = self.scan_finished,
+        );
+    }
+
+    fn complete_query(&mut self, mut coalesced: CoalescedQuery) -> bool {
+        let started_at = Instant::now();
+        self.matcher.set_query(&coalesced.request.query);
+        let mut tick_count = 0usize;
+        let mut interrupted_queries = 0usize;
+        let mut status = self.matcher.tick(0);
+        while status.running {
+            status = self.matcher.tick(NUCLEO_QUERY_TICK_MS);
+            tick_count += 1;
+            match self.query_rx.try_recv() {
+                Ok(request) => {
+                    coalesced.request = request;
+                    coalesced.replaced_queries += 1;
+                    interrupted_queries += 1;
+                    self.matcher.set_query(&coalesced.request.query);
+                    status = self.matcher.tick(0);
+                }
+                Err(TryRecvError::Empty) => {}
+                Err(TryRecvError::Disconnected) => break,
+            }
+        }
+        let request = coalesced.request;
+        if request.generation != self.generation {
+            tracing::debug!(
+                target: crate::logging::targets::APP_FILE_INDEX,
+                event_name = "file_index_matcher_query_rejected",
+                message = "file index matcher rejected stale mention query after nucleo work",
+                matcher_generation = self.generation,
+                request_generation = request.generation,
+                sequence = request.sequence,
+                query_chars = request.query.chars().count(),
+                replaced_queries = coalesced.replaced_queries,
+            );
+            return true;
+        }
+        let candidates = self.matcher.candidates(MAX_CANDIDATES);
+        let duration_ms = elapsed_ms(started_at);
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_matcher_query_finished",
+            message = "file index matcher completed mention query",
+            duration_ms,
+            generation = self.generation,
+            index_version = self.index_version,
+            requested_index_version = request.index_version,
+            sequence = request.sequence,
+            entries = self.matcher.len(),
+            injected_items = self.matcher.injected_items(),
+            matched_items = self.matcher.matched_item_count(),
+            query_chars = request.query.chars().count(),
+            query_bytes = request.query.len(),
+            result_count = candidates.len(),
+            scan_finished = self.scan_finished,
+            match_strategy = "nucleo",
+            nucleo_ticks = tick_count,
+            nucleo_running = status.running,
+            interrupted_queries,
+            replaced_queries = coalesced.replaced_queries,
+        );
+        let result = MentionMatchResult {
+            generation: self.generation,
+            index_version: self.index_version,
+            sequence: request.sequence,
+            query: request.query,
+            candidates,
+            scan_finished: self.scan_finished,
+        };
+        self.event_tx.send(FileIndexEvent::MatchResult(result)).is_ok()
+    }
+}
+
 fn spawn_scan(
     root: PathBuf,
     generation: u64,
@@ -263,33 +1037,112 @@ fn spawn_scan(
     let cancel = Arc::new(AtomicBool::new(false));
     let cancel_clone = Arc::clone(&cancel);
     std::thread::spawn(move || {
-        let mut batch = Vec::with_capacity(SCAN_BATCH_SIZE);
-        let mut emit_candidate = |candidate| {
-            batch.push(candidate);
-            if batch.len() < SCAN_BATCH_SIZE {
-                return true;
-            }
-            event_tx
-                .send(FileIndexEvent::ScanBatch { generation, entries: std::mem::take(&mut batch) })
-                .is_ok()
-        };
-        if !for_each_candidate(
-            &root,
-            &root,
-            respect_gitignore,
-            Some(&cancel_clone),
-            &mut emit_candidate,
-        ) {
-            return;
-        }
-        if !batch.is_empty()
-            && event_tx.send(FileIndexEvent::ScanBatch { generation, entries: batch }).is_err()
-        {
-            return;
-        }
-        let _ = event_tx.send(FileIndexEvent::ScanFinished { generation });
+        run_scan(&root, generation, respect_gitignore, &cancel_clone, &event_tx);
     });
     FileIndexScanHandle { cancel }
+}
+
+fn run_scan(
+    root: &Path,
+    generation: u64,
+    respect_gitignore: bool,
+    cancel: &Arc<AtomicBool>,
+    event_tx: &Sender<FileIndexEvent>,
+) {
+    let started_at = Instant::now();
+    tracing::info!(
+        target: crate::logging::targets::APP_FILE_INDEX,
+        event_name = "file_index_scan_started",
+        message = "file index scan started",
+        generation,
+        root = %root.display(),
+        respect_gitignore,
+        batch_size = SCAN_BATCH_SIZE,
+    );
+    let mut batch = Vec::with_capacity(SCAN_BATCH_SIZE);
+    let mut candidates_seen = 0usize;
+    let mut batches_sent = 0usize;
+    let mut emit_candidate = |candidate: FileCandidate| {
+        candidates_seen += 1;
+        batch.push(candidate);
+        if batch.len() < SCAN_BATCH_SIZE {
+            return true;
+        }
+        batches_sent += 1;
+        if batches_sent == 1 || batches_sent % 64 == 0 {
+            tracing::debug!(
+                target: crate::logging::targets::APP_FILE_INDEX,
+                event_name = "file_index_scan_progress",
+                message = "file index scan emitted candidate batch",
+                generation,
+                candidates_seen,
+                batches_sent,
+                duration_ms = elapsed_ms(started_at),
+            );
+        }
+        event_tx
+            .send(FileIndexEvent::ScanBatch { generation, entries: std::mem::take(&mut batch) })
+            .is_ok()
+    };
+    if !for_each_candidate(
+        root,
+        root,
+        respect_gitignore,
+        Some(1),
+        Some(cancel),
+        &mut emit_candidate,
+    ) {
+        tracing::info!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_scan_cancelled",
+            message = "file index shallow scan cancelled before completion",
+            generation,
+            candidates_seen,
+            batches_sent,
+            duration_ms = elapsed_ms(started_at),
+        );
+        return;
+    }
+    if !for_each_candidate(root, root, respect_gitignore, None, Some(cancel), &mut emit_candidate) {
+        tracing::info!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_scan_cancelled",
+            message = "file index scan cancelled before completion",
+            generation,
+            candidates_seen,
+            batches_sent,
+            duration_ms = elapsed_ms(started_at),
+        );
+        return;
+    }
+    let final_batch_len = batch.len();
+    if !batch.is_empty() {
+        batches_sent += 1;
+        if event_tx.send(FileIndexEvent::ScanBatch { generation, entries: batch }).is_err() {
+            tracing::info!(
+                target: crate::logging::targets::APP_FILE_INDEX,
+                event_name = "file_index_scan_abandoned",
+                message = "file index scan receiver dropped before final batch",
+                generation,
+                candidates_seen,
+                batches_sent,
+                final_batch_len,
+                duration_ms = elapsed_ms(started_at),
+            );
+            return;
+        }
+    }
+    let _ = event_tx.send(FileIndexEvent::ScanFinished { generation });
+    tracing::info!(
+        target: crate::logging::targets::APP_FILE_INDEX,
+        event_name = "file_index_scan_finished",
+        message = "file index scan finished",
+        generation,
+        candidates_seen,
+        batches_sent,
+        final_batch_len,
+        duration_ms = elapsed_ms(started_at),
+    );
 }
 
 fn spawn_watch(
@@ -302,82 +1155,183 @@ fn spawn_watch(
     let cancel_clone = Arc::clone(&cancel);
     let root_for_thread = root.to_path_buf();
     std::thread::spawn(move || {
+        tracing::info!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_watch_started",
+            message = "file index watcher thread started",
+            generation,
+            root = %root_for_thread.display(),
+            respect_gitignore,
+            debounce_ms = WATCH_DEBOUNCE_INTERVAL.as_millis(),
+        );
         let (watch_tx, watch_rx) = mpsc::channel();
         let mut watcher = match notify::recommended_watcher(move |result| {
             let _ = watch_tx.send(result);
         }) {
             Ok(watcher) => watcher,
             Err(err) => {
-                tracing::warn!(%err, "file index watcher setup failed");
+                tracing::warn!(
+                    target: crate::logging::targets::APP_FILE_INDEX,
+                    event_name = "file_index_watch_setup_failed",
+                    message = "file index watcher setup failed",
+                    generation,
+                    root = %root_for_thread.display(),
+                    error_message = %err,
+                );
                 return;
             }
         };
         if let Err(err) =
             notify::Watcher::watch(&mut watcher, &root_for_thread, notify::RecursiveMode::Recursive)
         {
-            tracing::warn!(%err, "file index watcher start failed");
+            tracing::warn!(
+                target: crate::logging::targets::APP_FILE_INDEX,
+                event_name = "file_index_watch_start_failed",
+                message = "file index watcher start failed",
+                generation,
+                root = %root_for_thread.display(),
+                error_message = %err,
+            );
             return;
         }
 
+        let mut pending = Vec::new();
         while !cancel_clone.load(AtomicOrdering::Relaxed) {
-            let event = match watch_rx.recv_timeout(WATCH_POLL_INTERVAL) {
-                Ok(event) => event,
-                Err(RecvTimeoutError::Timeout) => continue,
-                Err(RecvTimeoutError::Disconnected) => break,
-            };
-            match event {
-                Ok(event) => {
-                    if let Some(next_event) = normalize_watch_event(
+            let timeout =
+                if pending.is_empty() { WATCH_POLL_INTERVAL } else { WATCH_DEBOUNCE_INTERVAL };
+            match watch_rx.recv_timeout(timeout) {
+                Ok(event) => pending.push(event),
+                Err(RecvTimeoutError::Timeout) if pending.is_empty() => {}
+                Err(RecvTimeoutError::Timeout) => {
+                    if let Some(next_event) = normalize_watch_events(
                         &root_for_thread,
                         generation,
                         respect_gitignore,
-                        &event,
+                        pending.drain(..),
                     ) {
                         let _ = event_tx.send(next_event);
                     }
                 }
-                Err(err) => {
-                    tracing::warn!(%err, "file index watcher event failed");
-                    let _ = event_tx.send(FileIndexEvent::RebuildRequested { generation });
-                }
+                Err(RecvTimeoutError::Disconnected) => break,
             }
+        }
+        if let Some(next_event) = normalize_watch_events(
+            &root_for_thread,
+            generation,
+            respect_gitignore,
+            pending.drain(..),
+        ) {
+            let _ = event_tx.send(next_event);
         }
     });
     FileIndexWatchHandle { cancel }
 }
 
-fn normalize_watch_event(
+fn normalize_watch_events(
     root: &Path,
     generation: u64,
     respect_gitignore: bool,
-    event: &notify::Event,
+    events: impl IntoIterator<Item = notify::Result<notify::Event>>,
 ) -> Option<FileIndexEvent> {
     use notify::event::{CreateKind, EventKind, ModifyKind, RemoveKind, RenameMode};
 
-    if matches_ignore_semantics_change(root, &event.paths) {
+    let mut rebuild = false;
+    let mut create_or_modify_paths = Vec::new();
+    let mut rename_paths = Vec::new();
+    let mut remove_paths = Vec::new();
+    let mut raw_events = 0usize;
+
+    for event in events {
+        raw_events += 1;
+        let event = match event {
+            Ok(event) => event,
+            Err(err) => {
+                tracing::warn!(
+                    target: crate::logging::targets::APP_FILE_INDEX,
+                    event_name = "file_index_watch_event_failed",
+                    message = "file index watcher event failed",
+                    generation,
+                    error_message = %err,
+                );
+                rebuild = true;
+                continue;
+            }
+        };
+
+        if matches_ignore_semantics_change(root, &event.paths) {
+            rebuild = true;
+            continue;
+        }
+
+        match event.kind {
+            EventKind::Modify(ModifyKind::Name(RenameMode::Any | RenameMode::Both)) => {
+                extend_unique_paths(&mut rename_paths, event.paths);
+            }
+            EventKind::Create(CreateKind::Any | CreateKind::File | CreateKind::Folder)
+            | EventKind::Modify(
+                ModifyKind::Any
+                | ModifyKind::Data(_)
+                | ModifyKind::Metadata(_)
+                | ModifyKind::Name(RenameMode::To),
+            ) => {
+                extend_unique_paths(&mut create_or_modify_paths, event.paths);
+            }
+            EventKind::Modify(ModifyKind::Name(RenameMode::From))
+            | EventKind::Remove(RemoveKind::Any | RemoveKind::File | RemoveKind::Folder) => {
+                extend_unique_paths(&mut remove_paths, event.paths);
+            }
+            EventKind::Other => {
+                rebuild = true;
+            }
+            _ => {}
+        }
+    }
+
+    if rebuild {
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_watch_batch_rebuild",
+            message = "file index watcher batch requested rebuild",
+            generation,
+            raw_events,
+            create_or_modify_paths = create_or_modify_paths.len(),
+            rename_paths = rename_paths.len(),
+            remove_paths = remove_paths.len(),
+        );
         return Some(FileIndexEvent::RebuildRequested { generation });
     }
 
-    let changes = match event.kind {
-        EventKind::Modify(ModifyKind::Name(RenameMode::Any | RenameMode::Both)) => {
-            collect_rename_changes(root, respect_gitignore, &event.paths)
-        }
-        EventKind::Create(CreateKind::Any | CreateKind::File | CreateKind::Folder)
-        | EventKind::Modify(
-            ModifyKind::Any
-            | ModifyKind::Data(_)
-            | ModifyKind::Metadata(_)
-            | ModifyKind::Name(RenameMode::To),
-        ) => collect_create_or_modify_changes(root, respect_gitignore, &event.paths),
-        EventKind::Modify(ModifyKind::Name(RenameMode::From))
-        | EventKind::Remove(RemoveKind::Any | RemoveKind::File | RemoveKind::Folder) => {
-            collect_remove_changes(root, &event.paths)
-        }
-        EventKind::Other => return Some(FileIndexEvent::RebuildRequested { generation }),
-        _ => Vec::new(),
-    };
+    let mut changes = Vec::new();
+    changes.extend(collect_rename_changes(root, respect_gitignore, &rename_paths));
+    changes.extend(collect_create_or_modify_changes(
+        root,
+        respect_gitignore,
+        &create_or_modify_paths,
+    ));
+    changes.extend(collect_remove_changes(root, &remove_paths));
+    if raw_events > 0 {
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_watch_batch_normalized",
+            message = "file index watcher batch normalized",
+            generation,
+            raw_events,
+            create_or_modify_paths = create_or_modify_paths.len(),
+            rename_paths = rename_paths.len(),
+            remove_paths = remove_paths.len(),
+            changes = changes.len(),
+        );
+    }
 
     (!changes.is_empty()).then_some(FileIndexEvent::FsBatch { generation, changes })
+}
+
+fn extend_unique_paths(paths: &mut Vec<PathBuf>, next_paths: impl IntoIterator<Item = PathBuf>) {
+    for path in next_paths {
+        if !paths.contains(&path) {
+            paths.push(path);
+        }
+    }
 }
 
 fn matches_ignore_semantics_change(root: &Path, paths: &[PathBuf]) -> bool {
@@ -492,6 +1446,7 @@ fn for_each_candidate(
     root: &Path,
     walk_root: &Path,
     respect_gitignore: bool,
+    max_depth: Option<usize>,
     cancel: Option<&Arc<AtomicBool>>,
     emit: &mut impl FnMut(FileCandidate) -> bool,
 ) -> bool {
@@ -502,6 +1457,7 @@ fn for_each_candidate(
         .git_global(respect_gitignore)
         .git_exclude(respect_gitignore)
         .sort_by_file_path(std::cmp::Ord::cmp);
+    builder.max_depth(max_depth);
 
     for result in builder.build() {
         if cancel.is_some_and(|flag| flag.load(AtomicOrdering::Relaxed)) {
@@ -524,10 +1480,11 @@ fn collect_candidates(
     cancel: Option<&Arc<AtomicBool>>,
 ) -> Vec<FileCandidate> {
     let mut candidates = Vec::new();
-    let _ = for_each_candidate(root, walk_root, respect_gitignore, cancel, &mut |candidate| {
-        candidates.push(candidate);
-        true
-    });
+    let _ =
+        for_each_candidate(root, walk_root, respect_gitignore, None, cancel, &mut |candidate| {
+            candidates.push(candidate);
+            true
+        });
     candidates
 }
 
@@ -765,30 +1722,127 @@ mod tests {
     }
 
     #[test]
-    fn ranking_prefers_text_order_over_recency_for_equal_matches() {
-        let mut candidates = vec![
-            FileCandidate {
-                rel_path: "src/zebra.rs".to_owned(),
-                rel_path_lower: "src/zebra.rs".to_owned(),
-                basename_lower: "zebra.rs".to_owned(),
-                depth: 1,
-                modified: SystemTime::UNIX_EPOCH + Duration::from_secs(20),
-                is_dir: false,
-            },
-            FileCandidate {
-                rel_path: "src/alpha.rs".to_owned(),
-                rel_path_lower: "src/alpha.rs".to_owned(),
-                basename_lower: "alpha.rs".to_owned(),
-                depth: 1,
-                modified: SystemTime::UNIX_EPOCH + Duration::from_secs(1),
-                is_dir: false,
-            },
-        ];
+    fn matcher_entries_repair_lookup_after_swap_remove() {
+        let mut entries = MatcherEntries::default();
+        entries.upsert(candidate("a.rs"));
+        entries.upsert(candidate("b.rs"));
+        entries.upsert(candidate("c.rs"));
 
-        rank_and_truncate_candidates(&mut candidates, "rs");
+        assert!(entries.remove_exact("b.rs"));
+        entries.upsert(candidate("c.rs"));
+        assert!(entries.remove_exact("c.rs"));
 
-        assert_eq!(candidates[0].rel_path, "src/alpha.rs");
-        assert_eq!(candidates[1].rel_path, "src/zebra.rs");
+        let remaining =
+            entries.iter().map(|candidate| candidate.rel_path.as_str()).collect::<Vec<_>>();
+        assert_eq!(remaining, vec!["a.rs"]);
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn matcher_entries_replace_prefix_keeps_lookup_consistent() {
+        let mut entries = MatcherEntries::default();
+        entries.upsert(candidate("src/a.rs"));
+        entries.upsert(candidate("src/nested/b.rs"));
+        entries.upsert(candidate("tests/c.rs"));
+
+        let (removed, stats) =
+            entries.replace_prefix("src/", vec![candidate("src/new.rs"), candidate("src/lib.rs")]);
+
+        assert_eq!(removed, 2);
+        assert_eq!(stats.inserted, 2);
+        assert_eq!(stats.replaced, 0);
+        assert!(!entries.remove_exact("src/a.rs"));
+        assert!(entries.remove_exact("src/new.rs"));
+        assert!(entries.remove_exact("src/lib.rs"));
+        assert!(entries.remove_exact("tests/c.rs"));
+        assert_eq!(entries.len(), 0);
+    }
+
+    fn mention_matcher_paths(matcher: &mut MentionMatcher, query: &str) -> Vec<String> {
+        matcher.set_query(query);
+        while matcher.tick(NUCLEO_QUERY_TICK_MS).running {}
+        matcher.candidates(MAX_CANDIDATES).into_iter().map(|candidate| candidate.rel_path).collect()
+    }
+
+    #[test]
+    fn mention_matcher_streams_scan_batches_into_nucleo() {
+        let mut matcher = MentionMatcher::default();
+        let batch =
+            (0..75).map(|idx| candidate(&format!("src/file-{idx:03}.rs"))).collect::<Vec<_>>();
+
+        let stats = matcher.upsert_scan_batch(batch);
+        let paths = mention_matcher_paths(&mut matcher, "file");
+
+        assert_eq!(stats.inserted, 75);
+        assert_eq!(matcher.injected_items(), 75);
+        assert_eq!(paths.len(), MAX_CANDIDATES);
+        assert!(paths.iter().all(|path| path.contains("file")));
+    }
+
+    #[test]
+    fn mention_matcher_finds_root_level_directory() {
+        let mut matcher = MentionMatcher::default();
+        matcher.upsert_scan_batch(vec![
+            candidate("aaa_huge/file-000.rs"),
+            candidate("web_dev_work/"),
+            candidate("src/lib.rs"),
+        ]);
+
+        let paths = mention_matcher_paths(&mut matcher, "web_dev_work");
+
+        assert!(paths.iter().any(|path| path == "web_dev_work/"));
+    }
+
+    #[test]
+    fn mention_matcher_rebuilds_after_filesystem_removal() {
+        let mut matcher = MentionMatcher::default();
+        matcher.reset(vec![candidate("old.rs"), candidate("src/current.rs")]);
+
+        assert!(mention_matcher_paths(&mut matcher, "old").iter().any(|path| path == "old.rs"));
+
+        let stats = matcher.apply_change_batch(vec![FileIndexChange::RemoveExact {
+            rel_path: "old.rs".to_owned(),
+        }]);
+        let paths = mention_matcher_paths(&mut matcher, "old");
+
+        assert_eq!(stats.removed, 1);
+        assert!(!paths.iter().any(|path| path == "old.rs"));
+    }
+
+    #[test]
+    fn matcher_runtime_prioritizes_query_over_pending_scan_batches() {
+        let (index_tx, index_rx) = mpsc::channel();
+        let (query_tx, query_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::channel();
+        let mut runtime = FileIndexMatcherRuntime::new(1, index_rx, query_rx, event_tx);
+        runtime.reset(1, 1, vec![candidate("target.rs")], false);
+        for idx in 0..32 {
+            index_tx
+                .send(FileIndexMatcherCommand::ScanBatch {
+                    generation: 1,
+                    index_version: 2 + idx,
+                    entries: vec![candidate(&format!("bulk/file-{idx:03}.rs"))],
+                })
+                .expect("queue scan batch");
+        }
+        query_tx
+            .send(MentionMatchRequest {
+                generation: 1,
+                index_version: 1,
+                sequence: 7,
+                query: "target".to_owned(),
+            })
+            .expect("queue query");
+
+        assert!(runtime.handle_next_command());
+
+        let event = event_rx.recv_timeout(Duration::from_secs(2)).expect("match result");
+        let FileIndexEvent::MatchResult(result) = event else {
+            panic!("expected match result");
+        };
+        assert_eq!(result.sequence, 7);
+        assert!(result.candidates.iter().any(|candidate| candidate.rel_path == "target.rs"));
+        assert_eq!(runtime.matcher.len(), 1);
     }
 
     #[test]
@@ -807,7 +1861,27 @@ mod tests {
     }
 
     #[test]
-    fn fs_batch_create_updates_visible_candidates_without_real_watcher() {
+    fn spawn_scan_emits_root_children_before_deep_subtrees() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join("aaa_huge")).expect("create huge sibling");
+        std::fs::create_dir_all(tmp.path().join("web_dev_work")).expect("create target sibling");
+        for idx in 0..300 {
+            let path = tmp.path().join("aaa_huge").join(format!("file-{idx}.rs"));
+            std::fs::write(path, "").expect("write file");
+        }
+        let (tx, rx) = mpsc::channel();
+        let _scan = spawn_scan(tmp.path().to_path_buf(), 1, true, tx);
+
+        let first = rx.recv_timeout(Duration::from_secs(2)).expect("first scan event");
+        let FileIndexEvent::ScanBatch { entries, .. } = first else {
+            panic!("expected first scan batch");
+        };
+
+        assert!(entries.iter().any(|candidate| candidate.rel_path == "web_dev_work/"));
+    }
+
+    #[test]
+    fn fs_batch_create_updates_matcher_candidates_without_real_watcher() {
         let mut app = App::test_default();
         app.file_index.generation = 5;
         app.file_index.scan_finished = true;
@@ -824,6 +1898,11 @@ mod tests {
         drain_events(&mut app);
 
         assert!(app.surface_dirty.chat.repaint);
+        wait_for(&mut app, Duration::from_secs(1), |app| {
+            app.mention.as_ref().is_some_and(|mention| {
+                mention.candidates.iter().any(|candidate| candidate.rel_path == "new.rs")
+            })
+        });
         let mention = app.mention.as_ref().expect("mention");
         assert_eq!(
             mention
@@ -859,6 +1938,11 @@ mod tests {
         assert!(!app.file_index.entries.contains_key("before.rs"));
         assert!(app.file_index.entries.contains_key("after.rs"));
         assert!(app.file_index.entries.contains_key("keep.rs"));
+        wait_for(&mut app, Duration::from_secs(1), |app| {
+            app.mention.as_ref().is_some_and(|mention| {
+                mention.candidates.iter().any(|candidate| candidate.rel_path == "after.rs")
+            })
+        });
         let mention = app.mention.as_ref().expect("mention");
         let visible = mention
             .candidates
@@ -868,6 +1952,50 @@ mod tests {
         assert!(visible.contains(&"after.rs"));
         assert!(visible.contains(&"keep.rs"));
         assert!(!visible.contains(&"before.rs"));
+    }
+
+    #[test]
+    fn batched_watch_events_emit_single_fs_batch() {
+        use notify::Event;
+        use notify::event::{CreateKind, EventKind};
+
+        let (_app, tmp) = app_with_temp_files(&["a.rs", "b.rs"]);
+        let root = tmp.path().canonicalize().expect("canonicalize tempdir");
+        let events = vec![
+            Ok(Event::new(EventKind::Create(CreateKind::File)).add_path(root.join("a.rs"))),
+            Ok(Event::new(EventKind::Create(CreateKind::File)).add_path(root.join("b.rs"))),
+        ];
+
+        let event = normalize_watch_events(&root, 3, true, events).expect("watch event");
+
+        let FileIndexEvent::FsBatch { generation, changes } = event else {
+            panic!("expected fs batch");
+        };
+        assert_eq!(generation, 3);
+        assert_eq!(changes.len(), 2);
+        assert!(changes.iter().any(|change| {
+            matches!(change, FileIndexChange::Upsert(candidate) if candidate.rel_path == "a.rs")
+        }));
+        assert!(changes.iter().any(|change| {
+            matches!(change, FileIndexChange::Upsert(candidate) if candidate.rel_path == "b.rs")
+        }));
+    }
+
+    #[test]
+    fn batched_watch_events_prefer_rebuild_for_ignore_semantics_change() {
+        use notify::Event;
+        use notify::event::{CreateKind, EventKind};
+
+        let (_app, tmp) = app_with_temp_files(&["a.rs"]);
+        let root = tmp.path().canonicalize().expect("canonicalize tempdir");
+        let events = vec![
+            Ok(Event::new(EventKind::Create(CreateKind::File)).add_path(root.join("a.rs"))),
+            Ok(Event::new(EventKind::Create(CreateKind::File)).add_path(root.join(".gitignore"))),
+        ];
+
+        let event = normalize_watch_events(&root, 5, true, events).expect("watch event");
+
+        assert!(matches!(event, FileIndexEvent::RebuildRequested { generation: 5 }));
     }
 
     #[test]

--- a/src/app/file_index.rs
+++ b/src/app/file_index.rs
@@ -16,6 +16,7 @@ const EVENT_DRAIN_BUDGET: usize = 64;
 const WATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const WATCH_DEBOUNCE_INTERVAL: Duration = Duration::from_millis(50);
 const MAX_CANDIDATES: usize = 50;
+const MENTION_RANK_WINDOW: usize = 1_000;
 const NUCLEO_COLUMNS: u32 = 1;
 const NUCLEO_QUERY_TICK_MS: u64 = 10;
 const MATCHER_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(5);
@@ -484,9 +485,21 @@ impl MentionMatcher {
 
     fn candidates(&self, limit: usize) -> Vec<FileCandidate> {
         let snapshot = self.engine.snapshot();
-        let limit = u32::try_from(limit).unwrap_or(u32::MAX);
-        let end = snapshot.matched_item_count().min(limit);
-        snapshot.matched_items(0..end).map(|item| item.data.clone()).collect()
+        let window = limit.max(MENTION_RANK_WINDOW);
+        let end = snapshot.matched_item_count().min(u32::try_from(window).unwrap_or(u32::MAX));
+        let mut ranked = snapshot
+            .matched_items(0..end)
+            .enumerate()
+            .map(|(nucleo_rank, item)| {
+                let candidate = item.data.clone();
+                let rank = mention_candidate_rank(&self.last_query, &candidate, nucleo_rank);
+                (rank, candidate)
+            })
+            .collect::<Vec<_>>();
+        ranked.sort_by(|(left_rank, left), (right_rank, right)| {
+            left_rank.cmp(right_rank).then_with(|| left.rel_path_lower.cmp(&right.rel_path_lower))
+        });
+        ranked.into_iter().take(limit).map(|(_, candidate)| candidate).collect()
     }
 
     fn matched_item_count(&self) -> u32 {
@@ -511,6 +524,56 @@ impl MentionMatcher {
             columns[0] = Utf32String::from(candidate.rel_path.as_str());
         });
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct MentionCandidateRank {
+    path_prefix_bucket: u8,
+    depth: usize,
+    relevance_bucket: u8,
+    path_chars: usize,
+    nucleo_rank: usize,
+}
+
+fn mention_candidate_rank(
+    query: &str,
+    candidate: &FileCandidate,
+    nucleo_rank: usize,
+) -> MentionCandidateRank {
+    let query = query.trim().to_lowercase();
+    let path = candidate.rel_path_lower.as_str();
+    let basename = candidate.basename_lower.as_str();
+    let path_prefix_bucket = u8::from(query.is_empty() || !path.starts_with(&query));
+    let relevance_bucket = if !query.is_empty()
+        && (basename.starts_with(&query)
+            || path_segments(path).any(|segment| segment.starts_with(&query)))
+    {
+        0
+    } else if query_terms_match_path(&query, path) {
+        1
+    } else {
+        2
+    };
+
+    MentionCandidateRank {
+        path_prefix_bucket,
+        depth: candidate.depth,
+        relevance_bucket,
+        path_chars: candidate.rel_path.chars().count(),
+        nucleo_rank,
+    }
+}
+
+fn path_segments(path: &str) -> impl Iterator<Item = &str> {
+    path.split('/').filter(|segment| !segment.is_empty())
+}
+
+fn query_terms_match_path(query: &str, path: &str) -> bool {
+    let mut terms = query.split_whitespace().peekable();
+    if terms.peek().is_none() {
+        return false;
+    }
+    terms.all(|term| path.contains(term))
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -1791,6 +1854,49 @@ mod tests {
         let paths = mention_matcher_paths(&mut matcher, "web_dev_work");
 
         assert!(paths.iter().any(|path| path == "web_dev_work/"));
+    }
+
+    #[test]
+    fn mention_matcher_finds_query_containing_spaces() {
+        let mut matcher = MentionMatcher::default();
+        matcher.upsert_scan_batch(vec![
+            candidate("docs/my folder/read me.md"),
+            candidate("src/main.rs"),
+        ]);
+
+        let paths = mention_matcher_paths(&mut matcher, "my folder");
+
+        assert!(paths.iter().any(|path| path == "docs/my folder/read me.md"));
+    }
+
+    #[test]
+    fn mention_matcher_prefers_shallow_paths_over_deep_dependency_matches() {
+        let mut matcher = MentionMatcher::default();
+        matcher.upsert_scan_batch(vec![
+            candidate("tester/node_modules/@supabase/auth-js/dist/module/lib/errors.js"),
+            candidate("tester/node_modules/@supabase/storage-js/dist/module/lib/errors.js"),
+            candidate("docs/supabase error module.md"),
+        ]);
+
+        let paths = mention_matcher_paths(&mut matcher, "supabase error module");
+
+        assert_eq!(paths.first().map(String::as_str), Some("docs/supabase error module.md"));
+    }
+
+    #[test]
+    fn mention_matcher_keeps_explicit_deep_path_prefix_ahead_of_shallow_matches() {
+        let mut matcher = MentionMatcher::default();
+        matcher.upsert_scan_batch(vec![
+            candidate("docs/tester node_modules note.md"),
+            candidate("tester/node_modules/@supabase/auth-js/dist/module/lib/errors.js"),
+        ]);
+
+        let paths = mention_matcher_paths(&mut matcher, "tester/node_modules");
+
+        assert_eq!(
+            paths.first().map(String::as_str),
+            Some("tester/node_modules/@supabase/auth-js/dist/module/lib/errors.js")
+        );
     }
 
     #[test]

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -766,11 +766,7 @@ pub(super) fn handle_mention_key(app: &mut App, key: KeyEvent) -> KeyOutcome {
         }
         (KeyCode::Char(c), m) if is_printable_text_modifiers(m) => {
             let changed = app.input.textarea_insert_char(c);
-            if c.is_whitespace() {
-                mention::deactivate(app);
-            } else {
-                mention::update_query(app);
-            }
+            mention::update_query(app);
             changed.into()
         }
         // Any other key: deactivate mention and forward to normal handling
@@ -993,6 +989,21 @@ mod tests {
         assert!(handled.changed());
         let slash = app.slash.as_ref().expect("slash autocomplete should stay active");
         assert_eq!(slash.dialog.selected, 1);
+    }
+
+    #[test]
+    fn mention_space_key_remains_part_of_active_query() {
+        let mut app = App::test_default();
+        app.input.set_text("@");
+        let _ = app.input.set_cursor(0, 1);
+        mention::activate(&mut app);
+
+        let outcome =
+            handle_mention_key(&mut app, KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+
+        assert!(outcome.changed());
+        let mention = app.mention.as_ref().expect("mention should stay active");
+        assert_eq!(mention.query, " ");
     }
 
     #[test]

--- a/src/app/mention.rs
+++ b/src/app/mention.rs
@@ -14,6 +14,8 @@ pub struct MentionState {
     pub trigger_col: usize,
     /// Current query text after the `@` (e.g. "src/m" from "@src/m").
     pub query: String,
+    /// Character position where confirmation replacement should stop.
+    pub replace_end_col: usize,
     /// Filtered + sorted candidates.
     pub candidates: Vec<file_index::FileCandidate>,
     /// Shared autocomplete dialog navigation state.
@@ -24,6 +26,7 @@ pub struct MentionState {
     refresh_after_pending_match: bool,
     last_scan_batch_request_at: Option<Instant>,
     last_scan_batch_request_version: u64,
+    line_char_count: usize,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -34,6 +37,30 @@ enum MentionSearchStatus {
     NoMatches,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MentionSpanSource {
+    Active,
+    IndexedPath,
+    BareToken,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MentionSpan {
+    row: usize,
+    trigger_col: usize,
+    end_col: usize,
+    query: String,
+    source: MentionSpanSource,
+}
+
+#[derive(Clone, Copy)]
+struct ActiveMentionBounds {
+    row: usize,
+    trigger_col: usize,
+    replace_end_col: usize,
+    line_char_count: usize,
+}
+
 impl MentionState {
     #[must_use]
     pub fn new(
@@ -42,6 +69,7 @@ impl MentionState {
         query: String,
         candidates: Vec<file_index::FileCandidate>,
     ) -> Self {
+        let replace_end_col = trigger_col + 1 + query.chars().count();
         let search_status = if candidates.is_empty() {
             MentionSearchStatus::Hint
         } else {
@@ -51,6 +79,7 @@ impl MentionState {
             trigger_row,
             trigger_col,
             query,
+            replace_end_col,
             candidates,
             dialog: DialogState::default(),
             search_status,
@@ -59,6 +88,7 @@ impl MentionState {
             refresh_after_pending_match: false,
             last_scan_batch_request_at: None,
             last_scan_batch_request_version: 0,
+            line_char_count: replace_end_col,
         }
     }
 
@@ -90,49 +120,67 @@ impl MentionState {
     }
 }
 
-/// Detect an `@` mention at the current cursor position.
-/// Scans backwards from the cursor to find `@`. The `@` must be preceded by
-/// whitespace, a newline, or be at position 0 (to avoid false triggers mid-word).
-/// Returns `(trigger_row, trigger_col, query)` where `trigger_col` is the
-/// position of the `@` character itself.
-pub fn detect_mention_at_cursor(
+impl From<&MentionState> for ActiveMentionBounds {
+    fn from(mention: &MentionState) -> Self {
+        Self {
+            row: mention.trigger_row,
+            trigger_col: mention.trigger_col,
+            replace_end_col: mention.replace_end_col,
+            line_char_count: mention.line_char_count,
+        }
+    }
+}
+
+fn detect_mention_span_at_cursor(
     lines: &[String],
     cursor_row: usize,
     cursor_col: usize,
-) -> Option<(usize, usize, String)> {
+    file_index: Option<&file_index::FileIndexState>,
+    active: Option<ActiveMentionBounds>,
+) -> Option<MentionSpan> {
     let line = lines.get(cursor_row)?;
-    let chars: Vec<char> = line.chars().collect();
+    let chars = line.chars().collect::<Vec<_>>();
+    let cursor_col = cursor_col.min(chars.len());
 
-    let mut i = cursor_col;
-    while i > 0 {
-        i -= 1;
-        let ch = *chars.get(i)?;
-        if ch == '@' {
-            if i == 0 || chars.get(i - 1).is_some_and(|c| c.is_whitespace()) {
-                let query: String = chars[i + 1..cursor_col].iter().collect();
-                if query.chars().all(|c| !c.is_whitespace()) {
-                    return Some((cursor_row, i, query));
-                }
-            }
-            return None;
-        }
-        if ch.is_whitespace() {
-            return None;
-        }
-    }
-    None
+    valid_trigger_cols_before_cursor(&chars, cursor_col)
+        .into_iter()
+        .rev()
+        .filter_map(|trigger_col| {
+            resolve_mention_span(cursor_row, &chars, trigger_col, cursor_col, file_index, active)
+        })
+        .find(|span| cursor_col > span.trigger_col && cursor_col <= span.end_col)
+}
+
+fn valid_trigger_cols_before_cursor(chars: &[char], cursor_col: usize) -> Vec<usize> {
+    chars
+        .iter()
+        .take(cursor_col)
+        .enumerate()
+        .filter_map(|(col, ch)| {
+            (*ch == '@' && (col == 0 || chars[col - 1].is_whitespace())).then_some(col)
+        })
+        .collect()
 }
 
 /// Activate mention autocomplete after the user types `@`.
 pub fn activate(app: &mut App) {
-    let detection =
-        detect_mention_at_cursor(app.input.lines(), app.input.cursor_row(), app.input.cursor_col());
+    let detection = detect_mention_span_at_cursor(
+        app.input.lines(),
+        app.input.cursor_row(),
+        app.input.cursor_col(),
+        Some(&app.file_index),
+        app.mention.as_ref().map(ActiveMentionBounds::from),
+    );
 
-    let Some((trigger_row, trigger_col, query)) = detection else {
+    let Some(span) = detection else {
         return;
     };
 
-    app.mention = Some(MentionState::new(trigger_row, trigger_col, query, Vec::new()));
+    let line_char_count = app.input.lines().get(span.row).map_or(0, |line| line.chars().count());
+    let mut mention = MentionState::new(span.row, span.trigger_col, span.query, Vec::new());
+    mention.replace_end_col = span.end_col;
+    mention.line_char_count = line_char_count;
+    app.mention = Some(mention);
     app.slash = None;
     app.subagent = None;
     refresh_query_state(app);
@@ -140,21 +188,57 @@ pub fn activate(app: &mut App) {
 
 /// Update the query and re-filter candidates while mention is active.
 pub fn update_query(app: &mut App) {
-    let detection =
-        detect_mention_at_cursor(app.input.lines(), app.input.cursor_row(), app.input.cursor_col());
+    let active = app.mention.as_ref().map(ActiveMentionBounds::from);
+    let detection = detect_mention_span_at_cursor(
+        app.input.lines(),
+        app.input.cursor_row(),
+        app.input.cursor_col(),
+        Some(&app.file_index),
+        active,
+    );
 
-    let Some((trigger_row, trigger_col, query)) = detection else {
+    let Some(span) = detection else {
         deactivate(app);
         return;
     };
 
+    let line_char_count = app.input.lines().get(span.row).map_or(0, |line| line.chars().count());
+    let previous_line_char_count =
+        app.mention.as_ref().map_or(line_char_count, |mention| mention.line_char_count);
+    let previous_replace_end_col =
+        app.mention.as_ref().map_or(span.end_col, |mention| mention.replace_end_col);
+    let replace_end_col = if matches!(span.source, MentionSpanSource::Active) {
+        adjust_active_replace_end(
+            previous_replace_end_col,
+            previous_line_char_count,
+            line_char_count,
+        )
+        .max(span.end_col)
+    } else {
+        span.end_col
+    };
+
     if let Some(ref mut mention) = app.mention {
-        mention.trigger_row = trigger_row;
-        mention.trigger_col = trigger_col;
-        mention.query = query;
+        mention.trigger_row = span.row;
+        mention.trigger_col = span.trigger_col;
+        mention.query = span.query;
+        mention.replace_end_col = replace_end_col;
+        mention.line_char_count = line_char_count;
     }
 
     refresh_query_state(app);
+}
+
+fn adjust_active_replace_end(
+    previous_replace_end_col: usize,
+    previous_line_char_count: usize,
+    line_char_count: usize,
+) -> usize {
+    if line_char_count >= previous_line_char_count {
+        previous_replace_end_col + (line_char_count - previous_line_char_count)
+    } else {
+        previous_replace_end_col.saturating_sub(previous_line_char_count - line_char_count)
+    }
 }
 
 pub fn refresh_from_file_index(app: &mut App) {
@@ -166,7 +250,7 @@ pub fn refresh_from_file_index_after_scan_batch(app: &mut App) {
         return;
     };
 
-    if mention.query.chars().count() < MIN_QUERY_CHARS {
+    if query_is_hint(&mention.query) {
         mention.mark_hint();
         sync_focus(app);
         return;
@@ -267,7 +351,7 @@ fn refresh_query_state(app: &mut App) {
         return;
     };
 
-    if mention.query.chars().count() < MIN_QUERY_CHARS {
+    if query_is_hint(&mention.query) {
         mention.mark_hint();
         sync_focus(app);
         return;
@@ -299,7 +383,7 @@ fn request_match_for_active_mention(app: &mut App, mode: MatchRequestMode) {
         return;
     };
 
-    if query.chars().count() < MIN_QUERY_CHARS {
+    if query_is_hint(&query) {
         if let Some(mention) = app.mention.as_mut() {
             mention.mark_hint();
         }
@@ -332,8 +416,7 @@ fn request_match_for_active_mention(app: &mut App, mode: MatchRequestMode) {
     mention.refresh_after_pending_match = false;
     mention.last_scan_batch_request_at = Some(Instant::now());
     mention.last_scan_batch_request_version = index_version;
-    if matches!(mode, MatchRequestMode::UserQuery) {
-        mention.candidates.clear();
+    if matches!(mode, MatchRequestMode::UserQuery) && mention.candidates.is_empty() {
         mention.dialog.clamp(0, AUTOCOMPLETE_VISIBLE_ROWS);
     }
     mention.search_status = MentionSearchStatus::Searching;
@@ -357,6 +440,10 @@ fn request_match_for_active_mention(app: &mut App, mode: MatchRequestMode) {
     );
 }
 
+fn query_is_hint(query: &str) -> bool {
+    query.chars().count() < MIN_QUERY_CHARS || query.trim().is_empty()
+}
+
 fn sync_focus(app: &mut App) {
     if app.mention.as_ref().is_some_and(MentionState::has_selectable_candidates) {
         app.claim_focus_target(FocusTarget::Mention);
@@ -369,9 +456,14 @@ fn sync_focus(app: &mut App) {
 /// - If cursor is inside a valid `@mention` token, activate/update autocomplete.
 /// - Otherwise, deactivate mention autocomplete.
 pub fn sync_with_cursor(app: &mut App) {
-    let in_mention =
-        detect_mention_at_cursor(app.input.lines(), app.input.cursor_row(), app.input.cursor_col())
-            .is_some();
+    let in_mention = detect_mention_span_at_cursor(
+        app.input.lines(),
+        app.input.cursor_row(),
+        app.input.cursor_col(),
+        Some(&app.file_index),
+        app.mention.as_ref().map(ActiveMentionBounds::from),
+    )
+    .is_some();
     match (in_mention, app.mention.is_some()) {
         (true, true) => update_query(app),
         (true, false) => activate(app),
@@ -404,8 +496,10 @@ pub fn confirm_selection(app: &mut App) {
         return;
     }
 
-    let mention_end =
-        (trigger_col + 1..chars.len()).find(|&i| chars[i].is_whitespace()).unwrap_or(chars.len());
+    let mention_end = resolve_confirm_end_col(&mention, &chars, &app.file_index);
+    if mention_end <= trigger_col || mention_end > chars.len() {
+        return;
+    }
 
     let before: String = chars[..trigger_col].iter().collect();
     let after: String = chars[mention_end..].iter().collect();
@@ -417,6 +511,29 @@ pub fn confirm_selection(app: &mut App) {
 
     lines[trigger_row] = new_line;
     app.input.replace_lines_and_cursor(lines, trigger_row, new_cursor_col);
+}
+
+fn resolve_confirm_end_col(
+    mention: &MentionState,
+    chars: &[char],
+    file_index: &file_index::FileIndexState,
+) -> usize {
+    if mention.replace_end_col <= chars.len()
+        && mention.replace_end_col > mention.trigger_col
+        && chars.get(mention.trigger_col) == Some(&'@')
+    {
+        return mention.replace_end_col;
+    }
+
+    resolve_mention_span(
+        mention.trigger_row,
+        chars,
+        mention.trigger_col,
+        mention.trigger_col + 1,
+        Some(file_index),
+        None,
+    )
+    .map_or(mention.trigger_col, |span| span.end_col)
 }
 
 /// Deactivate mention autocomplete.
@@ -441,27 +558,32 @@ pub fn move_down(app: &mut App) {
     }
 }
 
-/// Find all `@path` references in a text string. Returns `(start_byte, end_byte, path)` tuples.
-/// A valid `@path` must start after whitespace or at position 0, and extends until
-/// the next whitespace or end of string.
-pub fn find_mention_spans(text: &str) -> Vec<(usize, usize, String)> {
+/// Find all `@path` references in a text string. Returns `(start_col, end_col, path)` tuples.
+pub fn find_mention_spans(
+    row: usize,
+    text: &str,
+    file_index: &file_index::FileIndexState,
+    active: Option<&MentionState>,
+) -> Vec<(usize, usize, String)> {
     let mut spans = Vec::new();
     let chars: Vec<char> = text.chars().collect();
     let mut i = 0;
+    let active = active.map(ActiveMentionBounds::from);
 
     while i < chars.len() {
         if chars[i] == '@' && (i == 0 || chars[i - 1].is_whitespace()) {
-            let start = i;
-            i += 1;
-            let path_start = i;
-            while i < chars.len() && !chars[i].is_whitespace() {
+            let cursor_col = active
+                .filter(|active| active.row == row && active.trigger_col == i)
+                .map_or(i + 1, |active| active.replace_end_col.min(chars.len()));
+            if let Some(span) =
+                resolve_mention_span(row, &chars, i, cursor_col, Some(file_index), active)
+            {
+                i = span.end_col.max(i + 1);
+                if !span.query.is_empty() {
+                    spans.push((span.trigger_col, span.end_col, span.query));
+                }
+            } else {
                 i += 1;
-            }
-            if i > path_start {
-                let path: String = chars[path_start..i].iter().collect();
-                let byte_start: usize = chars[..start].iter().map(|c| c.len_utf8()).sum();
-                let byte_end: usize = chars[..i].iter().map(|c| c.len_utf8()).sum();
-                spans.push((byte_start, byte_end, path));
             }
         } else {
             i += 1;
@@ -471,16 +593,125 @@ pub fn find_mention_spans(text: &str) -> Vec<(usize, usize, String)> {
     spans
 }
 
+fn resolve_mention_span(
+    row: usize,
+    chars: &[char],
+    trigger_col: usize,
+    cursor_col: usize,
+    file_index: Option<&file_index::FileIndexState>,
+    active: Option<ActiveMentionBounds>,
+) -> Option<MentionSpan> {
+    if chars.get(trigger_col) != Some(&'@')
+        || (trigger_col > 0 && !chars[trigger_col - 1].is_whitespace())
+    {
+        return None;
+    }
+
+    if let Some(active) = active
+        && active.row == row
+        && active.trigger_col == trigger_col
+        && cursor_col > trigger_col
+        && (cursor_col <= active.replace_end_col || chars.len() > active.line_char_count)
+    {
+        let end_col = active.replace_end_col.max(cursor_col).min(chars.len());
+        if end_col > trigger_col {
+            let query = chars[trigger_col + 1..cursor_col.min(end_col)].iter().collect();
+            return Some(MentionSpan {
+                row,
+                trigger_col,
+                end_col,
+                query,
+                source: MentionSpanSource::Active,
+            });
+        }
+    }
+
+    if let Some(file_index) = file_index
+        && let Some((end_col, query)) =
+            longest_indexed_path_span(chars, trigger_col, &file_index.entries)
+    {
+        let query = span_query(chars, trigger_col, cursor_col, end_col, &query);
+        return Some(MentionSpan {
+            row,
+            trigger_col,
+            end_col,
+            query,
+            source: MentionSpanSource::IndexedPath,
+        });
+    }
+
+    let end_col = bare_token_end_col(chars, trigger_col);
+    if end_col <= trigger_col + 1 {
+        if cursor_col == trigger_col + 1 {
+            return Some(MentionSpan {
+                row,
+                trigger_col,
+                end_col: cursor_col,
+                query: String::new(),
+                source: MentionSpanSource::BareToken,
+            });
+        }
+        return None;
+    }
+    let bare_query: String = chars[trigger_col + 1..end_col].iter().collect();
+    let query = span_query(chars, trigger_col, cursor_col, end_col, &bare_query);
+    Some(MentionSpan { row, trigger_col, end_col, query, source: MentionSpanSource::BareToken })
+}
+
+fn span_query(
+    chars: &[char],
+    trigger_col: usize,
+    cursor_col: usize,
+    end_col: usize,
+    fallback: &str,
+) -> String {
+    if cursor_col > trigger_col + 1 {
+        chars[trigger_col + 1..cursor_col.min(end_col)].iter().collect()
+    } else {
+        fallback.to_owned()
+    }
+}
+
+fn longest_indexed_path_span(
+    chars: &[char],
+    trigger_col: usize,
+    entries: &std::collections::BTreeMap<String, file_index::FileCandidate>,
+) -> Option<(usize, String)> {
+    let mut longest = None;
+    let mut candidate = String::new();
+    for (path_col, ch) in chars.iter().enumerate().skip(trigger_col + 1) {
+        candidate.push(*ch);
+        let end_col = path_col + 1;
+        if entries.contains_key(&candidate) {
+            longest = Some((end_col, candidate.clone()));
+        }
+    }
+    longest
+}
+
+fn bare_token_end_col(chars: &[char], trigger_col: usize) -> usize {
+    let mut end_col = trigger_col + 1;
+    while end_col < chars.len() && !chars[end_col].is_whitespace() {
+        end_col += 1;
+    }
+    end_col
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::app::App;
+    use std::path::PathBuf;
     use std::time::{Duration, SystemTime};
 
     fn app_with_temp_files(files: &[&str]) -> (App, tempfile::TempDir) {
         let tmp = tempfile::tempdir().expect("tempdir");
         for file in files {
             let path = tmp.path().join(file);
+            if file.ends_with('/') {
+                std::fs::create_dir_all(&path).expect("create dir");
+                continue;
+            }
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent).expect("create parent");
             }
@@ -489,6 +720,31 @@ mod tests {
         let mut app = App::test_default();
         app.cwd_raw = tmp.path().to_string_lossy().into_owned();
         (app, tmp)
+    }
+
+    fn candidate(rel_path: &str) -> file_index::FileCandidate {
+        file_index::FileCandidate {
+            rel_path: rel_path.to_owned(),
+            rel_path_lower: rel_path.to_lowercase(),
+            basename_lower: rel_path
+                .trim_end_matches('/')
+                .rsplit('/')
+                .next()
+                .unwrap()
+                .to_lowercase(),
+            depth: rel_path.matches('/').count(),
+            modified: SystemTime::UNIX_EPOCH,
+            is_dir: rel_path.ends_with('/'),
+        }
+    }
+
+    fn index_paths(app: &mut App, paths: &[&str]) {
+        app.file_index.root = Some(PathBuf::from(&app.cwd_raw));
+        app.file_index.respect_gitignore = app.config.respect_gitignore_effective();
+        app.file_index.scan_finished = true;
+        for path in paths {
+            app.file_index.entries.insert((*path).to_owned(), candidate(path));
+        }
     }
 
     fn run_search(app: &mut App) {
@@ -519,6 +775,80 @@ mod tests {
     }
 
     #[test]
+    fn detects_and_highlights_indexed_file_path_with_spaces() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["docs/my file.md"]);
+
+        let spans = find_mention_spans(0, "open @docs/my file.md now", &app.file_index, None);
+
+        assert_eq!(spans, vec![(5, 21, "docs/my file.md".to_owned())]);
+    }
+
+    #[test]
+    fn detects_and_highlights_indexed_folder_path_with_spaces() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["docs/my folder/"]);
+
+        let spans = find_mention_spans(0, "open @docs/my folder/ now", &app.file_index, None);
+
+        assert_eq!(spans, vec![(5, 21, "docs/my folder/".to_owned())]);
+    }
+
+    #[test]
+    fn longest_indexed_path_wins_when_paths_share_prefixes() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["foo", "foo bar.md"]);
+
+        let spans = find_mention_spans(0, "@foo bar.md", &app.file_index, None);
+
+        assert_eq!(spans, vec![(0, 11, "foo bar.md".to_owned())]);
+    }
+
+    #[test]
+    fn indexed_prefix_does_not_over_highlight_following_prose() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["docs/my"]);
+
+        let spans = find_mention_spans(0, "@docs/my folder now", &app.file_index, None);
+
+        assert_eq!(spans, vec![(0, 8, "docs/my".to_owned())]);
+    }
+
+    #[test]
+    fn reentering_autocomplete_inside_spaced_path_uses_cursor_query_and_full_span() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["docs/my folder/read me.md"]);
+        app.input.set_text("open @docs/my folder/read me.md now");
+        let _ = app.input.set_cursor(0, "open @docs/my folder/read".chars().count());
+
+        sync_with_cursor(&mut app);
+
+        let mention = app.mention.as_ref().expect("mention should be active");
+        assert_eq!(mention.query, "docs/my folder/read");
+        assert_eq!(mention.replace_end_col, "open @docs/my folder/read me.md".chars().count());
+    }
+
+    #[test]
+    fn editing_right_side_of_spaced_mention_keeps_full_replacement_span() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["docs/my folder/read me.txt", "docs/my folder/read me.md"]);
+        app.input.set_text("open @docs/my folder/read me.txt now");
+        let _ = app.input.set_cursor(0, "open @docs/my folder/read me.".chars().count());
+        sync_with_cursor(&mut app);
+
+        let _ = app.input.textarea_insert_char('m');
+        update_query(&mut app);
+        {
+            let mention = app.mention.as_mut().expect("mention should stay active");
+            mention.candidates = vec![candidate("docs/my folder/read me.md")];
+            mention.search_status = MentionSearchStatus::Ready;
+        }
+        confirm_selection(&mut app);
+
+        assert_eq!(app.input.lines()[0], "open @docs/my folder/read me.md now");
+    }
+
+    #[test]
     fn confirm_selection_replaces_full_existing_token_without_double_space() {
         let (mut app, _tmp) = app_with_temp_files(&["src/lib.rs"]);
         app.input.set_text("open @src/lib.txt now");
@@ -546,6 +876,39 @@ mod tests {
     }
 
     #[test]
+    fn confirming_spaced_candidate_at_end_inserts_trailing_space() {
+        let (mut app, _tmp) = app_with_temp_files(&["path with spaces.md"]);
+        app.input.set_text("@path");
+        let _ = app.input.set_cursor(0, "@path".chars().count());
+
+        activate(&mut app);
+        run_search(&mut app);
+        confirm_selection(&mut app);
+
+        assert_eq!(app.input.lines()[0], "@path with spaces.md ");
+    }
+
+    #[test]
+    fn confirming_spaced_candidate_before_text_does_not_add_double_space() {
+        let mut app = App::test_default();
+        app.input.set_text("open @path with typo later");
+        let trigger_col = "open ".chars().count();
+        let mut mention = MentionState::new(
+            0,
+            trigger_col,
+            "path with typo".to_owned(),
+            vec![candidate("path with spaces.md")],
+        );
+        mention.replace_end_col = "open @path with typo".chars().count();
+        mention.search_status = MentionSearchStatus::Ready;
+        app.mention = Some(mention);
+
+        confirm_selection(&mut app);
+
+        assert_eq!(app.input.lines()[0], "open @path with spaces.md later");
+    }
+
+    #[test]
     fn activate_with_empty_query_keeps_empty_candidates_until_threshold() {
         let (mut app, _tmp) = app_with_temp_files(&["src/main.rs"]);
         app.input.set_text("@");
@@ -560,6 +923,37 @@ mod tests {
             mention.placeholder_message().as_deref(),
             Some("Type a file or folder name after @")
         );
+    }
+
+    #[test]
+    fn whitespace_only_query_stays_hint_without_searching_everything() {
+        let (mut app, _tmp) = app_with_temp_files(&["src/main.rs"]);
+        app.input.set_text("@");
+        let _ = app.input.set_cursor(0, 1);
+        activate(&mut app);
+        app.input.set_text("@ ");
+        let _ = app.input.set_cursor(0, 2);
+        update_query(&mut app);
+
+        let mention = app.mention.as_ref().expect("mention should be active");
+        assert_eq!(mention.query, " ");
+        assert!(mention.candidates.is_empty());
+        assert!(matches!(mention.search_status, MentionSearchStatus::Hint));
+    }
+
+    #[test]
+    fn user_query_refresh_keeps_existing_candidates_visible() {
+        let mut app = App::test_default();
+        let mut mention = MentionState::new(0, 0, "src".to_owned(), vec![candidate("src/lib.rs")]);
+        mention.search_status = MentionSearchStatus::Ready;
+        app.mention = Some(mention);
+
+        request_match_for_active_mention(&mut app, MatchRequestMode::UserQuery);
+
+        let mention = app.mention.as_ref().expect("mention should remain active");
+        assert_eq!(mention.candidates.len(), 1);
+        assert_eq!(mention.candidates[0].rel_path, "src/lib.rs");
+        assert!(matches!(mention.search_status, MentionSearchStatus::Searching));
     }
 
     #[test]

--- a/src/app/mention.rs
+++ b/src/app/mention.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{AUTOCOMPLETE_VISIBLE_ROWS, App, FocusTarget, dialog::DialogState, file_index};
+use std::time::{Duration, Instant};
 
 /// Minimum query length before scanning the filesystem for matches.
 pub const MIN_QUERY_CHARS: usize = 1;
+const SCAN_BATCH_REFRESH_INTERVAL: Duration = Duration::from_millis(150);
 
 pub struct MentionState {
     /// Character position (row, col) where the `@` was typed.
@@ -17,6 +19,11 @@ pub struct MentionState {
     /// Shared autocomplete dialog navigation state.
     pub dialog: DialogState,
     search_status: MentionSearchStatus,
+    next_match_sequence: u64,
+    pending_match_sequence: Option<u64>,
+    refresh_after_pending_match: bool,
+    last_scan_batch_request_at: Option<Instant>,
+    last_scan_batch_request_version: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -47,6 +54,11 @@ impl MentionState {
             candidates,
             dialog: DialogState::default(),
             search_status,
+            next_match_sequence: 0,
+            pending_match_sequence: None,
+            refresh_after_pending_match: false,
+            last_scan_batch_request_at: None,
+            last_scan_batch_request_version: 0,
         }
     }
 
@@ -72,6 +84,8 @@ impl MentionState {
     fn mark_hint(&mut self) {
         self.candidates.clear();
         self.search_status = MentionSearchStatus::Hint;
+        self.pending_match_sequence = None;
+        self.refresh_after_pending_match = false;
         self.dialog.clamp(0, AUTOCOMPLETE_VISIBLE_ROWS);
     }
 }
@@ -144,6 +158,10 @@ pub fn update_query(app: &mut App) {
 }
 
 pub fn refresh_from_file_index(app: &mut App) {
+    request_match_for_active_mention(app, MatchRequestMode::IndexRefresh);
+}
+
+pub fn refresh_from_file_index_after_scan_batch(app: &mut App) {
     let Some(mention) = app.mention.as_mut() else {
         return;
     };
@@ -154,20 +172,94 @@ pub fn refresh_from_file_index(app: &mut App) {
         return;
     }
 
-    mention.candidates = file_index::visible_candidates(&app.file_index.entries, &mention.query);
+    let index_version = app.file_index.index_version;
+    if mention.last_scan_batch_request_version >= index_version {
+        return;
+    }
+    if let Some(last_request_at) = mention.last_scan_batch_request_at
+        && last_request_at.elapsed() < SCAN_BATCH_REFRESH_INTERVAL
+    {
+        return;
+    }
+
+    request_match_for_active_mention(app, MatchRequestMode::ScanBatchRefresh);
+}
+
+pub fn apply_match_result(app: &mut App, result: file_index::MentionMatchResult) -> bool {
+    let Some(mention) = app.mention.as_mut() else {
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "mention_match_result_rejected",
+            message = "mention match result rejected because mention is inactive",
+            generation = result.generation,
+            index_version = result.index_version,
+            sequence = result.sequence,
+            query_chars = result.query.chars().count(),
+            result_count = result.candidates.len(),
+        );
+        return false;
+    };
+
+    if result.generation != app.file_index.generation
+        || result.query != mention.query
+        || mention.pending_match_sequence != Some(result.sequence)
+    {
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "mention_match_result_rejected",
+            message = "mention match result rejected because it is stale",
+            result_generation = result.generation,
+            current_generation = app.file_index.generation,
+            result_index_version = result.index_version,
+            current_index_version = app.file_index.index_version,
+            sequence = result.sequence,
+            pending_sequence = mention.pending_match_sequence,
+            result_query_chars = result.query.chars().count(),
+            current_query_chars = mention.query.chars().count(),
+            query_matches = result.query == mention.query,
+            result_count = result.candidates.len(),
+        );
+        return false;
+    }
+
+    let result_count = result.candidates.len();
+    mention.candidates = result.candidates;
+    mention.pending_match_sequence = None;
+    let needs_follow_up = mention.refresh_after_pending_match
+        || result.index_version < app.file_index.index_version
+        || result.scan_finished != app.file_index.scan_finished;
+    mention.refresh_after_pending_match = false;
     mention.search_status = if mention.candidates.is_empty() {
-        if app.file_index.scan_finished {
+        if result.scan_finished {
             MentionSearchStatus::NoMatches
         } else {
             MentionSearchStatus::Searching
         }
-    } else if app.file_index.scan_finished {
+    } else if result.scan_finished {
         MentionSearchStatus::Ready
     } else {
         MentionSearchStatus::Searching
     };
     mention.dialog.clamp(mention.candidates.len(), AUTOCOMPLETE_VISIBLE_ROWS);
     sync_focus(app);
+    if needs_follow_up {
+        request_match_for_active_mention(app, MatchRequestMode::IndexRefresh);
+    }
+    tracing::debug!(
+        target: crate::logging::targets::APP_FILE_INDEX,
+        event_name = "mention_match_result_applied",
+        message = "mention applied file index match result",
+        generation = result.generation,
+        result_index_version = result.index_version,
+        current_index_version = app.file_index.index_version,
+        sequence = result.sequence,
+        query_chars = result.query.chars().count(),
+        result_count,
+        result_scan_finished = result.scan_finished,
+        current_scan_finished = app.file_index.scan_finished,
+        follow_up_requested = needs_follow_up,
+    );
+    true
 }
 
 fn refresh_query_state(app: &mut App) {
@@ -182,7 +274,87 @@ fn refresh_query_state(app: &mut App) {
     }
 
     file_index::ensure_started(app);
-    refresh_from_file_index(app);
+    request_match_for_active_mention(app, MatchRequestMode::UserQuery);
+}
+
+#[derive(Clone, Copy)]
+enum MatchRequestMode {
+    UserQuery,
+    IndexRefresh,
+    ScanBatchRefresh,
+}
+
+impl MatchRequestMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::UserQuery => "user_query",
+            Self::IndexRefresh => "index_refresh",
+            Self::ScanBatchRefresh => "scan_batch_refresh",
+        }
+    }
+}
+
+fn request_match_for_active_mention(app: &mut App, mode: MatchRequestMode) {
+    let Some(query) = app.mention.as_ref().map(|mention| mention.query.clone()) else {
+        return;
+    };
+
+    if query.chars().count() < MIN_QUERY_CHARS {
+        if let Some(mention) = app.mention.as_mut() {
+            mention.mark_hint();
+        }
+        sync_focus(app);
+        return;
+    }
+
+    let generation = app.file_index.generation;
+    let index_version = app.file_index.index_version;
+    let Some(mention) = app.mention.as_mut() else {
+        return;
+    };
+    if mention.pending_match_sequence.is_some() && !matches!(mode, MatchRequestMode::UserQuery) {
+        mention.refresh_after_pending_match = true;
+        tracing::debug!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "mention_match_request_deferred",
+            message = "mention deferred file index match request while one is pending",
+            generation,
+            index_version,
+            mode = mode.as_str(),
+            pending_sequence = mention.pending_match_sequence,
+            query_chars = query.chars().count(),
+        );
+        return;
+    }
+    mention.next_match_sequence = mention.next_match_sequence.saturating_add(1);
+    let sequence = mention.next_match_sequence;
+    mention.pending_match_sequence = Some(sequence);
+    mention.refresh_after_pending_match = false;
+    mention.last_scan_batch_request_at = Some(Instant::now());
+    mention.last_scan_batch_request_version = index_version;
+    if matches!(mode, MatchRequestMode::UserQuery) {
+        mention.candidates.clear();
+        mention.dialog.clamp(0, AUTOCOMPLETE_VISIBLE_ROWS);
+    }
+    mention.search_status = MentionSearchStatus::Searching;
+    sync_focus(app);
+
+    tracing::debug!(
+        target: crate::logging::targets::APP_FILE_INDEX,
+        event_name = "mention_match_request_sent",
+        message = "mention requested file index match",
+        generation,
+        index_version,
+        sequence,
+        mode = mode.as_str(),
+        query_chars = query.chars().count(),
+        query_bytes = query.len(),
+    );
+
+    file_index::request_match(
+        app,
+        file_index::MentionMatchRequest { generation, index_version, sequence, query },
+    );
 }
 
 fn sync_focus(app: &mut App) {
@@ -516,6 +688,7 @@ mod tests {
         app.input.set_text("@needle");
         let _ = app.input.set_cursor(0, "@needle".chars().count());
         update_query(&mut app);
+        run_search(&mut app);
 
         let mention = app.mention.as_ref().expect("mention should remain active");
         assert_eq!(app.file_index.generation, initial_generation);
@@ -524,8 +697,56 @@ mod tests {
     }
 
     #[test]
+    fn scan_refresh_does_not_starve_pending_query_result() {
+        let mut app = App::test_default();
+        app.file_index.index_version = 5;
+        app.file_index.scan_finished = false;
+        let mut state = MentionState::new(0, 0, "web".to_owned(), Vec::new());
+        state.next_match_sequence = 1;
+        state.pending_match_sequence = Some(1);
+        app.mention = Some(state);
+
+        refresh_from_file_index_after_scan_batch(&mut app);
+
+        let mention = app.mention.as_ref().expect("mention should remain active");
+        assert_eq!(mention.pending_match_sequence, Some(1));
+        assert!(mention.refresh_after_pending_match);
+
+        let generation = app.file_index.generation;
+        let applied = apply_match_result(
+            &mut app,
+            file_index::MentionMatchResult {
+                generation,
+                index_version: 1,
+                sequence: 1,
+                query: "web".to_owned(),
+                candidates: vec![file_index::FileCandidate {
+                    rel_path: "web_dev_work/".to_owned(),
+                    rel_path_lower: "web_dev_work/".to_owned(),
+                    basename_lower: "web_dev_work".to_owned(),
+                    depth: 0,
+                    modified: SystemTime::UNIX_EPOCH,
+                    is_dir: true,
+                }],
+                scan_finished: false,
+            },
+        );
+
+        let mention = app.mention.as_ref().expect("mention should remain active");
+        assert!(applied);
+        assert_eq!(mention.candidates[0].rel_path, "web_dev_work/");
+        assert_eq!(mention.pending_match_sequence, Some(2));
+        assert!(!mention.refresh_after_pending_match);
+    }
+
+    #[test]
     fn basename_prefix_ranks_ahead_of_shallow_path_substring() {
-        let mut candidates = vec![
+        let mut app = App::test_default();
+        app.file_index.root = Some(std::path::PathBuf::from(&app.cwd_raw));
+        app.file_index.respect_gitignore = app.config.respect_gitignore_effective();
+        app.file_index.scan_finished = true;
+        app.file_index.entries.insert(
+            "docs/guide-rs.txt".to_owned(),
             file_index::FileCandidate {
                 rel_path: "docs/guide-rs.txt".to_owned(),
                 rel_path_lower: "docs/guide-rs.txt".to_owned(),
@@ -534,6 +755,9 @@ mod tests {
                 modified: SystemTime::UNIX_EPOCH,
                 is_dir: false,
             },
+        );
+        app.file_index.entries.insert(
+            "src/rs-helper.rs".to_owned(),
             file_index::FileCandidate {
                 rel_path: "src/rs-helper.rs".to_owned(),
                 rel_path_lower: "src/rs-helper.rs".to_owned(),
@@ -542,10 +766,14 @@ mod tests {
                 modified: SystemTime::UNIX_EPOCH,
                 is_dir: false,
             },
-        ];
+        );
 
-        file_index::rank_and_truncate_candidates(&mut candidates, "rs");
+        app.input.set_text("@rs");
+        let _ = app.input.set_cursor(0, 3);
+        activate(&mut app);
+        run_search(&mut app);
 
-        assert_eq!(candidates[0].rel_path, "src/rs-helper.rs");
+        let mention = app.mention.as_ref().expect("mention should be active");
+        assert_eq!(mention.candidates[0].rel_path, "src/rs-helper.rs");
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -48,6 +48,7 @@ pub use cache_policy::{
     DEFAULT_TOOL_PREVIEW_LIMIT_BYTES, TextSplitDecision, TextSplitKind, default_cache_split_policy,
     find_text_split, find_text_split_index,
 };
+pub(crate) use cache_policy::{markdown_table_tail_is_open, starts_with_markdown_table_row};
 pub use config::{ConfigHelpSection, ConfigState, ConfigTab};
 pub use connect::{create_app, start_connection};
 pub use events::{handle_client_event, handle_terminal_event};

--- a/src/app/terminal_runtime/chat_session.rs
+++ b/src/app/terminal_runtime/chat_session.rs
@@ -1187,8 +1187,8 @@ mod tests {
     use crate::app::terminal_runtime::chat_terminal::ChatTerminal;
     use crate::app::terminal_runtime::chat_terminal::plan_inline_geometry;
     use crate::app::{
-        App, ChatMessage, ChatMessageId, HistoryOutputId, MessageBlock, MessageRole, TextBlock,
-        TextBlockSpacing,
+        App, AppStatus, ChatMessage, ChatMessageId, HistoryOutputId, MessageBlock, MessageRole,
+        TextBlock, TextBlockSpacing,
     };
     use crate::ui::inline_chat_rows::{
         LiveRowBoundaryKind, LiveRowSegment, SerializedLiveRows,
@@ -1232,6 +1232,10 @@ mod tests {
             end_row,
             commit_ready: true,
         }
+    }
+
+    fn assistant_blocks_message(blocks: Vec<MessageBlock>) -> ChatMessage {
+        ChatMessage::new(MessageRole::Assistant, blocks, None)
     }
 
     fn session_with_history(history: HistoryCommitState) -> ChatTerminalSession {
@@ -1348,6 +1352,45 @@ mod tests {
                 .any(|batch| batch.confirm_ids.contains(&HistoryOutputId::Block(second_id)))
         );
         assert_eq!(inserted_text, vec!["second paragraph"]);
+    }
+
+    #[test]
+    fn static_history_batches_preserve_rendered_table_prefix_before_mutable_tail() {
+        let table = concat!(
+            "| Hassle | What users report | Refs |\n",
+            "| --- | --- | --- |\n",
+            "| Input lag | Keystrokes echo late as context fills | #18943 |\n",
+            "| Paste freeze | Pasting many lines froze the terminal |  |\n",
+            "| Scrollback destroyed |  | #42002 |\n",
+        );
+        let mut app = App::test_default();
+        app.messages.push(assistant_blocks_message(vec![
+            MessageBlock::Text(TextBlock::from_complete(table)),
+            MessageBlock::Text(TextBlock::from_complete("streaming tail remains mutable")),
+        ]));
+        app.bind_active_turn_assistant(0);
+        app.status = AppStatus::Running;
+
+        let serialized =
+            serialize_live_rows_with_boundaries_excluding(&mut app, 180, &BTreeSet::new());
+        let batches = super::build_static_history_batches(&serialized, 180, &BTreeSet::new());
+        let inserted_text = batches
+            .iter()
+            .flat_map(|batch| batch.rows.slice(0..batch.rows.len()))
+            .map(line_text)
+            .collect::<Vec<_>>();
+        let excluded_ids = batches
+            .iter()
+            .flat_map(|batch| batch.confirm_ids.iter().cloned())
+            .collect::<BTreeSet<_>>();
+        let remaining_live_text =
+            serialized.rows_excluding_ids(&excluded_ids).iter().map(line_text).collect::<Vec<_>>();
+
+        assert!(inserted_text.iter().any(|line| line == "Claude"));
+        assert!(inserted_text.iter().any(|line| line.contains("Paste freeze")));
+        assert!(inserted_text.iter().any(|line| line.contains("Scrollback destroyed")));
+        assert!(!inserted_text.iter().any(|line| line.trim_start().starts_with('|')));
+        assert_eq!(remaining_live_text, vec!["streaming tail remains mutable"]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ impl DiagnosticsPreset {
     pub fn filter_directives(&self) -> &'static str {
         match self {
             Self::Runtime => {
-                "info,bridge.lifecycle=debug,bridge.protocol=debug,app.session=debug,app.tool=debug,app.command=debug,app.permission=debug,app.network=debug,app.update=debug"
+                "info,bridge.lifecycle=debug,bridge.protocol=debug,app.session=debug,app.tool=debug,app.command=debug,app.permission=debug,app.network=debug,app.update=debug,app.file_index=debug"
             }
             Self::Session => {
                 "info,bridge.lifecycle=debug,bridge.protocol=debug,app.session=debug,app.permission=debug,app.command=debug"
@@ -36,7 +36,7 @@ impl DiagnosticsPreset {
                 "info,bridge.lifecycle=debug,bridge.protocol=debug,bridge.sdk=debug,bridge.permission=debug,bridge.mcp=debug"
             }
             Self::Full => {
-                "info,app.render=trace,app.perf=info,bridge.lifecycle=debug,bridge.protocol=debug,bridge.sdk=debug,bridge.permission=debug,bridge.mcp=debug,app.session=debug,app.tool=debug,app.command=debug,app.permission=debug,app.network=debug,app.update=debug,app.cache=debug,app.input=debug,app.paste=debug,app.config=debug,app.auth=debug"
+                "info,app.render=trace,app.perf=info,bridge.lifecycle=debug,bridge.protocol=debug,bridge.sdk=debug,bridge.permission=debug,bridge.mcp=debug,app.session=debug,app.tool=debug,app.command=debug,app.permission=debug,app.network=debug,app.update=debug,app.cache=debug,app.input=debug,app.paste=debug,app.config=debug,app.auth=debug,app.file_index=debug"
             }
         }
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -18,6 +18,7 @@ pub mod targets {
     pub const APP_CACHE: &str = "app.cache";
     pub const APP_CONFIG: &str = "app.config";
     pub const APP_COMMAND: &str = "app.command";
+    pub const APP_FILE_INDEX: &str = "app.file_index";
     pub const APP_INPUT: &str = "app.input";
     pub const APP_LIFECYCLE: &str = "app.lifecycle";
     pub const APP_NETWORK: &str = "app.network";
@@ -783,6 +784,7 @@ impl BridgeDiagnosticRecord {
             targets::APP_CACHE => emit_for_level!(targets::APP_CACHE),
             targets::APP_CONFIG => emit_for_level!(targets::APP_CONFIG),
             targets::APP_COMMAND => emit_for_level!(targets::APP_COMMAND),
+            targets::APP_FILE_INDEX => emit_for_level!(targets::APP_FILE_INDEX),
             targets::APP_INPUT => emit_for_level!(targets::APP_INPUT),
             targets::APP_PERMISSION => emit_for_level!(targets::APP_PERMISSION),
             targets::APP_PASTE => emit_for_level!(targets::APP_PASTE),

--- a/src/ui/document_table.rs
+++ b/src/ui/document_table.rs
@@ -70,6 +70,8 @@ enum MarkdownBlock {
     Table(DocumentTable),
 }
 
+const URL_TOKEN_SOFT_MIN_WIDTH: usize = 24;
+
 impl DocumentTable {
     fn column_count(&self) -> usize {
         let body_cols = self.rows.iter().map(|row| row.cells.len()).max().unwrap_or(0);
@@ -416,10 +418,19 @@ fn measure_cell_widths(text: &str) -> (usize, usize) {
     let soft_min = text
         .lines()
         .flat_map(|line| line.split_whitespace())
-        .map(display_width)
+        .map(token_soft_min_width)
         .max()
         .unwrap_or(preferred);
     (preferred, soft_min)
+}
+
+fn token_soft_min_width(token: &str) -> usize {
+    let width = display_width(token);
+    if is_url_like_token(token) { width.min(URL_TOKEN_SOFT_MIN_WIDTH) } else { width }
+}
+
+fn is_url_like_token(token: &str) -> bool {
+    token.starts_with("http://") || token.starts_with("https://") || token.starts_with("www.")
 }
 
 fn collect_column_metrics(table: &DocumentTable, cols: usize) -> Vec<ColumnMetrics> {
@@ -808,6 +819,71 @@ mod tests {
         let blocks = split_markdown_tables("| a | b |\n| this is not a separator |\n| 1 | 2 |\n");
         assert_eq!(blocks.len(), 1);
         assert!(matches!(blocks[0], MarkdownBlock::Text(_)));
+    }
+
+    #[test]
+    fn structural_parser_preserves_empty_cells_in_valid_table_rows() {
+        let blocks = split_markdown_tables(
+            "| Hassle | What users report | Refs |\n\
+             | --- | --- | --- |\n\
+             | Paste freeze | Pasting many lines froze the terminal |  |\n\
+             | Scrollback destroyed |  | #42002 |\n",
+        );
+
+        let [MarkdownBlock::Table(table)] = blocks.as_slice() else {
+            panic!("expected one parsed table, got {} blocks", blocks.len());
+        };
+
+        assert_eq!(table.column_count(), 3);
+        assert_eq!(table.rows.len(), 2);
+        assert_eq!(table.rows[0].cells.len(), 3);
+        assert_eq!(table.rows[1].cells.len(), 3);
+        assert_eq!(table.rows[0].cells[2].plain_text, "");
+        assert_eq!(table.rows[1].cells[1].plain_text, "");
+    }
+
+    #[test]
+    fn valid_long_rows_after_empty_cells_stay_in_table_grid() {
+        let input = concat!(
+            "| Hassle | What users report | Refs |\n",
+            "| --- | --- | --- |\n",
+            "| Input lag | Keystrokes echo late as context fills | #18943, #41501 |\n",
+            "| Paste freeze | Pasting many lines wrote a large amount to stdout and froze the terminal | apiyi writeup, #9935 |\n",
+            "| Scrollback destroyed | Uses alternate screen and erases native scrollback | #42002, #43643 |\n",
+        );
+        let rendered = render_strings(input, 180);
+
+        assert!(rendered.iter().any(|line| line.contains("Paste freeze")));
+        assert!(rendered.iter().any(|line| line.contains("Scrollback destroyed")));
+        assert!(!rendered.iter().any(|line| line.contains("Hassle:")));
+        assert!(!rendered.iter().any(|line| line.trim_start().starts_with('|')));
+    }
+
+    #[test]
+    fn long_url_refs_do_not_force_stacked_layout_when_grid_can_wrap() {
+        let input = concat!(
+            "| Hassle | What users report | Refs |\n",
+            "| --- | --- | --- |\n",
+            "| Silent sync failures | Progress freezes at ninety-nine percent for hours on large folders, the bar never finishes, and the only workaround anyone finds is force-quitting the whole app | https://support.example.com/community/forums/sync/threads/1042-progress-stuck-at-99-percent-on-large-folders?sort=top&page=3#latest-reply |\n",
+            "| Disappearing files | Files vanish from the sync folder with no warning and reappear later | https://support.example.com/community/forums/data-loss/threads/1043-files-disappear-then-reappear-hours-later?utm_source=digest&ref=panel |\n",
+            "| Version conflicts | Conflicting copies pile up after editing on two devices, with cryptic suffixes added to filenames, and no clear way to tell which version is the latest one here | https://github.com/example/desktop-client/issues/887?q=is%3Aissue+conflicted+copy+filename+suffix+multi-device&utm_campaign=triage |\n",
+        );
+        let rendered = render_strings(input, 120);
+
+        assert!(rendered.iter().any(|line| line.contains("Silent sync failures")));
+        assert!(rendered.iter().any(|line| line.contains("progress-stuck-at-99")));
+        assert!(!rendered.iter().any(|line| line.contains("Hassle:")));
+        assert!(!rendered.iter().any(|line| line.contains("Refs:")));
+        assert!(!rendered.iter().any(|line| line.trim_start().starts_with('|')));
+    }
+
+    #[test]
+    fn url_tokens_have_capped_soft_min_width() {
+        let (_preferred, soft_min) = measure_cell_widths(
+            "https://support.example.com/community/forums/sync/threads/1042-progress-stuck-at-99-percent-on-large-folders?sort=top&page=3#latest-reply",
+        );
+
+        assert_eq!(soft_min, URL_TOKEN_SOFT_MIN_WIDTH);
     }
 
     #[test]

--- a/src/ui/inline_chat_rows.rs
+++ b/src/ui/inline_chat_rows.rs
@@ -5,6 +5,7 @@ use crate::agent::model;
 use crate::app::{
     App, AppStatus, ChatMessage, ChatMessageId, HistoryOutputId, MessageBlock, MessageRole,
     NoticeBlock, SystemSeverity, TextBlock, TextBlockSpacing, ToolCallInfo, WelcomeBlock,
+    markdown_table_tail_is_open, starts_with_markdown_table_row,
 };
 use crate::ui::message::{MessageRenderContext, SpinnerState, render_text_block_cached};
 use crate::ui::message_rows::{MessageRowSegment, build_user_system_message_rows};
@@ -731,7 +732,8 @@ fn assistant_render_items_from_message(
                 if text.text.is_empty() {
                     continue;
                 }
-                let commit_ready = active_tail_block_idx != Some(block_idx);
+                let commit_ready =
+                    assistant_text_block_commit_ready(message, block_idx, active_tail_block_idx);
                 if let Some(pending) = pending_text.as_mut()
                     && pending.can_merge(commit_ready)
                 {
@@ -804,6 +806,51 @@ fn assistant_render_items_from_message(
 
     flush_pending_text_run(&mut pending_text, &mut items);
     items
+}
+
+fn assistant_text_block_commit_ready(
+    message: &ChatMessage,
+    block_idx: usize,
+    active_tail_block_idx: Option<usize>,
+) -> bool {
+    let Some(active_tail_block_idx) = active_tail_block_idx else {
+        return true;
+    };
+    if active_tail_block_idx == block_idx {
+        return false;
+    }
+    if active_tail_block_idx < block_idx {
+        return true;
+    }
+
+    !assistant_text_handoff_continues_open_table(message, block_idx)
+}
+
+fn assistant_text_handoff_continues_open_table(message: &ChatMessage, block_idx: usize) -> bool {
+    let Some(MessageBlock::Text(text)) = message.blocks.get(block_idx) else {
+        return false;
+    };
+    if !markdown_table_tail_is_open(&text.text) {
+        return false;
+    }
+
+    next_visible_assistant_text(message, block_idx)
+        .is_some_and(|next| starts_with_markdown_table_row(&next.text))
+}
+
+fn next_visible_assistant_text(message: &ChatMessage, block_idx: usize) -> Option<&TextBlock> {
+    for block in message.blocks.iter().skip(block_idx + 1) {
+        match block {
+            MessageBlock::Text(text) if text.text.is_empty() => {}
+            MessageBlock::Text(text) => return Some(text),
+            MessageBlock::ToolCall(tool) if tool.hidden_unless_focused_interaction() => {}
+            MessageBlock::Welcome(_)
+            | MessageBlock::ImageAttachment(_)
+            | MessageBlock::UserDialog(_) => {}
+            MessageBlock::Notice(_) | MessageBlock::ToolCall(_) => return None,
+        }
+    }
+    None
 }
 
 fn last_visible_assistant_block_idx(message: &ChatMessage) -> Option<usize> {
@@ -1722,6 +1769,46 @@ mod tests {
                 .segments()
                 .iter()
                 .any(|segment| segment.ids.contains(&HistoryOutputId::Block(second_id)))
+        );
+    }
+
+    #[test]
+    fn active_assistant_table_handoff_keeps_prefix_mutable_with_pipe_row_tail() {
+        let first = TextBlock::from_complete(concat!(
+            "| Hassle | What users report | Refs |\n",
+            "| --- | --- | --- |\n",
+            "| Input lag | Keystrokes echo late as context fills | #18943 |\n",
+        ));
+        let second = TextBlock::from_complete(
+            "| Slow startup | Startup output lands after a long delay | #42002 |\n",
+        );
+        let mut app = App::test_default();
+        app.messages.push(assistant_blocks_message(vec![
+            MessageBlock::Text(first),
+            MessageBlock::Text(second),
+        ]));
+        app.bind_active_turn_assistant(0);
+        app.status = AppStatus::Running;
+
+        let serialized = serialize_all_rows_with_boundaries(&mut app, 180);
+        let committed_ids = serialized
+            .segments()
+            .iter()
+            .filter(|segment| segment.commit_ready)
+            .flat_map(|segment| segment.ids.iter().cloned())
+            .collect::<BTreeSet<_>>();
+        let remaining =
+            serialize_live_rows_with_boundaries_excluding(&mut app, 180, &committed_ids);
+        let remaining_text = line_texts(remaining.rows());
+
+        assert_eq!(serialized.stable_row_count(), 0);
+        assert!(
+            remaining_text.iter().any(|line| line.contains("Slow startup")),
+            "expected table continuation to remain visible: {remaining_text:?}"
+        );
+        assert!(
+            !remaining_text.iter().any(|line| line.trim_start().starts_with("| Slow startup |")),
+            "table continuation must not render as a raw pipe row: {remaining_text:?}"
         );
     }
 

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -102,16 +102,23 @@ pub(crate) fn configure_input_textarea(app: &mut App) {
         textarea.set_cursor_style(Style::default().add_modifier(Modifier::REVERSED));
     }
 
-    if needs_highlight_update {
+    if needs_highlight_update || app.mention.is_some() {
         let lines = app.input.lines().to_vec();
+        let active_mention = app.mention.as_ref();
+        let file_index = &app.file_index;
         let textarea = app.input.editor_mut();
         textarea.clear_custom_highlight();
-        apply_textarea_highlights(textarea, &lines);
+        apply_textarea_highlights(textarea, &lines, file_index, active_mention);
         app.input.highlight_version = app.input.content_version;
     }
 }
 
-fn apply_textarea_highlights(textarea: &mut TextArea<'_>, lines: &[String]) {
+fn apply_textarea_highlights(
+    textarea: &mut TextArea<'_>,
+    lines: &[String],
+    file_index: &crate::app::file_index::FileIndexState,
+    active_mention: Option<&mention::MentionState>,
+) {
     let slash_style = Style::default().fg(theme::SLASH_COMMAND);
     let mention_style = Style::default().fg(Color::Cyan);
     let subagent_style = Style::default().fg(theme::SUBAGENT_TOKEN);
@@ -127,7 +134,7 @@ fn apply_textarea_highlights(textarea: &mut TextArea<'_>, lines: &[String]) {
             );
         }
 
-        for (start, end, _) in mention::find_mention_spans(line) {
+        for (start, end, _) in mention::find_mention_spans(row, line, file_index, active_mention) {
             textarea.custom_highlight(
                 ((row, start), (row, end)),
                 mention_style,


### PR DESCRIPTION
## Summary

- Move `@` file mention matching onto the file-index matcher path so expensive searches do not run on the UI path.
- Support raw `@` file and folder mentions for indexed paths containing spaces, including highlighting, cursor re-entry, right-side editing, and confirm replacement.
- Keep existing mention suggestions visible while refreshed queries are pending, and rank mention results toward explicit prefixes and shallower project paths before deep dependency matches.
- Preserve streamed markdown table rendering across cache splits so partial table updates do not corrupt layout.
- Sharpen the README rationale for the native TUI by describing concrete terminal UX failures and the Crossterm/Ratatui rendering benefit.

## Why

The mention autocomplete path was doing too much work synchronously and used whitespace-based token boundaries, which made spaced paths unreliable and caused visible suggestion flicker on large indexes. The matcher now owns fuzzy filtering, while the app keeps deterministic mention spans and stable replacement behavior.

Streaming markdown table rendering also needed stronger cache-boundary handling so table rows stay coherent as assistant output arrives incrementally.

Closes # N/A

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `cargo check --offline`
- Manual:
  - Inspected latest runtime logs for mention matcher latency, interrupted queries, and large-index behavior.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: README.md
