### PR TITLE
feat(input): make image and paste placeholders atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- **Mention file autocomplete** (#226, @srothgan): Move `@` file matching off the UI path, support raw indexed file and folder mentions with spaces, and keep suggestions stable while refreshed queries are pending.
+- **Mention file autocomplete** (#226, @srothgan): Move `@` file matching off the UI path, support raw indexed file and folder mentions with spaces, preserve whole-mention replacement boundaries, and rank shallow project paths ahead of deep dependency matches unless the query explicitly targets the deep path.
+- **Atomic input placeholders** (#227, @srothgan): Treat image badges and pasted-text placeholders as shared textarea atoms, keeping cursor movement, deletion, undo/redo, image attachment state, and paste expansion aligned through `tui-textarea-2` `0.12.0` atomic range support.
 
 ### Documentation
 
@@ -15,7 +16,6 @@ All notable changes to this project will be documented in this file.
 ### Fixes
 
 - **Inline chat resize transactions** (#217, @srothgan): Treat terminal size as a draw-transaction snapshot, recover from mid-draw resizes with purge/replay, and clip stale inline viewport geometry before owned-region clears.
-- **Mention autocomplete ranking and replacement** (#226, @srothgan): Resolve spaced `@` mention spans from active state and indexed paths, preserve whole-mention replacement boundaries, and rank shallow project paths ahead of deep dependency matches unless the query explicitly targets the deep path.
 - **Streaming markdown tables** (#226, @srothgan): Preserve table rendering across streamed cache splits so partial assistant updates do not corrupt table layout.
 
 ### Maintenance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3916,9 +3916,9 @@ dependencies = [
 
 [[package]]
 name = "tui-textarea-2"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db511c6000af883f4140245239ff98ff212e32e8d2f0e6cfc9f5acc018f2b800"
+checksum = "a6223d7c35c182bccd9af9e3e2ae695312b1c295617a2c3ed34a643176ee256e"
 dependencies = [
  "crossterm",
  "portable-atomic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter", "json"] }
 time = { version = "0.3.47", features = ["formatting", "macros"] }
 two-face = { version = "0.5.1", default-features = false, features = ["syntect-fancy"] }
 tui-markdown = { version = "0.3.7" }
-tui-textarea-2 = "0.11.0"
+tui-textarea-2 = "0.12.0"
 unicode-segmentation = "1.13.3"
 unicode-width = "0.2.2"
 uuid = { version = "1.23.2", features = ["v4"] }

--- a/src/app/clipboard_image.rs
+++ b/src/app/clipboard_image.rs
@@ -83,32 +83,6 @@ pub fn validate_image(data: &str, mime_type: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Find `[Image #N]` badge spans in a line.
-///
-/// Returns `(byte_start, byte_end, 1-based_index)` for each badge found.
-/// Shared by both the input editing logic and the UI highlighting code.
-pub fn find_image_badge_spans(line: &str) -> Vec<(usize, usize, usize)> {
-    let mut spans = Vec::new();
-    let mut search_from = 0;
-    while let Some(start) = line[search_from..].find("[Image #") {
-        let abs_start = search_from + start;
-        if let Some(end_rel) = line[abs_start..].find(']') {
-            let abs_end = abs_start + end_rel + 1;
-            let inner = &line[abs_start + 8..abs_start + end_rel];
-            if !inner.is_empty()
-                && inner.chars().all(|c| c.is_ascii_digit())
-                && let Ok(idx) = inner.parse::<usize>()
-            {
-                spans.push((abs_start, abs_end, idx));
-            }
-            search_from = abs_end;
-        } else {
-            break;
-        }
-    }
-    spans
-}
-
 /// Encode already-retrieved clipboard image data to a base64 PNG.
 ///
 /// Accepts the `arboard::ImageData` obtained from a clipboard that the caller
@@ -220,28 +194,6 @@ mod tests {
         assert!(validate_image("aGVsbG8=", "image/jpeg").is_ok());
         assert!(validate_image("aGVsbG8=", "image/gif").is_ok());
         assert!(validate_image("aGVsbG8=", "image/webp").is_ok());
-    }
-
-    // --- find_image_badge_spans ---
-
-    #[test]
-    fn find_badge_spans_basic() {
-        let spans = find_image_badge_spans("hello [Image #1] world [Image #2]");
-        assert_eq!(spans.len(), 2);
-        assert_eq!(spans[0].2, 1);
-        assert_eq!(spans[1].2, 2);
-    }
-
-    #[test]
-    fn find_badge_spans_ignores_non_numeric() {
-        let spans = find_image_badge_spans("[Image #abc] [Image #1]");
-        assert_eq!(spans.len(), 1);
-        assert_eq!(spans[0].2, 1);
-    }
-
-    #[test]
-    fn find_badge_spans_empty() {
-        assert!(find_image_badge_spans("no badges here").is_empty());
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Simon Peter Rothgang
 // SPDX-License-Identifier: Apache-2.0
 
-use tui_textarea::{CursorMove, TextArea, WrapMode};
+use tui_textarea::{AtomicDeleteDirection, AtomicRange, CursorMove, TextArea, WrapMode};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputSnapshot {
@@ -116,7 +116,19 @@ impl InputState {
             lines.push(String::new());
         }
         self.editor.set_lines(lines, (cursor_row, cursor_col));
+        self.refresh_atomic_ranges();
         self.bump_content_version();
+    }
+
+    fn refresh_atomic_ranges(&mut self) {
+        let lines = self.lines().to_vec();
+        let ranges = crate::app::input_atoms::atomic_ranges_for_textarea(&lines);
+        self.editor.set_atomic_ranges(ranges);
+    }
+
+    #[must_use]
+    pub fn atomic_ranges(&self) -> &[AtomicRange] {
+        self.editor.atomic_ranges()
     }
 
     pub fn clear_custom_highlights(&mut self) {
@@ -174,7 +186,8 @@ impl InputState {
 
     /// Replace the input with the given text, placing the cursor at the end.
     pub fn set_text(&mut self, text: &str) {
-        let mut lines: Vec<String> = text.split('\n').map(String::from).collect();
+        let normalized = normalize_line_endings(text);
+        let mut lines: Vec<String> = normalized.split('\n').map(String::from).collect();
         if lines.is_empty() {
             lines.push(String::new());
         }
@@ -200,12 +213,14 @@ impl InputState {
 
     pub fn textarea_insert_char(&mut self, c: char) -> bool {
         self.editor.insert_char(c);
+        self.refresh_atomic_ranges();
         self.bump_content_version();
         true
     }
 
     pub fn textarea_insert_newline(&mut self) -> bool {
         self.editor.insert_newline();
+        self.refresh_atomic_ranges();
         self.bump_content_version();
         true
     }
@@ -213,6 +228,7 @@ impl InputState {
     pub fn textarea_delete_char_before(&mut self) -> bool {
         let changed = self.editor.delete_char();
         if changed {
+            self.refresh_atomic_ranges();
             self.bump_content_version();
         }
         changed
@@ -221,6 +237,7 @@ impl InputState {
     pub fn textarea_delete_char_after(&mut self) -> bool {
         let changed = self.editor.delete_next_char();
         if changed {
+            self.refresh_atomic_ranges();
             self.bump_content_version();
         }
         changed
@@ -265,6 +282,7 @@ impl InputState {
     pub fn textarea_undo(&mut self) -> bool {
         let changed = self.editor.undo();
         if changed {
+            self.refresh_atomic_ranges();
             self.bump_content_version();
         }
         changed
@@ -273,6 +291,7 @@ impl InputState {
     pub fn textarea_redo(&mut self) -> bool {
         let changed = self.editor.redo();
         if changed {
+            self.refresh_atomic_ranges();
             self.bump_content_version();
         }
         changed
@@ -293,6 +312,7 @@ impl InputState {
     pub fn textarea_delete_word_before(&mut self) -> bool {
         let changed = self.editor.delete_word();
         if changed {
+            self.refresh_atomic_ranges();
             self.bump_content_version();
         }
         changed
@@ -301,6 +321,7 @@ impl InputState {
     pub fn textarea_delete_word_after(&mut self) -> bool {
         let changed = self.editor.delete_next_word();
         if changed {
+            self.refresh_atomic_ranges();
             self.bump_content_version();
         }
         changed
@@ -309,6 +330,7 @@ impl InputState {
     pub fn textarea_delete_line_before(&mut self) -> bool {
         let changed = self.editor.delete_line_by_head();
         if changed {
+            self.refresh_atomic_ranges();
             self.bump_content_version();
         }
         changed
@@ -317,6 +339,7 @@ impl InputState {
     pub fn textarea_delete_line_after(&mut self) -> bool {
         let changed = self.editor.delete_line_by_end();
         if changed {
+            self.refresh_atomic_ranges();
             self.bump_content_version();
         }
         changed
@@ -325,9 +348,20 @@ impl InputState {
     pub fn textarea_yank(&mut self) -> bool {
         let changed = self.editor.paste();
         if changed {
+            self.refresh_atomic_ranges();
             self.bump_content_version();
         }
         changed
+    }
+
+    pub fn textarea_delete_atomic_range_at_cursor(
+        &mut self,
+        direction: AtomicDeleteDirection,
+    ) -> Option<AtomicRange> {
+        let range = self.editor.delete_atomic_range_at_cursor(direction)?;
+        self.refresh_atomic_ranges();
+        self.bump_content_version();
+        Some(range)
     }
 
     pub fn insert_newline(&mut self) {
@@ -344,6 +378,7 @@ impl InputState {
         }
         let changed = self.editor.insert_str(&normalized);
         if changed {
+            self.refresh_atomic_ranges();
             self.bump_content_version();
         }
     }
@@ -367,13 +402,14 @@ impl InputState {
 
     /// Store the full text as a paste block and return its placeholder label.
     pub fn allocate_paste_block_placeholder(&mut self, text: &str) -> String {
+        let normalized = normalize_line_endings(text);
         let idx = next_free_paste_block_index(self.lines(), &self.paste_blocks);
         if idx < self.paste_blocks.len() {
-            text.clone_into(&mut self.paste_blocks[idx]);
+            normalized.clone_into(&mut self.paste_blocks[idx]);
         } else {
-            self.paste_blocks.push(text.to_owned());
+            self.paste_blocks.push(normalized.clone());
         }
-        paste_placeholder_label(idx, count_text_chars(text))
+        paste_placeholder_label(idx, count_text_chars(&normalized))
     }
 
     /// Append text to the paste block under the cursor if the cursor currently
@@ -391,10 +427,11 @@ impl InputState {
             return false;
         };
 
+        let normalized = normalize_line_endings(text);
         let Some(block) = self.paste_blocks.get_mut(idx) else {
             return false;
         };
-        block.push_str(text);
+        block.push_str(&normalized);
 
         let head = &current_line[..start];
         let tail = &current_line[end..];
@@ -468,39 +505,6 @@ impl InputState {
         u16::try_from(self.lines().len()).unwrap_or(u16::MAX)
     }
 
-    /// If the cursor is inside or immediately adjacent to an `[Image #N]` badge,
-    /// delete the entire badge and return the 1-based image index N.
-    ///
-    /// `direction` should be `"before"` for Backspace (cursor after badge) or
-    /// `"after"` for Delete (cursor before badge).
-    pub fn delete_image_badge(&mut self, direction: &str) -> Option<usize> {
-        let (row, col) = self.cursor();
-        let line = self.lines().get(row)?.clone();
-        let cursor_byte = char_to_byte_index(&line, col);
-
-        for (byte_start, byte_end, idx) in
-            crate::app::clipboard_image::find_image_badge_spans(&line)
-        {
-            let hit = match direction {
-                // Backspace: cursor is anywhere inside or at the end of the badge.
-                "before" => cursor_byte > byte_start && cursor_byte <= byte_end,
-                // Delete: cursor is anywhere inside or at the start of the badge.
-                "after" => cursor_byte >= byte_start && cursor_byte < byte_end,
-                _ => false,
-            };
-            if hit {
-                // Remove the badge text from the line.
-                let mut lines = self.lines().to_vec();
-                let l = &mut lines[row];
-                l.replace_range(byte_start..byte_end, "");
-                let new_col = byte_to_char_index(l, byte_start);
-                self.replace_lines_and_cursor(lines, row, new_col);
-                return Some(idx);
-            }
-        }
-        None
-    }
-
     /// Renumber all `[Image #N]` badges in the input to match the current
     /// `pending_images` indices (1-based). Call after removing an image.
     pub fn renumber_image_badges(&mut self) {
@@ -509,32 +513,24 @@ impl InputState {
         let mut new_cursor_col = cursor_col;
         let mut counter = 0usize;
         for (row_idx, line) in lines.iter_mut().enumerate() {
+            let atoms = crate::app::input_atoms::resolve_line_atoms(row_idx, line);
             let mut result = String::with_capacity(line.len());
             let mut search_from = 0usize;
-            // Badge text is pure ASCII (`[Image #N]`), so byte len == char len.
             let mut col_delta: isize = 0;
-            while let Some(rel_start) = line[search_from..].find("[Image #") {
-                let abs_start = search_from + rel_start;
-                if let Some(end_rel) = line[abs_start..].find(']') {
-                    let abs_end = abs_start + end_rel + 1;
-                    let inner = &line[abs_start + 8..abs_start + end_rel];
-                    if !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit()) {
-                        counter += 1;
-                        let new_badge = format!("[Image #{counter}]");
-                        result.push_str(&line[search_from..abs_start]);
-                        let old_len = abs_end - abs_start;
-                        let new_len = new_badge.len();
-                        col_delta += new_len.cast_signed() - old_len.cast_signed();
-                        result.push_str(&new_badge);
-                        search_from = abs_end;
-                        continue;
-                    }
-                    // Not a valid badge, copy as-is.
-                    result.push_str(&line[search_from..abs_end]);
-                    search_from = abs_end;
-                } else {
-                    break;
+            for atom in atoms {
+                if !matches!(atom.kind, crate::app::input_atoms::InputAtomKind::ImageBadge { .. }) {
+                    continue;
                 }
+                counter += 1;
+                let new_badge = format!("[Image #{counter}]");
+                result.push_str(&line[search_from..atom.start_byte]);
+                result.push_str(&new_badge);
+                if row_idx == cursor_row && cursor_col >= atom.end_col {
+                    let old_len = atom.end_col.saturating_sub(atom.start_col);
+                    let new_len = new_badge.chars().count();
+                    col_delta += new_len.cast_signed() - old_len.cast_signed();
+                }
+                search_from = atom.end_byte;
             }
             result.push_str(&line[search_from..]);
             *line = result;
@@ -545,11 +541,6 @@ impl InputState {
         }
         self.replace_lines_and_cursor(lines, cursor_row, new_cursor_col);
     }
-}
-
-/// Convert a byte index to a character index within a string.
-fn byte_to_char_index(s: &str, byte_idx: usize) -> usize {
-    s[..byte_idx].chars().count()
 }
 
 impl Default for InputState {
@@ -618,16 +609,17 @@ fn find_next_placeholder_with_suffix(
     line: &str,
     search_from: usize,
 ) -> Option<(usize, usize, usize)> {
-    let mut start_search = search_from;
-    while start_search < line.len() {
-        let rel = line[start_search..].find(PASTE_PREFIX)?;
-        let start = start_search + rel;
-        if let Some((idx, end_rel)) = parse_paste_placeholder_with_suffix(&line[start..]) {
-            return Some((start, start + end_rel, idx));
+    crate::app::input_atoms::resolve_line_atoms(0, line).into_iter().find_map(|atom| {
+        if atom.start_byte < search_from {
+            return None;
         }
-        start_search = start + PASTE_PREFIX.len();
-    }
-    None
+        match atom.kind {
+            crate::app::input_atoms::InputAtomKind::PasteBlock { index, .. } => {
+                Some((atom.start_byte, atom.end_byte, index))
+            }
+            crate::app::input_atoms::InputAtomKind::ImageBadge { .. } => None,
+        }
+    })
 }
 
 fn expand_placeholders_in_line(line: &str, paste_blocks: &[String]) -> String {
@@ -678,40 +670,10 @@ fn find_placeholder_ending_at_col(line: &str, cursor_col: usize) -> Option<(usiz
     None
 }
 
-/// Parse a placeholder at the start of a line.
-///
-/// Returns `(paste_block_index, placeholder_end_byte_index)`.
-pub fn parse_paste_placeholder_with_suffix(line: &str) -> Option<(usize, usize)> {
-    let rest = line.strip_prefix(PASTE_PREFIX)?;
-    let close_rel = rest.find(PASTE_SUFFIX)?;
-    let rest = &rest[..close_rel];
-    let num_str = rest.split(" - ").next()?;
-    let n: usize = num_str.parse().ok()?;
-    if n == 0 {
-        return None;
-    }
-    let end = PASTE_PREFIX.len() + close_rel + PASTE_SUFFIX.len();
-    Some((n - 1, end))
-}
-
 /// Parse the placeholder index directly before the cursor, even when the
 /// placeholder is embedded within a line.
 pub fn parse_paste_placeholder_before_cursor(line: &str, cursor_col: usize) -> Option<usize> {
     find_placeholder_ending_at_col(line, cursor_col).map(|(_, _, idx)| idx)
-}
-
-/// Return all placeholder highlight ranges in a line as `(start_col, end_col)`.
-#[must_use]
-pub fn parse_paste_placeholder_ranges(line: &str) -> Vec<(usize, usize)> {
-    let mut ranges = Vec::new();
-    let mut search_from = 0usize;
-    while let Some((start, end, _)) = find_next_placeholder_with_suffix(line, search_from) {
-        let start_col = line[..start].chars().count();
-        let end_col = line[..end].chars().count();
-        ranges.push((start_col, end_col));
-        search_from = end;
-    }
-    ranges
 }
 
 #[cfg(test)]
@@ -722,6 +684,7 @@ mod tests {
 
     use super::*;
     use pretty_assertions::assert_eq;
+    use tui_textarea::{AtomicDeleteDirection, AtomicRange};
 
     // char_to_byte_index
 
@@ -1595,11 +1558,53 @@ mod tests {
     }
 
     #[test]
-    fn parse_placeholder_with_trailing_suffix_text() {
-        let line = "[Pasted Text 2 - 42 chars]tail";
-        let parsed = parse_paste_placeholder_with_suffix(line).unwrap();
-        assert_eq!(parsed.0, 1);
-        assert_eq!(&line[..parsed.1], "[Pasted Text 2 - 42 chars]");
+    fn set_text_registers_atomic_ranges() {
+        let mut input = InputState::new();
+        input.set_text("é [Image #1] [Pasted Text 2 - 3 chars]");
+
+        assert_eq!(
+            input.atomic_ranges(),
+            &[
+                AtomicRange {
+                    row: 0,
+                    start_col: "é ".chars().count(),
+                    end_col: "é [Image #1]".chars().count(),
+                },
+                AtomicRange {
+                    row: 0,
+                    start_col: "é [Image #1] ".chars().count(),
+                    end_col: "é [Image #1] [Pasted Text 2 - 3 chars]".chars().count(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn atomic_deletion_refreshes_ranges_and_undo_restores_them() {
+        let mut input = InputState::new();
+        input.set_text("a[Image #1]b");
+        let _ = input.set_cursor_col("a[Image #1]".chars().count());
+
+        let deleted = input.textarea_delete_atomic_range_at_cursor(AtomicDeleteDirection::Backward);
+
+        assert!(deleted.is_some());
+        assert_eq!(input.text(), "ab");
+        assert!(input.atomic_ranges().is_empty());
+
+        assert!(input.textarea_undo());
+        assert_eq!(input.text(), "a[Image #1]b");
+        assert_eq!(input.atomic_ranges().len(), 1);
+    }
+
+    #[test]
+    fn paste_block_storage_normalizes_line_endings() {
+        let mut input = InputState::new();
+
+        input.insert_paste_block("a\r\nb\rc");
+
+        assert_eq!(input.lines(), vec!["[Pasted Text 1 - 5 chars]"]);
+        assert_eq!(input.paste_blocks, vec!["a\nb\nc"]);
+        assert_eq!(input.text(), "a\nb\nc");
     }
 
     #[test]
@@ -1651,7 +1656,7 @@ mod tests {
         let mut input = InputState::new();
         let original = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk";
         input.insert_paste_block(original);
-        assert!(input.append_to_active_paste_block("\nl\nm"));
+        assert!(input.append_to_active_paste_block("\r\nl\rm"));
         assert_eq!(input.lines()[0], "[Pasted Text 1 - 25 chars]");
         assert_eq!(input.text(), "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm");
     }

--- a/src/app/input_atoms.rs
+++ b/src/app/input_atoms.rs
@@ -1,0 +1,295 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use tui_textarea::{AtomicDeleteDirection, AtomicRange};
+
+const IMAGE_PREFIX: &str = "[Image #";
+const PASTE_PREFIX: &str = "[Pasted Text ";
+const PASTE_SEPARATOR: &str = " - ";
+const PASTE_SUFFIX: &str = " chars]";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InputAtomKind {
+    ImageBadge {
+        one_based_index: usize,
+    },
+    /// Zero-based index into `InputState::paste_blocks`.
+    PasteBlock {
+        index: usize,
+        char_count: usize,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InputAtom {
+    pub kind: InputAtomKind,
+    pub row: usize,
+    pub start_byte: usize,
+    pub end_byte: usize,
+    pub start_col: usize,
+    pub end_col: usize,
+}
+
+// File/folder mentions and skill mentions are intentionally excluded for now.
+// They need a separate design because they interact with autocomplete and command routing.
+
+#[must_use]
+pub fn resolve_input_atoms(lines: &[String]) -> Vec<InputAtom> {
+    let mut atoms = Vec::new();
+    for (row, line) in lines.iter().enumerate() {
+        atoms.extend(resolve_line_atoms(row, line));
+    }
+    atoms
+}
+
+#[must_use]
+pub fn resolve_line_atoms(row: usize, line: &str) -> Vec<InputAtom> {
+    let mut candidates = Vec::new();
+    collect_image_atoms(row, line, &mut candidates);
+    collect_paste_atoms(row, line, &mut candidates);
+    candidates.sort_by_key(|atom| (atom.row, atom.start_byte));
+
+    let mut atoms: Vec<InputAtom> = Vec::with_capacity(candidates.len());
+    for atom in candidates {
+        let overlaps_previous = atoms.last().is_some_and(|previous| {
+            previous.row == atom.row && atom.start_byte < previous.end_byte
+        });
+        if !overlaps_previous {
+            atoms.push(atom);
+        }
+    }
+    atoms
+}
+
+#[must_use]
+pub fn atom_at_cursor(
+    lines: &[String],
+    cursor_row: usize,
+    cursor_col: usize,
+    direction: AtomicDeleteDirection,
+) -> Option<InputAtom> {
+    lines.get(cursor_row).into_iter().flat_map(|line| resolve_line_atoms(cursor_row, line)).find(
+        |atom| match direction {
+            AtomicDeleteDirection::Backward => {
+                atom.start_col < cursor_col && cursor_col <= atom.end_col
+            }
+            AtomicDeleteDirection::Forward => {
+                atom.start_col <= cursor_col && cursor_col < atom.end_col
+            }
+        },
+    )
+}
+
+#[must_use]
+pub fn atomic_ranges_for_textarea(lines: &[String]) -> Vec<AtomicRange> {
+    resolve_input_atoms(lines)
+        .into_iter()
+        .map(|atom| AtomicRange { row: atom.row, start_col: atom.start_col, end_col: atom.end_col })
+        .collect()
+}
+
+fn collect_image_atoms(row: usize, line: &str, atoms: &mut Vec<InputAtom>) {
+    let mut search_from = 0usize;
+    while search_from < line.len() {
+        let Some(rel_start) = line[search_from..].find(IMAGE_PREFIX) else {
+            break;
+        };
+        let start = search_from + rel_start;
+        if let Some((one_based_index, end)) = parse_image_badge_at(line, start) {
+            atoms.push(new_atom(
+                InputAtomKind::ImageBadge { one_based_index },
+                row,
+                line,
+                start,
+                end,
+            ));
+            search_from = end;
+        } else {
+            search_from = start + IMAGE_PREFIX.len();
+        }
+    }
+}
+
+fn collect_paste_atoms(row: usize, line: &str, atoms: &mut Vec<InputAtom>) {
+    let mut search_from = 0usize;
+    while search_from < line.len() {
+        let Some(rel_start) = line[search_from..].find(PASTE_PREFIX) else {
+            break;
+        };
+        let start = search_from + rel_start;
+        if let Some((index, char_count, end)) = parse_paste_placeholder_at(line, start) {
+            atoms.push(new_atom(
+                InputAtomKind::PasteBlock { index, char_count },
+                row,
+                line,
+                start,
+                end,
+            ));
+            search_from = end;
+        } else {
+            search_from = start + PASTE_PREFIX.len();
+        }
+    }
+}
+
+fn parse_image_badge_at(line: &str, start: usize) -> Option<(usize, usize)> {
+    let rest = line.get(start..)?.strip_prefix(IMAGE_PREFIX)?;
+    let digits_len = rest.bytes().take_while(u8::is_ascii_digit).count();
+    if digits_len == 0 || rest.as_bytes().get(digits_len).copied() != Some(b']') {
+        return None;
+    }
+    let one_based_index: usize = rest[..digits_len].parse().ok()?;
+    if one_based_index == 0 {
+        return None;
+    }
+    Some((one_based_index, start + IMAGE_PREFIX.len() + digits_len + 1))
+}
+
+fn parse_paste_placeholder_at(line: &str, start: usize) -> Option<(usize, usize, usize)> {
+    let rest = line.get(start..)?.strip_prefix(PASTE_PREFIX)?;
+    let n_len = rest.bytes().take_while(u8::is_ascii_digit).count();
+    if n_len == 0 {
+        return None;
+    }
+    let one_based_index: usize = rest[..n_len].parse().ok()?;
+    if one_based_index == 0 {
+        return None;
+    }
+
+    let rest = rest.get(n_len..)?.strip_prefix(PASTE_SEPARATOR)?;
+    let char_count_len = rest.bytes().take_while(u8::is_ascii_digit).count();
+    if char_count_len == 0 {
+        return None;
+    }
+    let char_count: usize = rest[..char_count_len].parse().ok()?;
+    if char_count == 0 || !rest.get(char_count_len..)?.starts_with(PASTE_SUFFIX) {
+        return None;
+    }
+
+    let end = start
+        + PASTE_PREFIX.len()
+        + n_len
+        + PASTE_SEPARATOR.len()
+        + char_count_len
+        + PASTE_SUFFIX.len();
+    Some((one_based_index - 1, char_count, end))
+}
+
+fn new_atom(
+    kind: InputAtomKind,
+    row: usize,
+    line: &str,
+    start_byte: usize,
+    end_byte: usize,
+) -> InputAtom {
+    InputAtom {
+        kind,
+        row,
+        start_byte,
+        end_byte,
+        start_col: byte_to_char_index(line, start_byte),
+        end_col: byte_to_char_index(line, end_byte),
+    }
+}
+
+fn byte_to_char_index(s: &str, byte_idx: usize) -> usize {
+    s[..byte_idx].chars().count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn detects_image_badges() {
+        let atoms = resolve_line_atoms(0, "hello [Image #1] world [Image #23]");
+        assert_eq!(
+            atoms.iter().map(|atom| atom.kind).collect::<Vec<_>>(),
+            vec![
+                InputAtomKind::ImageBadge { one_based_index: 1 },
+                InputAtomKind::ImageBadge { one_based_index: 23 },
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_image_badges() {
+        let atoms =
+            resolve_line_atoms(0, "[Image #0] [Image #] [Image #abc] [Image #1x] [Image #2]");
+        assert_eq!(atoms.len(), 1);
+        assert_eq!(atoms[0].kind, InputAtomKind::ImageBadge { one_based_index: 2 });
+    }
+
+    #[test]
+    fn detects_paste_placeholders() {
+        let atoms = resolve_line_atoms(1, "[Pasted Text 1 - 42 chars] x [Pasted Text 3 - 5 chars]");
+        assert_eq!(
+            atoms.iter().map(|atom| atom.kind).collect::<Vec<_>>(),
+            vec![
+                InputAtomKind::PasteBlock { index: 0, char_count: 42 },
+                InputAtomKind::PasteBlock { index: 2, char_count: 5 },
+            ]
+        );
+        assert!(atoms.iter().all(|atom| atom.row == 1));
+    }
+
+    #[test]
+    fn rejects_malformed_paste_placeholders() {
+        let atoms = resolve_line_atoms(
+            0,
+            "[Pasted Text 0 - 1 chars] [Pasted Text 1] [Pasted Text 1 - 0 chars] \
+             [Pasted Text 2 - 3 words] [Pasted Text 4 - 9 chars]",
+        );
+        assert_eq!(atoms.len(), 1);
+        assert_eq!(atoms[0].kind, InputAtomKind::PasteBlock { index: 3, char_count: 9 });
+    }
+
+    #[test]
+    fn returns_byte_and_char_ranges_after_unicode() {
+        let line = "é [Image #7]";
+        let atoms = resolve_line_atoms(2, line);
+        assert_eq!(atoms.len(), 1);
+        assert_eq!(atoms[0].start_byte, "é ".len());
+        assert_eq!(atoms[0].start_col, "é ".chars().count());
+        assert_eq!(atoms[0].end_byte, line.len());
+        assert_eq!(atoms[0].end_col, line.chars().count());
+    }
+
+    #[test]
+    fn detects_mixed_atoms_in_order() {
+        let atoms = resolve_input_atoms(&[
+            "x [Pasted Text 2 - 3 chars]".to_owned(),
+            "[Image #1]".to_owned(),
+        ]);
+        assert_eq!(
+            atoms.iter().map(|atom| atom.kind).collect::<Vec<_>>(),
+            vec![
+                InputAtomKind::PasteBlock { index: 1, char_count: 3 },
+                InputAtomKind::ImageBadge { one_based_index: 1 },
+            ]
+        );
+    }
+
+    #[test]
+    fn atom_at_cursor_uses_directional_boundaries() {
+        let lines = vec!["ab[Image #1]cd".to_owned()];
+        let start = "ab".chars().count();
+        let end = "ab[Image #1]".chars().count();
+
+        assert!(atom_at_cursor(&lines, 0, start, AtomicDeleteDirection::Backward).is_none());
+        assert!(atom_at_cursor(&lines, 0, end, AtomicDeleteDirection::Forward).is_none());
+        assert!(atom_at_cursor(&lines, 0, end, AtomicDeleteDirection::Backward).is_some());
+        assert!(atom_at_cursor(&lines, 0, start, AtomicDeleteDirection::Forward).is_some());
+        assert!(atom_at_cursor(&lines, 0, start + 1, AtomicDeleteDirection::Backward).is_some());
+    }
+
+    #[test]
+    fn converts_atoms_to_textarea_ranges() {
+        let ranges = atomic_ranges_for_textarea(&["x[Image #1]".to_owned()]);
+        assert_eq!(
+            ranges,
+            vec![AtomicRange { row: 0, start_col: 1, end_col: "x[Image #1]".chars().count() }]
+        );
+    }
+}

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -14,10 +14,12 @@ use crate::app::keymap::{
     TerminalAction,
 };
 use crate::app::state::AutocompleteKind;
+use crate::app::{input_atoms, input_atoms::InputAtomKind};
 use crate::app::{mention, permissions, questions, slash, subagent};
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use std::rc::Rc;
 use std::time::Instant;
+use tui_textarea::AtomicDeleteDirection;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RuntimeCommand {
@@ -316,28 +318,28 @@ fn execute_input_action(app: &mut App, action: InputAction) -> KeyOutcome {
 }
 
 fn delete_input_char_before(app: &mut App) -> bool {
-    if try_delete_image_badge(app, "before") {
+    if try_delete_input_atom(app, AtomicDeleteDirection::Backward) {
         return true;
     }
     app.input.textarea_delete_char_before()
 }
 
 fn delete_input_char_after(app: &mut App) -> bool {
-    if try_delete_image_badge(app, "after") {
+    if try_delete_input_atom(app, AtomicDeleteDirection::Forward) {
         return true;
     }
     app.input.textarea_delete_char_after()
 }
 
 fn delete_input_word_before(app: &mut App) -> bool {
-    if try_delete_image_badge(app, "before") {
+    if try_delete_input_atom(app, AtomicDeleteDirection::Backward) {
         return true;
     }
     app.input.textarea_delete_word_before()
 }
 
 fn delete_input_word_after(app: &mut App) -> bool {
-    if try_delete_image_badge(app, "after") {
+    if try_delete_input_atom(app, AtomicDeleteDirection::Forward) {
         return true;
     }
     app.input.textarea_delete_word_after()
@@ -643,19 +645,42 @@ pub(super) fn reclaim_input_from_inline_prompt_if_needed(app: &mut App) {
     }
 }
 
-/// If the cursor is inside or adjacent to an `[Image #N]` badge, delete the
-/// entire badge, remove the associated image from `pending_images`, and
-/// renumber remaining badges. Returns `true` if a badge was deleted.
-fn try_delete_image_badge(app: &mut App, direction: &str) -> bool {
-    let Some(one_based_idx) = app.input.delete_image_badge(direction) else {
+fn try_delete_input_atom(app: &mut App, direction: AtomicDeleteDirection) -> bool {
+    let (cursor_row, cursor_col) = app.input.cursor();
+    let Some(atom) =
+        input_atoms::atom_at_cursor(app.input.lines(), cursor_row, cursor_col, direction)
+    else {
         return false;
     };
-    let array_idx = one_based_idx.saturating_sub(1);
-    if array_idx < app.pending_images.len() {
-        app.pending_images.remove(array_idx);
+    if app.input.textarea_delete_atomic_range_at_cursor(direction).is_none() {
+        return false;
     }
-    app.input.renumber_image_badges();
-    app.request_chat_repaint();
+
+    match atom.kind {
+        InputAtomKind::ImageBadge { one_based_index } => {
+            let array_idx = one_based_index - 1;
+            if array_idx < app.pending_images.len() {
+                app.pending_images.remove(array_idx);
+            }
+            app.input.renumber_image_badges();
+            app.request_chat_repaint();
+        }
+        InputAtomKind::PasteBlock { index, .. } => {
+            if app
+                .active_paste_session
+                .is_some_and(|session| session.placeholder_index == Some(index))
+            {
+                app.active_paste_session = None;
+            }
+            if app
+                .pending_paste_session
+                .is_some_and(|session| session.placeholder_index == Some(index))
+            {
+                app.pending_paste_session = None;
+            }
+            app.request_chat_repaint();
+        }
+    }
     true
 }
 
@@ -679,7 +704,7 @@ fn handle_printable_key(app: &mut App, key: KeyEvent) -> bool {
         CharAction::RetroCapture(delete_count) => {
             // Burst confirmation retro-captured already-inserted leading chars.
             for _ in 0..delete_count {
-                let _ = app.input.textarea_delete_char_before();
+                let _ = delete_input_char_before(app);
             }
             tracing::debug!(
                 target: crate::logging::targets::APP_PASTE,
@@ -760,7 +785,7 @@ pub(super) fn handle_mention_key(app: &mut App, key: KeyEvent) -> KeyOutcome {
             KeyOutcome::Handled(true)
         }
         (KeyCode::Backspace, _) => {
-            let changed = app.input.textarea_delete_char_before();
+            let changed = delete_input_char_before(app);
             mention::update_query(app);
             changed.into()
         }
@@ -803,7 +828,7 @@ fn handle_slash_key(app: &mut App, key: KeyEvent) -> KeyOutcome {
             KeyOutcome::Handled(true)
         }
         (KeyCode::Backspace, _) => {
-            let changed = app.input.textarea_delete_char_before();
+            let changed = delete_input_char_before(app);
             slash::update_query(app);
             changed.into()
         }
@@ -845,7 +870,7 @@ fn handle_subagent_key(app: &mut App, key: KeyEvent) -> KeyOutcome {
             KeyOutcome::Handled(true)
         }
         (KeyCode::Backspace, _) => {
-            let changed = app.input.textarea_delete_char_before();
+            let changed = delete_input_char_before(app);
             subagent::update_query(app);
             changed.into()
         }
@@ -938,6 +963,88 @@ mod tests {
 
         assert_eq!(outcome, KeyOutcome::Handled(true));
         assert_eq!(app.input.cursor_col(), 1);
+    }
+
+    #[test]
+    fn backspace_after_image_atom_removes_pending_image_and_renumbers_badges() {
+        let mut app = App::test_default();
+        app.input.set_text("[Image #1] text [Image #2]");
+        let _ = app.input.set_cursor_col("[Image #1]".chars().count());
+        app.pending_images = vec![
+            crate::app::clipboard_image::ImageAttachment {
+                data: "first".to_owned(),
+                mime_type: "image/png".to_owned(),
+            },
+            crate::app::clipboard_image::ImageAttachment {
+                data: "second".to_owned(),
+                mime_type: "image/png".to_owned(),
+            },
+        ];
+        app.surface_dirty.chat.repaint = false;
+
+        let outcome = execute_key_action(
+            &mut app,
+            KeyAction::Input(InputAction::DeleteCharBefore),
+            KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+        );
+
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+        assert_eq!(app.input.text(), " text [Image #1]");
+        assert_eq!(app.pending_images.len(), 1);
+        assert_eq!(app.pending_images[0].data, "second");
+        assert!(app.surface_dirty.chat.repaint);
+    }
+
+    #[test]
+    fn delete_before_paste_atom_removes_placeholder_only_and_clears_session() {
+        let mut app = App::test_default();
+        app.input.insert_str("before ");
+        app.input.insert_paste_block("a\r\nb\rc");
+        app.input.insert_str(" after");
+        let _ = app.input.set_cursor_col("before ".chars().count());
+        app.active_paste_session = Some(crate::app::PasteSessionState {
+            id: 1,
+            start: crate::app::SelectionPoint { row: 0, col: "before ".chars().count() },
+            placeholder_index: Some(0),
+        });
+        app.pending_paste_session = app.active_paste_session;
+        app.surface_dirty.chat.repaint = false;
+
+        let outcome = execute_key_action(
+            &mut app,
+            KeyAction::Input(InputAction::DeleteCharAfter),
+            KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE),
+        );
+
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+        assert_eq!(app.input.lines(), vec!["before  after"]);
+        assert_eq!(app.input.text(), "before  after");
+        assert_eq!(app.input.paste_blocks, vec!["a\nb\nc"]);
+        assert!(app.active_paste_session.is_none());
+        assert!(app.pending_paste_session.is_none());
+        assert!(app.surface_dirty.chat.repaint);
+    }
+
+    #[test]
+    fn autocomplete_backspace_uses_atom_side_effects() {
+        let mut app = App::test_default();
+        app.input.set_text("[Image #1]");
+        let _ = app.input.set_cursor_col("[Image #1]".chars().count());
+        app.pending_images = vec![crate::app::clipboard_image::ImageAttachment {
+            data: "image".to_owned(),
+            mime_type: "image/png".to_owned(),
+        }];
+        app.mention = Some(mention::MentionState::new(0, 0, String::new(), Vec::new()));
+        app.claim_focus_target(FocusTarget::Mention);
+        app.surface_dirty.chat.repaint = false;
+
+        let outcome =
+            handle_mention_key(&mut app, KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+        assert!(app.input.is_empty());
+        assert!(app.pending_images.is_empty());
+        assert!(app.surface_dirty.chat.repaint);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -14,6 +14,7 @@ mod focus;
 mod git_context;
 mod inline_interactions;
 pub(crate) mod input;
+pub(crate) mod input_atoms;
 mod input_submit;
 pub mod keymap;
 mod keys;

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Simon Peter Rothgang
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::app::input::parse_paste_placeholder_ranges;
+use crate::app::input_atoms::{self, InputAtomKind};
 use crate::app::mention;
 use crate::app::subagent;
 use crate::app::{App, FocusOwner};
@@ -150,20 +150,19 @@ fn apply_textarea_highlights(
             );
         }
 
-        for (start, end) in parse_paste_placeholder_ranges(line) {
-            textarea.custom_highlight(
-                ((row, start), (row, end)),
-                paste_style,
-                HIGHLIGHT_PASTE_PRIORITY,
-            );
-        }
-
-        for (start, end, _) in crate::app::clipboard_image::find_image_badge_spans(line) {
-            textarea.custom_highlight(
-                ((row, start), (row, end)),
-                image_badge_style,
-                HIGHLIGHT_IMAGE_BADGE_PRIORITY,
-            );
+        for atom in input_atoms::resolve_line_atoms(row, line) {
+            match atom.kind {
+                InputAtomKind::PasteBlock { .. } => textarea.custom_highlight(
+                    ((row, atom.start_col), (row, atom.end_col)),
+                    paste_style,
+                    HIGHLIGHT_PASTE_PRIORITY,
+                ),
+                InputAtomKind::ImageBadge { .. } => textarea.custom_highlight(
+                    ((row, atom.start_col), (row, atom.end_col)),
+                    image_badge_style,
+                    HIGHLIGHT_IMAGE_BADGE_PRIORITY,
+                ),
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add shared strict parsing for image badges and pasted-text placeholders as input atoms.
- Register `tui-textarea-2` atomic ranges after input mutations so cursor movement and deletion treat atoms as indivisible editor content.
- Replace image-only deletion with generic atom deletion that preserves pending image alignment, paste placeholder expansion behavior, paste session cleanup, and image badge renumbering.
- Update `tui-textarea-2` to crates.io `0.12.0` for released atomic range support.

## Why

Image badges and large-paste placeholders are structural inline content, but they were previously editable as ordinary text. That allowed cursor placement and deletion inside tokens, which could desynchronize visible input from `pending_images` or `paste_blocks`.

This keeps app-specific parsing and side effects in the app while relying on `tui-textarea-2` for generic editor invariants such as cursor normalization, atomic deletion, word movement, wrapping-aware movement, and undo-aware range removal.

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
- Manual:
  - Verified image badges and pasted-text placeholders behave atomically in the TUI.
  - Verified the app works against crates.io `tui-textarea-2` `0.12.0`.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
