### PR TITLE
chore(release): publish 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.13.0] - 2026-07-02 [Changes][v0.13.0]
 
 ### Features
 
@@ -661,6 +661,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.13.0]: https://github.com/srothgan/claude-code-rust/compare/v0.12.4...v0.13.0
 [v0.12.4]: https://github.com/srothgan/claude-code-rust/compare/v0.12.3...v0.12.4
 [v0.12.3]: https://github.com/srothgan/claude-code-rust/compare/v0.12.2...v0.12.3
 [v0.12.2]: https://github.com/srothgan/claude-code-rust/compare/v0.12.1...v0.12.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.12.4"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/docs/src/about.md
+++ b/docs/src/about.md
@@ -6,7 +6,7 @@ The goal is a faster, lower-memory terminal experience with reliable scrollback,
 
 ## Project Status
 
-The project is pre-1.0. The current release line is `0.12.x`, and the crate version is tracked in the root `Cargo.toml`.
+The project is pre-1.0. The current release line is `0.13.x`, and the crate version is tracked in the root `Cargo.toml`.
 
 The project is useful today, but the runtime still depends on the upstream Claude Agent SDK bridge. Startup readiness, authentication behavior, billing, model availability, and service limits are controlled by Anthropic.
 


### PR DESCRIPTION
## Summary

- Bump the crate package version and lockfile metadata to `0.13.0`.
- Promote the changelog `Unreleased` entries to the `0.13.0` release dated `2026-07-02`.
- Add the `v0.13.0` changelog compare link.
- Update the docs project status copy to reference the `0.13.x` release line.

## Why

Prepare the `0.13.0` release branch with the version metadata, changelog state, and docs copy expected for tagging and publishing. The release workflow will create `v0.13.0`, build release binaries, create the GitHub Release from the `0.13.0` changelog section, sync the npm package version from `Cargo.toml`, and publish npm.

Closes #

## Validation

- 

## Notes

- Breaking changes: N/A
- Docs updated: Yes -- `CHANGELOG.md` and `docs/src/about.md`
