### PR TITLE
refactor(app): extract focused app state groups

### DIFF
--- a/bin/claude-rs.js
+++ b/bin/claude-rs.js
@@ -12,6 +12,51 @@ const TARGETS = {
   "win32:x64": { target: "x86_64-pc-windows-msvc", exe: "claude-rs.exe" }
 };
 
+const BRIDGE_RUNTIME_EXE =
+  process.platform === "win32" ? "claude-rs-bridge-node.exe" : "claude-rs-bridge-node";
+const BRIDGE_RUNTIME_VERSION_MARKER = ".bridge-node-version";
+
+// Postinstall copies the installing Node as the bridge runtime, but postinstall
+// only runs on package install - a later Node upgrade leaves the copy stale.
+// Since this launcher runs under the user's current Node on every start, it can
+// cheaply detect the mismatch via the version marker and refresh the copy.
+// Best-effort: if the copy is locked by a running session or anything else
+// fails, keep the existing runtime and retry on a future launch.
+function refreshBridgeRuntime(installDir) {
+  const runtimePath = path.join(installDir, BRIDGE_RUNTIME_EXE);
+  const markerPath = path.join(installDir, BRIDGE_RUNTIME_VERSION_MARKER);
+  const tempPath = `${runtimePath}.tmp-${process.pid}`;
+
+  try {
+    if (!fs.existsSync(runtimePath)) {
+      return;
+    }
+
+    let markerVersion = "";
+    try {
+      markerVersion = fs.readFileSync(markerPath, "utf8").trim();
+    } catch {
+      // Missing or unreadable marker: treat the copy as stale and refresh.
+    }
+    if (markerVersion === process.version) {
+      return;
+    }
+
+    fs.copyFileSync(process.execPath, tempPath);
+    if (process.platform !== "win32") {
+      fs.chmodSync(tempPath, 0o755);
+    }
+    fs.renameSync(tempPath, runtimePath);
+    fs.writeFileSync(markerPath, `${process.version}\n`);
+  } catch {
+    try {
+      fs.rmSync(tempPath, { force: true });
+    } catch {
+      // Leave the temp file for the OS/next run; the old runtime still works.
+    }
+  }
+}
+
 function resolveInstall() {
   const key = `${process.platform}:${process.arch}`;
   const info = TARGETS[key];
@@ -36,6 +81,8 @@ if (resolved.error) {
   console.error(resolved.error);
   process.exit(1);
 }
+
+refreshBridgeRuntime(path.dirname(resolved.binaryPath));
 
 const child = spawn(resolved.binaryPath, process.argv.slice(2), {
   stdio: "inherit",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rust",
-  "version": "0.10.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rust",
-      "version": "0.10.0",
+      "version": "0.13.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-rust",
-  "version": "0.10.0",
+  "version": "0.13.0",
   "description": "Claude Code Rust - native Rust terminal interface for Claude Code",
   "keywords": [
     "cli",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -17,6 +17,7 @@ const TARGETS = {
 const MAX_REDIRECTS = 5;
 const BRIDGE_RUNTIME_EXE =
   process.platform === "win32" ? "claude-rs-bridge-node.exe" : "claude-rs-bridge-node";
+const BRIDGE_RUNTIME_VERSION_MARKER = ".bridge-node-version";
 
 function getTargetInfo() {
   return TARGETS[`${process.platform}:${process.arch}`];
@@ -62,6 +63,7 @@ async function downloadFile(url, outPath, redirects = 0) {
 function installRenamedBridgeRuntime(installDir) {
   const sourcePath = process.execPath;
   const runtimePath = path.join(installDir, BRIDGE_RUNTIME_EXE);
+  const markerPath = path.join(installDir, BRIDGE_RUNTIME_VERSION_MARKER);
 
   try {
     if (!sourcePath || !fs.existsSync(sourcePath)) {
@@ -88,10 +90,15 @@ function installRenamedBridgeRuntime(installDir) {
       );
     }
 
+    // Record the copied runtime's version so the `claude-rs` launcher can
+    // detect a stale copy after the user upgrades Node and refresh it.
+    fs.writeFileSync(markerPath, `${version}\n`);
+
     console.log(`Installed renamed Agent SDK bridge runtime ${BRIDGE_RUNTIME_EXE} (${version})`);
   } catch (error) {
     try {
       fs.rmSync(runtimePath, { force: true });
+      fs.rmSync(markerPath, { force: true });
     } catch {
       // Best-effort cleanup only; the Rust binary can still fall back to `node`.
     }
@@ -122,8 +129,14 @@ async function main() {
   const tempPath = `${binaryPath}.tmp`;
 
   fs.mkdirSync(installDir, { recursive: true });
-  await downloadFile(url, tempPath);
-  fs.renameSync(tempPath, binaryPath);
+  fs.rmSync(tempPath, { force: true });
+  try {
+    await downloadFile(url, tempPath);
+    fs.renameSync(tempPath, binaryPath);
+  } catch (error) {
+    fs.rmSync(tempPath, { force: true });
+    throw error;
+  }
 
   if (process.platform !== "win32") {
     fs.chmodSync(binaryPath, 0o755);

--- a/src/app/config/edit.rs
+++ b/src/app/config/edit.rs
@@ -337,6 +337,7 @@ impl OverlayModelOption {
 
 pub(crate) fn model_overlay_options(app: &App) -> Vec<OverlayModelOption> {
     let mut options = app
+        .sdk_inventory
         .available_models
         .iter()
         .map(|model| OverlayModelOption {

--- a/src/app/config/edit.rs
+++ b/src/app/config/edit.rs
@@ -518,7 +518,7 @@ fn open_language_overlay(app: &mut App) {
 }
 
 pub(super) fn open_session_rename_overlay(app: &mut App) {
-    let Some(session_id) = app.session_id.as_ref() else {
+    let Some(session_id) = app.session_runtime.session_id.as_ref() else {
         return;
     };
     let session_id = session_id.to_string();
@@ -536,10 +536,12 @@ pub(super) fn open_session_rename_overlay(app: &mut App) {
 }
 
 pub(super) fn generate_session_title(app: &mut App) {
-    let Some(session_id) = app.session_id.as_ref().map(std::string::ToString::to_string) else {
+    let Some(session_id) =
+        app.session_runtime.session_id.as_ref().map(std::string::ToString::to_string)
+    else {
         return;
     };
-    let Some(conn) = app.conn.clone() else {
+    let Some(conn) = app.session_runtime.conn.clone() else {
         app.config.last_error = Some("No active bridge connection".to_owned());
         app.config.status_message = None;
         return;
@@ -729,11 +731,13 @@ fn handle_session_rename_overlay_key(app: &mut App, key: KeyEvent) {
 }
 
 fn confirm_session_rename_overlay(app: &mut App) {
-    let Some(session_id) = app.session_id.as_ref().map(std::string::ToString::to_string) else {
+    let Some(session_id) =
+        app.session_runtime.session_id.as_ref().map(std::string::ToString::to_string)
+    else {
         app.config.clear_overlay();
         return;
     };
-    let Some(conn) = app.conn.clone() else {
+    let Some(conn) = app.session_runtime.conn.clone() else {
         app.config.set_overlay_error("No active bridge connection");
         return;
     };

--- a/src/app/config/mcp/actions.rs
+++ b/src/app/config/mcp/actions.rs
@@ -37,10 +37,10 @@ pub(crate) fn handle_mcp_key(app: &mut App, key: KeyEvent) -> bool {
 }
 
 pub(crate) fn reconnect_mcp_server(app: &mut App, server_name: &str) {
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         return;
     };
-    let Some(ref sid) = app.session_id else {
+    let Some(ref sid) = app.session_runtime.session_id else {
         return;
     };
     let session_id = sid.to_string();
@@ -69,10 +69,10 @@ pub(crate) fn reconnect_mcp_server(app: &mut App, server_name: &str) {
 }
 
 pub(crate) fn set_mcp_server_enabled(app: &mut App, server_name: &str, enabled: bool) {
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         return;
     };
-    let Some(ref sid) = app.session_id else {
+    let Some(ref sid) = app.session_runtime.session_id else {
         return;
     };
     let session_id = sid.to_string();
@@ -103,10 +103,10 @@ pub(crate) fn set_mcp_server_enabled(app: &mut App, server_name: &str, enabled: 
 }
 
 pub(crate) fn authenticate_mcp_server(app: &mut App, server_name: &str) {
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         return;
     };
-    let Some(ref sid) = app.session_id else {
+    let Some(ref sid) = app.session_runtime.session_id else {
         return;
     };
     let session_id = sid.to_string();
@@ -137,10 +137,10 @@ pub(crate) fn authenticate_mcp_server(app: &mut App, server_name: &str) {
 }
 
 pub(crate) fn clear_mcp_server_auth(app: &mut App, server_name: &str) {
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         return;
     };
-    let Some(ref sid) = app.session_id else {
+    let Some(ref sid) = app.session_runtime.session_id else {
         return;
     };
     let session_id = sid.to_string();

--- a/src/app/config/mcp/auth.rs
+++ b/src/app/config/mcp/auth.rs
@@ -8,10 +8,10 @@ pub(crate) fn submit_mcp_oauth_callback_url(
     server_name: &str,
     callback_url: String,
 ) {
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         return;
     };
-    let Some(ref sid) = app.session_id else {
+    let Some(ref sid) = app.session_runtime.session_id else {
         return;
     };
     let session_id = sid.to_string();

--- a/src/app/config/mcp/elicitation.rs
+++ b/src/app/config/mcp/elicitation.rs
@@ -9,7 +9,7 @@ pub(crate) fn send_mcp_elicitation_response(
     action: crate::agent::types::ElicitationAction,
     content: Option<serde_json::Value>,
 ) {
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         tracing::warn!(
             target: crate::logging::targets::APP_PERMISSION,
             event_name = "elicitation_response_blocked",
@@ -21,7 +21,7 @@ pub(crate) fn send_mcp_elicitation_response(
         );
         return;
     };
-    let Some(ref sid) = app.session_id else {
+    let Some(ref sid) = app.session_runtime.session_id else {
         tracing::warn!(
             target: crate::logging::targets::APP_PERMISSION,
             event_name = "elicitation_response_blocked",

--- a/src/app/config/mcp/removal.rs
+++ b/src/app/config/mcp/removal.rs
@@ -84,7 +84,7 @@ fn remove_dynamic_mcp_server_from_config(app: &mut App, server_name: &str) {
         app.config.status_message = None;
         return;
     }
-    let Some(conn) = app.conn.clone() else {
+    let Some(conn) = app.session_runtime.conn.clone() else {
         apply_mcp_config_remove_failure(
             app,
             server_name,
@@ -93,7 +93,7 @@ fn remove_dynamic_mcp_server_from_config(app: &mut App, server_name: &str) {
         );
         return;
     };
-    let Some(session_id) = app.session_id.as_ref().map(ToString::to_string) else {
+    let Some(session_id) = app.session_runtime.session_id.as_ref().map(ToString::to_string) else {
         apply_mcp_config_remove_failure(
             app,
             server_name,

--- a/src/app/config/mcp/snapshot.rs
+++ b/src/app/config/mcp/snapshot.rs
@@ -16,11 +16,11 @@ pub(crate) fn refresh_mcp_snapshot(app: &mut App) {
 }
 
 pub(crate) fn request_mcp_snapshot(app: &mut App) {
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         app.mcp.in_flight = false;
         return;
     };
-    let Some(ref sid) = app.session_id else {
+    let Some(ref sid) = app.session_runtime.session_id else {
         app.mcp.in_flight = false;
         return;
     };

--- a/src/app/config/settings.rs
+++ b/src/app/config/settings.rs
@@ -561,7 +561,7 @@ pub fn setting_spec(id: SettingId) -> &'static SettingSpec {
 #[must_use]
 pub fn resolved_setting(app: &App, spec: &SettingSpec) -> ResolvedSetting {
     let document = app.config.document_for(spec.file);
-    resolve_setting_document(document, spec.id, &app.available_models)
+    resolve_setting_document(document, spec.id, &app.sdk_inventory.available_models)
 }
 
 #[must_use]
@@ -628,7 +628,7 @@ pub fn setting_detail_options(app: &App, spec: &SettingSpec) -> Vec<String> {
                 options.iter().map(|option| option.label.to_owned()).collect()
             }
             SettingOptions::RuntimeCatalog(RuntimeCatalogKind::Models) => {
-                if app.available_models.is_empty() {
+                if app.sdk_inventory.available_models.is_empty() {
                     vec![
                         DEFAULT_MODEL_ALIAS_LABEL.to_owned(),
                         "Connect to load available models".to_owned(),

--- a/src/app/config/status.rs
+++ b/src/app/config/status.rs
@@ -8,10 +8,10 @@ pub fn request_status_snapshot_if_needed(app: &App) {
     if app.config.active_tab != ConfigTab::Status {
         return;
     }
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         return;
     };
-    let Some(ref sid) = app.session_id else {
+    let Some(ref sid) = app.session_runtime.session_id else {
         return;
     };
     let session_id = sid.to_string();

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -958,7 +958,8 @@ fn thinking_effort_rejects_max_as_persisted_setting() {
 #[test]
 fn model_effort_overlay_uses_persistable_effort_levels_when_runtime_omits_level_list() {
     let (_dir, mut app) = open_settings_test_app();
-    app.available_models = vec![AvailableModel::new("opus", "Opus").supports_effort(true)];
+    app.sdk_inventory.available_models =
+        vec![AvailableModel::new("opus", "Opus").supports_effort(true)];
     store::set_model(&mut app.config.committed_settings_document, Some("opus"));
     select_setting(&mut app, SettingId::ThinkingEffort);
 
@@ -974,7 +975,7 @@ fn model_effort_overlay_uses_persistable_effort_levels_when_runtime_omits_level_
 #[test]
 fn model_effort_overlay_filters_session_only_max_from_runtime_levels() {
     let (_dir, mut app) = open_settings_test_app();
-    app.available_models = vec![
+    app.sdk_inventory.available_models = vec![
         AvailableModel::new("opus", "Opus")
             .supports_effort(true)
             .supported_effort_levels(EffortLevel::ALL.to_vec()),
@@ -996,7 +997,7 @@ fn model_overlay_confirm_persists_model_without_rewriting_effort() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join(".claude").join("settings.json");
     let mut app = open_settings_app_in_dir(&dir);
-    app.available_models = vec![
+    app.sdk_inventory.available_models = vec![
         AvailableModel::new("fable", "Fable 5").supports_effort(true),
         AvailableModel::new("opus", "Opus").supports_effort(true),
     ];
@@ -1025,7 +1026,7 @@ fn thinking_effort_overlay_confirm_persists_effort_without_rewriting_model() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join(".claude").join("settings.json");
     let mut app = open_settings_app_in_dir(&dir);
-    app.available_models = vec![
+    app.sdk_inventory.available_models = vec![
         AvailableModel::new("fable", "Fable 5")
             .supports_effort(true)
             .supported_effort_levels(EffortLevel::PERSISTABLE_SETTINGS.to_vec()),
@@ -1108,7 +1109,7 @@ fn save_preserves_invalid_unedited_values() {
 #[test]
 fn resolved_model_uses_runtime_fallback_when_catalog_rejects_value() {
     let mut app = App::test_default();
-    app.available_models = vec![AvailableModel::new("sonnet", "Claude Sonnet")];
+    app.sdk_inventory.available_models = vec![AvailableModel::new("sonnet", "Claude Sonnet")];
     store::set_model(&mut app.config.committed_settings_document, Some("unknown"));
 
     let resolved = resolved_setting(&app, setting_spec(SettingId::Model));
@@ -1120,7 +1121,7 @@ fn resolved_model_uses_runtime_fallback_when_catalog_rejects_value() {
 #[test]
 fn resolved_model_accepts_runtime_alias_resolved_model_id() {
     let mut app = App::test_default();
-    app.available_models =
+    app.sdk_inventory.available_models =
         vec![AvailableModel::new("fable", "Fable 5").resolved_model("claude-fable-5")];
     store::set_model(&mut app.config.committed_settings_document, Some("claude-fable-5"));
 
@@ -1133,7 +1134,7 @@ fn resolved_model_accepts_runtime_alias_resolved_model_id() {
 #[test]
 fn model_overlay_options_are_sorted_alphabetically() {
     let mut app = App::test_default();
-    app.available_models = vec![
+    app.sdk_inventory.available_models = vec![
         AvailableModel::new("sonnet", "Sonnet"),
         AvailableModel::new("haiku", "Haiku"),
         AvailableModel::new("opus", "Opus"),

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -184,7 +184,7 @@ fn open_does_not_force_stop_active_turn() {
 
     assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::Config));
     assert!(matches!(app.status, AppStatus::Running));
-    assert!(app.pending_cancel_origin.is_none());
+    assert!(app.turn.pending_cancel_origin.is_none());
 }
 
 #[test]

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -44,8 +44,8 @@ fn app_with_status_connection()
 -> (App, tokio::sync::mpsc::UnboundedReceiver<crate::agent::wire::CommandEnvelope>) {
     let mut app = App::test_default();
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.config.active_tab = ConfigTab::Status;
     app.recent_sessions = vec![crate::app::RecentSessionInfo {
         session_id: "session-1".to_owned(),
@@ -1565,7 +1565,7 @@ fn enter_closes_settings_without_editing_selected_row() {
 fn mcp_enter_opens_details_overlay_instead_of_closing_config() {
     let (_dir, mut app) = open_settings_test_app();
     app.config.active_tab = ConfigTab::Mcp;
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.mcp.servers = vec![crate::agent::model::McpServerStatus {
         name: "filesystem".to_owned(),
         status: crate::agent::model::McpServerConnectionStatus::Connected,
@@ -1754,8 +1754,8 @@ fn mcp_manage_plugin_action_opens_installed_plugin_actions_overlay() {
 fn unknown_plugin_owned_mcp_server_does_not_call_set_servers_for_dynamic_remove() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.mcp.servers = vec![dynamic_http_mcp_server_status(
         "plugin:Unknown:unknown",
         "https://unknown.example.test/mcp",
@@ -1893,8 +1893,8 @@ fn non_config_mcp_server_does_not_offer_remove_action() {
 fn mcp_config_remove_success_reloads_runtime_without_extra_snapshot() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.mcp.servers = vec![
         crate::agent::model::McpServerStatus {
             name: "filesystem".to_owned(),
@@ -1956,8 +1956,8 @@ fn mcp_config_remove_success_reloads_runtime_without_extra_snapshot() {
 fn dynamic_mcp_config_remove_uses_sdk_set_servers_and_preserves_other_dynamic_servers() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     let mut keep_headers = BTreeMap::new();
     keep_headers.insert("Authorization".to_owned(), "Bearer token".to_owned());
     app.mcp.servers = vec![
@@ -2062,8 +2062,8 @@ fn dynamic_mcp_config_remove_uses_sdk_set_servers_and_preserves_other_dynamic_se
 fn dynamic_mcp_config_remove_waits_for_snapshot_when_sdk_result_does_not_name_server() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.mcp.servers = vec![connected_mcp_server_status(
         "session-search",
         "dynamic",
@@ -2263,8 +2263,8 @@ fn removed_config_guard_stops_suppressing_when_confirming_snapshot_still_contain
 fn dynamic_mcp_config_remove_failure_from_sdk_keeps_server_visible() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.mcp.servers = vec![connected_mcp_server_status(
         "session-search",
         "dynamic",
@@ -2314,8 +2314,8 @@ fn dynamic_mcp_config_remove_failure_from_sdk_keeps_server_visible() {
 fn dynamic_mcp_config_remove_refuses_to_drop_unrepresentable_dynamic_servers() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.mcp.servers = vec![
         connected_mcp_server_status(
             "session-search",
@@ -2398,8 +2398,8 @@ fn empty_mcp_callback_url_sets_overlay_error_and_keeps_overlay_open() {
 fn mcp_tab_refresh_key_requests_snapshot() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.config.active_tab = ConfigTab::Mcp;
     app.mcp.servers.push(crate::agent::model::McpServerStatus {
         name: "stale".to_owned(),
@@ -2431,8 +2431,8 @@ fn mcp_tab_refresh_key_requests_snapshot() {
 fn request_mcp_snapshot_sends_outside_mcp_tab() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.config.active_tab = ConfigTab::Status;
 
     super::mcp::request_mcp_snapshot(&mut app);
@@ -2449,8 +2449,8 @@ fn request_mcp_snapshot_sends_outside_mcp_tab() {
 fn refresh_mcp_snapshot_clears_existing_servers_before_request() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.mcp.servers.push(crate::agent::model::McpServerStatus {
         name: "stale".to_owned(),
         status: crate::agent::model::McpServerConnectionStatus::Connected,
@@ -2476,8 +2476,8 @@ fn refresh_mcp_snapshot_clears_existing_servers_before_request() {
 fn refresh_mcp_snapshot_if_needed_skips_outside_mcp_tab() {
     let (_dir, mut app) = open_settings_test_app();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     app.config.active_tab = ConfigTab::Status;
 
     super::mcp::refresh_mcp_snapshot_if_needed(&mut app);

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -17,7 +17,7 @@ use super::config::ConfigState;
 use super::plugins::PluginsState;
 use super::state::{
     CacheMetrics, HistoryRetentionPolicy, HistoryRetentionStats, RenderCacheBudget,
-    SessionPickerState, SessionRuntimeState, StartupState, Transcript,
+    SdkInventoryState, SessionPickerState, SessionRuntimeState, StartupState, Transcript,
 };
 use super::trust;
 use super::view::SurfaceMode;
@@ -136,6 +136,7 @@ pub fn create_app(cli: &Cli) -> App {
             "-",
         )]),
         session_runtime: SessionRuntimeState::default(),
+        sdk_inventory: SdkInventoryState::default(),
         input: super::InputState::new(),
         status: AppStatus::Connecting,
         resuming_session_id: None,
@@ -157,16 +158,9 @@ pub fn create_app(cli: &Cli) -> App {
         spinner_last_advance_at: None,
         tool_call_scopes: HashMap::new(),
         terminals,
-        tasks: Vec::new(),
         focus: FocusManager::default(),
         keymap: super::keymap::ResolvedKeymap::defaults(),
-        available_commands: Vec::new(),
-        rewind_targets: Vec::new(),
-        rewind_targets_session_id: None,
-        rewind_targets_in_flight: false,
         plugins: PluginsState::default(),
-        available_agents: Vec::new(),
-        available_models: Vec::new(),
         recent_sessions: Vec::new(),
         session_picker: SessionPickerState::default(),
         chat_render: super::ChatRenderState::default(),

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -17,7 +17,7 @@ use super::config::ConfigState;
 use super::plugins::PluginsState;
 use super::state::{
     CacheMetrics, HistoryRetentionPolicy, HistoryRetentionStats, RenderCacheBudget,
-    SessionPickerState,
+    SessionPickerState, StartupState, Transcript,
 };
 use super::trust;
 use super::view::SurfaceMode;
@@ -29,7 +29,7 @@ use crate::agent::model;
 use crate::agent::wire::SessionLaunchSettings;
 use crate::error::AppError;
 use crate::{Cli, Command};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 use tokio::sync::mpsc;
@@ -130,14 +130,12 @@ pub fn create_app(cli: &Cli) -> App {
         config: ConfigState::default(),
         trust: trust::TrustState::default(),
         settings_home_override: None,
-        messages: vec![super::ChatMessage::welcome(
+        transcript: Transcript::new(vec![super::ChatMessage::welcome(
             env!("CARGO_PKG_VERSION"),
             "-",
             &cwd_display,
             "-",
-        )],
-        message_retained_bytes: Vec::new(),
-        retained_history_bytes: 0,
+        )]),
         input: super::InputState::new(),
         status: AppStatus::Connecting,
         resuming_session_id: None,
@@ -145,8 +143,7 @@ pub fn create_app(cli: &Cli) -> App {
             &cli.command,
             Some(Command::Resume { session_id: Some(_) })
         ),
-        pending_command_label: None,
-        pending_command_ack: None,
+        turn: super::state::TurnState::default(),
         should_quit: false,
         exit_error: None,
         session_id: None,
@@ -159,22 +156,14 @@ pub fn create_app(cli: &Cli) -> App {
         mode: None,
         config_options: std::collections::BTreeMap::new(),
         login_hint: None,
-        pending_compact_clear: false,
-        pending_interaction_ids: Vec::new(),
-        cancelled_turn_pending_hint: false,
-        pending_cancel_origin: None,
-        pending_auto_submit_after_cancel: false,
         event_tx,
         event_rx,
         file_index_event_tx,
         file_index_event_rx,
         spinner_frame: 0,
         spinner_last_advance_at: None,
-        active_turn_assistant_message_idx: None,
-        active_task_ids: HashSet::new(),
         tool_call_scopes: HashMap::new(),
         terminals,
-        tool_call_index: HashMap::new(),
         tasks: Vec::new(),
         focus: FocusManager::default(),
         keymap: super::keymap::ResolvedKeymap::defaults(),
@@ -193,11 +182,7 @@ pub fn create_app(cli: &Cli) -> App {
         slash: None,
         subagent: None,
         pending_submit: None,
-        paste_burst: super::paste_burst::PasteBurstDetector::new(),
-        pending_paste_text: String::new(),
-        pending_paste_session: None,
-        active_paste_session: None,
-        next_paste_session_id: 1,
+        paste: super::state::PasteState::default(),
         pending_images: Vec::new(),
         git_context: super::git_context::GitContextState::default(),
         update_notice: None,
@@ -208,42 +193,24 @@ pub fn create_app(cli: &Cli) -> App {
         runtime_session_state: None,
         prompt_suggestion: None,
         last_rate_limit_update: None,
-        turn_notice_refs: Vec::new(),
-        is_compacting: false,
         account_info: None,
-        terminal_tool_calls: Vec::new(),
-        terminal_tool_call_membership: HashSet::new(),
         notifications: super::notify::NotificationManager::new(),
         perf,
         render_cache_budget: RenderCacheBudget::default(),
-        render_cache_slots: Vec::new(),
-        render_cache_total_bytes: 0,
-        render_cache_protected_bytes: 0,
-        render_cache_evictable: std::collections::BTreeSet::new(),
-        render_cache_tail_msg_idx: None,
         history_retention: HistoryRetentionPolicy::default(),
         history_retention_stats: HistoryRetentionStats::default(),
         cache_metrics: CacheMetrics::default(),
         fps_ema: None,
         last_frame_at: None,
         last_chat_render_trace_state: None,
-        startup_connection_requested: false,
-        connection_started: false,
-        startup_bridge_script: cli.bridge_script.clone(),
-        startup_resume_id: match &cli.command {
-            Some(Command::Resume { session_id: Some(id) }) => Some(id.clone()),
-            _ => None,
-        },
-        startup_resume_requested: matches!(
-            &cli.command,
-            Some(Command::Resume { session_id: Some(_) })
+        startup: StartupState::new(
+            cli.bridge_script.clone(),
+            match &cli.command {
+                Some(Command::Resume { session_id: Some(id) }) => Some(id.clone()),
+                _ => None,
+            },
+            matches!(&cli.command, Some(Command::Resume { session_id: None })),
         ),
-        startup_session_picker_requested: matches!(
-            &cli.command,
-            Some(Command::Resume { session_id: None })
-        ),
-        startup_recent_sessions_loaded: false,
-        startup_session_picker_resolved: false,
     };
 
     if let Err(err) = super::config::initialize_shared_state(&mut app) {
@@ -267,17 +234,16 @@ pub fn create_app(cli: &Cli) -> App {
 
 /// Spawn the background bridge task.
 pub fn start_connection(app: &mut App) {
-    if !app.startup_connection_requested || app.connection_started {
+    if !app.startup.mark_connection_started() {
         return;
     }
 
-    app.connection_started = true;
     let params = StartConnectionParams {
         event_tx: app.event_tx.clone(),
         cwd_raw: app.cwd_raw.clone(),
-        bridge_script: app.startup_bridge_script.clone(),
-        resume_id: app.startup_resume_id.clone(),
-        resume_requested: app.startup_resume_requested,
+        bridge_script: app.startup.bridge_script().cloned(),
+        resume_id: app.startup.resume_id().map(str::to_owned),
+        resume_requested: app.startup.resume_requested(),
         session_launch_settings: session_start::session_launch_settings_for_reason(
             app,
             session_start::SessionStartReason::Startup,

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -17,7 +17,7 @@ use super::config::ConfigState;
 use super::plugins::PluginsState;
 use super::state::{
     CacheMetrics, HistoryRetentionPolicy, HistoryRetentionStats, RenderCacheBudget,
-    SessionPickerState, StartupState, Transcript,
+    SessionPickerState, SessionRuntimeState, StartupState, Transcript,
 };
 use super::trust;
 use super::view::SurfaceMode;
@@ -25,7 +25,6 @@ use super::{App, AppStatus, FocusManager};
 use super::{SurfaceDirtyState, TerminalLifecycleState};
 use crate::agent::client::AgentConnection;
 use crate::agent::events::ClientEvent;
-use crate::agent::model;
 use crate::agent::wire::SessionLaunchSettings;
 use crate::error::AppError;
 use crate::{Cli, Command};
@@ -136,6 +135,7 @@ pub fn create_app(cli: &Cli) -> App {
             &cwd_display,
             "-",
         )]),
+        session_runtime: SessionRuntimeState::default(),
         input: super::InputState::new(),
         status: AppStatus::Connecting,
         resuming_session_id: None,
@@ -146,16 +146,9 @@ pub fn create_app(cli: &Cli) -> App {
         turn: super::state::TurnState::default(),
         should_quit: false,
         exit_error: None,
-        session_id: None,
-        conn: None,
-        session_scope_epoch: 0,
-        current_model: None,
         cwd_raw: cwd.to_string_lossy().to_string(),
         cwd: cwd_display,
         files_accessed: 0,
-        mode: None,
-        config_options: std::collections::BTreeMap::new(),
-        login_hint: None,
         event_tx,
         event_rx,
         file_index_event_tx,
@@ -186,14 +179,8 @@ pub fn create_app(cli: &Cli) -> App {
         pending_images: Vec::new(),
         git_context: super::git_context::GitContextState::default(),
         update_notice: None,
-        session_usage: super::SessionUsageState::default(),
         usage: super::UsageState::default(),
         mcp: super::McpState::default(),
-        fast_mode_state: model::FastModeState::Off,
-        runtime_session_state: None,
-        prompt_suggestion: None,
-        last_rate_limit_update: None,
-        account_info: None,
         notifications: super::notify::NotificationManager::new(),
         perf,
         render_cache_budget: RenderCacheBudget::default(),

--- a/src/app/events/client.rs
+++ b/src/app/events/client.rs
@@ -314,9 +314,10 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
                 );
                 return;
             }
-            app.rewind_targets = targets;
-            app.rewind_targets_session_id = Some(crate::agent::model::SessionId::new(session_id));
-            app.rewind_targets_in_flight = false;
+            app.sdk_inventory.rewind_targets = targets;
+            app.sdk_inventory.rewind_targets_session_id =
+                Some(crate::agent::model::SessionId::new(session_id));
+            app.sdk_inventory.rewind_targets_in_flight = false;
             crate::app::slash::sync_with_cursor(app);
         }
         ClientEvent::RewindResultReceived { result } => {

--- a/src/app/events/client.rs
+++ b/src/app/events/client.rs
@@ -96,7 +96,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             crate::app::config::handle_mcp_operation_error(app, &error);
         }
         ClientEvent::McpSetServersResult { session_id, result } => {
-            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+            if app.session_runtime.session_id.as_ref().map(ToString::to_string).as_deref()
                 != Some(session_id.as_str())
             {
                 return;
@@ -190,7 +190,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             app.request_chat_visible_rebuild();
         }
         ClientEvent::RuntimeReloadCompleted { session_id } => {
-            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+            if app.session_runtime.session_id.as_ref().map(ToString::to_string).as_deref()
                 != Some(session_id.as_str())
             {
                 return;
@@ -198,7 +198,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             crate::app::plugins::apply_runtime_reload_success(app);
         }
         ClientEvent::RuntimeReloadFailed { session_id, message } => {
-            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+            if app.session_runtime.session_id.as_ref().map(ToString::to_string).as_deref()
                 != Some(session_id.as_str())
             {
                 return;
@@ -248,7 +248,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             session::handle_logout_completed_event(app);
         }
         ClientEvent::StatusSnapshotReceived { session_id, account } => {
-            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+            if app.session_runtime.session_id.as_ref().map(ToString::to_string).as_deref()
                 != Some(session_id.as_str())
             {
                 tracing::debug!(
@@ -267,7 +267,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             let token_source = account.token_source.clone();
             let api_key_source = account.api_key_source.clone();
             let api_provider = account.api_provider.clone();
-            app.account_info = Some(account);
+            app.session_runtime.account_info = Some(account);
             app.sync_welcome_snapshot();
             app.request_active_surface_repaint();
             tracing::info!(
@@ -285,7 +285,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             );
         }
         ClientEvent::ContextUsageReceived { session_id, percentage } => {
-            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+            if app.session_runtime.session_id.as_ref().map(ToString::to_string).as_deref()
                 != Some(session_id.as_str())
             {
                 tracing::debug!(
@@ -301,7 +301,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             crate::app::session_runtime::apply_context_usage_snapshot(app, percentage);
         }
         ClientEvent::RewindTargetsReceived { session_id, targets } => {
-            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+            if app.session_runtime.session_id.as_ref().map(ToString::to_string).as_deref()
                 != Some(session_id.as_str())
             {
                 tracing::debug!(
@@ -323,7 +323,7 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             session::handle_rewind_result_event(app, &result);
         }
         ClientEvent::McpSnapshotReceived { session_id, mut servers, source, error } => {
-            if app.session_id.as_ref().map(ToString::to_string).as_deref()
+            if app.session_runtime.session_id.as_ref().map(ToString::to_string).as_deref()
                 != Some(session_id.as_str())
             {
                 tracing::debug!(
@@ -402,19 +402,19 @@ pub fn handle_client_event(app: &mut App, event: ClientEvent) {
             );
         }
         ClientEvent::UsageRefreshStarted { epoch } => {
-            if app.session_scope_epoch != epoch {
+            if app.session_runtime.session_scope_epoch != epoch {
                 return;
             }
             crate::app::usage::apply_refresh_started(app);
         }
         ClientEvent::UsageSnapshotReceived { epoch, snapshot } => {
-            if app.session_scope_epoch != epoch {
+            if app.session_runtime.session_scope_epoch != epoch {
                 return;
             }
             crate::app::usage::apply_refresh_success(app, snapshot);
         }
         ClientEvent::UsageRefreshFailed { epoch, message, source } => {
-            if app.session_scope_epoch != epoch {
+            if app.session_runtime.session_scope_epoch != epoch {
                 return;
             }
             crate::app::usage::apply_refresh_failure(app, message, source);

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -309,9 +309,10 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             }
         }
         model::SessionUpdate::ModeStateUpdate(mode) => {
-            let mode_changed = app.mode.as_ref().map(|current| current.current_mode_id.as_str())
-                != Some(mode.current_mode_id.as_str());
-            app.mode = Some(mode);
+            let mode_changed =
+                app.session_runtime.mode.as_ref().map(|current| current.current_mode_id.as_str())
+                    != Some(mode.current_mode_id.as_str());
+            app.session_runtime.mode = Some(mode);
             if mode_changed {
                 app.invalidate_layout(InvalidationLevel::Global);
             }
@@ -322,7 +323,7 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
         model::SessionUpdate::CurrentModeUpdate(update) => {
             let mode_id = update.current_mode_id.to_string();
             let mut mode_changed = false;
-            if let Some(ref mut mode) = app.mode {
+            if let Some(ref mut mode) = app.session_runtime.mode {
                 mode_changed = mode.current_mode_id != mode_id;
                 if let Some(info) = mode.available_modes.iter().find(|m| m.id == mode_id) {
                     mode.current_mode_name.clone_from(&info.name);
@@ -344,7 +345,7 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             let next_display_short = update.current_model.display_name_short.clone();
             let next_display_long = update.current_model.display_name_long.clone();
             let pending_ack_before = format!("{:?}", app.turn.pending_command_ack);
-            app.current_model = Some(update.current_model);
+            app.session_runtime.current_model = Some(update.current_model);
             let clearing_pending =
                 matches!(app.turn.pending_command_ack, Some(PendingCommandAck::CurrentModel));
             if matches!(app.turn.pending_command_ack, Some(PendingCommandAck::CurrentModel)) {
@@ -366,7 +367,7 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             handle_config_option_update(app, config);
         }
         model::SessionUpdate::FastModeUpdate(state) => {
-            app.fast_mode_state = state;
+            app.session_runtime.fast_mode_state = state;
         }
         model::SessionUpdate::RateLimitUpdate(update) => {
             rate_limit::handle_rate_limit_update(app, &update);
@@ -388,7 +389,8 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             );
         }
         model::SessionUpdate::PromptSuggestionUpdate(suggestion) => {
-            app.prompt_suggestion = (!suggestion.trim().is_empty()).then_some(suggestion);
+            app.session_runtime.prompt_suggestion =
+                (!suggestion.trim().is_empty()).then_some(suggestion);
         }
         model::SessionUpdate::RuntimeSessionStateUpdate(state) => {
             handle_runtime_session_state_update(app, state);
@@ -432,7 +434,7 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
 }
 
 fn handle_runtime_session_state_update(app: &mut App, state: model::RuntimeSessionState) {
-    app.runtime_session_state = Some(state);
+    app.session_runtime.runtime_session_state = Some(state);
     match state {
         model::RuntimeSessionState::Running => {
             if matches!(app.status, AppStatus::Ready | AppStatus::Thinking | AppStatus::Running)
@@ -507,7 +509,7 @@ fn handle_config_option_update(app: &mut App, config: model::ConfigOptionUpdate)
         serde_json::Value::Array(_) => "array",
         serde_json::Value::Object(_) => "object",
     };
-    app.config_options.insert(option_id.clone(), value);
+    app.session_runtime.config_options.insert(option_id.clone(), value);
     tracing::debug!(
         target: crate::logging::targets::APP_CONFIG,
         event_name = "config_option_update_applied",

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -289,7 +289,7 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
                 source = cmds.source.as_deref().unwrap_or("unknown"),
                 generation = cmds.generation,
             );
-            app.available_commands = cmds.available_commands;
+            app.sdk_inventory.available_commands = cmds.available_commands;
             crate::app::plugins::clamp_selection(app);
             if app.slash.is_some() {
                 super::slash::update_query(app);
@@ -303,7 +303,7 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
                 outcome = "success",
                 agent_count = agents.available_agents.len(),
             );
-            app.available_agents = agents.available_agents;
+            app.sdk_inventory.available_agents = agents.available_agents;
             if app.subagent.is_some() {
                 super::subagent::update_query(app);
             }

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -175,7 +175,7 @@ fn log_resize_classification(app: &App, size_change: TerminalSizeChange, action:
 fn dispatch_key_by_view(app: &mut App, key: crossterm::event::KeyEvent) -> TerminalEventOutcome {
     match app.surface_mode {
         SurfaceMode::Chat => {
-            app.active_paste_session = None;
+            app.paste.clear_active_session();
             TerminalEventOutcome::from_key_outcome(super::keys::dispatch_key_by_focus(app, key))
         }
         SurfaceMode::Fullscreen(FullscreenView::Config) => {
@@ -196,7 +196,7 @@ fn dispatch_key_by_view(app: &mut App, key: crossterm::event::KeyEvent) -> Termi
 fn dispatch_mouse_by_view(app: &mut App, mouse: crossterm::event::MouseEvent) {
     match app.surface_mode {
         SurfaceMode::Chat => {
-            app.active_paste_session = None;
+            app.paste.clear_active_session();
             let _ = mouse;
         }
         SurfaceMode::Fullscreen(_) => {
@@ -211,8 +211,7 @@ fn dispatch_paste_by_view(app: &mut App, text: &str) -> bool {
             if !matches!(
                 app.status,
                 AppStatus::Connecting | AppStatus::CommandPending | AppStatus::Error
-            ) && !app.is_compacting
-            {
+            ) {
                 reclaim_input_from_inline_prompt_if_needed(app);
                 app.queue_paste_text(text);
                 return true;
@@ -316,7 +315,7 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             if mode_changed {
                 app.invalidate_layout(InvalidationLevel::Global);
             }
-            if matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentMode)) {
+            if matches!(app.turn.pending_command_ack, Some(PendingCommandAck::CurrentMode)) {
                 session::clear_pending_command(app);
             }
         }
@@ -336,7 +335,7 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             if mode_changed {
                 app.invalidate_layout(InvalidationLevel::Global);
             }
-            if matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentMode)) {
+            if matches!(app.turn.pending_command_ack, Some(PendingCommandAck::CurrentMode)) {
                 session::clear_pending_command(app);
             }
         }
@@ -344,11 +343,11 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             let next_resolved_id = update.current_model.resolved_id.clone();
             let next_display_short = update.current_model.display_name_short.clone();
             let next_display_long = update.current_model.display_name_long.clone();
-            let pending_ack_before = format!("{:?}", app.pending_command_ack);
+            let pending_ack_before = format!("{:?}", app.turn.pending_command_ack);
             app.current_model = Some(update.current_model);
             let clearing_pending =
-                matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentModel));
-            if matches!(app.pending_command_ack, Some(PendingCommandAck::CurrentModel)) {
+                matches!(app.turn.pending_command_ack, Some(PendingCommandAck::CurrentModel));
+            if matches!(app.turn.pending_command_ack, Some(PendingCommandAck::CurrentModel)) {
                 session::clear_pending_command(app);
             }
             tracing::debug!(
@@ -400,9 +399,9 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
         model::SessionUpdate::SessionStatusUpdate(status) => {
             // TODO(runtime-verification): confirm in real SDK sessions that compaction
             // status updates are emitted consistently; if not, add a fallback indicator.
-            let was_compacting = app.is_compacting;
+            let was_compacting = app.turn.is_compacting;
             if matches!(status, model::SessionStatus::Compacting) {
-                app.is_compacting = true;
+                app.turn.is_compacting = true;
             } else {
                 clear_compaction_state(app, true);
             }
@@ -415,7 +414,7 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
                 message = "session status update applied",
                 outcome = "success",
                 session_status = ?status,
-                compacting = app.is_compacting,
+                compacting = app.turn.is_compacting,
             );
         }
         model::SessionUpdate::SystemNoticeUpdate { severity, message } => {
@@ -437,7 +436,7 @@ fn handle_runtime_session_state_update(app: &mut App, state: model::RuntimeSessi
     match state {
         model::RuntimeSessionState::Running => {
             if matches!(app.status, AppStatus::Ready | AppStatus::Thinking | AppStatus::Running)
-                && !app.is_compacting
+                && !app.turn.is_compacting
             {
                 app.status = AppStatus::Running;
             }
@@ -445,8 +444,8 @@ fn handle_runtime_session_state_update(app: &mut App, state: model::RuntimeSessi
         model::RuntimeSessionState::RequiresAction => {}
         model::RuntimeSessionState::Idle => {
             if matches!(app.status, AppStatus::Thinking | AppStatus::Running)
-                && !app.is_compacting
-                && app.pending_cancel_origin.is_none()
+                && !app.turn.is_compacting
+                && app.turn.pending_cancel_origin.is_none()
             {
                 app.status = AppStatus::Ready;
             }
@@ -482,12 +481,12 @@ pub(crate) fn push_system_message_with_severity(
 }
 
 pub(super) fn clear_compaction_state(app: &mut App, emit_manual_success: bool) {
-    if !app.is_compacting && !app.pending_compact_clear {
+    if !app.turn.is_compacting && !app.turn.pending_compact_clear {
         return;
     }
-    let should_emit_success = emit_manual_success && app.pending_compact_clear;
-    app.pending_compact_clear = false;
-    app.is_compacting = false;
+    let should_emit_success = emit_manual_success && app.turn.pending_compact_clear;
+    app.turn.pending_compact_clear = false;
+    app.turn.is_compacting = false;
     if should_emit_success {
         push_system_message_with_severity(
             app,
@@ -519,7 +518,7 @@ fn handle_config_option_update(app: &mut App, config: model::ConfigOptionUpdate)
     );
 
     if matches!(
-        app.pending_command_ack.as_ref(),
+        app.turn.pending_command_ack.as_ref(),
         Some(PendingCommandAck::ConfigOption { option_id: expected }) if expected == &option_id
     ) {
         session::clear_pending_command(app);

--- a/src/app/events/notices.rs
+++ b/src/app/events/notices.rs
@@ -12,10 +12,6 @@ struct TurnNoticeTracking {
     stage: NoticeStage,
 }
 
-pub(super) fn clear_turn_notice_tracking(app: &mut App) {
-    app.clear_turn_notice_refs();
-}
-
 pub(super) fn emit_system_notice(app: &mut App, severity: SystemSeverity, message: &str) {
     insert_notice(app, severity, message, None);
 }
@@ -29,7 +25,7 @@ pub(super) fn upsert_turn_notice(
 ) {
     prune_invalid_turn_notice_refs(app);
     let Some(existing) =
-        app.turn_notice_refs.iter().find(|notice_ref| notice_ref.dedup_key == dedup_key).cloned()
+        app.turn.notice_refs.iter().find(|notice_ref| notice_ref.dedup_key == dedup_key).cloned()
     else {
         insert_new_notice(app, dedup_key, stage, severity, message);
         return;
@@ -77,14 +73,14 @@ pub(super) fn upsert_turn_notice(
 
 fn update_turn_notice_ref_stage(app: &mut App, dedup_key: &NoticeDedupKey, stage: NoticeStage) {
     if let Some(notice_ref) =
-        app.turn_notice_refs.iter_mut().find(|notice_ref| &notice_ref.dedup_key == dedup_key)
+        app.turn.notice_refs.iter_mut().find(|notice_ref| &notice_ref.dedup_key == dedup_key)
     {
         notice_ref.stage = stage;
     }
 }
 
 fn remove_turn_notice_refs(app: &mut App, dedup_key: &NoticeDedupKey) {
-    app.turn_notice_refs.retain(|notice_ref| &notice_ref.dedup_key != dedup_key);
+    app.turn.notice_refs.retain(|notice_ref| &notice_ref.dedup_key != dedup_key);
 }
 
 fn insert_new_notice(
@@ -117,7 +113,7 @@ fn insert_inline_notice(
     message: &str,
     tracking: Option<TurnNoticeTracking>,
 ) {
-    let Some(owner) = app.messages.get_mut(owner_idx) else {
+    let Some(owner) = app.transcript.messages.get_mut(owner_idx) else {
         insert_standalone_notice(app, severity, message, tracking);
         return;
     };
@@ -127,7 +123,7 @@ fn insert_inline_notice(
     app.sync_after_message_blocks_changed(owner_idx);
     app.invalidate_layout(InvalidationLevel::MessageChanged(owner_idx));
     if let Some(tracking) = tracking {
-        app.turn_notice_refs.push(TurnNoticeRef {
+        app.turn.notice_refs.push(TurnNoticeRef {
             dedup_key: tracking.dedup_key,
             stage: tracking.stage,
             location: TurnNoticeLocation::Inline { msg_idx: owner_idx, block_idx },
@@ -141,7 +137,7 @@ fn insert_standalone_notice(
     message: &str,
     tracking: Option<TurnNoticeTracking>,
 ) {
-    let msg_idx = app.messages.len();
+    let msg_idx = app.transcript.messages.len();
     let dedup_key = tracking.as_ref().map(|entry| entry.dedup_key.clone());
     app.push_message_tracked(ChatMessage::new(
         MessageRole::System(Some(severity)),
@@ -150,7 +146,7 @@ fn insert_standalone_notice(
     ));
     app.enforce_history_retention_tracked();
     if let Some(tracking) = tracking {
-        app.turn_notice_refs.push(TurnNoticeRef {
+        app.turn.notice_refs.push(TurnNoticeRef {
             dedup_key: tracking.dedup_key,
             stage: tracking.stage,
             location: TurnNoticeLocation::Standalone { msg_idx },
@@ -176,7 +172,7 @@ fn update_inline_notice(
     message: &str,
 ) -> bool {
     let Some(MessageBlock::Notice(notice)) =
-        app.messages.get_mut(msg_idx).and_then(|msg| msg.blocks.get_mut(block_idx))
+        app.transcript.messages.get_mut(msg_idx).and_then(|msg| msg.blocks.get_mut(block_idx))
     else {
         return false;
     };
@@ -198,7 +194,7 @@ fn update_standalone_notice(
     severity: SystemSeverity,
     message: &str,
 ) -> bool {
-    let Some(msg) = app.messages.get_mut(msg_idx) else {
+    let Some(msg) = app.transcript.messages.get_mut(msg_idx) else {
         return false;
     };
     if !matches!(msg.role, MessageRole::System(_)) {
@@ -220,7 +216,7 @@ fn update_standalone_notice(
 }
 
 fn remove_standalone_notice(app: &mut App, msg_idx: usize) -> bool {
-    let Some(msg) = app.messages.get(msg_idx) else {
+    let Some(msg) = app.transcript.messages.get(msg_idx) else {
         return false;
     };
     let has_notice = matches!(msg.role, MessageRole::System(_))
@@ -232,14 +228,14 @@ fn remove_standalone_notice(app: &mut App, msg_idx: usize) -> bool {
 }
 
 fn prune_invalid_turn_notice_refs(app: &mut App) {
-    app.turn_notice_refs.retain(|notice_ref| match &notice_ref.location {
+    app.turn.notice_refs.retain(|notice_ref| match &notice_ref.location {
         TurnNoticeLocation::Inline { msg_idx, block_idx } => matches!(
-            app.messages.get(*msg_idx).and_then(|msg| msg.blocks.get(*block_idx)),
+            app.transcript.messages.get(*msg_idx).and_then(|msg| msg.blocks.get(*block_idx)),
             Some(MessageBlock::Notice(notice))
                 if notice.dedup_key.as_ref() == Some(&notice_ref.dedup_key)
         ),
         TurnNoticeLocation::Standalone { msg_idx } => matches!(
-            app.messages.get(*msg_idx),
+            app.transcript.messages.get(*msg_idx),
             Some(ChatMessage {
                 role: MessageRole::System(_),
                 blocks,
@@ -264,7 +260,7 @@ mod tests {
     #[test]
     fn inline_notice_insert_updates_canonical_assistant_message() {
         let mut app = App::test_default();
-        app.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+        app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
         app.bind_active_turn_assistant(0);
 
         upsert_turn_notice(
@@ -275,8 +271,8 @@ mod tests {
             "retrying",
         );
 
-        assert_eq!(app.messages[0].blocks.len(), 1);
-        let Some(MessageBlock::Notice(notice)) = app.messages[0].blocks.first() else {
+        assert_eq!(app.transcript.messages[0].blocks.len(), 1);
+        let Some(MessageBlock::Notice(notice)) = app.transcript.messages[0].blocks.first() else {
             panic!("expected notice block");
         };
         assert_eq!(notice.severity, SystemSeverity::Warning);
@@ -286,7 +282,7 @@ mod tests {
     #[test]
     fn inline_notice_update_mutates_canonical_notice() {
         let mut app = App::test_default();
-        app.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+        app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
         app.bind_active_turn_assistant(0);
 
         upsert_turn_notice(
@@ -305,7 +301,7 @@ mod tests {
             "failed",
         ));
 
-        let Some(MessageBlock::Notice(notice)) = app.messages[0].blocks.first() else {
+        let Some(MessageBlock::Notice(notice)) = app.transcript.messages[0].blocks.first() else {
             panic!("expected notice block");
         };
         assert_eq!(notice.severity, SystemSeverity::Error);
@@ -323,10 +319,10 @@ mod tests {
             SystemSeverity::Warning,
             "retrying before assistant",
         );
-        assert_eq!(app.messages.len(), 1);
-        assert_eq!(app.turn_notice_refs.len(), 1);
+        assert_eq!(app.transcript.messages.len(), 1);
+        assert_eq!(app.turn.notice_refs.len(), 1);
 
-        app.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+        app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
         app.bind_active_turn_assistant(1);
 
         upsert_turn_notice(
@@ -337,15 +333,15 @@ mod tests {
             "retrying with assistant",
         );
 
-        assert_eq!(app.messages.len(), 1);
-        assert!(matches!(app.messages[0].role, MessageRole::Assistant));
-        let Some(MessageBlock::Notice(notice)) = app.messages[0].blocks.first() else {
+        assert_eq!(app.transcript.messages.len(), 1);
+        assert!(matches!(app.transcript.messages[0].role, MessageRole::Assistant));
+        let Some(MessageBlock::Notice(notice)) = app.transcript.messages[0].blocks.first() else {
             panic!("expected migrated inline notice");
         };
         assert_eq!(notice.text.text, "retrying with assistant");
-        assert_eq!(app.turn_notice_refs.len(), 1);
+        assert_eq!(app.turn.notice_refs.len(), 1);
         assert!(matches!(
-            app.turn_notice_refs[0].location,
+            app.turn.notice_refs[0].location,
             TurnNoticeLocation::Inline { msg_idx: 0, block_idx: 0 }
         ));
     }

--- a/src/app/events/rate_limit.rs
+++ b/src/app/events/rate_limit.rs
@@ -125,7 +125,7 @@ fn reset_bucket_from_epoch_secs(value: f64) -> Option<u64> {
 }
 
 pub(super) fn handle_rate_limit_update(app: &mut App, update: &model::RateLimitUpdate) {
-    app.last_rate_limit_update = Some(update.clone());
+    app.session_runtime.last_rate_limit_update = Some(update.clone());
     tracing::debug!(
         target: crate::logging::targets::APP_SESSION,
         event_name = "rate_limit_update_applied",
@@ -175,8 +175,8 @@ pub(super) fn handle_compaction_boundary_update(
     if matches!(boundary.trigger, model::CompactionTrigger::Manual) {
         app.turn.pending_compact_clear = true;
     }
-    app.session_usage.last_compaction_trigger = Some(boundary.trigger);
-    app.session_usage.last_compaction_pre_tokens = Some(boundary.pre_tokens);
+    app.session_runtime.session_usage.last_compaction_trigger = Some(boundary.trigger);
+    app.session_runtime.session_usage.last_compaction_pre_tokens = Some(boundary.pre_tokens);
     tracing::debug!(
         "CompactionBoundary: trigger={:?} pre_tokens={}",
         boundary.trigger,

--- a/src/app/events/rate_limit.rs
+++ b/src/app/events/rate_limit.rs
@@ -171,9 +171,9 @@ pub(super) fn handle_compaction_boundary_update(
     app: &mut App,
     boundary: model::CompactionBoundary,
 ) {
-    app.is_compacting = true;
+    app.turn.is_compacting = true;
     if matches!(boundary.trigger, model::CompactionTrigger::Manual) {
-        app.pending_compact_clear = true;
+        app.turn.pending_compact_clear = true;
     }
     app.session_usage.last_compaction_trigger = Some(boundary.trigger);
     app.session_usage.last_compaction_pre_tokens = Some(boundary.pre_tokens);

--- a/src/app/events/retraction.rs
+++ b/src/app/events/retraction.rs
@@ -25,8 +25,8 @@ pub(super) fn handle_transcript_retraction(
     let mut changed = false;
     let mut rebuild_indices = false;
 
-    for msg_idx in (0..app.messages.len()).rev() {
-        let (removed, empty_assistant) = match app.messages.get_mut(msg_idx) {
+    for msg_idx in (0..app.transcript.messages.len()).rev() {
+        let (removed, empty_assistant) = match app.transcript.messages.get_mut(msg_idx) {
             Some(message) => {
                 let before_len = message.blocks.len();
                 message.blocks.retain(|block| {

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -52,7 +52,7 @@ pub(super) fn handle_connected_client_event(
         true,
         ChatResetRenderMode::PreserveInlineViewport,
     );
-    app.available_models = available_models;
+    app.sdk_inventory.available_models = available_models;
     app.sync_welcome_snapshot();
     if !history_updates.is_empty() {
         load_resume_history(app, history_updates);
@@ -194,8 +194,8 @@ pub(super) fn handle_connection_failed_event(app: &mut App, msg: &str) {
 }
 
 pub(super) fn handle_slash_command_error_event(app: &mut App, msg: &str) {
-    app.rewind_targets_in_flight = false;
-    app.rewind_targets_session_id = None;
+    app.sdk_inventory.rewind_targets_in_flight = false;
+    app.sdk_inventory.rewind_targets_session_id = None;
     if app.config.pending_session_title_change.take().is_some() {
         app.config.last_error = Some(msg.to_owned());
         app.config.status_message = None;
@@ -308,7 +308,7 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
     let available_model_count = available_models.len();
     super::clear_compaction_state(app, false);
     apply_session_cwd(app, cwd);
-    app.available_models = available_models;
+    app.sdk_inventory.available_models = available_models;
     reset_for_new_session(
         app,
         session_id,

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -123,7 +123,7 @@ pub(super) fn handle_sessions_listed_event(
             });
         }
     }
-    app.startup_recent_sessions_loaded = true;
+    app.startup.mark_recent_sessions_loaded();
     reconcile_session_picker_selection(app, selected_session_id.as_deref());
     maybe_open_startup_session_picker(app);
     tracing::info!(
@@ -151,16 +151,13 @@ pub(super) fn handle_auth_required_event(
     app.clear_session_runtime_identity();
     super::clear_compaction_state(app, false);
     app.last_rate_limit_update = None;
-    app.cancelled_turn_pending_hint = false;
-    app.pending_cancel_origin = None;
-    app.pending_auto_submit_after_cancel = false;
+    app.turn.clear_cancel_state();
     app.account_info = None;
     app.mcp = super::super::McpState::default();
     app.config.pending_session_title_change = None;
     crate::app::usage::reset_for_session_change(app);
     app.finalize_turn_runtime_artifacts(model::ToolCallStatus::Failed);
-    app.clear_active_turn_assistant();
-    super::notices::clear_turn_notice_tracking(app);
+    app.turn.reset_for_new_session();
     tracing::warn!(
         target: crate::logging::targets::APP_AUTH,
         event_name = "auth_required_detected",
@@ -174,23 +171,18 @@ pub(super) fn handle_connection_failed_event(app: &mut App, msg: &str) {
     app.bump_session_scope_epoch();
     app.clear_session_runtime_identity();
     super::clear_compaction_state(app, false);
-    app.cancelled_turn_pending_hint = false;
-    app.pending_cancel_origin = None;
-    app.pending_auto_submit_after_cancel = false;
+    app.turn.clear_cancel_state();
     app.last_rate_limit_update = None;
     app.account_info = None;
     app.mcp = super::super::McpState::default();
     app.config.pending_session_title_change = None;
     crate::app::usage::reset_for_session_change(app);
     app.resuming_session_id = None;
-    app.pending_command_label = None;
-    app.pending_command_ack = None;
     app.finalize_turn_runtime_artifacts(model::ToolCallStatus::Failed);
     app.input.clear();
     app.pending_submit = None;
     app.status = AppStatus::Error;
-    app.clear_active_turn_assistant();
-    super::notices::clear_turn_notice_tracking(app);
+    app.turn.reset_for_new_session();
     push_connection_error_message(app, msg);
     tracing::error!(
         target: crate::logging::targets::APP_SESSION,
@@ -217,8 +209,8 @@ pub(super) fn handle_slash_command_error_event(app: &mut App, msg: &str) {
 
 pub(super) fn handle_auth_completed_event(app: &mut App, conn: &Rc<AgentConnection>) {
     app.login_hint = None;
-    app.pending_command_label = Some("Starting session...".to_owned());
-    app.pending_command_ack = None;
+    app.turn.pending_command_label = Some("Starting session...".to_owned());
+    app.turn.pending_command_ack = None;
     push_system_message_with_severity(
         app,
         Some(SystemSeverity::Info),
@@ -267,8 +259,8 @@ pub(super) fn handle_logout_completed_event(app: &mut App) {
     );
 
     if let Some(conn) = app.conn.clone() {
-        app.pending_command_label = Some("Starting session...".to_owned());
-        app.pending_command_ack = None;
+        app.turn.pending_command_label = Some("Starting session...".to_owned());
+        app.turn.pending_command_ack = None;
         if let Err(e) = start_new_session(app, &conn, SessionStartReason::Logout) {
             tracing::error!(
                 target: crate::logging::targets::APP_AUTH,
@@ -315,8 +307,6 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
     let history_update_count = history_updates.len();
     let available_model_count = available_models.len();
     super::clear_compaction_state(app, false);
-    app.pending_cancel_origin = None;
-    app.pending_auto_submit_after_cancel = false;
     apply_session_cwd(app, cwd);
     app.available_models = available_models;
     reset_for_new_session(
@@ -340,7 +330,7 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
     crate::app::file_index::restart(app);
     crate::app::config::refresh_runtime_tabs_for_session_change(app);
     // After session replacement, terminal scrollback is stale. Rebuild from
-    // app.messages, which was rebuilt only from bridge-reported session history.
+    // app.transcript.messages, which was rebuilt only from bridge-reported session history.
     app.request_chat_purge_replay_rebuild(crate::app::ChatPurgeReplayOptions::session_replacement());
     tracing::info!(
         target: crate::logging::targets::APP_SESSION,
@@ -489,19 +479,17 @@ pub(super) fn handle_service_status_event(
 
 pub(super) fn handle_fatal_error_event(app: &mut App, error: AppError) {
     app.finalize_turn_runtime_artifacts(model::ToolCallStatus::Failed);
-    app.clear_active_turn_assistant();
+    app.turn.reset_for_new_session();
     app.exit_error = Some(error);
     app.should_quit = true;
     app.status = AppStatus::Error;
     app.pending_submit = None;
-    app.pending_command_label = None;
-    app.pending_command_ack = None;
 }
 
 /// Clear pending slash-command UI. Turn and session lifecycle handlers own non-command status.
 pub(super) fn clear_pending_command(app: &mut App) {
-    app.pending_command_label = None;
-    app.pending_command_ack = None;
+    app.turn.pending_command_label = None;
+    app.turn.pending_command_ack = None;
     if matches!(app.status, AppStatus::CommandPending) {
         app.status = AppStatus::Ready;
     }
@@ -557,14 +545,11 @@ fn reconcile_session_picker_selection(app: &mut App, selected_session_id: Option
 }
 
 fn maybe_open_startup_session_picker(app: &mut App) {
-    if !app.startup_session_picker_requested || app.startup_session_picker_resolved {
-        return;
-    }
-    if app.conn.is_none() || !app.startup_recent_sessions_loaded {
+    if app.conn.is_none() || !app.startup.startup_picker_is_ready() {
         return;
     }
 
-    app.startup_session_picker_resolved = true;
+    app.startup.resolve_session_picker();
     let session_count = super::super::session_picker::picker_session_count(app);
     if session_count == 0 {
         push_system_message_with_severity(

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -41,7 +41,7 @@ pub(super) fn handle_connected_client_event(
     let history_update_count = history_updates.len();
     let available_model_count = available_models.len();
     if let Some(slot) = take_connection_slot() {
-        app.conn = Some(slot.conn);
+        app.session_runtime.conn = Some(slot.conn);
     }
     apply_session_cwd(app, cwd);
     reset_for_new_session(
@@ -71,7 +71,7 @@ pub(super) fn handle_connected_client_event(
         outcome = "success",
         session_id = %session_id_for_log,
         cwd = %app.cwd_raw,
-        current_model = ?app.current_model.as_ref().map(|model| model.resolved_id.clone()),
+        current_model = ?app.session_runtime.current_model.as_ref().map(|model| model.resolved_id.clone()),
         history_update_count,
         available_model_count,
     );
@@ -146,13 +146,13 @@ pub(super) fn handle_auth_required_event(
     clear_pending_command(app);
     app.status = AppStatus::Ready;
     app.resuming_session_id = None;
-    app.login_hint = Some(LoginHint { method_name, method_description });
+    app.session_runtime.login_hint = Some(LoginHint { method_name, method_description });
     app.bump_session_scope_epoch();
     app.clear_session_runtime_identity();
     super::clear_compaction_state(app, false);
-    app.last_rate_limit_update = None;
+    app.session_runtime.last_rate_limit_update = None;
     app.turn.clear_cancel_state();
-    app.account_info = None;
+    app.session_runtime.account_info = None;
     app.mcp = super::super::McpState::default();
     app.config.pending_session_title_change = None;
     crate::app::usage::reset_for_session_change(app);
@@ -172,8 +172,8 @@ pub(super) fn handle_connection_failed_event(app: &mut App, msg: &str) {
     app.clear_session_runtime_identity();
     super::clear_compaction_state(app, false);
     app.turn.clear_cancel_state();
-    app.last_rate_limit_update = None;
-    app.account_info = None;
+    app.session_runtime.last_rate_limit_update = None;
+    app.session_runtime.account_info = None;
     app.mcp = super::super::McpState::default();
     app.config.pending_session_title_change = None;
     crate::app::usage::reset_for_session_change(app);
@@ -208,7 +208,7 @@ pub(super) fn handle_slash_command_error_event(app: &mut App, msg: &str) {
 }
 
 pub(super) fn handle_auth_completed_event(app: &mut App, conn: &Rc<AgentConnection>) {
-    app.login_hint = None;
+    app.session_runtime.login_hint = None;
     app.turn.pending_command_label = Some("Starting session...".to_owned());
     app.turn.pending_command_ack = None;
     push_system_message_with_severity(
@@ -246,7 +246,7 @@ pub(super) fn handle_logout_completed_event(app: &mut App) {
     // during initialization and will fire AuthRequired immediately.
     app.bump_session_scope_epoch();
     app.clear_session_runtime_identity();
-    app.account_info = None;
+    app.session_runtime.account_info = None;
     app.mcp = super::super::McpState::default();
     app.config.pending_session_title_change = None;
     crate::app::usage::reset_for_session_change(app);
@@ -258,7 +258,7 @@ pub(super) fn handle_logout_completed_event(app: &mut App) {
         outcome = "success",
     );
 
-    if let Some(conn) = app.conn.clone() {
+    if let Some(conn) = app.session_runtime.conn.clone() {
         app.turn.pending_command_label = Some("Starting session...".to_owned());
         app.turn.pending_command_ack = None;
         if let Err(e) = start_new_session(app, &conn, SessionStartReason::Logout) {
@@ -339,7 +339,7 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
         outcome = "success",
         session_id = %session_id_for_log,
         cwd = %app.cwd_raw,
-        current_model = ?app.current_model.as_ref().map(|model| model.resolved_id.clone()),
+        current_model = ?app.session_runtime.current_model.as_ref().map(|model| model.resolved_id.clone()),
         history_update_count,
         available_model_count,
         restored_input = restored_input.is_some(),
@@ -347,7 +347,7 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
 }
 
 pub(super) fn handle_rewind_result_event(app: &mut App, result: &model::RewindResult) {
-    if app.session_id.as_ref().map(ToString::to_string).as_deref()
+    if app.session_runtime.session_id.as_ref().map(ToString::to_string).as_deref()
         != Some(result.session_id.as_str())
     {
         tracing::debug!(
@@ -430,14 +430,14 @@ pub(super) fn ensure_update_notice_message(app: &mut App) {
     let Some(notice) = app.update_notice.as_ref() else {
         return;
     };
-    if notice.emitted_session_scope_epoch == Some(app.session_scope_epoch) {
+    if notice.emitted_session_scope_epoch == Some(app.session_runtime.session_scope_epoch) {
         return;
     }
 
     let message = format_update_available_message(&notice.latest_version, &notice.current_version);
     push_system_message_with_severity(app, Some(SystemSeverity::Warning), &message);
     if let Some(notice) = app.update_notice.as_mut() {
-        notice.emitted_session_scope_epoch = Some(app.session_scope_epoch);
+        notice.emitted_session_scope_epoch = Some(app.session_runtime.session_scope_epoch);
     }
 }
 
@@ -545,7 +545,7 @@ fn reconcile_session_picker_selection(app: &mut App, selected_session_id: Option
 }
 
 fn maybe_open_startup_session_picker(app: &mut App) {
-    if app.conn.is_none() || !app.startup.startup_picker_is_ready() {
+    if app.session_runtime.conn.is_none() || !app.startup.startup_picker_is_ready() {
         return;
     }
 

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -56,9 +56,7 @@ fn reset_session_identity_state(
     app.last_rate_limit_update = None;
     app.should_quit = false;
     app.files_accessed = 0;
-    app.cancelled_turn_pending_hint = false;
-    app.pending_cancel_origin = None;
-    app.pending_auto_submit_after_cancel = false;
+    app.turn.clear_cancel_state();
     app.account_info = None;
 }
 
@@ -78,16 +76,14 @@ fn reset_messages_for_new_session(app: &mut App, preserve_current_welcome_tip: b
 fn reset_input_state_for_new_session(app: &mut App) {
     app.input.clear();
     app.pending_submit = None;
-    app.pending_paste_text.clear();
-    app.pending_paste_session = None;
-    app.active_paste_session = None;
+    app.paste.clear_all_sessions();
     app.pending_images.clear();
 }
 
 fn reset_interaction_state_for_new_session(app: &mut App) {
-    app.pending_interaction_ids.clear();
+    app.turn.reset_for_new_session();
     app.clear_tool_scope_tracking();
-    app.tool_call_index.clear();
+    app.clear_tool_call_index();
     app.tasks.clear();
     app.focus = super::super::FocusManager::default();
     app.available_commands.clear();
@@ -123,7 +119,7 @@ fn append_resume_user_message_chunk(app: &mut App, chunk: &model::ContentChunk) 
         return;
     }
 
-    if let Some(last) = app.messages.last_mut()
+    if let Some(last) = app.transcript.messages.last_mut()
         && matches!(last.role, MessageRole::User)
     {
         if let Some(MessageBlock::Text(block)) = last.blocks.last_mut() {
@@ -137,7 +133,7 @@ fn append_resume_user_message_chunk(app: &mut App, chunk: &model::ContentChunk) 
                     .with_source_message_uuid(chunk.source_message_uuid.as_deref()),
             ));
         }
-        let last_idx = app.messages.len().saturating_sub(1);
+        let last_idx = app.transcript.messages.len().saturating_sub(1);
         app.sync_after_message_blocks_changed(last_idx);
         return;
     }
@@ -176,9 +172,7 @@ pub(super) fn load_resume_history(app: &mut App, history_updates: &[model::Sessi
     app.clear_active_turn_assistant();
     super::clear_compaction_state(app, false);
     app.status = super::super::AppStatus::Ready;
-    app.cancelled_turn_pending_hint = false;
-    app.pending_cancel_origin = None;
-    app.pending_auto_submit_after_cancel = false;
+    app.turn.clear_cancel_state();
     app.enforce_history_retention_tracked();
 }
 
@@ -196,7 +190,12 @@ mod tests {
         app.chat_render.composer.total_rows = 6;
         app.chat_render.live_region.anchor_valid = true;
         app.chat_render.live_region.last_rendered_rows = 9;
-        app.messages.push(ChatMessage::welcome("1.2.3", "Pro", "/workspace/demo", "session-1"));
+        app.transcript.messages.push(ChatMessage::welcome(
+            "1.2.3",
+            "Pro",
+            "/workspace/demo",
+            "session-1",
+        ));
 
         reset_for_new_session(
             &mut app,
@@ -217,7 +216,7 @@ mod tests {
     #[test]
     fn startup_session_reset_preserves_inline_viewport_for_diffed_repaint() {
         let mut app = App::test_default();
-        app.messages.push(ChatMessage::welcome("1.2.3", "-", "/workspace/demo", "-"));
+        app.transcript.messages.push(ChatMessage::welcome("1.2.3", "-", "/workspace/demo", "-"));
         app.surface_dirty.chat.rebuild = ChatRebuildKind::None;
         app.surface_dirty.chat.repaint = false;
 
@@ -237,7 +236,12 @@ mod tests {
     #[test]
     fn replacement_session_reset_defers_transcript_render() {
         let mut app = App::test_default();
-        app.messages.push(ChatMessage::welcome("1.2.3", "Pro", "/workspace/demo", "session-1"));
+        app.transcript.messages.push(ChatMessage::welcome(
+            "1.2.3",
+            "Pro",
+            "/workspace/demo",
+            "session-1",
+        ));
         app.surface_dirty.chat.rebuild = ChatRebuildKind::None;
         app.surface_dirty.chat.repaint = false;
 

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -36,28 +36,30 @@ fn reset_session_identity_state(
     mode: Option<super::super::ModeState>,
 ) {
     app.bump_session_scope_epoch();
-    app.session_id = Some(session_id);
-    app.current_model = Some(current_model.clone());
-    app.mode = mode;
-    app.config_options.clear();
+    app.session_runtime.session_id = Some(session_id);
+    app.session_runtime.current_model = Some(current_model.clone());
+    app.session_runtime.mode = mode;
+    app.session_runtime.config_options.clear();
     if let Some(requested_id) = current_model.requested_id {
-        app.config_options.insert("model".to_owned(), serde_json::Value::String(requested_id));
+        app.session_runtime
+            .config_options
+            .insert("model".to_owned(), serde_json::Value::String(requested_id));
     }
-    app.login_hint = None;
+    app.session_runtime.login_hint = None;
     super::clear_compaction_state(app, false);
-    app.session_usage = super::super::SessionUsageState::default();
+    app.session_runtime.session_usage = super::super::SessionUsageState::default();
     app.rewind_targets.clear();
     app.rewind_targets_session_id = None;
     app.rewind_targets_in_flight = false;
     app.status = super::super::AppStatus::Ready;
-    app.fast_mode_state = model::FastModeState::Off;
-    app.runtime_session_state = None;
-    app.prompt_suggestion = None;
-    app.last_rate_limit_update = None;
+    app.session_runtime.fast_mode_state = model::FastModeState::Off;
+    app.session_runtime.runtime_session_state = None;
+    app.session_runtime.prompt_suggestion = None;
+    app.session_runtime.last_rate_limit_update = None;
     app.should_quit = false;
     app.files_accessed = 0;
     app.turn.clear_cancel_state();
-    app.account_info = None;
+    app.session_runtime.account_info = None;
 }
 
 fn reset_messages_for_new_session(app: &mut App, preserve_current_welcome_tip: bool) {

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -48,9 +48,7 @@ fn reset_session_identity_state(
     app.session_runtime.login_hint = None;
     super::clear_compaction_state(app, false);
     app.session_runtime.session_usage = super::super::SessionUsageState::default();
-    app.rewind_targets.clear();
-    app.rewind_targets_session_id = None;
-    app.rewind_targets_in_flight = false;
+    app.sdk_inventory.clear_rewind_targets();
     app.status = super::super::AppStatus::Ready;
     app.session_runtime.fast_mode_state = model::FastModeState::Off;
     app.session_runtime.runtime_session_state = None;
@@ -86,10 +84,10 @@ fn reset_interaction_state_for_new_session(app: &mut App) {
     app.turn.reset_for_new_session();
     app.clear_tool_scope_tracking();
     app.clear_tool_call_index();
-    app.tasks.clear();
+    app.sdk_inventory.tasks.clear();
     app.focus = super::super::FocusManager::default();
-    app.available_commands.clear();
-    app.available_agents.clear();
+    app.sdk_inventory.available_commands.clear();
+    app.sdk_inventory.available_agents.clear();
     app.config.clear_overlay();
     app.config.pending_session_title_change = None;
 }
@@ -262,15 +260,15 @@ mod tests {
     #[test]
     fn session_reset_clears_rewind_target_state() {
         let mut app = App::test_default();
-        app.rewind_targets = vec![model::RewindTarget {
+        app.sdk_inventory.rewind_targets = vec![model::RewindTarget {
             uuid: "user-1".to_owned(),
             first_text: "prompt".to_owned(),
             input_text: "prompt".to_owned(),
             index: 0,
             previous_assistant_uuid: None,
         }];
-        app.rewind_targets_session_id = Some(model::SessionId::new("session-1"));
-        app.rewind_targets_in_flight = true;
+        app.sdk_inventory.rewind_targets_session_id = Some(model::SessionId::new("session-1"));
+        app.sdk_inventory.rewind_targets_in_flight = true;
 
         reset_for_new_session(
             &mut app,
@@ -281,8 +279,8 @@ mod tests {
             ChatResetRenderMode::DeferTranscriptRender,
         );
 
-        assert!(app.rewind_targets.is_empty());
-        assert!(app.rewind_targets_session_id.is_none());
-        assert!(!app.rewind_targets_in_flight);
+        assert!(app.sdk_inventory.rewind_targets.is_empty());
+        assert!(app.sdk_inventory.rewind_targets_session_id.is_none());
+        assert!(!app.sdk_inventory.rewind_targets_in_flight);
     }
 }

--- a/src/app/events/streaming.rs
+++ b/src/app/events/streaming.rs
@@ -17,7 +17,7 @@ pub(super) fn handle_agent_message_chunk(app: &mut App, chunk: model::ContentChu
         return;
     }
     if let Some(owner_idx) = app.active_turn_assistant_idx()
-        && let Some(owner) = app.messages.get_mut(owner_idx)
+        && let Some(owner) = app.transcript.messages.get_mut(owner_idx)
     {
         append_agent_stream_text(
             &mut owner.blocks,
@@ -28,7 +28,7 @@ pub(super) fn handle_agent_message_chunk(app: &mut App, chunk: model::ContentChu
         return;
     }
 
-    if let Some(last) = app.messages.last_mut()
+    if let Some(last) = app.transcript.messages.last_mut()
         && matches!(last.role, MessageRole::Assistant)
     {
         append_agent_stream_text(
@@ -36,7 +36,7 @@ pub(super) fn handle_agent_message_chunk(app: &mut App, chunk: model::ContentChu
             &text.text,
             chunk.source_message_uuid.as_deref(),
         );
-        let last_idx = app.messages.len().saturating_sub(1);
+        let last_idx = app.transcript.messages.len().saturating_sub(1);
         app.bind_active_turn_assistant(last_idx);
         app.sync_after_message_blocks_changed(last_idx);
         return;
@@ -156,7 +156,7 @@ mod tests {
     fn streaming_text_chunk_appends_to_canonical_active_assistant_message() {
         let mut app = App::test_default();
         app.status = crate::app::AppStatus::Thinking;
-        app.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+        app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
         app.bind_active_turn_assistant(0);
 
         handle_agent_message_chunk(
@@ -167,11 +167,11 @@ mod tests {
         );
 
         assert_eq!(app.active_turn_assistant_idx(), Some(0));
-        assert_eq!(app.messages[0].blocks.len(), 2);
-        let Some(MessageBlock::Text(first)) = app.messages[0].blocks.first() else {
+        assert_eq!(app.transcript.messages[0].blocks.len(), 2);
+        let Some(MessageBlock::Text(first)) = app.transcript.messages[0].blocks.first() else {
             panic!("expected first text block");
         };
-        let Some(MessageBlock::Text(second)) = app.messages[0].blocks.get(1) else {
+        let Some(MessageBlock::Text(second)) = app.transcript.messages[0].blocks.get(1) else {
             panic!("expected second text block");
         };
         assert_eq!(first.text, "first\n\n");
@@ -184,7 +184,7 @@ mod tests {
     fn streaming_text_keeps_contiguous_chunks_in_one_block_when_source_uuid_changes() {
         let mut app = App::test_default();
         app.status = crate::app::AppStatus::Thinking;
-        app.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+        app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
         app.bind_active_turn_assistant(0);
 
         for (text, source_message_uuid) in
@@ -197,8 +197,8 @@ mod tests {
             );
         }
 
-        assert_eq!(app.messages[0].blocks.len(), 1);
-        let Some(MessageBlock::Text(block)) = app.messages[0].blocks.first() else {
+        assert_eq!(app.transcript.messages[0].blocks.len(), 1);
+        let Some(MessageBlock::Text(block)) = app.transcript.messages[0].blocks.first() else {
             panic!("expected text block");
         };
         assert_eq!(block.text, "Hello!");

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -772,7 +772,7 @@ fn app_with_bridge_connection()
 -> (App, tokio::sync::mpsc::UnboundedReceiver<crate::agent::wire::CommandEnvelope>) {
     let mut app = make_test_app();
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
     (app, rx)
 }
 
@@ -1157,7 +1157,7 @@ fn test_app_defaults() {
     assert!(!app.surface_dirty.fullscreen.redraw);
     assert!(!app.surface_dirty.terminal_mode);
     assert!(!app.should_quit);
-    assert!(app.session_id.is_none());
+    assert!(app.session_runtime.session_id.is_none());
     assert_eq!(app.files_accessed, 0);
     assert!(app.turn.pending_interaction_ids.is_empty());
     assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::None);
@@ -1507,8 +1507,8 @@ fn connected_updates_welcome_once_even_after_chat_started() {
 #[test]
 fn current_model_update_does_not_mutate_welcome_snapshot_after_settings_reconcile() {
     let mut app = make_test_app();
-    app.session_id = Some(model::SessionId::new("session-1"));
-    app.current_model = Some(test_current_model("opus"));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.current_model = Some(test_current_model("opus"));
     app.transcript.messages =
         vec![ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "session-1")];
     crate::app::config::store::set_model(&mut app.config.committed_settings_document, Some("opus"));
@@ -1548,7 +1548,7 @@ fn connected_resets_session_scoped_view_data() {
         seven_day_sonnet: None,
         extra_usage: None,
     });
-    app.account_info = Some(crate::agent::model::AccountInfo {
+    app.session_runtime.account_info = Some(crate::agent::model::AccountInfo {
         email: Some("old@example.com".into()),
         organization: None,
         subscription_type: None,
@@ -1571,7 +1571,7 @@ fn connected_resets_session_scoped_view_data() {
     assert!(matches!(app.transcript.messages[0].role, MessageRole::Welcome));
     assert_eq!(app.files_accessed, 0);
     assert!(app.usage.snapshot.is_none());
-    assert!(app.account_info.is_none());
+    assert!(app.session_runtime.account_info.is_none());
     assert!(app.plugins.installed.is_empty());
     assert!(app.plugins.last_inventory_refresh_at.is_none());
     assert!(app.config.pending_session_title_change.is_none());
@@ -1580,7 +1580,7 @@ fn connected_resets_session_scoped_view_data() {
 #[test]
 fn current_model_update_leaves_existing_welcome_snapshot_unchanged() {
     let mut app = make_test_app();
-    app.current_model = Some(test_current_model("opus"));
+    app.session_runtime.current_model = Some(test_current_model("opus"));
     app.transcript.messages.push(ChatMessage::welcome(
         env!("CARGO_PKG_VERSION"),
         "-",
@@ -1635,7 +1635,7 @@ fn auth_required_sets_hint_without_prefilling_login_command() {
 
     assert!(matches!(app.status, AppStatus::Ready));
     assert_eq!(app.input.text(), "keep me");
-    let Some(hint) = &app.login_hint else {
+    let Some(hint) = &app.session_runtime.login_hint else {
         panic!("expected login hint");
     };
     assert_eq!(hint.method_name, "oauth");
@@ -1669,7 +1669,10 @@ fn update_available_pushes_warning_system_message_with_versions_and_install_comm
     };
     assert_eq!(update_notice.current_version, "0.2.0");
     assert_eq!(update_notice.latest_version, "0.3.0");
-    assert_eq!(update_notice.emitted_session_scope_epoch, Some(app.session_scope_epoch));
+    assert_eq!(
+        update_notice.emitted_session_scope_epoch,
+        Some(app.session_runtime.session_scope_epoch)
+    );
 }
 
 #[test]
@@ -1799,9 +1802,12 @@ fn session_replaced_resets_chat_and_transient_state() {
     );
 
     assert!(matches!(app.status, AppStatus::Ready));
-    assert_eq!(app.session_id.as_ref().map(ToString::to_string).as_deref(), Some("replacement"));
     assert_eq!(
-        app.current_model.as_ref().map(|model| model.resolved_id.as_str()),
+        app.session_runtime.session_id.as_ref().map(ToString::to_string).as_deref(),
+        Some("replacement")
+    );
+    assert_eq!(
+        app.session_runtime.current_model.as_ref().map(|model| model.resolved_id.as_str()),
         Some("new-model")
     );
     assert_eq!(app.transcript.messages.len(), 1);
@@ -1899,7 +1905,7 @@ async fn connected_requests_usage_refresh_when_usage_tab_is_open() {
 #[test]
 fn stale_status_snapshot_for_old_session_is_ignored() {
     let mut app = make_test_app();
-    app.session_id = Some(model::SessionId::new("current-session"));
+    app.session_runtime.session_id = Some(model::SessionId::new("current-session"));
 
     handle_client_event(
         &mut app,
@@ -1916,7 +1922,7 @@ fn stale_status_snapshot_for_old_session_is_ignored() {
         },
     );
 
-    assert!(app.account_info.is_none());
+    assert!(app.session_runtime.account_info.is_none());
 }
 
 #[test]
@@ -1928,7 +1934,7 @@ fn status_snapshot_updates_welcome_subscription() {
         "/test",
         "session-1",
     ));
-    app.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
 
     handle_client_event(
         &mut app,
@@ -1962,7 +1968,7 @@ fn status_snapshot_does_not_commit_welcome_when_session_overview_is_suppressed()
         "/test",
         "session-1",
     ));
-    app.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
 
     handle_client_event(
         &mut app,
@@ -1989,7 +1995,7 @@ fn status_snapshot_does_not_commit_welcome_when_session_overview_is_suppressed()
 #[test]
 fn stale_mcp_snapshot_for_old_session_is_ignored() {
     let mut app = make_test_app();
-    app.session_id = Some(model::SessionId::new("current-session"));
+    app.session_runtime.session_id = Some(model::SessionId::new("current-session"));
     app.mcp.servers.push(crate::agent::model::McpServerStatus {
         name: "current".into(),
         status: crate::agent::model::McpServerConnectionStatus::Connected,
@@ -2025,7 +2031,7 @@ fn stale_mcp_snapshot_for_old_session_is_ignored() {
 #[test]
 fn removed_config_mcp_server_is_filtered_from_current_session_snapshot() {
     let mut app = make_test_app();
-    app.session_id = Some(model::SessionId::new("current-session"));
+    app.session_runtime.session_id = Some(model::SessionId::new("current-session"));
     app.mcp.removed_config_servers.insert(
         crate::app::state::types::RemovedMcpServerKey::new("user".to_owned(), "notion".to_owned()),
         crate::app::state::types::RemovedMcpServerGuard {
@@ -2070,7 +2076,7 @@ fn removed_config_mcp_server_is_filtered_from_current_session_snapshot() {
 #[test]
 fn removed_config_mcp_guard_clears_after_matching_source_snapshot_proves_absence() {
     let mut app = make_test_app();
-    app.session_id = Some(model::SessionId::new("current-session"));
+    app.session_runtime.session_id = Some(model::SessionId::new("current-session"));
     app.mcp.removed_config_servers.insert(
         crate::app::state::types::RemovedMcpServerKey::new("user".to_owned(), "notion".to_owned()),
         crate::app::state::types::RemovedMcpServerGuard {
@@ -2104,7 +2110,7 @@ fn removed_config_mcp_guard_clears_after_matching_source_snapshot_proves_absence
 #[test]
 fn removed_config_mcp_guard_stays_after_matching_source_snapshot_error() {
     let mut app = make_test_app();
-    app.session_id = Some(model::SessionId::new("current-session"));
+    app.session_runtime.session_id = Some(model::SessionId::new("current-session"));
     app.mcp.removed_config_servers.insert(
         crate::app::state::types::RemovedMcpServerKey::new("user".to_owned(), "notion".to_owned()),
         crate::app::state::types::RemovedMcpServerGuard {
@@ -2138,7 +2144,7 @@ fn removed_config_mcp_guard_stays_after_matching_source_snapshot_error() {
 #[test]
 fn stale_usage_refresh_result_for_old_epoch_is_ignored() {
     let mut app = make_test_app();
-    app.session_scope_epoch = 5;
+    app.session_runtime.session_scope_epoch = 5;
 
     handle_client_event(
         &mut app,
@@ -2487,7 +2493,7 @@ fn startup_picker_waits_for_connected_after_sessions_listed() {
     assert!(!app.startup.session_picker_resolved());
 
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
     handle_client_event(&mut app, connected_event("claude-updated"));
 
     assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::SessionPicker));
@@ -2501,7 +2507,7 @@ fn startup_picker_empty_list_stays_in_chat_with_info_message() {
     app.startup.request_connection();
     assert!(app.startup.mark_connection_started());
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
 
     handle_client_event(&mut app, connected_event("claude-updated"));
     assert_eq!(app.surface_mode, SurfaceMode::Chat);
@@ -2569,7 +2575,7 @@ fn current_model_update_updates_state_and_clears_pending_when_expected() {
     app.status = AppStatus::CommandPending;
     app.turn.pending_command_label = Some("Switching model...".into());
     app.turn.pending_command_ack = Some(PendingCommandAck::CurrentModel);
-    app.current_model = Some(test_current_model("old-model"));
+    app.session_runtime.current_model = Some(test_current_model("old-model"));
 
     handle_client_event(
         &mut app,
@@ -2579,7 +2585,10 @@ fn current_model_update_updates_state_and_clears_pending_when_expected() {
     );
 
     assert!(matches!(app.status, AppStatus::Ready));
-    assert_eq!(app.current_model.as_ref().map(|model| model.resolved_id.as_str()), Some("sonnet"));
+    assert_eq!(
+        app.session_runtime.current_model.as_ref().map(|model| model.resolved_id.as_str()),
+        Some("sonnet")
+    );
     assert!(app.turn.pending_command_label.is_none());
     assert!(app.turn.pending_command_ack.is_none());
 }
@@ -2603,7 +2612,10 @@ fn non_matching_config_option_update_keeps_pending() {
     );
 
     assert!(matches!(app.status, AppStatus::CommandPending));
-    assert_eq!(app.config_options.get("max_thinking_tokens"), Some(&serde_json::json!(2048)));
+    assert_eq!(
+        app.session_runtime.config_options.get("max_thinking_tokens"),
+        Some(&serde_json::json!(2048))
+    );
     assert_eq!(app.turn.pending_command_label.as_deref(), Some("Switching model..."));
     assert!(matches!(
         app.turn.pending_command_ack.as_ref(),
@@ -2958,7 +2970,7 @@ fn turn_complete_without_cancel_does_not_render_interrupted_hint() {
 #[test]
 fn turn_complete_keeps_history_and_adds_compaction_success_after_manual_boundary() {
     let mut app = make_test_app();
-    app.session_id = Some(model::SessionId::new("session-x"));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-x"));
     app.transcript.messages.push(user_msg("/compact"));
     app.transcript
         .messages
@@ -2987,7 +2999,10 @@ fn turn_complete_keeps_history_and_adds_compaction_success_after_manual_boundary
         panic!("expected text block");
     };
     assert_eq!(block.text, "Session successfully compacted.");
-    assert_eq!(app.session_id.as_ref().map(ToString::to_string).as_deref(), Some("session-x"));
+    assert_eq!(
+        app.session_runtime.session_id.as_ref().map(ToString::to_string).as_deref(),
+        Some("session-x")
+    );
 }
 
 #[test]
@@ -3278,14 +3293,14 @@ fn turn_error_clears_tool_scope_tracking() {
 fn auth_required_clears_active_turn_runtime_tracking() {
     let mut app = make_test_app();
     app.status = AppStatus::Running;
-    app.session_id = Some(model::SessionId::new("session-auth"));
-    app.current_model = Some(test_current_model("claude-old"));
-    app.mode = Some(crate::app::ModeState {
+    app.session_runtime.session_id = Some(model::SessionId::new("session-auth"));
+    app.session_runtime.current_model = Some(test_current_model("claude-old"));
+    app.session_runtime.mode = Some(crate::app::ModeState {
         current_mode_id: "plan".into(),
         current_mode_name: "Plan".into(),
         available_modes: vec![crate::app::ModeInfo { id: "plan".into(), name: "Plan".into() }],
     });
-    app.fast_mode_state = model::FastModeState::On;
+    app.session_runtime.fast_mode_state = model::FastModeState::On;
     app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "task-1",
         model::ToolCallStatus::InProgress,
@@ -3312,30 +3327,30 @@ fn auth_required_clears_active_turn_runtime_tracking() {
         panic!("expected tool call block");
     };
     assert_eq!(tc.status, model::ToolCallStatus::Failed);
-    assert!(app.session_id.is_none());
-    assert!(app.current_model.is_none());
-    assert!(app.mode.is_none());
-    assert_eq!(app.fast_mode_state, model::FastModeState::Off);
+    assert!(app.session_runtime.session_id.is_none());
+    assert!(app.session_runtime.current_model.is_none());
+    assert!(app.session_runtime.mode.is_none());
+    assert_eq!(app.session_runtime.fast_mode_state, model::FastModeState::Off);
 }
 
 #[test]
 fn logout_completed_clears_session_runtime_identity_caches() {
     let mut app = make_test_app();
-    app.session_id = Some(model::SessionId::new("session-x"));
-    app.current_model = Some(test_current_model("claude-old"));
-    app.mode = Some(crate::app::ModeState {
+    app.session_runtime.session_id = Some(model::SessionId::new("session-x"));
+    app.session_runtime.current_model = Some(test_current_model("claude-old"));
+    app.session_runtime.mode = Some(crate::app::ModeState {
         current_mode_id: "plan".into(),
         current_mode_name: "Plan".into(),
         available_modes: vec![crate::app::ModeInfo { id: "plan".into(), name: "Plan".into() }],
     });
-    app.fast_mode_state = model::FastModeState::On;
+    app.session_runtime.fast_mode_state = model::FastModeState::On;
 
     handle_client_event(&mut app, ClientEvent::LogoutCompleted);
 
-    assert!(app.session_id.is_none());
-    assert!(app.current_model.is_none());
-    assert!(app.mode.is_none());
-    assert_eq!(app.fast_mode_state, model::FastModeState::Off);
+    assert!(app.session_runtime.session_id.is_none());
+    assert!(app.session_runtime.current_model.is_none());
+    assert!(app.session_runtime.mode.is_none());
+    assert_eq!(app.session_runtime.fast_mode_state, model::FastModeState::Off);
 }
 
 #[test]
@@ -3416,8 +3431,11 @@ fn compaction_boundary_enables_compacting_and_records_boundary() {
 
     assert!(app.turn.is_compacting);
     assert!(app.turn.pending_compact_clear);
-    assert_eq!(app.session_usage.last_compaction_trigger, Some(model::CompactionTrigger::Manual));
-    assert_eq!(app.session_usage.last_compaction_pre_tokens, Some(123_456));
+    assert_eq!(
+        app.session_runtime.session_usage.last_compaction_trigger,
+        Some(model::CompactionTrigger::Manual)
+    );
+    assert_eq!(app.session_runtime.session_usage.last_compaction_pre_tokens, Some(123_456));
 }
 
 #[test]
@@ -3437,14 +3455,17 @@ fn auto_compaction_boundary_sets_compacting_without_manual_success_pending() {
 
     assert!(app.turn.is_compacting);
     assert!(!app.turn.pending_compact_clear);
-    assert_eq!(app.session_usage.last_compaction_trigger, Some(model::CompactionTrigger::Auto));
-    assert_eq!(app.session_usage.last_compaction_pre_tokens, Some(234_567));
+    assert_eq!(
+        app.session_runtime.session_usage.last_compaction_trigger,
+        Some(model::CompactionTrigger::Auto)
+    );
+    assert_eq!(app.session_runtime.session_usage.last_compaction_pre_tokens, Some(234_567));
 }
 
 #[test]
 fn fast_mode_update_sets_state() {
     let mut app = make_test_app();
-    assert_eq!(app.fast_mode_state, model::FastModeState::Off);
+    assert_eq!(app.session_runtime.fast_mode_state, model::FastModeState::Off);
 
     handle_client_event(
         &mut app,
@@ -3453,7 +3474,7 @@ fn fast_mode_update_sets_state() {
         )),
     );
 
-    assert_eq!(app.fast_mode_state, model::FastModeState::Cooldown);
+    assert_eq!(app.session_runtime.fast_mode_state, model::FastModeState::Cooldown);
 }
 
 #[test]
@@ -3567,7 +3588,7 @@ fn plan_limit_turn_error_upgrades_inline_notice_in_active_assistant() {
 #[test]
 fn different_rate_limit_incident_in_later_turn_keeps_older_notice() {
     let mut app = make_test_app();
-    app.last_rate_limit_update = Some(model::RateLimitUpdate {
+    app.session_runtime.last_rate_limit_update = Some(model::RateLimitUpdate {
         status: model::RateLimitStatus::AllowedWarning,
         error_code: None,
         resets_at: Some(1_741_280_000.0),
@@ -4004,7 +4025,7 @@ fn enter_submits_draft_when_permission_arrives_mid_compose() {
     let (mut app, mut bridge_rx) = app_with_bridge_connection();
     let tool_id = "perm-submit";
     append_tool_call_block(&mut app, tool_id);
-    app.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
     app.input.set_text("ship the fix");
 
     let (response_tx, mut response_rx) = oneshot::channel();
@@ -4242,7 +4263,7 @@ fn update_notice_is_not_duplicated_within_same_session_epoch() {
     );
     assert_eq!(
         app.update_notice.as_ref().and_then(|notice| notice.emitted_session_scope_epoch),
-        Some(app.session_scope_epoch)
+        Some(app.session_runtime.session_scope_epoch)
     );
 }
 
@@ -4265,7 +4286,7 @@ fn update_notice_is_re_emitted_after_epoch_change() {
     );
     assert_eq!(
         app.update_notice.as_ref().and_then(|notice| notice.emitted_session_scope_epoch),
-        Some(app.session_scope_epoch)
+        Some(app.session_runtime.session_scope_epoch)
     );
 }
 
@@ -4304,7 +4325,7 @@ fn update_available_persists_across_connected_session_reset() {
         app.update_notice
             .as_ref()
             .and_then(|update_notice| update_notice.emitted_session_scope_epoch),
-        Some(app.session_scope_epoch)
+        Some(app.session_runtime.session_scope_epoch)
     );
 }
 
@@ -4354,7 +4375,7 @@ fn update_available_persists_across_session_replaced_reset() {
         app.update_notice
             .as_ref()
             .and_then(|update_notice| update_notice.emitted_session_scope_epoch),
-        Some(app.session_scope_epoch)
+        Some(app.session_runtime.session_scope_epoch)
     );
 }
 
@@ -4567,7 +4588,7 @@ fn plan_approval_raw_ctrl_y_does_not_resolve_permission() {
 fn second_esc_after_permission_rejection_requests_turn_cancel() {
     let (mut app, mut rx) = app_with_bridge_connection();
     app.status = AppStatus::Running;
-    app.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
     let mut response_rx = attach_pending_permission(
         &mut app,
         "perm-1",
@@ -5024,12 +5045,12 @@ fn available_commands_update_replaces_previous_commands() {
 #[test]
 fn prompt_suggestion_tab_accepts_empty_input() {
     let mut app = make_test_app();
-    app.prompt_suggestion = Some("Write focused tests".to_owned());
+    app.session_runtime.prompt_suggestion = Some("Write focused tests".to_owned());
 
     handle_normal_key(&mut app, KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
 
     assert_eq!(app.input.text(), "Write focused tests");
-    assert!(app.prompt_suggestion.is_none());
+    assert!(app.session_runtime.prompt_suggestion.is_none());
 }
 
 #[test]
@@ -5041,7 +5062,10 @@ fn runtime_session_state_updates_status_with_guards() {
             model::RuntimeSessionState::Running,
         )),
     );
-    assert_eq!(app.runtime_session_state, Some(model::RuntimeSessionState::Running));
+    assert_eq!(
+        app.session_runtime.runtime_session_state,
+        Some(model::RuntimeSessionState::Running)
+    );
     assert!(matches!(app.status, AppStatus::Running));
 
     app.status = AppStatus::Error;

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -86,11 +86,11 @@ fn assistant_msg(blocks: Vec<MessageBlock>) -> ChatMessage {
 }
 
 fn append_tool_call_block(app: &mut App, tool_id: &str) -> (usize, usize) {
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         tool_id,
         model::ToolCallStatus::InProgress,
     )))]));
-    let msg_idx = app.messages.len().saturating_sub(1);
+    let msg_idx = app.transcript.messages.len().saturating_sub(1);
     app.index_tool_call(tool_id.into(), msg_idx, 0);
     (msg_idx, 0)
 }
@@ -165,7 +165,8 @@ enum BlockSnapshot {
 }
 
 fn message_snapshots(app: &App) -> Vec<MessageSnapshot> {
-    app.messages
+    app.transcript
+        .messages
         .iter()
         .map(|message| MessageSnapshot {
             role: message.role.clone(),
@@ -253,7 +254,7 @@ fn assert_seed_resize_measurements_preserved(app: &App) {
 #[test]
 fn transcript_retraction_removes_matching_text_blocks_only() {
     let mut app = App::test_default();
-    app.messages.push(assistant_msg(vec![
+    app.transcript.messages.push(assistant_msg(vec![
         source_text("stale", "old-assistant"),
         source_text("keep", "new-assistant"),
     ]));
@@ -266,9 +267,9 @@ fn transcript_retraction_removes_matching_text_blocks_only() {
         )),
     );
 
-    assert_eq!(app.messages.len(), 1);
-    assert_eq!(app.messages[0].blocks.len(), 1);
-    let MessageBlock::Text(block) = &app.messages[0].blocks[0] else {
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert_eq!(app.transcript.messages[0].blocks.len(), 1);
+    let MessageBlock::Text(block) = &app.transcript.messages[0].blocks[0] else {
         panic!("expected text block");
     };
     assert_eq!(block.text, "keep");
@@ -282,7 +283,7 @@ fn transcript_retraction_removes_tool_blocks_and_rebuilds_indices() {
     stale_tool.source_message_uuids = vec!["assistant-tool".to_owned(), "user-result".to_owned()];
     stale_tool.sdk_tool_name = "Bash".to_owned();
     stale_tool.terminal_id = Some("term-old".to_owned());
-    app.messages.push(assistant_msg(vec![
+    app.transcript.messages.push(assistant_msg(vec![
         MessageBlock::ToolCall(Box::new(stale_tool)),
         source_text("replacement", "assistant-new"),
     ]));
@@ -298,10 +299,10 @@ fn transcript_retraction_removes_tool_blocks_and_rebuilds_indices() {
     );
 
     assert!(app.lookup_tool_call("tool-old").is_none());
-    assert!(app.terminal_tool_calls.is_empty());
-    assert_eq!(app.messages.len(), 1);
-    assert_eq!(app.messages[0].blocks.len(), 1);
-    let MessageBlock::Text(block) = &app.messages[0].blocks[0] else {
+    assert!(app.terminal_tool_calls().is_empty());
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert_eq!(app.transcript.messages[0].blocks.len(), 1);
+    let MessageBlock::Text(block) = &app.transcript.messages[0].blocks[0] else {
         panic!("expected replacement text");
     };
     assert_eq!(block.text, "replacement");
@@ -310,7 +311,7 @@ fn transcript_retraction_removes_tool_blocks_and_rebuilds_indices() {
 #[test]
 fn transcript_retraction_then_replacement_leaves_canonical_assistant_content() {
     let mut app = App::test_default();
-    app.messages.push(assistant_msg(vec![source_text("stale", "assistant-old")]));
+    app.transcript.messages.push(assistant_msg(vec![source_text("stale", "assistant-old")]));
 
     handle_client_event(
         &mut app,
@@ -329,8 +330,8 @@ fn transcript_retraction_then_replacement_leaves_canonical_assistant_content() {
         )),
     );
 
-    assert_eq!(app.messages.len(), 1);
-    let MessageBlock::Text(block) = &app.messages[0].blocks[0] else {
+    assert_eq!(app.transcript.messages.len(), 1);
+    let MessageBlock::Text(block) = &app.transcript.messages[0].blocks[0] else {
         panic!("expected replacement text");
     };
     assert_eq!(block.text, "replacement");
@@ -411,14 +412,14 @@ fn turn_complete_after_cancelled_task_leaves_no_stale_active_task_ids() {
         &mut app,
         ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(task_tc)),
     );
-    assert!(app.active_task_ids.contains("task-1"), "task must be tracked while InProgress");
+    assert!(app.turn.active_task_ids.contains("task-1"), "task must be tracked while InProgress");
 
     // User cancels then TurnComplete finalizes the turn
     handle_client_event(&mut app, ClientEvent::TurnCancelled);
     handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
     // Stale task ID must be gone after turn boundary
-    assert!(app.active_task_ids.is_empty(), "stale task id must not survive TurnComplete");
+    assert!(app.turn.active_task_ids.is_empty(), "stale task id must not survive TurnComplete");
 
     // Next turn: a normal main-agent Glob must get MainAgent scope, not Subagent
     let glob_tc = model::ToolCall::new("glob-1", "Glob **/*.rs")
@@ -637,8 +638,8 @@ fn agent_message_chunk_splits_into_frozen_text_blocks() {
         )),
     );
 
-    assert_eq!(app.messages.len(), 1);
-    let Some(last) = app.messages.last() else {
+    assert_eq!(app.transcript.messages.len(), 1);
+    let Some(last) = app.transcript.messages.last() else {
         panic!("missing assistant message");
     };
     assert!(matches!(last.role, MessageRole::Assistant));
@@ -724,7 +725,7 @@ fn test_current_model(model_name: &str) -> model::CurrentModel {
 }
 
 fn canonical_messages_contain_text(app: &App, expected: &str) -> bool {
-    app.messages.iter().any(|message| {
+    app.transcript.messages.iter().any(|message| {
         message.blocks.iter().any(|block| match block {
             MessageBlock::Text(text) => text.text == expected,
             MessageBlock::Notice(notice) => notice.text.text == expected,
@@ -749,7 +750,11 @@ fn live_rows_contain_text(app: &mut App, expected: &str) -> bool {
 
 fn session_overview_has_welcome(app: &App) -> bool {
     app.show_session_overview
-        && app.messages.iter().any(|message| matches!(message.role, MessageRole::Welcome))
+        && app
+            .transcript
+            .messages
+            .iter()
+            .any(|message| matches!(message.role, MessageRole::Welcome))
 }
 
 fn connected_event(model_name: &str) -> ClientEvent {
@@ -819,7 +824,8 @@ fn execute_tool_update_uses_raw_output_fallback() {
     let Some((mi, bi)) = app.lookup_tool_call("tc-exec") else {
         panic!("tool call not indexed");
     };
-    let Some(MessageBlock::ToolCall(tc)) = app.messages.get(mi).and_then(|m| m.blocks.get(bi))
+    let Some(MessageBlock::ToolCall(tc)) =
+        app.transcript.messages.get(mi).and_then(|m| m.blocks.get(bi))
     else {
         panic!("tool call block missing");
     };
@@ -846,7 +852,8 @@ fn powershell_raw_input_update_does_not_populate_terminal_command() {
     let Some((mi, bi)) = app.lookup_tool_call("tc-pwsh") else {
         panic!("tool call not indexed");
     };
-    let Some(MessageBlock::ToolCall(tc)) = app.messages.get(mi).and_then(|m| m.blocks.get(bi))
+    let Some(MessageBlock::ToolCall(tc)) =
+        app.transcript.messages.get(mi).and_then(|m| m.blocks.get(bi))
     else {
         panic!("tool call block missing");
     };
@@ -858,7 +865,7 @@ fn powershell_raw_input_update_does_not_populate_terminal_command() {
 #[test]
 fn late_tool_update_for_removed_tool_does_not_corrupt_active_task_set() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "tool-stale",
         model::ToolCallStatus::Completed,
     )))]));
@@ -881,7 +888,7 @@ fn late_tool_update_for_removed_tool_does_not_corrupt_active_task_set() {
         ClientEvent::SessionUpdate(model::SessionUpdate::ToolCallUpdate(update)),
     );
 
-    assert!(app.active_task_ids.is_empty());
+    assert!(app.turn.active_task_ids.is_empty());
 }
 
 #[test]
@@ -921,16 +928,16 @@ fn repeated_tool_call_updates_existing_execute_snapshot_state() {
     );
 
     let (mi, bi) = app.lookup_tool_call("tc-dup").expect("tool call not indexed");
-    let MessageBlock::ToolCall(tc) = &app.messages[mi].blocks[bi] else {
+    let MessageBlock::ToolCall(tc) = &app.transcript.messages[mi].blocks[bi] else {
         panic!("expected tool call block");
     };
     assert_eq!(tc.terminal_output.as_deref(), Some("second"));
     assert_eq!(tc.terminal_id.as_deref(), Some("term-2"));
     assert_eq!(tc.terminal_command.as_deref(), Some("echo second"));
-    assert!(app.terminal_tool_calls.iter().any(|entry| entry.terminal_id == "term-2"
+    assert!(app.terminal_tool_calls().iter().any(|entry| entry.terminal_id == "term-2"
         && entry.msg_idx == mi
         && entry.block_idx == bi));
-    assert!(app.terminal_tool_calls.iter().all(|entry| entry.terminal_id != "term-1"));
+    assert!(app.terminal_tool_calls().iter().all(|entry| entry.terminal_id != "term-1"));
 }
 
 #[test]
@@ -972,14 +979,16 @@ fn has_in_progress_empty_messages() {
 #[test]
 fn has_in_progress_no_tool_calls() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![MessageBlock::Text(TextBlock::from_complete("hello"))]));
+    app.transcript
+        .messages
+        .push(assistant_msg(vec![MessageBlock::Text(TextBlock::from_complete("hello"))]));
     assert!(!tool_calls::has_in_progress_tool_calls(&app));
 }
 
 #[test]
 fn has_in_progress_with_pending_tool() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "tc1",
         model::ToolCallStatus::Pending,
     )))]));
@@ -990,7 +999,7 @@ fn has_in_progress_with_pending_tool() {
 #[test]
 fn has_in_progress_with_in_progress_tool() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "tc1",
         model::ToolCallStatus::InProgress,
     )))]));
@@ -1001,7 +1010,7 @@ fn has_in_progress_with_in_progress_tool() {
 #[test]
 fn has_in_progress_all_completed() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "tc1",
         model::ToolCallStatus::Completed,
     )))]));
@@ -1011,7 +1020,7 @@ fn has_in_progress_all_completed() {
 #[test]
 fn has_in_progress_all_failed() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "tc1",
         model::ToolCallStatus::Failed,
     )))]));
@@ -1023,7 +1032,7 @@ fn has_in_progress_all_failed() {
 #[test]
 fn has_in_progress_user_message_last() {
     let mut app = make_test_app();
-    app.messages.push(user_msg("hi"));
+    app.transcript.messages.push(user_msg("hi"));
     assert!(!tool_calls::has_in_progress_tool_calls(&app));
 }
 
@@ -1031,11 +1040,11 @@ fn has_in_progress_user_message_last() {
 #[test]
 fn has_in_progress_requires_explicit_owner() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "tc1",
         model::ToolCallStatus::InProgress,
     )))]));
-    app.messages.push(user_msg("thanks"));
+    app.transcript.messages.push(user_msg("thanks"));
     assert!(!tool_calls::has_in_progress_tool_calls(&app));
 }
 
@@ -1043,12 +1052,12 @@ fn has_in_progress_requires_explicit_owner() {
 #[test]
 fn has_in_progress_uses_owned_assistant_not_latest_assistant() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "tc1",
         model::ToolCallStatus::InProgress,
     )))]));
-    app.messages.push(user_msg("ok"));
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(user_msg("ok"));
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "tc2",
         model::ToolCallStatus::Completed,
     )))]));
@@ -1059,7 +1068,7 @@ fn has_in_progress_uses_owned_assistant_not_latest_assistant() {
 #[test]
 fn has_in_progress_mixed_completed_and_pending() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![
+    app.transcript.messages.push(assistant_msg(vec![
         MessageBlock::ToolCall(Box::new(tool_call("tc1", model::ToolCallStatus::Completed))),
         MessageBlock::ToolCall(Box::new(tool_call("tc2", model::ToolCallStatus::InProgress))),
     ]));
@@ -1071,7 +1080,7 @@ fn has_in_progress_mixed_completed_and_pending() {
 #[test]
 fn has_in_progress_text_and_tools_mixed() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![
+    app.transcript.messages.push(assistant_msg(vec![
         MessageBlock::Text(TextBlock::from_complete("thinking...")),
         MessageBlock::ToolCall(Box::new(tool_call("tc1", model::ToolCallStatus::Completed))),
         MessageBlock::Text(TextBlock::from_complete("done")),
@@ -1095,7 +1104,7 @@ fn has_in_progress_stress_100_tools_one_pending() {
         "tc_pending",
         model::ToolCallStatus::Pending,
     ))));
-    app.messages.push(assistant_msg(blocks));
+    app.transcript.messages.push(assistant_msg(blocks));
     app.bind_active_turn_assistant_to_tail();
     assert!(tool_calls::has_in_progress_tool_calls(&app));
 }
@@ -1112,7 +1121,7 @@ fn has_in_progress_stress_100_tools_all_done() {
             )))
         })
         .collect();
-    app.messages.push(assistant_msg(blocks));
+    app.transcript.messages.push(assistant_msg(blocks));
     assert!(!tool_calls::has_in_progress_tool_calls(&app));
 }
 
@@ -1120,7 +1129,7 @@ fn has_in_progress_stress_100_tools_all_done() {
 #[test]
 fn has_in_progress_failed_and_completed_mix() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![
+    app.transcript.messages.push(assistant_msg(vec![
         MessageBlock::ToolCall(Box::new(tool_call("tc1", model::ToolCallStatus::Completed))),
         MessageBlock::ToolCall(Box::new(tool_call("tc2", model::ToolCallStatus::Failed))),
         MessageBlock::ToolCall(Box::new(tool_call("tc3", model::ToolCallStatus::Completed))),
@@ -1132,7 +1141,7 @@ fn has_in_progress_failed_and_completed_mix() {
 #[test]
 fn has_in_progress_empty_assistant_blocks() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![]));
+    app.transcript.messages.push(assistant_msg(vec![]));
     assert!(!tool_calls::has_in_progress_tool_calls(&app));
 }
 
@@ -1141,7 +1150,7 @@ fn has_in_progress_empty_assistant_blocks() {
 #[test]
 fn test_app_defaults() {
     let app = make_test_app();
-    assert!(app.messages.is_empty());
+    assert!(app.transcript.messages.is_empty());
     assert_eq!(app.surface_mode, SurfaceMode::Chat);
     assert_eq!(app.surface_mode, SurfaceMode::Chat);
     assert_eq!(app.terminal_lifecycle, TerminalLifecycleState::Running(SurfaceMode::Chat));
@@ -1150,11 +1159,11 @@ fn test_app_defaults() {
     assert!(!app.should_quit);
     assert!(app.session_id.is_none());
     assert_eq!(app.files_accessed, 0);
-    assert!(app.pending_interaction_ids.is_empty());
+    assert!(app.turn.pending_interaction_ids.is_empty());
     assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::None);
     assert!(app.tasks.is_empty());
     assert!(app.mention.is_none());
-    assert!(!app.cancelled_turn_pending_hint);
+    assert!(!app.turn.cancelled_pending_hint);
     assert!(matches!(app.status, AppStatus::Ready));
 }
 
@@ -1244,8 +1253,8 @@ fn resize_while_released_to_child_stores_size_without_drawing_hidden_chat() {
 fn resize_does_not_mutate_messages() {
     let mut app = make_test_app();
     app.terminal_lifecycle = TerminalLifecycleState::Running(SurfaceMode::Chat);
-    app.messages.push(user_msg("hello"));
-    app.messages.push(assistant_msg(vec![
+    app.transcript.messages.push(user_msg("hello"));
+    app.transcript.messages.push(assistant_msg(vec![
         MessageBlock::Text(TextBlock::from_complete("answer")),
         MessageBlock::ToolCall(Box::new(tool_call("tc-resize", model::ToolCallStatus::InProgress))),
     ]));
@@ -1260,10 +1269,10 @@ fn resize_does_not_mutate_messages() {
 fn resize_does_not_clear_active_assistant_ownership() {
     let mut app = make_test_app();
     app.terminal_lifecycle = TerminalLifecycleState::Running(SurfaceMode::Chat);
-    app.messages.push(user_msg("hello"));
-    app.messages.push(assistant_msg(vec![MessageBlock::Text(TextBlock::from_complete(
-        "streaming answer",
-    ))]));
+    app.transcript.messages.push(user_msg("hello"));
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::Text(
+        TextBlock::from_complete("streaming answer"),
+    )]));
     app.bind_active_turn_assistant(1);
 
     handle_terminal_event(&mut app, Event::Resize(120, 40));
@@ -1293,12 +1302,12 @@ fn turn_complete_after_cancel_renders_interrupted_hint() {
     let mut app = make_test_app();
 
     handle_client_event(&mut app, ClientEvent::TurnCancelled);
-    assert!(app.cancelled_turn_pending_hint);
+    assert!(app.turn.cancelled_pending_hint);
 
     handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
-    assert!(!app.cancelled_turn_pending_hint);
-    let last = app.messages.last().expect("expected interruption hint message");
+    assert!(!app.turn.cancelled_pending_hint);
+    let last = app.transcript.messages.last().expect("expected interruption hint message");
     assert!(matches!(last.role, MessageRole::System(Some(SystemSeverity::Info))));
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
         panic!("expected text block");
@@ -1309,15 +1318,20 @@ fn turn_complete_after_cancel_renders_interrupted_hint() {
 #[test]
 fn connected_updates_welcome_session_id_while_pristine() {
     let mut app = make_test_app();
-    app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
-    let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first_mut() else {
+    app.transcript.messages.push(ChatMessage::welcome(
+        env!("CARGO_PKG_VERSION"),
+        "-",
+        "/test",
+        "-",
+    ));
+    let Some(MessageBlock::Welcome(welcome)) = app.transcript.messages[0].blocks.first_mut() else {
         panic!("expected welcome block");
     };
     welcome.tip_seed = 7;
 
     handle_client_event(&mut app, connected_event("claude-updated"));
 
-    let Some(first) = app.messages.first() else {
+    let Some(first) = app.transcript.messages.first() else {
         panic!("missing welcome message");
     };
     let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
@@ -1330,7 +1344,12 @@ fn connected_updates_welcome_session_id_while_pristine() {
 #[test]
 fn connected_session_preserves_inline_viewport_for_startup_welcome_transition() {
     let mut app = make_test_app();
-    app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
+    app.transcript.messages.push(ChatMessage::welcome(
+        env!("CARGO_PKG_VERSION"),
+        "-",
+        "/test",
+        "-",
+    ));
     app.surface_dirty.chat.rebuild = ChatRebuildKind::None;
     app.surface_dirty.chat.repaint = false;
 
@@ -1343,11 +1362,16 @@ fn connected_session_preserves_inline_viewport_for_startup_welcome_transition() 
 #[test]
 fn connected_keeps_subscription_placeholder_until_status_snapshot_arrives() {
     let mut app = make_test_app();
-    app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "old", "/test", "old"));
+    app.transcript.messages.push(ChatMessage::welcome(
+        env!("CARGO_PKG_VERSION"),
+        "old",
+        "/test",
+        "old",
+    ));
 
     handle_client_event(&mut app, connected_event("opus"));
 
-    let Some(first) = app.messages.first() else {
+    let Some(first) = app.transcript.messages.first() else {
         panic!("missing welcome message");
     };
     let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
@@ -1394,7 +1418,12 @@ fn connected_requests_mcp_snapshot_even_outside_mcp_tab() {
 #[test]
 fn connected_updates_cwd_and_clears_resuming_marker() {
     let mut app = make_test_app();
-    app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
+    app.transcript.messages.push(ChatMessage::welcome(
+        env!("CARGO_PKG_VERSION"),
+        "-",
+        "/test",
+        "-",
+    ));
     app.resuming_session_id = Some("resume-123".into());
 
     handle_client_event(
@@ -1412,7 +1441,7 @@ fn connected_updates_cwd_and_clears_resuming_marker() {
     assert_eq!(app.cwd_raw, "/changed");
     assert_eq!(app.cwd, "/changed");
     assert!(app.resuming_session_id.is_none());
-    let Some(first) = app.messages.first() else {
+    let Some(first) = app.transcript.messages.first() else {
         panic!("missing welcome message");
     };
     let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
@@ -1451,16 +1480,21 @@ fn connected_reconciles_trust_for_new_cwd() {
 #[test]
 fn connected_updates_welcome_once_even_after_chat_started() {
     let mut app = make_test_app();
-    app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
-    let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first_mut() else {
+    app.transcript.messages.push(ChatMessage::welcome(
+        env!("CARGO_PKG_VERSION"),
+        "-",
+        "/test",
+        "-",
+    ));
+    let Some(MessageBlock::Welcome(welcome)) = app.transcript.messages[0].blocks.first_mut() else {
         panic!("expected welcome block");
     };
     welcome.tip_seed = 11;
-    app.messages.push(user_msg("hello"));
+    app.transcript.messages.push(user_msg("hello"));
 
     handle_client_event(&mut app, connected_event("claude-updated"));
 
-    let Some(first) = app.messages.first() else {
+    let Some(first) = app.transcript.messages.first() else {
         panic!("missing first message");
     };
     let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
@@ -1475,7 +1509,8 @@ fn current_model_update_does_not_mutate_welcome_snapshot_after_settings_reconcil
     let mut app = make_test_app();
     app.session_id = Some(model::SessionId::new("session-1"));
     app.current_model = Some(test_current_model("opus"));
-    app.messages = vec![ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "session-1")];
+    app.transcript.messages =
+        vec![ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "session-1")];
     crate::app::config::store::set_model(&mut app.config.committed_settings_document, Some("opus"));
 
     crate::app::config::store::set_model(
@@ -1491,7 +1526,7 @@ fn current_model_update_does_not_mutate_welcome_snapshot_after_settings_reconcil
         )),
     );
 
-    let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first() else {
+    let Some(MessageBlock::Welcome(welcome)) = app.transcript.messages[0].blocks.first() else {
         panic!("expected welcome block");
     };
     assert_eq!(welcome.session_id, "session-1");
@@ -1501,7 +1536,7 @@ fn current_model_update_does_not_mutate_welcome_snapshot_after_settings_reconcil
 #[test]
 fn connected_resets_session_scoped_view_data() {
     let mut app = make_test_app();
-    app.messages.push(user_msg("hello"));
+    app.transcript.messages.push(user_msg("hello"));
     app.status = AppStatus::Running;
     app.files_accessed = 9;
     app.usage.snapshot = Some(UsageSnapshot {
@@ -1532,8 +1567,8 @@ fn connected_resets_session_scoped_view_data() {
     handle_client_event(&mut app, connected_event("claude-updated"));
 
     assert!(matches!(app.status, AppStatus::Ready));
-    assert_eq!(app.messages.len(), 1);
-    assert!(matches!(app.messages[0].role, MessageRole::Welcome));
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert!(matches!(app.transcript.messages[0].role, MessageRole::Welcome));
     assert_eq!(app.files_accessed, 0);
     assert!(app.usage.snapshot.is_none());
     assert!(app.account_info.is_none());
@@ -1546,8 +1581,13 @@ fn connected_resets_session_scoped_view_data() {
 fn current_model_update_leaves_existing_welcome_snapshot_unchanged() {
     let mut app = make_test_app();
     app.current_model = Some(test_current_model("opus"));
-    app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
-    app.messages.push(user_msg("hello"));
+    app.transcript.messages.push(ChatMessage::welcome(
+        env!("CARGO_PKG_VERSION"),
+        "-",
+        "/test",
+        "-",
+    ));
+    app.transcript.messages.push(user_msg("hello"));
 
     handle_client_event(
         &mut app,
@@ -1556,7 +1596,7 @@ fn current_model_update_leaves_existing_welcome_snapshot_unchanged() {
         )),
     );
 
-    let Some(first) = app.messages.first() else {
+    let Some(first) = app.transcript.messages.first() else {
         panic!("missing first message");
     };
     let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
@@ -1571,7 +1611,7 @@ fn current_model_update_leaves_existing_welcome_snapshot_unchanged() {
         )),
     );
 
-    let Some(first) = app.messages.first() else {
+    let Some(first) = app.transcript.messages.first() else {
         panic!("missing first message");
     };
     let Some(MessageBlock::Welcome(welcome)) = first.blocks.first() else {
@@ -1615,10 +1655,13 @@ fn update_available_pushes_warning_system_message_with_versions_and_install_comm
         },
     );
 
-    assert_eq!(app.messages.len(), 1);
-    assert!(matches!(app.messages[0].role, MessageRole::System(Some(SystemSeverity::Warning))));
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert!(matches!(
+        app.transcript.messages[0].role,
+        MessageRole::System(Some(SystemSeverity::Warning))
+    ));
     assert_eq!(
-        first_block_text(&app.messages[0]),
+        first_block_text(&app.transcript.messages[0]),
         "Update available: current v0.2.0, latest v0.3.0. Upgrade to latest version via npm install -g claude-code-rust."
     );
     let Some(update_notice) = app.update_notice.as_ref() else {
@@ -1642,7 +1685,7 @@ fn service_status_warning_pushes_system_warning_without_locking_input() {
     );
 
     assert!(matches!(app.status, AppStatus::Ready));
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system message");
     };
     assert!(matches!(last.role, MessageRole::System(Some(SystemSeverity::Warning))));
@@ -1678,6 +1721,7 @@ fn service_status_warning_survives_status_snapshot_welcome_update() {
     );
 
     let warning_count = app
+        .transcript
         .messages
         .iter()
         .filter(|message| {
@@ -1703,7 +1747,7 @@ fn service_status_error_pushes_system_error_without_locking_input() {
 
     assert!(matches!(app.status, AppStatus::Ready));
     assert_eq!(app.input.text(), "draft stays");
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system message");
     };
     assert!(matches!(last.role, MessageRole::System(Some(SystemSeverity::Error))));
@@ -1712,16 +1756,23 @@ fn service_status_error_pushes_system_error_without_locking_input() {
 #[test]
 fn session_replaced_resets_chat_and_transient_state() {
     let mut app = make_test_app();
-    app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "-"));
-    let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first_mut() else {
+    app.transcript.messages.push(ChatMessage::welcome(
+        env!("CARGO_PKG_VERSION"),
+        "-",
+        "/test",
+        "-",
+    ));
+    let Some(MessageBlock::Welcome(welcome)) = app.transcript.messages[0].blocks.first_mut() else {
         panic!("expected welcome block");
     };
     welcome.tip_seed = 5;
-    app.messages.push(user_msg("hello"));
-    app.messages.push(assistant_msg(vec![MessageBlock::Text(TextBlock::from_complete("world"))]));
+    app.transcript.messages.push(user_msg("hello"));
+    app.transcript
+        .messages
+        .push(assistant_msg(vec![MessageBlock::Text(TextBlock::from_complete("world"))]));
     app.status = AppStatus::Running;
     app.files_accessed = 9;
-    app.pending_interaction_ids.push("perm-1".into());
+    app.turn.pending_interaction_ids.push("perm-1".into());
     app.tasks.push(task_item("task-1", "Task", model::TaskStatus::InProgress));
     app.mention = Some(mention::MentionState::new(0, 0, String::new(), Vec::new()));
     app.mcp.servers.push(crate::agent::model::McpServerStatus {
@@ -1753,17 +1804,17 @@ fn session_replaced_resets_chat_and_transient_state() {
         app.current_model.as_ref().map(|model| model.resolved_id.as_str()),
         Some("new-model")
     );
-    assert_eq!(app.messages.len(), 1);
-    assert!(matches!(app.messages[0].role, MessageRole::Welcome));
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert!(matches!(app.transcript.messages[0].role, MessageRole::Welcome));
     assert_eq!(app.files_accessed, 0);
-    assert!(app.pending_interaction_ids.is_empty());
+    assert!(app.turn.pending_interaction_ids.is_empty());
     assert!(app.tasks.is_empty());
     assert!(app.mention.is_none());
     assert!(app.mcp.servers.is_empty());
     assert!(app.mcp.removed_config_servers.is_empty());
     assert_eq!(app.cwd_raw, "/replacement");
     assert_eq!(app.cwd, "/replacement");
-    let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first() else {
+    let Some(MessageBlock::Welcome(welcome)) = app.transcript.messages[0].blocks.first() else {
         panic!("expected welcome block");
     };
     assert_eq!(welcome.cwd, "/replacement");
@@ -1871,7 +1922,12 @@ fn stale_status_snapshot_for_old_session_is_ignored() {
 #[test]
 fn status_snapshot_updates_welcome_subscription() {
     let mut app = make_test_app();
-    app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "session-1"));
+    app.transcript.messages.push(ChatMessage::welcome(
+        env!("CARGO_PKG_VERSION"),
+        "-",
+        "/test",
+        "session-1",
+    ));
     app.session_id = Some(model::SessionId::new("session-1"));
 
     handle_client_event(
@@ -1889,7 +1945,7 @@ fn status_snapshot_updates_welcome_subscription() {
         },
     );
 
-    let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first() else {
+    let Some(MessageBlock::Welcome(welcome)) = app.transcript.messages[0].blocks.first() else {
         panic!("expected welcome block");
     };
     assert_eq!(welcome.subscription, "Claude Max");
@@ -1900,7 +1956,12 @@ fn status_snapshot_updates_welcome_subscription() {
 fn status_snapshot_does_not_commit_welcome_when_session_overview_is_suppressed() {
     let mut app = make_test_app();
     app.show_session_overview = false;
-    app.messages.push(ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/test", "session-1"));
+    app.transcript.messages.push(ChatMessage::welcome(
+        env!("CARGO_PKG_VERSION"),
+        "-",
+        "/test",
+        "session-1",
+    ));
     app.session_id = Some(model::SessionId::new("session-1"));
 
     handle_client_event(
@@ -1918,7 +1979,7 @@ fn status_snapshot_does_not_commit_welcome_when_session_overview_is_suppressed()
         },
     );
 
-    let Some(MessageBlock::Welcome(welcome)) = app.messages[0].blocks.first() else {
+    let Some(MessageBlock::Welcome(welcome)) = app.transcript.messages[0].blocks.first() else {
         panic!("expected welcome block");
     };
     assert_eq!(welcome.subscription, "Claude Max");
@@ -2157,26 +2218,26 @@ fn slash_command_error_clears_rewind_target_loading_state() {
 fn slash_command_error_during_running_turn_does_not_stop_turn_status() {
     let mut app = make_test_app();
     app.status = AppStatus::Running;
-    app.pending_command_label = Some("Switching mode...".into());
-    app.pending_command_ack = Some(PendingCommandAck::CurrentMode);
+    app.turn.pending_command_label = Some("Switching mode...".into());
+    app.turn.pending_command_ack = Some(PendingCommandAck::CurrentMode);
 
     handle_client_event(&mut app, ClientEvent::SlashCommandError("failed to set mode".into()));
 
     assert!(matches!(app.status, AppStatus::Running));
-    assert!(app.pending_command_label.is_none());
-    assert!(app.pending_command_ack.is_none());
+    assert!(app.turn.pending_command_label.is_none());
+    assert!(app.turn.pending_command_ack.is_none());
 }
 
 #[test]
 fn slash_command_error_during_active_turn_inserts_inline_notice() {
     let mut app = make_test_app();
     app.status = AppStatus::Running;
-    app.messages.push(assistant_msg(vec![MessageBlock::Text(TextBlock::from_complete(
-        "streaming answer",
-    ))]));
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::Text(
+        TextBlock::from_complete("streaming answer"),
+    )]));
     app.bind_active_turn_assistant(0);
-    app.pending_command_label = Some("Switching mode...".into());
-    app.pending_command_ack = Some(PendingCommandAck::CurrentMode);
+    app.turn.pending_command_label = Some("Switching mode...".into());
+    app.turn.pending_command_ack = Some(PendingCommandAck::CurrentMode);
 
     handle_client_event(
         &mut app,
@@ -2184,12 +2245,12 @@ fn slash_command_error_during_active_turn_inserts_inline_notice() {
     );
 
     assert!(matches!(app.status, AppStatus::Running));
-    assert!(app.pending_command_label.is_none());
-    assert!(app.pending_command_ack.is_none());
-    assert_eq!(app.messages.len(), 1);
-    assert!(app.turn_notice_refs.is_empty());
+    assert!(app.turn.pending_command_label.is_none());
+    assert!(app.turn.pending_command_ack.is_none());
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert!(app.turn.notice_refs.is_empty());
     let [MessageBlock::Text(text), MessageBlock::Notice(notice)] =
-        app.messages[0].blocks.as_slice()
+        app.transcript.messages[0].blocks.as_slice()
     else {
         panic!("expected assistant text followed by inline notice");
     };
@@ -2203,8 +2264,8 @@ fn slash_command_error_during_active_turn_inserts_inline_notice() {
 fn slash_command_error_without_active_turn_inserts_standalone_notice() {
     let mut app = make_test_app();
     app.status = AppStatus::CommandPending;
-    app.pending_command_label = Some("Switching mode...".into());
-    app.pending_command_ack = Some(PendingCommandAck::CurrentMode);
+    app.turn.pending_command_label = Some("Switching mode...".into());
+    app.turn.pending_command_ack = Some(PendingCommandAck::CurrentMode);
 
     handle_client_event(
         &mut app,
@@ -2212,11 +2273,11 @@ fn slash_command_error_without_active_turn_inserts_standalone_notice() {
     );
 
     assert!(matches!(app.status, AppStatus::Ready));
-    assert!(app.pending_command_label.is_none());
-    assert!(app.pending_command_ack.is_none());
+    assert!(app.turn.pending_command_label.is_none());
+    assert!(app.turn.pending_command_ack.is_none());
     let Some(ChatMessage {
         role: MessageRole::System(Some(SystemSeverity::Error)), blocks, ..
-    }) = app.messages.last()
+    }) = app.transcript.messages.last()
     else {
         panic!("expected standalone system notice");
     };
@@ -2232,14 +2293,14 @@ fn slash_command_error_without_active_turn_inserts_standalone_notice() {
 fn slash_command_error_during_thinking_turn_does_not_stop_turn_status() {
     let mut app = make_test_app();
     app.status = AppStatus::Thinking;
-    app.pending_command_label = Some("Switching model...".into());
-    app.pending_command_ack = Some(PendingCommandAck::CurrentModel);
+    app.turn.pending_command_label = Some("Switching model...".into());
+    app.turn.pending_command_ack = Some(PendingCommandAck::CurrentModel);
 
     handle_client_event(&mut app, ClientEvent::SlashCommandError("failed to set model".into()));
 
     assert!(matches!(app.status, AppStatus::Thinking));
-    assert!(app.pending_command_label.is_none());
-    assert!(app.pending_command_ack.is_none());
+    assert!(app.turn.pending_command_label.is_none());
+    assert!(app.turn.pending_command_ack.is_none());
 }
 
 #[test]
@@ -2343,7 +2404,7 @@ fn slash_command_error_for_pending_session_rename_stays_in_config_feedback() {
     assert!(app.config.pending_session_title_change.is_none());
     assert_eq!(app.config.last_error.as_deref(), Some("failed to rename session: boom"));
     assert!(app.config.status_message.is_none());
-    assert!(app.messages.is_empty());
+    assert!(app.transcript.messages.is_empty());
 }
 
 #[test]
@@ -2374,7 +2435,7 @@ fn mcp_operation_error_stays_in_mcp_feedback_and_out_of_chat() {
     assert_eq!(app.config.last_error, app.mcp.last_error);
     assert!(app.config.status_message.is_none());
     assert!(!app.mcp.in_flight);
-    assert!(app.messages.is_empty());
+    assert!(app.transcript.messages.is_empty());
 }
 
 #[test]
@@ -2410,7 +2471,9 @@ fn sessions_listed_completes_pending_session_title_generation() {
 #[test]
 fn startup_picker_waits_for_connected_after_sessions_listed() {
     let mut app = make_test_app();
-    app.startup_session_picker_requested = true;
+    app.startup = crate::app::state::StartupState::new(None, None, true);
+    app.startup.request_connection();
+    assert!(app.startup.mark_connection_started());
 
     handle_client_event(
         &mut app,
@@ -2420,33 +2483,35 @@ fn startup_picker_waits_for_connected_after_sessions_listed() {
     );
 
     assert_eq!(app.surface_mode, SurfaceMode::Chat);
-    assert!(app.startup_recent_sessions_loaded);
-    assert!(!app.startup_session_picker_resolved);
+    assert!(app.startup.recent_sessions_loaded());
+    assert!(!app.startup.session_picker_resolved());
 
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
     handle_client_event(&mut app, connected_event("claude-updated"));
 
     assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::SessionPicker));
-    assert!(app.startup_session_picker_resolved);
+    assert!(app.startup.session_picker_resolved());
 }
 
 #[test]
 fn startup_picker_empty_list_stays_in_chat_with_info_message() {
     let mut app = make_test_app();
-    app.startup_session_picker_requested = true;
+    app.startup = crate::app::state::StartupState::new(None, None, true);
+    app.startup.request_connection();
+    assert!(app.startup.mark_connection_started());
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     app.conn = Some(Rc::new(crate::agent::client::AgentConnection::new(tx)));
 
     handle_client_event(&mut app, connected_event("claude-updated"));
     assert_eq!(app.surface_mode, SurfaceMode::Chat);
-    assert!(!app.startup_session_picker_resolved);
+    assert!(!app.startup.session_picker_resolved());
 
     handle_client_event(&mut app, ClientEvent::SessionsListed { sessions: Vec::new() });
 
     assert_eq!(app.surface_mode, SurfaceMode::Chat);
-    assert!(app.startup_session_picker_resolved);
-    let last = app.messages.last().expect("info message");
+    assert!(app.startup.session_picker_resolved());
+    let last = app.transcript.messages.last().expect("info message");
     let text = match last.blocks.first().expect("text block") {
         MessageBlock::Text(block) => block.text.as_str(),
         _ => panic!("expected text block"),
@@ -2502,8 +2567,8 @@ fn sessions_listed_refresh_preserves_picker_selection_by_session_id() {
 fn current_model_update_updates_state_and_clears_pending_when_expected() {
     let mut app = make_test_app();
     app.status = AppStatus::CommandPending;
-    app.pending_command_label = Some("Switching model...".into());
-    app.pending_command_ack = Some(PendingCommandAck::CurrentModel);
+    app.turn.pending_command_label = Some("Switching model...".into());
+    app.turn.pending_command_ack = Some(PendingCommandAck::CurrentModel);
     app.current_model = Some(test_current_model("old-model"));
 
     handle_client_event(
@@ -2515,16 +2580,16 @@ fn current_model_update_updates_state_and_clears_pending_when_expected() {
 
     assert!(matches!(app.status, AppStatus::Ready));
     assert_eq!(app.current_model.as_ref().map(|model| model.resolved_id.as_str()), Some("sonnet"));
-    assert!(app.pending_command_label.is_none());
-    assert!(app.pending_command_ack.is_none());
+    assert!(app.turn.pending_command_label.is_none());
+    assert!(app.turn.pending_command_ack.is_none());
 }
 
 #[test]
 fn non_matching_config_option_update_keeps_pending() {
     let mut app = make_test_app();
     app.status = AppStatus::CommandPending;
-    app.pending_command_label = Some("Switching model...".into());
-    app.pending_command_ack =
+    app.turn.pending_command_label = Some("Switching model...".into());
+    app.turn.pending_command_ack =
         Some(PendingCommandAck::ConfigOption { option_id: "model".to_owned() });
 
     handle_client_event(
@@ -2539,9 +2604,9 @@ fn non_matching_config_option_update_keeps_pending() {
 
     assert!(matches!(app.status, AppStatus::CommandPending));
     assert_eq!(app.config_options.get("max_thinking_tokens"), Some(&serde_json::json!(2048)));
-    assert_eq!(app.pending_command_label.as_deref(), Some("Switching model..."));
+    assert_eq!(app.turn.pending_command_label.as_deref(), Some("Switching model..."));
     assert!(matches!(
-        app.pending_command_ack.as_ref(),
+        app.turn.pending_command_ack.as_ref(),
         Some(PendingCommandAck::ConfigOption { option_id }) if option_id == "model"
     ));
 }
@@ -2564,8 +2629,8 @@ fn resume_does_not_add_confirmation_system_message() {
         },
     );
 
-    assert_eq!(app.messages.len(), 1);
-    assert!(matches!(app.messages[0].role, MessageRole::Welcome));
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert!(matches!(app.transcript.messages[0].role, MessageRole::Welcome));
     assert!(app.resuming_session_id.is_none());
     assert!(matches!(app.status, AppStatus::Ready));
 }
@@ -2595,12 +2660,12 @@ fn resume_history_renders_user_message_chunks() {
         },
     );
 
-    assert_eq!(app.messages.len(), 3);
-    assert!(matches!(app.messages[0].role, MessageRole::Welcome));
-    assert!(matches!(app.messages[1].role, MessageRole::User));
-    assert!(matches!(app.messages[2].role, MessageRole::Assistant));
+    assert_eq!(app.transcript.messages.len(), 3);
+    assert!(matches!(app.transcript.messages[0].role, MessageRole::Welcome));
+    assert!(matches!(app.transcript.messages[1].role, MessageRole::User));
+    assert!(matches!(app.transcript.messages[2].role, MessageRole::Assistant));
 
-    let Some(MessageBlock::Text(user_text)) = app.messages[1].blocks.first() else {
+    let Some(MessageBlock::Text(user_text)) = app.transcript.messages[1].blocks.first() else {
         panic!("expected user text block");
     };
     assert_eq!(user_text.text, "first user line");
@@ -2608,8 +2673,8 @@ fn resume_history_renders_user_message_chunks() {
     assert!(canonical_messages_contain_text(&app, "assistant reply"));
     assert!(!session_overview_has_welcome(&app));
     assert!(matches!(app.status, AppStatus::Ready));
-    assert_eq!(app.pending_cancel_origin, None);
-    assert!(!app.pending_auto_submit_after_cancel);
+    assert_eq!(app.turn.pending_cancel_origin, None);
+    assert!(!app.turn.pending_auto_submit_after_cancel);
 
     handle_client_event(
         &mut app,
@@ -2632,7 +2697,7 @@ fn resume_history_renders_user_message_chunks() {
 #[test]
 fn session_replaced_restores_input_after_loading_history() {
     let mut app = make_test_app();
-    app.pending_command_label = Some("Rewinding conversation...".to_owned());
+    app.turn.pending_command_label = Some("Rewinding conversation...".to_owned());
     app.status = AppStatus::CommandPending;
     let history_updates = vec![model::SessionUpdate::AgentMessageChunk(model::ContentChunk::new(
         model::ContentBlock::Text(model::TextContent::new("assistant reply")),
@@ -2652,7 +2717,7 @@ fn session_replaced_restores_input_after_loading_history() {
     );
 
     assert_eq!(app.input.text(), "selected prompt");
-    assert!(app.pending_command_label.is_none());
+    assert!(app.turn.pending_command_label.is_none());
     assert!(matches!(app.status, AppStatus::Ready));
     assert!(canonical_messages_contain_text(&app, "assistant reply"));
 }
@@ -2687,8 +2752,8 @@ fn startup_resume_history_renders_from_canonical_messages() {
     assert!(live_rows_contain_text(&mut app, "startup assistant reply"));
     assert!(!session_overview_has_welcome(&app));
     assert!(matches!(app.status, AppStatus::Ready));
-    assert_eq!(app.pending_cancel_origin, None);
-    assert!(!app.pending_auto_submit_after_cancel);
+    assert_eq!(app.turn.pending_cancel_origin, None);
+    assert!(!app.turn.pending_auto_submit_after_cancel);
 
     handle_client_event(
         &mut app,
@@ -2743,8 +2808,8 @@ fn startup_resume_history_allows_immediate_prompt_submit() {
         crate::agent::wire::BridgeCommand::Prompt { session_id, .. }
             if session_id == "startup-resume"
     ));
-    assert_eq!(app.pending_cancel_origin, None);
-    assert!(!app.pending_auto_submit_after_cancel);
+    assert_eq!(app.turn.pending_cancel_origin, None);
+    assert!(!app.turn.pending_auto_submit_after_cancel);
     assert!(rx.try_recv().is_err(), "resume submit should not send cancel");
 }
 
@@ -2780,6 +2845,7 @@ fn resume_history_preserves_turn_order_between_user_and_assistant_messages() {
     );
 
     let rendered: Vec<(MessageRole, String)> = app
+        .transcript
         .messages
         .iter()
         .filter_map(|message| {
@@ -2825,7 +2891,8 @@ fn resume_history_forces_open_tool_calls_to_failed() {
     let Some((mi, bi)) = app.lookup_tool_call("resume-open") else {
         panic!("missing tool call index");
     };
-    let Some(MessageBlock::ToolCall(tc)) = app.messages.get(mi).and_then(|m| m.blocks.get(bi))
+    let Some(MessageBlock::ToolCall(tc)) =
+        app.transcript.messages.get(mi).and_then(|m| m.blocks.get(bi))
     else {
         panic!("expected tool call block");
     };
@@ -2877,7 +2944,7 @@ fn resume_history_clears_tool_scope_tracking_after_loading() {
         },
     );
 
-    assert!(app.active_task_ids.is_empty());
+    assert!(app.turn.active_task_ids.is_empty());
     assert_eq!(app.tool_call_scope("resume-task"), None);
 }
 
@@ -2885,15 +2952,16 @@ fn resume_history_clears_tool_scope_tracking_after_loading() {
 fn turn_complete_without_cancel_does_not_render_interrupted_hint() {
     let mut app = make_test_app();
     handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
-    assert!(app.messages.is_empty());
+    assert!(app.transcript.messages.is_empty());
 }
 
 #[test]
 fn turn_complete_keeps_history_and_adds_compaction_success_after_manual_boundary() {
     let mut app = make_test_app();
     app.session_id = Some(model::SessionId::new("session-x"));
-    app.messages.push(user_msg("/compact"));
-    app.messages
+    app.transcript.messages.push(user_msg("/compact"));
+    app.transcript
+        .messages
         .push(assistant_msg(vec![MessageBlock::Text(TextBlock::from_complete("compacted"))]));
     handle_client_event(
         &mut app,
@@ -2904,14 +2972,14 @@ fn turn_complete_keeps_history_and_adds_compaction_success_after_manual_boundary
             },
         )),
     );
-    assert!(app.pending_compact_clear);
+    assert!(app.turn.pending_compact_clear);
 
     handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
-    assert!(!app.pending_compact_clear);
-    assert_eq!(app.messages.len(), 3);
+    assert!(!app.turn.pending_compact_clear);
+    assert_eq!(app.transcript.messages.len(), 3);
     let Some(ChatMessage { role: MessageRole::System(Some(SystemSeverity::Info)), blocks, .. }) =
-        app.messages.last()
+        app.transcript.messages.last()
     else {
         panic!("expected compaction success system message");
     };
@@ -2925,7 +2993,7 @@ fn turn_complete_keeps_history_and_adds_compaction_success_after_manual_boundary
 #[test]
 fn first_agent_chunk_clears_unconfirmed_compacting_without_success_message() {
     let mut app = make_test_app();
-    app.is_compacting = true;
+    app.turn.is_compacting = true;
 
     handle_client_event(
         &mut app,
@@ -2936,9 +3004,9 @@ fn first_agent_chunk_clears_unconfirmed_compacting_without_success_message() {
         )),
     );
 
-    assert!(!app.is_compacting);
-    assert!(!app.pending_compact_clear);
-    assert!(app.messages.iter().all(|message| {
+    assert!(!app.turn.is_compacting);
+    assert!(!app.turn.pending_compact_clear);
+    assert!(app.transcript.messages.iter().all(|message| {
         !matches!(
             message,
             ChatMessage { role: MessageRole::System(Some(SystemSeverity::Info)), .. }
@@ -2949,7 +3017,7 @@ fn first_agent_chunk_clears_unconfirmed_compacting_without_success_message() {
 #[test]
 fn session_status_idle_does_not_emit_compaction_success_without_boundary() {
     let mut app = make_test_app();
-    app.is_compacting = true;
+    app.turn.is_compacting = true;
 
     handle_client_event(
         &mut app,
@@ -2958,16 +3026,16 @@ fn session_status_idle_does_not_emit_compaction_success_without_boundary() {
         )),
     );
 
-    assert!(!app.is_compacting);
-    assert!(!app.pending_compact_clear);
-    assert!(app.messages.is_empty());
+    assert!(!app.turn.is_compacting);
+    assert!(!app.turn.pending_compact_clear);
+    assert!(app.transcript.messages.is_empty());
 }
 
 #[test]
 fn turn_error_keeps_history_when_compact_pending() {
     let mut app = make_test_app();
-    app.pending_compact_clear = true;
-    app.messages.push(user_msg("/compact"));
+    app.turn.pending_compact_clear = true;
+    app.transcript.messages.push(user_msg("/compact"));
 
     handle_client_event(
         &mut app,
@@ -2978,12 +3046,12 @@ fn turn_error_keeps_history_when_compact_pending() {
         },
     );
 
-    assert!(!app.pending_compact_clear);
+    assert!(!app.turn.pending_compact_clear);
     assert!(matches!(app.status, AppStatus::Error));
-    assert_eq!(app.messages.len(), 3);
-    assert!(matches!(app.messages[0].role, MessageRole::User));
+    assert_eq!(app.transcript.messages.len(), 3);
+    assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
     let Some(ChatMessage { role: MessageRole::System(Some(SystemSeverity::Info)), blocks, .. }) =
-        app.messages.get(1)
+        app.transcript.messages.get(1)
     else {
         panic!("expected compaction success system message");
     };
@@ -2991,7 +3059,9 @@ fn turn_error_keeps_history_when_compact_pending() {
         panic!("expected text block");
     };
     assert_eq!(block.text, "Session successfully compacted.");
-    let Some(ChatMessage { role: MessageRole::System(_), blocks, .. }) = app.messages.last() else {
+    let Some(ChatMessage { role: MessageRole::System(_), blocks, .. }) =
+        app.transcript.messages.last()
+    else {
         panic!("expected system error message");
     };
     let Some(MessageBlock::Text(block)) = blocks.first() else {
@@ -3004,21 +3074,21 @@ fn turn_error_keeps_history_when_compact_pending() {
 #[test]
 fn turn_cancel_keeps_manual_compaction_success_pending_until_exit() {
     let mut app = make_test_app();
-    app.pending_compact_clear = true;
-    app.is_compacting = true;
+    app.turn.pending_compact_clear = true;
+    app.turn.is_compacting = true;
 
     handle_client_event(&mut app, ClientEvent::TurnCancelled);
 
-    assert!(app.pending_compact_clear);
-    assert!(app.is_compacting);
+    assert!(app.turn.pending_compact_clear);
+    assert!(app.turn.is_compacting);
 }
 
 #[test]
 fn turn_error_after_cancel_keeps_compaction_success_before_interrupted_hint() {
     let mut app = make_test_app();
-    app.messages.push(user_msg("/compact"));
-    app.pending_compact_clear = true;
-    app.is_compacting = true;
+    app.transcript.messages.push(user_msg("/compact"));
+    app.turn.pending_compact_clear = true;
+    app.turn.is_compacting = true;
 
     handle_client_event(&mut app, ClientEvent::TurnCancelled);
     handle_client_event(
@@ -3030,13 +3100,16 @@ fn turn_error_after_cancel_keeps_compaction_success_before_interrupted_hint() {
         },
     );
 
-    assert_eq!(app.messages.len(), 3);
-    assert!(matches!(app.messages[1].role, MessageRole::System(Some(SystemSeverity::Info))));
-    let Some(MessageBlock::Text(block)) = app.messages[1].blocks.first() else {
+    assert_eq!(app.transcript.messages.len(), 3);
+    assert!(matches!(
+        app.transcript.messages[1].role,
+        MessageRole::System(Some(SystemSeverity::Info))
+    ));
+    let Some(MessageBlock::Text(block)) = app.transcript.messages[1].blocks.first() else {
         panic!("expected text block");
     };
     assert_eq!(block.text, "Session successfully compacted.");
-    let Some(MessageBlock::Text(block)) = app.messages[2].blocks.first() else {
+    let Some(MessageBlock::Text(block)) = app.transcript.messages[2].blocks.first() else {
         panic!("expected text block");
     };
     assert_eq!(block.text, "Conversation interrupted. Tell the model how to proceed.");
@@ -3056,11 +3129,13 @@ fn turn_error_plan_limit_shows_next_steps_guidance() {
     );
 
     assert!(matches!(app.status, AppStatus::Error));
-    let Some(ChatMessage { role: MessageRole::System(_), blocks, .. }) = app.messages.last() else {
+    let Some(ChatMessage { role: MessageRole::System(_), blocks, .. }) =
+        app.transcript.messages.last()
+    else {
         panic!("expected system error message");
     };
     assert!(matches!(blocks.first(), Some(MessageBlock::Notice(_))));
-    let text = first_block_text(app.messages.last().expect("expected message"));
+    let text = first_block_text(app.transcript.messages.last().expect("expected message"));
     assert!(text.contains("Turn blocked by account or plan limits"));
     assert!(text.contains("Next steps:"));
     assert!(text.contains("Check quota/billing"));
@@ -3081,11 +3156,13 @@ fn classified_turn_error_plan_limit_uses_guidance_without_text_matching() {
     );
 
     assert!(matches!(app.status, AppStatus::Error));
-    let Some(ChatMessage { role: MessageRole::System(_), blocks, .. }) = app.messages.last() else {
+    let Some(ChatMessage { role: MessageRole::System(_), blocks, .. }) =
+        app.transcript.messages.last()
+    else {
         panic!("expected system error message");
     };
     assert!(matches!(blocks.first(), Some(MessageBlock::Notice(_))));
-    let text = first_block_text(app.messages.last().expect("expected message"));
+    let text = first_block_text(app.transcript.messages.last().expect("expected message"));
     assert!(text.contains("Turn blocked by account or plan limits"));
     assert!(text.contains("Next steps:"));
 }
@@ -3126,7 +3203,7 @@ fn classified_turn_error_model_unavailable_suggests_model_switch() {
     assert!(matches!(app.status, AppStatus::Error));
     assert!(!app.should_quit);
     assert_eq!(app.exit_error, None);
-    let text = first_block_text(app.messages.last().expect("expected message"));
+    let text = first_block_text(app.transcript.messages.last().expect("expected message"));
     assert!(text.contains("The selected model is unavailable"));
     assert!(text.contains("Use /model"));
 }
@@ -3148,7 +3225,7 @@ fn classified_turn_error_account_access_does_not_quit_for_login() {
     assert!(matches!(app.status, AppStatus::Error));
     assert!(!app.should_quit);
     assert_eq!(app.exit_error, None);
-    let text = first_block_text(app.messages.last().expect("expected message"));
+    let text = first_block_text(app.transcript.messages.last().expect("expected message"));
     assert!(text.contains("current account or organization"));
     assert!(text.contains("cannot use the requested resource"));
 }
@@ -3169,7 +3246,7 @@ fn classified_turn_error_transient_service_suggests_retry() {
 
     assert!(matches!(app.status, AppStatus::Error));
     assert!(!app.should_quit);
-    let text = first_block_text(app.messages.last().expect("expected message"));
+    let text = first_block_text(app.transcript.messages.last().expect("expected message"));
     assert!(text.contains("temporarily overloaded or unavailable"));
     assert!(text.contains("retry"));
 }
@@ -3177,7 +3254,7 @@ fn classified_turn_error_transient_service_suggests_retry() {
 #[test]
 fn turn_error_clears_tool_scope_tracking() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "task-1",
         model::ToolCallStatus::InProgress,
     )))]));
@@ -3193,7 +3270,7 @@ fn turn_error_clears_tool_scope_tracking() {
         },
     );
 
-    assert!(app.active_task_ids.is_empty());
+    assert!(app.turn.active_task_ids.is_empty());
     assert_eq!(app.tool_call_scope("task-1"), None);
 }
 
@@ -3209,14 +3286,14 @@ fn auth_required_clears_active_turn_runtime_tracking() {
         available_modes: vec![crate::app::ModeInfo { id: "plan".into(), name: "Plan".into() }],
     });
     app.fast_mode_state = model::FastModeState::On;
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "task-1",
         model::ToolCallStatus::InProgress,
     )))]));
     app.bind_active_turn_assistant(0);
     app.register_tool_call_scope("task-1".into(), ToolCallScope::SubagentRoot);
     app.insert_active_task("task-1".into());
-    app.pending_interaction_ids.push("task-1".into());
+    app.turn.pending_interaction_ids.push("task-1".into());
     app.claim_focus_target(FocusTarget::Permission);
 
     handle_client_event(
@@ -3228,10 +3305,10 @@ fn auth_required_clears_active_turn_runtime_tracking() {
     );
 
     assert_eq!(app.active_turn_assistant_idx(), None);
-    assert!(app.active_task_ids.is_empty());
-    assert!(app.pending_interaction_ids.is_empty());
+    assert!(app.turn.active_task_ids.is_empty());
+    assert!(app.turn.pending_interaction_ids.is_empty());
     assert_ne!(app.focus_owner(), FocusOwner::Permission);
-    let Some(MessageBlock::ToolCall(tc)) = app.messages[0].blocks.first() else {
+    let Some(MessageBlock::ToolCall(tc)) = app.transcript.messages[0].blocks.first() else {
         panic!("expected tool call block");
     };
     assert_eq!(tc.status, model::ToolCallStatus::Failed);
@@ -3279,7 +3356,7 @@ fn fatal_event_sets_exit_error_and_quits() {
 fn connection_failed_clears_active_turn_runtime_tracking() {
     let mut app = make_test_app();
     app.status = AppStatus::Running;
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "task-1",
         model::ToolCallStatus::InProgress,
     )))]));
@@ -3290,8 +3367,8 @@ fn connection_failed_clears_active_turn_runtime_tracking() {
     handle_client_event(&mut app, ClientEvent::ConnectionFailed("bridge down".into()));
 
     assert_eq!(app.active_turn_assistant_idx(), None);
-    assert!(app.active_task_ids.is_empty());
-    let Some(MessageBlock::ToolCall(tc)) = app.messages[0].blocks.first() else {
+    assert!(app.turn.active_task_ids.is_empty());
+    let Some(MessageBlock::ToolCall(tc)) = app.transcript.messages[0].blocks.first() else {
         panic!("expected tool call block");
     };
     assert_eq!(tc.status, model::ToolCallStatus::Failed);
@@ -3301,7 +3378,7 @@ fn connection_failed_clears_active_turn_runtime_tracking() {
 fn fatal_event_clears_active_turn_runtime_tracking() {
     let mut app = make_test_app();
     app.status = AppStatus::Running;
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tool_call(
         "task-1",
         model::ToolCallStatus::InProgress,
     )))]));
@@ -3315,8 +3392,8 @@ fn fatal_event_clears_active_turn_runtime_tracking() {
     );
 
     assert_eq!(app.active_turn_assistant_idx(), None);
-    assert!(app.active_task_ids.is_empty());
-    let Some(MessageBlock::ToolCall(tc)) = app.messages[0].blocks.first() else {
+    assert!(app.turn.active_task_ids.is_empty());
+    let Some(MessageBlock::ToolCall(tc)) = app.transcript.messages[0].blocks.first() else {
         panic!("expected tool call block");
     };
     assert_eq!(tc.status, model::ToolCallStatus::Failed);
@@ -3325,7 +3402,7 @@ fn fatal_event_clears_active_turn_runtime_tracking() {
 #[test]
 fn compaction_boundary_enables_compacting_and_records_boundary() {
     let mut app = make_test_app();
-    assert!(!app.is_compacting);
+    assert!(!app.turn.is_compacting);
 
     handle_client_event(
         &mut app,
@@ -3337,8 +3414,8 @@ fn compaction_boundary_enables_compacting_and_records_boundary() {
         )),
     );
 
-    assert!(app.is_compacting);
-    assert!(app.pending_compact_clear);
+    assert!(app.turn.is_compacting);
+    assert!(app.turn.pending_compact_clear);
     assert_eq!(app.session_usage.last_compaction_trigger, Some(model::CompactionTrigger::Manual));
     assert_eq!(app.session_usage.last_compaction_pre_tokens, Some(123_456));
 }
@@ -3346,7 +3423,7 @@ fn compaction_boundary_enables_compacting_and_records_boundary() {
 #[test]
 fn auto_compaction_boundary_sets_compacting_without_manual_success_pending() {
     let mut app = make_test_app();
-    assert!(!app.is_compacting);
+    assert!(!app.turn.is_compacting);
 
     handle_client_event(
         &mut app,
@@ -3358,8 +3435,8 @@ fn auto_compaction_boundary_sets_compacting_without_manual_success_pending() {
         )),
     );
 
-    assert!(app.is_compacting);
-    assert!(!app.pending_compact_clear);
+    assert!(app.turn.is_compacting);
+    assert!(!app.turn.pending_compact_clear);
     assert_eq!(app.session_usage.last_compaction_trigger, Some(model::CompactionTrigger::Auto));
     assert_eq!(app.session_usage.last_compaction_pre_tokens, Some(234_567));
 }
@@ -3407,9 +3484,12 @@ fn rate_limit_notices_dedup_and_upgrade_in_place() {
         ClientEvent::SessionUpdate(model::SessionUpdate::RateLimitUpdate(warning_update.clone())),
     );
 
-    assert_eq!(app.messages.len(), 1);
-    assert!(matches!(app.messages[0].role, MessageRole::System(Some(SystemSeverity::Warning))));
-    assert!(matches!(app.messages[0].blocks.first(), Some(MessageBlock::Notice(_))));
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert!(matches!(
+        app.transcript.messages[0].role,
+        MessageRole::System(Some(SystemSeverity::Warning))
+    ));
+    assert!(matches!(app.transcript.messages[0].blocks.first(), Some(MessageBlock::Notice(_))));
 
     let rejected_update =
         model::RateLimitUpdate { status: model::RateLimitStatus::Rejected, ..warning_update };
@@ -3422,19 +3502,22 @@ fn rate_limit_notices_dedup_and_upgrade_in_place() {
         ClientEvent::SessionUpdate(model::SessionUpdate::RateLimitUpdate(rejected_update)),
     );
 
-    assert_eq!(app.messages.len(), 1);
-    assert!(matches!(app.messages[0].role, MessageRole::System(Some(SystemSeverity::Error))));
-    assert!(first_block_text(&app.messages[0]).contains("Rate limit reached"));
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert!(matches!(
+        app.transcript.messages[0].role,
+        MessageRole::System(Some(SystemSeverity::Error))
+    ));
+    assert!(first_block_text(&app.transcript.messages[0]).contains("Rate limit reached"));
 }
 
 #[test]
 fn plan_limit_turn_error_upgrades_inline_notice_in_active_assistant() {
     let mut app = make_test_app();
     app.status = AppStatus::Thinking;
-    app.messages.push(user_msg("hello"));
-    app.messages.push(assistant_msg(vec![MessageBlock::Text(TextBlock::from_complete(
-        "partial response",
-    ))]));
+    app.transcript.messages.push(user_msg("hello"));
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::Text(
+        TextBlock::from_complete("partial response"),
+    )]));
     app.bind_active_turn_assistant(1);
 
     handle_client_event(
@@ -3454,10 +3537,10 @@ fn plan_limit_turn_error_upgrades_inline_notice_in_active_assistant() {
             has_chargeable_saved_payment_method: None,
         })),
     );
-    assert_eq!(app.messages.len(), 2);
-    assert_eq!(app.messages[1].blocks.len(), 2);
-    assert!(matches!(app.messages[1].blocks[1], MessageBlock::Notice(_)));
-    assert_eq!(app.turn_notice_refs.len(), 1);
+    assert_eq!(app.transcript.messages.len(), 2);
+    assert_eq!(app.transcript.messages[1].blocks.len(), 2);
+    assert!(matches!(app.transcript.messages[1].blocks[1], MessageBlock::Notice(_)));
+    assert_eq!(app.turn.notice_refs.len(), 1);
 
     handle_client_event(
         &mut app,
@@ -3470,15 +3553,15 @@ fn plan_limit_turn_error_upgrades_inline_notice_in_active_assistant() {
     );
 
     assert!(matches!(app.status, AppStatus::Error));
-    assert_eq!(app.messages.len(), 2);
-    assert_eq!(app.messages[1].blocks.len(), 2);
-    let Some(MessageBlock::Notice(block)) = app.messages[1].blocks.get(1) else {
+    assert_eq!(app.transcript.messages.len(), 2);
+    assert_eq!(app.transcript.messages[1].blocks.len(), 2);
+    let Some(MessageBlock::Notice(block)) = app.transcript.messages[1].blocks.get(1) else {
         panic!("expected inline notice block");
     };
     assert_eq!(block.severity, SystemSeverity::Warning);
     assert!(block.text.text.contains("Approaching rate limit"));
     assert!(block.text.text.contains("Turn blocked by account or plan limits"));
-    assert!(app.turn_notice_refs.is_empty());
+    assert!(app.turn.notice_refs.is_empty());
 }
 
 #[test]
@@ -3499,8 +3582,8 @@ fn different_rate_limit_incident_in_later_turn_keeps_older_notice() {
         has_chargeable_saved_payment_method: None,
     });
     app.status = AppStatus::Thinking;
-    app.messages.push(user_msg("first"));
-    app.messages.push(assistant_msg(vec![]));
+    app.transcript.messages.push(user_msg("first"));
+    app.transcript.messages.push(assistant_msg(vec![]));
     app.bind_active_turn_assistant(1);
 
     handle_client_event(
@@ -3512,16 +3595,16 @@ fn different_rate_limit_incident_in_later_turn_keeps_older_notice() {
             terminal_reason: None,
         },
     );
-    assert_eq!(app.messages.len(), 2);
-    let first_notice_text = match app.messages[1].blocks.as_slice() {
+    assert_eq!(app.transcript.messages.len(), 2);
+    let first_notice_text = match app.transcript.messages[1].blocks.as_slice() {
         [MessageBlock::Notice(block)] => block.text.text.clone(),
         _ => panic!("expected first turn notice"),
     };
     assert!(first_notice_text.contains("Approaching rate limit"));
 
     app.status = AppStatus::Thinking;
-    app.messages.push(user_msg("second"));
-    app.messages.push(assistant_msg(vec![]));
+    app.transcript.messages.push(user_msg("second"));
+    app.transcript.messages.push(assistant_msg(vec![]));
     app.bind_active_turn_assistant(3);
     handle_client_event(
         &mut app,
@@ -3541,12 +3624,13 @@ fn different_rate_limit_incident_in_later_turn_keeps_older_notice() {
         })),
     );
 
-    assert_eq!(app.messages.len(), 4);
-    let Some(MessageBlock::Notice(first_notice)) = app.messages[1].blocks.first() else {
+    assert_eq!(app.transcript.messages.len(), 4);
+    let Some(MessageBlock::Notice(first_notice)) = app.transcript.messages[1].blocks.first() else {
         panic!("expected first turn notice");
     };
     assert_eq!(first_notice.text.text, first_notice_text);
-    let Some(MessageBlock::Notice(second_notice)) = app.messages[3].blocks.first() else {
+    let Some(MessageBlock::Notice(second_notice)) = app.transcript.messages[3].blocks.first()
+    else {
         panic!("expected second turn notice");
     };
     assert!(second_notice.text.text.contains("daily rate limit"));
@@ -3557,8 +3641,8 @@ fn different_rate_limit_incident_in_later_turn_keeps_older_notice() {
 fn turn_notice_tracking_clears_on_turn_complete_and_session_reset() {
     let mut app = make_test_app();
     app.status = AppStatus::Thinking;
-    app.messages.push(user_msg("hello"));
-    app.messages.push(assistant_msg(vec![]));
+    app.transcript.messages.push(user_msg("hello"));
+    app.transcript.messages.push(assistant_msg(vec![]));
     app.bind_active_turn_assistant(1);
 
     handle_client_event(
@@ -3579,14 +3663,14 @@ fn turn_notice_tracking_clears_on_turn_complete_and_session_reset() {
         })),
     );
 
-    assert_eq!(app.turn_notice_refs.len(), 1);
+    assert_eq!(app.turn.notice_refs.len(), 1);
     handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
-    assert!(app.turn_notice_refs.is_empty());
+    assert!(app.turn.notice_refs.is_empty());
 
     app.status = AppStatus::Thinking;
-    app.messages.push(user_msg("again"));
-    app.messages.push(assistant_msg(vec![]));
-    app.bind_active_turn_assistant(app.messages.len() - 1);
+    app.transcript.messages.push(user_msg("again"));
+    app.transcript.messages.push(assistant_msg(vec![]));
+    app.bind_active_turn_assistant(app.transcript.messages.len() - 1);
     handle_client_event(
         &mut app,
         ClientEvent::SessionUpdate(model::SessionUpdate::RateLimitUpdate(model::RateLimitUpdate {
@@ -3604,7 +3688,7 @@ fn turn_notice_tracking_clears_on_turn_complete_and_session_reset() {
             has_chargeable_saved_payment_method: None,
         })),
     );
-    assert_eq!(app.turn_notice_refs.len(), 1);
+    assert_eq!(app.turn.notice_refs.len(), 1);
 
     handle_client_event(
         &mut app,
@@ -3617,16 +3701,16 @@ fn turn_notice_tracking_clears_on_turn_complete_and_session_reset() {
             history_updates: Vec::new(),
         },
     );
-    assert!(app.turn_notice_refs.is_empty());
+    assert!(app.turn.notice_refs.is_empty());
 }
 
 #[test]
 fn turn_error_after_cancel_shows_interrupted_hint_instead_of_error_block() {
     let mut app = make_test_app();
-    app.messages.push(user_msg("build app"));
+    app.transcript.messages.push(user_msg("build app"));
 
     handle_client_event(&mut app, ClientEvent::TurnCancelled);
-    assert!(app.cancelled_turn_pending_hint);
+    assert!(app.turn.cancelled_pending_hint);
 
     handle_client_event(
         &mut app,
@@ -3637,10 +3721,10 @@ fn turn_error_after_cancel_shows_interrupted_hint_instead_of_error_block() {
         },
     );
 
-    assert!(!app.cancelled_turn_pending_hint);
+    assert!(!app.turn.cancelled_pending_hint);
     assert!(matches!(app.status, AppStatus::Ready));
 
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected interruption hint message");
     };
     assert!(matches!(last.role, MessageRole::System(Some(SystemSeverity::Info))));
@@ -3653,7 +3737,7 @@ fn turn_error_after_cancel_shows_interrupted_hint_instead_of_error_block() {
 #[test]
 fn turn_cancel_marks_active_tools_failed() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![
+    app.transcript.messages.push(assistant_msg(vec![
         MessageBlock::ToolCall(Box::new(tool_call("tc1", model::ToolCallStatus::InProgress))),
         MessageBlock::ToolCall(Box::new(tool_call("tc2", model::ToolCallStatus::Pending))),
         MessageBlock::ToolCall(Box::new(tool_call("tc3", model::ToolCallStatus::Completed))),
@@ -3661,7 +3745,7 @@ fn turn_cancel_marks_active_tools_failed() {
 
     handle_client_event(&mut app, ClientEvent::TurnCancelled);
 
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("missing assistant message");
     };
     let statuses: Vec<model::ToolCallStatus> = last
@@ -3685,14 +3769,14 @@ fn turn_cancel_marks_active_tools_failed() {
 #[test]
 fn turn_complete_marks_lingering_tools_completed() {
     let mut app = make_test_app();
-    app.messages.push(assistant_msg(vec![
+    app.transcript.messages.push(assistant_msg(vec![
         MessageBlock::ToolCall(Box::new(tool_call("tc1", model::ToolCallStatus::InProgress))),
         MessageBlock::ToolCall(Box::new(tool_call("tc2", model::ToolCallStatus::Pending))),
     ]));
 
     handle_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("missing assistant message");
     };
     let statuses: Vec<model::ToolCallStatus> = last
@@ -3720,7 +3804,7 @@ fn ctrl_v_not_inserted_by_chat_key_handlers() {
 #[test]
 fn pending_paste_payload_blocks_overlapping_key_text_insertion() {
     let mut app = make_test_app();
-    app.pending_paste_text = "clipboard".to_owned();
+    app.paste.pending_text = "clipboard".to_owned();
 
     handle_normal_key(&mut app, KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
 
@@ -3829,13 +3913,13 @@ fn permission_owner_handles_up_down_for_pending_interactions() {
 
     handle_terminal_event(&mut app, Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)));
 
-    assert_eq!(app.pending_interaction_ids, vec!["perm-b", "perm-a"]);
+    assert_eq!(app.turn.pending_interaction_ids, vec!["perm-b", "perm-a"]);
 }
 
 #[test]
 fn permission_focus_allows_typing_for_non_permission_keys() {
     let mut app = make_test_app();
-    app.pending_interaction_ids.push("perm-1".into());
+    app.turn.pending_interaction_ids.push("perm-1".into());
     app.claim_focus_target(FocusTarget::Permission);
 
     handle_terminal_event(
@@ -3878,7 +3962,7 @@ fn permission_request_with_existing_draft_does_not_claim_focus() {
     );
 
     assert_eq!(app.focus_owner(), FocusOwner::Input);
-    assert_eq!(app.pending_interaction_ids, vec![tool_id]);
+    assert_eq!(app.turn.pending_interaction_ids, vec![tool_id]);
     assert_eq!(permission_focus_state(&app, tool_id), Some(false));
 }
 
@@ -3911,7 +3995,7 @@ fn question_request_with_existing_draft_does_not_claim_focus() {
     );
 
     assert_eq!(app.focus_owner(), FocusOwner::Input);
-    assert_eq!(app.pending_interaction_ids, vec![tool_id]);
+    assert_eq!(app.turn.pending_interaction_ids, vec![tool_id]);
     assert_eq!(question_focus_state(&app, tool_id), Some(false));
 }
 
@@ -3957,7 +4041,7 @@ fn enter_submits_draft_when_permission_arrives_mid_compose() {
     super::super::finalize_deferred_submit(&mut app);
 
     assert!(app.pending_submit.is_none());
-    assert!(app.pending_interaction_ids.is_empty());
+    assert!(app.turn.pending_interaction_ids.is_empty());
     assert!(bridge_rx.try_recv().is_ok());
     assert!(response_rx.try_recv().is_err());
 }
@@ -4092,7 +4176,9 @@ fn space_toggles_focused_question_without_reclaiming_input() {
     assert_eq!(app.focus_owner(), FocusOwner::Permission);
     assert_eq!(app.input.text(), "");
     let (mi, bi) = app.lookup_tool_call("question-space").expect("question tool call");
-    let MessageBlock::ToolCall(tc) = app.messages.get(mi).unwrap().blocks.get(bi).unwrap() else {
+    let MessageBlock::ToolCall(tc) =
+        app.transcript.messages.get(mi).unwrap().blocks.get(bi).unwrap()
+    else {
         panic!("expected tool call block");
     };
     let question = tc.pending_question.as_ref().expect("pending question");
@@ -4111,13 +4197,13 @@ fn stale_inline_interaction_queue_head_is_pruned_before_enter_response() {
         ],
         false,
     );
-    app.pending_interaction_ids.insert(0, "stale-id".into());
+    app.turn.pending_interaction_ids.insert(0, "stale-id".into());
 
     handle_terminal_event(&mut app, Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)));
 
     let response = response_rx.try_recv().expect("permission response");
     assert!(matches!(response.outcome, model::RequestPermissionOutcome::Selected(_)));
-    assert!(app.pending_interaction_ids.is_empty());
+    assert!(app.turn.pending_interaction_ids.is_empty());
 }
 
 #[test]
@@ -4150,7 +4236,10 @@ fn update_notice_is_not_duplicated_within_same_session_epoch() {
     session::ensure_update_notice_message(&mut app);
     session::ensure_update_notice_message(&mut app);
 
-    assert_eq!(app.messages.iter().filter(|msg| is_update_notice_message(msg)).count(), 1);
+    assert_eq!(
+        app.transcript.messages.iter().filter(|msg| is_update_notice_message(msg)).count(),
+        1
+    );
     assert_eq!(
         app.update_notice.as_ref().and_then(|notice| notice.emitted_session_scope_epoch),
         Some(app.session_scope_epoch)
@@ -4170,7 +4259,10 @@ fn update_notice_is_re_emitted_after_epoch_change() {
     app.bump_session_scope_epoch();
     session::ensure_update_notice_message(&mut app);
 
-    assert_eq!(app.messages.iter().filter(|msg| is_update_notice_message(msg)).count(), 2);
+    assert_eq!(
+        app.transcript.messages.iter().filter(|msg| is_update_notice_message(msg)).count(),
+        2
+    );
     assert_eq!(
         app.update_notice.as_ref().and_then(|notice| notice.emitted_session_scope_epoch),
         Some(app.session_scope_epoch)
@@ -4190,9 +4282,16 @@ fn update_available_persists_across_connected_session_reset() {
     );
     handle_client_event(&mut app, connected_event("claude-updated"));
 
-    assert_eq!(app.messages.iter().filter(|msg| is_update_notice_message(msg)).count(), 1);
-    assert!(matches!(app.messages.first().map(|msg| &msg.role), Some(MessageRole::Welcome)));
+    assert_eq!(
+        app.transcript.messages.iter().filter(|msg| is_update_notice_message(msg)).count(),
+        1
+    );
+    assert!(matches!(
+        app.transcript.messages.first().map(|msg| &msg.role),
+        Some(MessageRole::Welcome)
+    ));
     let notice = app
+        .transcript
         .messages
         .iter()
         .find(|msg| is_update_notice_message(msg))
@@ -4233,9 +4332,16 @@ fn update_available_persists_across_session_replaced_reset() {
         },
     );
 
-    assert_eq!(app.messages.iter().filter(|msg| is_update_notice_message(msg)).count(), 1);
-    assert!(matches!(app.messages.first().map(|msg| &msg.role), Some(MessageRole::Welcome)));
+    assert_eq!(
+        app.transcript.messages.iter().filter(|msg| is_update_notice_message(msg)).count(),
+        1
+    );
+    assert!(matches!(
+        app.transcript.messages.first().map(|msg| &msg.role),
+        Some(MessageRole::Welcome)
+    ));
     let notice = app
+        .transcript
         .messages
         .iter()
         .find(|msg| is_update_notice_message(msg))
@@ -4268,10 +4374,10 @@ fn attach_pending_permission(
         selected_index: 0,
         focused,
     });
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tc))]));
-    let msg_idx = app.messages.len().saturating_sub(1);
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tc))]));
+    let msg_idx = app.transcript.messages.len().saturating_sub(1);
     app.index_tool_call(tool_id.into(), msg_idx, 0);
-    app.pending_interaction_ids.push(tool_id.into());
+    app.turn.pending_interaction_ids.push(tool_id.into());
     app.claim_focus_target(FocusTarget::Permission);
     response_rx
 }
@@ -4296,10 +4402,10 @@ fn attach_pending_question(
         question_index: 0,
         total_questions: 1,
     });
-    app.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tc))]));
-    let msg_idx = app.messages.len().saturating_sub(1);
+    app.transcript.messages.push(assistant_msg(vec![MessageBlock::ToolCall(Box::new(tc))]));
+    let msg_idx = app.transcript.messages.len().saturating_sub(1);
     app.index_tool_call(tool_id.into(), msg_idx, 0);
-    app.pending_interaction_ids.push(tool_id.into());
+    app.turn.pending_interaction_ids.push(tool_id.into());
     if focused {
         app.claim_focus_target(FocusTarget::Permission);
     }
@@ -4308,7 +4414,7 @@ fn attach_pending_question(
 
 fn permission_focus_state(app: &App, tool_id: &str) -> Option<bool> {
     let (mi, bi) = app.lookup_tool_call(tool_id)?;
-    let MessageBlock::ToolCall(tc) = app.messages.get(mi)?.blocks.get(bi)? else {
+    let MessageBlock::ToolCall(tc) = app.transcript.messages.get(mi)?.blocks.get(bi)? else {
         return None;
     };
     tc.pending_permission.as_ref().map(|permission| permission.focused)
@@ -4316,7 +4422,7 @@ fn permission_focus_state(app: &App, tool_id: &str) -> Option<bool> {
 
 fn question_focus_state(app: &App, tool_id: &str) -> Option<bool> {
     let (mi, bi) = app.lookup_tool_call(tool_id)?;
-    let MessageBlock::ToolCall(tc) = app.messages.get(mi)?.blocks.get(bi)? else {
+    let MessageBlock::ToolCall(tc) = app.transcript.messages.get(mi)?.blocks.get(bi)? else {
         return None;
     };
     tc.pending_question.as_ref().map(|question| question.focused)
@@ -4344,7 +4450,7 @@ fn permission_ctrl_y_does_not_resolve_pending_permission() {
         response_rx.try_recv(),
         Err(tokio::sync::oneshot::error::TryRecvError::Empty)
     ));
-    assert_eq!(app.pending_interaction_ids, vec!["perm-1"]);
+    assert_eq!(app.turn.pending_interaction_ids, vec!["perm-1"]);
 }
 
 #[test]
@@ -4378,7 +4484,7 @@ fn permission_ctrl_a_does_not_resolve_pending_permission() {
         response_rx.try_recv(),
         Err(tokio::sync::oneshot::error::TryRecvError::Empty)
     ));
-    assert_eq!(app.pending_interaction_ids, vec!["perm-1"]);
+    assert_eq!(app.turn.pending_interaction_ids, vec!["perm-1"]);
 }
 
 #[test]
@@ -4419,7 +4525,7 @@ fn permission_ctrl_n_does_not_bypass_mention_focus() {
         response_rx.try_recv(),
         Err(tokio::sync::oneshot::error::TryRecvError::Empty)
     ));
-    assert_eq!(app.pending_interaction_ids, vec!["perm-1"]);
+    assert_eq!(app.turn.pending_interaction_ids, vec!["perm-1"]);
 }
 
 #[test]
@@ -4454,7 +4560,7 @@ fn plan_approval_raw_ctrl_y_does_not_resolve_permission() {
         Err(tokio::sync::oneshot::error::TryRecvError::Empty)
     ));
     assert_eq!(app.input.text(), "seed");
-    assert_eq!(app.pending_interaction_ids, vec!["perm-1"]);
+    assert_eq!(app.turn.pending_interaction_ids, vec!["perm-1"]);
 }
 
 #[test]
@@ -4479,12 +4585,12 @@ fn second_esc_after_permission_rejection_requests_turn_cancel() {
         panic!("expected selected permission response");
     };
     assert_eq!(selected.option_id.clone(), "deny");
-    assert!(app.pending_interaction_ids.is_empty());
-    assert_eq!(app.pending_cancel_origin, None);
+    assert!(app.turn.pending_interaction_ids.is_empty());
+    assert_eq!(app.turn.pending_cancel_origin, None);
 
     handle_terminal_event(&mut app, Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
 
-    assert_eq!(app.pending_cancel_origin, Some(CancelOrigin::Manual));
+    assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual));
     let envelope = rx.try_recv().expect("second Esc should send turn cancel");
     assert!(matches!(
         envelope.command,
@@ -4532,7 +4638,7 @@ fn ctrl_c_clears_local_draft_before_quitting() {
     let mut app = make_test_app();
     app.input.set_text("draft");
     app.pending_submit = Some(app.input.snapshot());
-    app.pending_paste_text = "queued paste".to_owned();
+    app.paste.pending_text = "queued paste".to_owned();
     app.pending_images.push(crate::app::clipboard_image::ImageAttachment {
         data: "image-data".to_owned(),
         mime_type: "image/png".to_owned(),
@@ -4546,7 +4652,7 @@ fn ctrl_c_clears_local_draft_before_quitting() {
     assert!(!app.should_quit);
     assert!(app.input.is_empty());
     assert!(app.pending_submit.is_none());
-    assert!(app.pending_paste_text.is_empty());
+    assert!(app.paste.pending_text.is_empty());
     assert!(app.pending_images.is_empty());
 
     handle_terminal_event(
@@ -4657,7 +4763,7 @@ fn error_state_blocks_paste_events() {
 
     handle_terminal_event(&mut app, Event::Paste("blocked".into()));
 
-    assert!(app.pending_paste_text.is_empty());
+    assert!(app.paste.pending_text.is_empty());
     assert!(app.input.is_empty());
 }
 
@@ -4734,7 +4840,7 @@ fn settings_view_ignores_paste_events() {
 
     handle_terminal_event(&mut app, Event::Paste("blocked".into()));
 
-    assert!(app.pending_paste_text.is_empty());
+    assert!(app.paste.pending_text.is_empty());
     assert!(app.input.is_empty());
 }
 
@@ -4782,8 +4888,8 @@ fn trusted_view_accept_key_does_not_edit_chat_input() {
 
     assert_eq!(app.surface_mode, SurfaceMode::Chat);
     assert_eq!(app.input.text(), "seed");
-    assert!(app.pending_paste_text.is_empty());
-    assert!(app.startup_connection_requested);
+    assert!(app.paste.pending_text.is_empty());
+    assert!(app.startup.connection_requested());
 }
 
 #[test]
@@ -4793,7 +4899,7 @@ fn trusted_view_ignores_paste_events() {
 
     handle_terminal_event(&mut app, Event::Paste("blocked".into()));
 
-    assert!(app.pending_paste_text.is_empty());
+    assert!(app.paste.pending_text.is_empty());
     assert!(app.input.is_empty());
 }
 
@@ -4804,7 +4910,7 @@ fn session_picker_ignores_paste_events() {
 
     handle_terminal_event(&mut app, Event::Paste("blocked".into()));
 
-    assert!(app.pending_paste_text.is_empty());
+    assert!(app.paste.pending_text.is_empty());
     assert!(app.input.is_empty());
 }
 
@@ -4814,15 +4920,15 @@ fn buffered_paste_char_does_not_request_redraw() {
     let now = Instant::now();
 
     assert_eq!(
-        app.paste_burst.on_char('a', now),
+        app.paste.burst.on_char('a', now),
         super::super::paste_burst::CharAction::Passthrough('a')
     );
     assert_eq!(
-        app.paste_burst.on_char('b', now + Duration::from_millis(1)),
+        app.paste.burst.on_char('b', now + Duration::from_millis(1)),
         super::super::paste_burst::CharAction::Consumed
     );
     assert_eq!(
-        app.paste_burst.on_char('c', now + Duration::from_millis(2)),
+        app.paste.burst.on_char('c', now + Duration::from_millis(2)),
         super::super::paste_burst::CharAction::RetroCapture(1)
     );
 
@@ -4860,9 +4966,9 @@ fn api_retry_updates_single_warning_notice() {
         }),
     );
 
-    assert_eq!(app.messages.len(), 1);
-    assert_eq!(app.turn_notice_refs.len(), 1);
-    let MessageBlock::Notice(notice) = &app.messages[0].blocks[0] else {
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert_eq!(app.turn.notice_refs.len(), 1);
+    let MessageBlock::Notice(notice) = &app.transcript.messages[0].blocks[0] else {
         panic!("expected API retry notice");
     };
     assert_eq!(notice.severity, SystemSeverity::Warning);
@@ -4880,8 +4986,8 @@ fn system_notice_update_uses_notice_lane() {
         }),
     );
 
-    assert_eq!(app.messages.len(), 1);
-    let MessageBlock::Notice(notice) = &app.messages[0].blocks[0] else {
+    assert_eq!(app.transcript.messages.len(), 1);
+    let MessageBlock::Notice(notice) = &app.transcript.messages[0].blocks[0] else {
         panic!("expected system notice");
     };
     assert_eq!(notice.severity, SystemSeverity::Warning);
@@ -4960,9 +5066,12 @@ fn settings_parse_error_surfaces_system_error_message() {
         }),
     );
 
-    assert_eq!(app.messages.len(), 1);
-    assert!(matches!(app.messages[0].role, MessageRole::System(Some(SystemSeverity::Error))));
-    let MessageBlock::Text(text) = &app.messages[0].blocks[0] else {
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert!(matches!(
+        app.transcript.messages[0].role,
+        MessageRole::System(Some(SystemSeverity::Error))
+    ));
+    let MessageBlock::Text(text) = &app.transcript.messages[0].blocks[0] else {
         panic!("expected settings parse error text");
     };
     assert_eq!(

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -943,7 +943,11 @@ fn repeated_tool_call_updates_existing_execute_snapshot_state() {
 #[test]
 fn todowrite_tool_call_does_not_mutate_task_state() {
     let mut app = make_test_app();
-    app.tasks.push(task_item("task-1", "Existing task", model::TaskStatus::InProgress));
+    app.sdk_inventory.tasks.push(task_item(
+        "task-1",
+        "Existing task",
+        model::TaskStatus::InProgress,
+    ));
     let todo_call = model::ToolCall::new("tc-todo-update", "TodoWrite")
         .kind(model::ToolKind::Other)
         .raw_input(serde_json::json!({
@@ -964,10 +968,10 @@ fn todowrite_tool_call_does_not_mutate_task_state() {
         ClientEvent::SessionUpdate(model::SessionUpdate::ToolCallUpdate(update)),
     );
 
-    assert_eq!(app.tasks.len(), 1);
-    assert_eq!(app.tasks[0].task_id, "task-1");
-    assert_eq!(app.tasks[0].subject, "Existing task");
-    assert_eq!(app.tasks[0].status, model::TaskStatus::InProgress);
+    assert_eq!(app.sdk_inventory.tasks.len(), 1);
+    assert_eq!(app.sdk_inventory.tasks[0].task_id, "task-1");
+    assert_eq!(app.sdk_inventory.tasks[0].subject, "Existing task");
+    assert_eq!(app.sdk_inventory.tasks[0].status, model::TaskStatus::InProgress);
 }
 
 #[test]
@@ -1161,7 +1165,7 @@ fn test_app_defaults() {
     assert_eq!(app.files_accessed, 0);
     assert!(app.turn.pending_interaction_ids.is_empty());
     assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::None);
-    assert!(app.tasks.is_empty());
+    assert!(app.sdk_inventory.tasks.is_empty());
     assert!(app.mention.is_none());
     assert!(!app.turn.cancelled_pending_hint);
     assert!(matches!(app.status, AppStatus::Ready));
@@ -1776,7 +1780,7 @@ fn session_replaced_resets_chat_and_transient_state() {
     app.status = AppStatus::Running;
     app.files_accessed = 9;
     app.turn.pending_interaction_ids.push("perm-1".into());
-    app.tasks.push(task_item("task-1", "Task", model::TaskStatus::InProgress));
+    app.sdk_inventory.tasks.push(task_item("task-1", "Task", model::TaskStatus::InProgress));
     app.mention = Some(mention::MentionState::new(0, 0, String::new(), Vec::new()));
     app.mcp.servers.push(crate::agent::model::McpServerStatus {
         name: "supabase".into(),
@@ -1814,7 +1818,7 @@ fn session_replaced_resets_chat_and_transient_state() {
     assert!(matches!(app.transcript.messages[0].role, MessageRole::Welcome));
     assert_eq!(app.files_accessed, 0);
     assert!(app.turn.pending_interaction_ids.is_empty());
-    assert!(app.tasks.is_empty());
+    assert!(app.sdk_inventory.tasks.is_empty());
     assert!(app.mention.is_none());
     assert!(app.mcp.servers.is_empty());
     assert!(app.mcp.removed_config_servers.is_empty());
@@ -2201,9 +2205,9 @@ fn slash_command_error_while_resuming_returns_ready_and_clears_marker() {
 #[test]
 fn slash_command_error_clears_rewind_target_loading_state() {
     let mut app = make_test_app();
-    app.rewind_targets_in_flight = true;
-    app.rewind_targets_session_id = Some(model::SessionId::new("session-1"));
-    app.rewind_targets = vec![model::RewindTarget {
+    app.sdk_inventory.rewind_targets_in_flight = true;
+    app.sdk_inventory.rewind_targets_session_id = Some(model::SessionId::new("session-1"));
+    app.sdk_inventory.rewind_targets = vec![model::RewindTarget {
         uuid: "user-1".into(),
         first_text: "hello".into(),
         input_text: "hello".into(),
@@ -2216,8 +2220,8 @@ fn slash_command_error_clears_rewind_target_loading_state() {
         ClientEvent::SlashCommandError("failed to load rewind targets".into()),
     );
 
-    assert!(!app.rewind_targets_in_flight);
-    assert!(app.rewind_targets_session_id.is_none());
+    assert!(!app.sdk_inventory.rewind_targets_in_flight);
+    assert!(app.sdk_inventory.rewind_targets_session_id.is_none());
 }
 
 #[test]
@@ -5037,7 +5041,7 @@ fn available_commands_update_replaces_previous_commands() {
     );
 
     assert_eq!(
-        app.available_commands,
+        app.sdk_inventory.available_commands,
         vec![model::AvailableCommand::new("/new", "New command").input_hint("<arg>")]
     );
 }

--- a/src/app/events/tool_calls.rs
+++ b/src/app/events/tool_calls.rs
@@ -161,7 +161,7 @@ pub(super) fn upsert_tool_call_into_assistant_message(app: &mut App, tool_info: 
     }
 
     if let Some(msg_idx) = app.active_turn_assistant_idx()
-        && let Some(owner) = app.messages.get_mut(msg_idx)
+        && let Some(owner) = app.transcript.messages.get_mut(msg_idx)
     {
         let block_idx = owner.blocks.len();
         let tc_id = tool_info.id.clone();
@@ -173,9 +173,9 @@ pub(super) fn upsert_tool_call_into_assistant_message(app: &mut App, tool_info: 
         return;
     }
 
-    let msg_idx = app.messages.len().saturating_sub(1);
-    if app.messages.last().is_some_and(|m| matches!(m.role, MessageRole::Assistant)) {
-        if let Some(last) = app.messages.last_mut() {
+    let msg_idx = app.transcript.messages.len().saturating_sub(1);
+    if app.transcript.messages.last().is_some_and(|m| matches!(m.role, MessageRole::Assistant)) {
+        if let Some(last) = app.transcript.messages.last_mut() {
             let block_idx = last.blocks.len();
             let tc_id = tool_info.id.clone();
             let terminal_id = App::tracked_terminal_id_for_tool(&tool_info);
@@ -188,7 +188,7 @@ pub(super) fn upsert_tool_call_into_assistant_message(app: &mut App, tool_info: 
     } else {
         let tc_id = tool_info.id.clone();
         let terminal_id = App::tracked_terminal_id_for_tool(&tool_info);
-        let new_idx = app.messages.len();
+        let new_idx = app.transcript.messages.len();
         app.push_message_tracked(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(tool_info))],
@@ -204,7 +204,7 @@ fn update_existing_tool_call(app: &mut App, mi: usize, bi: usize, tool_info: &To
     let mut layout_dirty = false;
     let mut terminal_tracking = None;
     if let Some(MessageBlock::ToolCall(existing)) =
-        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+        app.transcript.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     {
         let existing = existing.as_mut();
         let mut changed = false;
@@ -354,7 +354,7 @@ pub(super) fn shorten_tool_title(title: &str, cwd_raw: &str) -> String {
 /// Check if any tool call in the current assistant message is still in-progress.
 pub(super) fn has_in_progress_tool_calls(app: &App) -> bool {
     if let Some(owner_idx) = app.active_turn_assistant_idx()
-        && let Some(owner) = app.messages.get(owner_idx)
+        && let Some(owner) = app.transcript.messages.get(owner_idx)
     {
         return owner.blocks.iter().any(|block| {
             matches!(

--- a/src/app/events/tool_calls.rs
+++ b/src/app/events/tool_calls.rs
@@ -454,7 +454,7 @@ pub(super) fn log_terminal_spawned(app: &App, tc: &ToolCallInfo, source: &str) {
 }
 
 pub(super) fn current_session_id(app: &App) -> String {
-    app.session_id.as_ref().map_or_else(String::new, ToString::to_string)
+    app.session_runtime.session_id.as_ref().map_or_else(String::new, ToString::to_string)
 }
 
 pub(super) fn json_value_size(value: Option<&serde_json::Value>) -> Option<u64> {

--- a/src/app/events/tool_updates.rs
+++ b/src/app/events/tool_updates.rs
@@ -29,14 +29,15 @@ pub(super) fn handle_tool_call_update_session(app: &mut App, tcu: &model::ToolCa
         );
     }
     let tool_scope = app.tool_call_scope(&id_str);
-    let previous_status = app.messages.get(mi).and_then(|message| message.blocks.get(bi)).and_then(
-        |block| match block {
-            MessageBlock::ToolCall(tc) => Some(tc.status),
-            _ => None,
-        },
-    );
+    let previous_status =
+        app.transcript.messages.get(mi).and_then(|message| message.blocks.get(bi)).and_then(
+            |block| match block {
+                MessageBlock::ToolCall(tc) => Some(tc.status),
+                _ => None,
+            },
+        );
     let previous_terminal_id =
-        app.messages.get(mi).and_then(|message| message.blocks.get(bi)).and_then(
+        app.transcript.messages.get(mi).and_then(|message| message.blocks.get(bi)).and_then(
             |block| match block {
                 MessageBlock::ToolCall(tc) => tc.terminal_id.clone(),
                 _ => None,
@@ -105,7 +106,7 @@ fn apply_tool_call_update_to_indexed_block(
     let mut detach_terminal = false;
 
     if let Some(MessageBlock::ToolCall(tc)) =
-        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+        app.transcript.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     {
         let tc = tc.as_mut();
         let mut changed = false;
@@ -382,7 +383,9 @@ fn log_tool_call_update_applied(
 
     let Some(tc) = app
         .lookup_tool_call(id_str)
-        .and_then(|(mi, bi)| app.messages.get(mi).and_then(|message| message.blocks.get(bi)))
+        .and_then(|(mi, bi)| {
+            app.transcript.messages.get(mi).and_then(|message| message.blocks.get(bi))
+        })
         .and_then(|block| match block {
             MessageBlock::ToolCall(tc) => Some(tc.as_ref()),
             _ => None,
@@ -579,7 +582,9 @@ fn log_command_update_applied(
 ) {
     let Some(tc) = app
         .lookup_tool_call(id_str)
-        .and_then(|(mi, bi)| app.messages.get(mi).and_then(|message| message.blocks.get(bi)))
+        .and_then(|(mi, bi)| {
+            app.transcript.messages.get(mi).and_then(|message| message.blocks.get(bi))
+        })
         .and_then(|block| match block {
             MessageBlock::ToolCall(tc) => Some(tc.as_ref()),
             _ => None,
@@ -736,7 +741,7 @@ mod tests {
     fn completed_execute_update_detaches_terminal_subscription() {
         let mut app = App::test_default();
         let tool_id = "tool-1";
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(make_bash_tool_call(
                 tool_id,
@@ -757,21 +762,20 @@ mod tests {
 
         handle_tool_call_update_session(&mut app, &update);
 
-        let MessageBlock::ToolCall(tc) = &app.messages[0].blocks[0] else {
+        let MessageBlock::ToolCall(tc) = &app.transcript.messages[0].blocks[0] else {
             panic!("expected tool call block");
         };
         assert_eq!(tc.status, model::ToolCallStatus::Completed);
         assert_eq!(tc.terminal_id, None);
         assert_eq!(tc.terminal_output.as_deref(), Some("done"));
-        assert!(app.terminal_tool_calls.is_empty());
-        assert!(app.terminal_tool_call_membership.is_empty());
+        assert!(app.terminal_tool_calls().is_empty());
     }
 
     #[test]
     fn repeated_terminal_updates_do_not_duplicate_subscription() {
         let mut app = App::test_default();
         let tool_id = "tool-1";
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(make_bash_tool_call(
                 tool_id,
@@ -790,16 +794,15 @@ mod tests {
         handle_tool_call_update_session(&mut app, &update);
         handle_tool_call_update_session(&mut app, &update);
 
-        assert_eq!(app.terminal_tool_calls.len(), 1);
-        assert_eq!(app.terminal_tool_call_membership.len(), 1);
-        assert_eq!(app.terminal_tool_calls[0].terminal_id, "term-1");
+        assert_eq!(app.terminal_tool_calls().len(), 1);
+        assert_eq!(app.terminal_tool_calls()[0].terminal_id, "term-1");
     }
 
     #[test]
     fn terminal_update_replaces_stale_subscription_for_same_tool_call() {
         let mut app = App::test_default();
         let tool_id = "tool-1";
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(make_bash_tool_call(
                 tool_id,
@@ -818,10 +821,9 @@ mod tests {
 
         handle_tool_call_update_session(&mut app, &update);
 
-        assert_eq!(app.terminal_tool_calls.len(), 1);
-        assert_eq!(app.terminal_tool_call_membership.len(), 1);
-        assert_eq!(app.terminal_tool_calls[0].terminal_id, "term-2");
-        let MessageBlock::ToolCall(tc) = &app.messages[0].blocks[0] else {
+        assert_eq!(app.terminal_tool_calls().len(), 1);
+        assert_eq!(app.terminal_tool_calls()[0].terminal_id, "term-2");
+        let MessageBlock::ToolCall(tc) = &app.transcript.messages[0].blocks[0] else {
             panic!("expected tool call block");
         };
         assert_eq!(tc.terminal_id.as_deref(), Some("term-2"));
@@ -858,7 +860,7 @@ mod tests {
     fn task_metadata_update_is_applied_to_tool_call() {
         let mut app = App::test_default();
         let tool_id = "task-1";
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(make_task_tool_call(
                 tool_id,
@@ -879,7 +881,7 @@ mod tests {
 
         handle_tool_call_update_session(&mut app, &update);
 
-        let MessageBlock::ToolCall(tc) = &app.messages[0].blocks[0] else {
+        let MessageBlock::ToolCall(tc) = &app.transcript.messages[0].blocks[0] else {
             panic!("expected tool call block");
         };
         assert_eq!(
@@ -896,7 +898,7 @@ mod tests {
     fn task_metadata_update_merges_partial_patches() {
         let mut app = App::test_default();
         let tool_id = "task-1";
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(make_task_tool_call(
                 tool_id,
@@ -943,7 +945,7 @@ mod tests {
         );
         handle_tool_call_update_session(&mut app, &terminal_update);
 
-        let MessageBlock::ToolCall(tc) = &app.messages[0].blocks[0] else {
+        let MessageBlock::ToolCall(tc) = &app.transcript.messages[0].blocks[0] else {
             panic!("expected tool call block");
         };
         assert_eq!(
@@ -971,7 +973,7 @@ mod tests {
     fn killed_task_update_clears_active_task_scope() {
         let mut app = App::test_default();
         let tool_id = "task-1";
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(make_task_tool_call(
                 tool_id,
@@ -990,18 +992,18 @@ mod tests {
 
         handle_tool_call_update_session(&mut app, &update);
 
-        let MessageBlock::ToolCall(tc) = &app.messages[0].blocks[0] else {
+        let MessageBlock::ToolCall(tc) = &app.transcript.messages[0].blocks[0] else {
             panic!("expected tool call block");
         };
         assert_eq!(tc.status, model::ToolCallStatus::Killed);
-        assert!(!app.active_task_ids.contains(tool_id));
+        assert!(!app.turn.active_task_ids.contains(tool_id));
     }
 
     #[test]
     fn completed_tool_update_mutates_canonical_tool_block() {
         let mut app = App::test_default();
         let tool_id = "tool-1";
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(make_bash_tool_call(
                 tool_id,
@@ -1023,7 +1025,7 @@ mod tests {
         handle_tool_call_update_session(&mut app, &update);
 
         assert_eq!(app.active_turn_assistant_idx(), Some(0));
-        let MessageBlock::ToolCall(tc) = &app.messages[0].blocks[0] else {
+        let MessageBlock::ToolCall(tc) = &app.transcript.messages[0].blocks[0] else {
             panic!("expected tool call block");
         };
         assert_eq!(tc.status, model::ToolCallStatus::Completed);

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -552,7 +552,8 @@ pub(super) fn handle_turn_error_event(
     app.pending_submit = None;
     app.status = AppStatus::Error;
     let rate_limit_context = if matches!(error_class, TurnErrorClass::PlanLimit) {
-        app.last_rate_limit_update
+        app.session_runtime
+            .last_rate_limit_update
             .clone()
             .filter(|update| !matches!(update.status, model::RateLimitStatus::Allowed))
     } else {

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -453,8 +453,8 @@ fn finish_ready_turn_exit(app: &mut App, exit: TurnExitState, tool_status: model
     app.finalize_turn_runtime_artifacts(tool_status);
     app.status = AppStatus::Ready;
     app.files_accessed = 0;
-    app.rewind_targets_session_id = None;
-    app.rewind_targets_in_flight = false;
+    app.sdk_inventory.rewind_targets_session_id = None;
+    app.sdk_inventory.rewind_targets_in_flight = false;
     app.sync_git_context();
 
     let removed_tail_assistant = remove_empty_tail_assistant(app, exit.tail_assistant_idx);

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -62,7 +62,7 @@ pub(super) fn handle_permission_request_event(
         return;
     };
 
-    if app.pending_interaction_ids.iter().any(|id| id == &tool_id) {
+    if app.turn.pending_interaction_ids.iter().any(|id| id == &tool_id) {
         tracing::warn!(
             target: crate::logging::targets::APP_PERMISSION,
             event_name = "permission_request_rejected",
@@ -77,9 +77,10 @@ pub(super) fn handle_permission_request_event(
     }
 
     let mut layout_dirty = false;
-    let auto_focus = app.pending_interaction_ids.is_empty() && !app.has_draft_input_for_focus();
+    let auto_focus =
+        app.turn.pending_interaction_ids.is_empty() && !app.has_draft_input_for_focus();
     if let Some(MessageBlock::ToolCall(tc)) =
-        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+        app.transcript.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     {
         let tc = tc.as_mut();
         tc.pending_permission = Some(InlinePermission {
@@ -92,7 +93,7 @@ pub(super) fn handle_permission_request_event(
         });
         tc.invalidate_render_cache();
         layout_dirty = true;
-        app.pending_interaction_ids.push(tool_id.clone());
+        app.turn.pending_interaction_ids.push(tool_id.clone());
         if auto_focus {
             app.claim_focus_target(FocusTarget::Permission);
         }
@@ -227,7 +228,7 @@ fn resolve_permission_context(app: &App, tool_call_id: &str) -> Option<SubagentP
 
 fn indexed_tool_call<'a>(app: &'a App, tool_call_id: &str) -> Option<&'a ToolCallInfo> {
     let (mi, bi) = app.lookup_tool_call(tool_call_id)?;
-    let MessageBlock::ToolCall(tc) = app.messages.get(mi)?.blocks.get(bi)? else {
+    let MessageBlock::ToolCall(tc) = app.transcript.messages.get(mi)?.blocks.get(bi)? else {
         return None;
     };
     Some(tc.as_ref())
@@ -268,7 +269,7 @@ pub(super) fn handle_question_request_event(
         return;
     };
 
-    if app.pending_interaction_ids.iter().any(|id| id == &tool_id) {
+    if app.turn.pending_interaction_ids.iter().any(|id| id == &tool_id) {
         tracing::warn!(
             target: crate::logging::targets::APP_PERMISSION,
             event_name = "question_request_rejected",
@@ -284,9 +285,10 @@ pub(super) fn handle_question_request_event(
     }
 
     let mut layout_dirty = false;
-    let auto_focus = app.pending_interaction_ids.is_empty() && !app.has_draft_input_for_focus();
+    let auto_focus =
+        app.turn.pending_interaction_ids.is_empty() && !app.has_draft_input_for_focus();
     if let Some(MessageBlock::ToolCall(tc)) =
-        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+        app.transcript.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     {
         let tc = tc.as_mut();
         tc.pending_question = Some(InlineQuestion {
@@ -303,7 +305,7 @@ pub(super) fn handle_question_request_event(
         });
         tc.invalidate_render_cache();
         layout_dirty = true;
-        app.pending_interaction_ids.push(tool_id.clone());
+        app.turn.pending_interaction_ids.push(tool_id.clone());
         if auto_focus {
             app.claim_focus_target(FocusTarget::Permission);
         }
@@ -355,7 +357,7 @@ pub(super) fn handle_user_dialog_request_event(
     let dialog_kind = request.dialog_kind.clone();
     let option_count = request.options.len();
 
-    if app.pending_interaction_ids.iter().any(|id| id == &request_id) {
+    if app.turn.pending_interaction_ids.iter().any(|id| id == &request_id) {
         tracing::warn!(
             target: crate::logging::targets::APP_PERMISSION,
             event_name = "user_dialog_request_rejected",
@@ -371,8 +373,9 @@ pub(super) fn handle_user_dialog_request_event(
         return;
     }
 
-    let auto_focus = app.pending_interaction_ids.is_empty() && !app.has_draft_input_for_focus();
-    let mi = app.messages.len();
+    let auto_focus =
+        app.turn.pending_interaction_ids.is_empty() && !app.has_draft_input_for_focus();
+    let mi = app.transcript.messages.len();
     let bi = 0;
     let mut block = UserDialogBlock::new(request, response_tx);
     block.focused = auto_focus;
@@ -382,7 +385,7 @@ pub(super) fn handle_user_dialog_request_event(
         None,
     ));
     app.index_tool_call(request_id.clone(), mi, bi);
-    app.pending_interaction_ids.push(request_id.clone());
+    app.turn.pending_interaction_ids.push(request_id.clone());
     if auto_focus {
         app.claim_focus_target(FocusTarget::Permission);
     }
@@ -421,27 +424,28 @@ fn reject_permission_request(
 }
 
 pub(super) fn handle_turn_cancelled_event(app: &mut App) {
-    if app.pending_cancel_origin.is_none() {
-        app.pending_cancel_origin = Some(CancelOrigin::Manual);
+    if app.turn.pending_cancel_origin.is_none() {
+        app.turn.pending_cancel_origin = Some(CancelOrigin::Manual);
     }
-    app.cancelled_turn_pending_hint =
-        matches!(app.pending_cancel_origin, Some(CancelOrigin::Manual));
+    app.turn.cancelled_pending_hint =
+        matches!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual));
     let _ = app.finalize_in_progress_tool_calls(model::ToolCallStatus::Failed);
 }
 
 fn begin_turn_exit(app: &mut App, emit_manual_compaction_success: bool) -> TurnExitState {
     let state = TurnExitState {
         tail_assistant_idx: app
+            .transcript
             .messages
             .iter()
             .rposition(|m| matches!(m.role, MessageRole::Assistant)),
         turn_was_active: matches!(app.status, AppStatus::Thinking | AppStatus::Running),
-        cancelled_requested: app.pending_cancel_origin,
-        show_interrupted_hint: matches!(app.pending_cancel_origin, Some(CancelOrigin::Manual)),
+        cancelled_requested: app.turn.pending_cancel_origin,
+        show_interrupted_hint: matches!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual)),
     };
     clear_compaction_state(app, emit_manual_compaction_success);
-    app.pending_cancel_origin = None;
-    app.cancelled_turn_pending_hint = false;
+    app.turn.pending_cancel_origin = None;
+    app.turn.cancelled_pending_hint = false;
     state
 }
 
@@ -462,8 +466,7 @@ fn finish_ready_turn_exit(app: &mut App, exit: TurnExitState, tool_status: model
     {
         mark_turn_exit_assistant_layout_dirty(app, exit.tail_assistant_idx);
     }
-    app.clear_active_turn_assistant();
-    super::notices::clear_turn_notice_tracking(app);
+    app.turn.reset_for_turn_exit();
 }
 
 pub(super) fn handle_turn_complete_event(
@@ -544,7 +547,7 @@ pub(super) fn handle_turn_error_event(
     );
     apply_turn_error_class_side_effects(app, error_class, &summary, api_error_status);
     app.finalize_turn_runtime_artifacts(model::ToolCallStatus::Failed);
-    app.pending_auto_submit_after_cancel = false;
+    app.turn.pending_auto_submit_after_cancel = false;
     app.input.clear();
     app.pending_submit = None;
     app.status = AppStatus::Error;
@@ -560,8 +563,7 @@ pub(super) fn handle_turn_error_event(
     if removed_tail_assistant.is_none() && exit.turn_was_active {
         mark_turn_exit_assistant_layout_dirty(app, exit.tail_assistant_idx);
     }
-    app.clear_active_turn_assistant();
-    super::notices::clear_turn_notice_tracking(app);
+    app.turn.reset_for_turn_exit();
     request_post_turn_resize_purge_replay_if_needed(app);
     crate::app::session_runtime::request_context_usage_refresh(app);
 }
@@ -668,6 +670,7 @@ fn push_interrupted_hint(app: &mut App) {
 fn remove_empty_tail_assistant(app: &mut App, idx: Option<usize>) -> Option<usize> {
     let idx = idx?;
     let should_remove = app
+        .transcript
         .messages
         .get(idx)
         .is_some_and(|msg| matches!(msg.role, MessageRole::Assistant) && msg.blocks.is_empty());
@@ -682,7 +685,12 @@ fn mark_turn_exit_assistant_layout_dirty(app: &mut App, idx: Option<usize>) {
     let Some(idx) = idx else {
         return;
     };
-    if app.messages.get(idx).is_some_and(|msg| matches!(msg.role, MessageRole::Assistant)) {
+    if app
+        .transcript
+        .messages
+        .get(idx)
+        .is_some_and(|msg| matches!(msg.role, MessageRole::Assistant))
+    {
         app.invalidate_layout(InvalidationLevel::MessageChanged(idx));
     }
 }
@@ -813,9 +821,9 @@ mod tests {
     }
 
     fn push_tool(app: &mut App, tool: crate::app::ToolCallInfo) {
-        let msg_idx = app.messages.len();
+        let msg_idx = app.transcript.messages.len();
         let tool_id = tool.id.clone();
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(tool))],
             None,
@@ -842,7 +850,7 @@ mod tests {
     ) -> Option<crate::app::SubagentPermissionContext> {
         let (mi, bi) = app.lookup_tool_call(tool_id)?;
         let Some(MessageBlock::ToolCall(tool)) =
-            app.messages.get(mi).and_then(|msg| msg.blocks.get(bi))
+            app.transcript.messages.get(mi).and_then(|msg| msg.blocks.get(bi))
         else {
             return None;
         };
@@ -877,50 +885,53 @@ mod tests {
     fn turn_complete_removes_empty_tail_assistant() {
         let mut app = App::test_default();
         app.status = AppStatus::Thinking;
-        app.messages.push(user_message("hello"));
-        app.messages.push(empty_assistant_message());
+        app.transcript.messages.push(user_message("hello"));
+        app.transcript.messages.push(empty_assistant_message());
 
         handle_turn_complete_event(&mut app, None);
 
-        assert_eq!(app.messages.len(), 1);
-        assert!(matches!(app.messages[0].role, MessageRole::User));
+        assert_eq!(app.transcript.messages.len(), 1);
+        assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
     }
 
     #[test]
     fn cancelled_turn_error_removes_empty_tail_assistant_before_hint() {
         let mut app = App::test_default();
         app.status = AppStatus::Thinking;
-        app.pending_cancel_origin = Some(CancelOrigin::Manual);
-        app.messages.push(user_message("hello"));
-        app.messages.push(empty_assistant_message());
+        app.turn.pending_cancel_origin = Some(CancelOrigin::Manual);
+        app.transcript.messages.push(user_message("hello"));
+        app.transcript.messages.push(empty_assistant_message());
 
         handle_turn_error_event(&mut app, "cancelled", None, None, None);
 
-        assert_eq!(app.messages.len(), 2);
-        assert!(matches!(app.messages[0].role, MessageRole::User));
-        assert!(matches!(app.messages[1].role, MessageRole::System(Some(SystemSeverity::Info))));
+        assert_eq!(app.transcript.messages.len(), 2);
+        assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
+        assert!(matches!(
+            app.transcript.messages[1].role,
+            MessageRole::System(Some(SystemSeverity::Info))
+        ));
     }
 
     #[test]
     fn turn_error_removes_empty_tail_assistant_before_error_message() {
         let mut app = App::test_default();
         app.status = AppStatus::Thinking;
-        app.messages.push(user_message("hello"));
-        app.messages.push(empty_assistant_message());
+        app.transcript.messages.push(user_message("hello"));
+        app.transcript.messages.push(empty_assistant_message());
 
         handle_turn_error_event(&mut app, "boom", None, None, None);
 
-        assert_eq!(app.messages.len(), 2);
-        assert!(matches!(app.messages[0].role, MessageRole::User));
-        assert!(matches!(app.messages[1].role, MessageRole::System(None)));
+        assert_eq!(app.transcript.messages.len(), 2);
+        assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
+        assert!(matches!(app.transcript.messages[1].role, MessageRole::System(None)));
     }
 
     #[test]
     fn turn_complete_keeps_canonical_assistant_and_clears_active_owner() {
         let mut app = App::test_default();
         app.status = AppStatus::Thinking;
-        app.messages.push(user_message("hello"));
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(user_message("hello"));
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::Text(TextBlock::from_complete("done"))],
             None,
@@ -931,8 +942,8 @@ mod tests {
 
         assert_eq!(app.status, AppStatus::Ready);
         assert_eq!(app.active_turn_assistant_idx(), None);
-        assert_eq!(app.messages.len(), 2);
-        let Some(MessageBlock::Text(text)) = app.messages[1].blocks.first() else {
+        assert_eq!(app.transcript.messages.len(), 2);
+        let Some(MessageBlock::Text(text)) = app.transcript.messages[1].blocks.first() else {
             panic!("expected assistant text block");
         };
         assert_eq!(text.text, "done");
@@ -944,8 +955,8 @@ mod tests {
         app.surface_dirty = crate::app::SurfaceDirtyState::default();
         app.terminal_lifecycle = TerminalLifecycleState::Running(SurfaceMode::Chat);
         app.status = AppStatus::Running;
-        app.messages.push(user_message("hello"));
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(user_message("hello"));
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::Text(TextBlock::from_complete("streamed"))],
             None,
@@ -967,7 +978,7 @@ mod tests {
     fn permission_request_marks_canonical_tool_pending_permission() {
         let mut app = App::test_default();
         let tool_id = "bash-1";
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(crate::app::ToolCallInfo {
                 id: tool_id.to_owned(),
@@ -1010,7 +1021,7 @@ mod tests {
 
         handle_permission_request_event(&mut app, request, tx);
 
-        let Some(MessageBlock::ToolCall(tool)) = app.messages[0].blocks.first() else {
+        let Some(MessageBlock::ToolCall(tool)) = app.transcript.messages[0].blocks.first() else {
             panic!("expected tool call block");
         };
         assert!(tool.pending_permission.is_some());

--- a/src/app/inline_interactions.rs
+++ b/src/app/inline_interactions.rs
@@ -5,14 +5,14 @@ use super::{App, FocusTarget, InvalidationLevel, MessageBlock, ToolCallInfo};
 use crossterm::event::{KeyCode, KeyEvent};
 
 pub(super) fn focused_interaction_id(app: &App) -> Option<&str> {
-    app.pending_interaction_ids.first().map(String::as_str)
+    app.turn.pending_interaction_ids.first().map(String::as_str)
 }
 
 fn interaction_id_is_valid(app: &App, tool_id: &str) -> bool {
     let Some((mi, bi)) = app.lookup_tool_call(tool_id) else {
         return false;
     };
-    match app.messages.get(mi).and_then(|msg| msg.blocks.get(bi)) {
+    match app.transcript.messages.get(mi).and_then(|msg| msg.blocks.get(bi)) {
         Some(MessageBlock::ToolCall(tc)) => {
             tc.pending_permission.is_some() || tc.pending_question.is_some()
         }
@@ -23,8 +23,8 @@ fn interaction_id_is_valid(app: &App, tool_id: &str) -> bool {
 
 pub(super) fn focused_interaction(app: &App) -> Option<&ToolCallInfo> {
     let tool_id = focused_interaction_id(app)?;
-    let (mi, bi) = app.tool_call_index.get(tool_id).copied()?;
-    let MessageBlock::ToolCall(tc) = app.messages.get(mi)?.blocks.get(bi)? else {
+    let (mi, bi) = app.lookup_tool_call(tool_id)?;
+    let MessageBlock::ToolCall(tc) = app.transcript.messages.get(mi)?.blocks.get(bi)? else {
         return None;
     };
     Some(tc.as_ref())
@@ -32,8 +32,8 @@ pub(super) fn focused_interaction(app: &App) -> Option<&ToolCallInfo> {
 
 pub(super) fn get_focused_interaction_tc(app: &mut App) -> Option<&mut ToolCallInfo> {
     let tool_id = focused_interaction_id(app)?;
-    let (mi, bi) = app.tool_call_index.get(tool_id).copied()?;
-    match app.messages.get_mut(mi)?.blocks.get_mut(bi)? {
+    let (mi, bi) = app.lookup_tool_call(tool_id)?;
+    match app.transcript.messages.get_mut(mi)?.blocks.get_mut(bi)? {
         MessageBlock::ToolCall(tc)
             if tc.pending_permission.is_some() || tc.pending_question.is_some() =>
         {
@@ -60,14 +60,14 @@ pub(super) fn invalidate_if_changed(
 }
 
 pub(super) fn set_interaction_focused(app: &mut App, queue_index: usize, focused: bool) {
-    let Some(tool_id) = app.pending_interaction_ids.get(queue_index).cloned() else {
+    let Some(tool_id) = app.turn.pending_interaction_ids.get(queue_index).cloned() else {
         return;
     };
-    let Some((mi, bi)) = app.tool_call_index.get(&tool_id).copied() else {
+    let Some((mi, bi)) = app.lookup_tool_call(&tool_id) else {
         return;
     };
     let mut invalidated = false;
-    if let Some(msg) = app.messages.get_mut(mi) {
+    if let Some(msg) = app.transcript.messages.get_mut(mi) {
         match msg.blocks.get_mut(bi) {
             Some(MessageBlock::ToolCall(tc)) => {
                 let tc = tc.as_mut();
@@ -107,10 +107,10 @@ pub(super) fn focused_interaction_is_active(app: &App) -> bool {
     let Some(tool_id) = focused_interaction_id(app) else {
         return false;
     };
-    let Some((mi, bi)) = app.tool_call_index.get(tool_id).copied() else {
+    let Some((mi, bi)) = app.lookup_tool_call(tool_id) else {
         return false;
     };
-    match app.messages.get(mi).and_then(|msg| msg.blocks.get(bi)) {
+    match app.transcript.messages.get(mi).and_then(|msg| msg.blocks.get(bi)) {
         Some(MessageBlock::ToolCall(tc)) => {
             tc.pending_permission.as_ref().is_some_and(|permission| permission.focused)
                 || tc.pending_question.as_ref().is_some_and(|question| question.focused)
@@ -126,25 +126,25 @@ pub(super) fn has_focused_user_dialog(app: &App) -> bool {
     let Some(tool_id) = focused_interaction_id(app) else {
         return false;
     };
-    let Some((mi, bi)) = app.tool_call_index.get(tool_id).copied() else {
+    let Some((mi, bi)) = app.lookup_tool_call(tool_id) else {
         return false;
     };
     matches!(
-        app.messages.get(mi).and_then(|msg| msg.blocks.get(bi)),
+        app.transcript.messages.get(mi).and_then(|msg| msg.blocks.get(bi)),
         Some(MessageBlock::UserDialog(dialog)) if dialog.focused && !dialog.answered
     )
 }
 
 pub(super) fn clear_inline_interaction_focus(app: &mut App) {
     let mut changed = false;
-    for idx in 0..app.pending_interaction_ids.len() {
-        let Some(tool_id) = app.pending_interaction_ids.get(idx).cloned() else {
+    for idx in 0..app.turn.pending_interaction_ids.len() {
+        let Some(tool_id) = app.turn.pending_interaction_ids.get(idx).cloned() else {
             continue;
         };
-        let Some((mi, bi)) = app.tool_call_index.get(&tool_id).copied() else {
+        let Some((mi, bi)) = app.lookup_tool_call(&tool_id) else {
             continue;
         };
-        if let Some(msg) = app.messages.get_mut(mi) {
+        if let Some(msg) = app.transcript.messages.get_mut(mi) {
             let mut interaction_changed = false;
             match msg.blocks.get_mut(bi) {
                 Some(MessageBlock::ToolCall(tc)) => {
@@ -194,7 +194,7 @@ pub(super) fn focus_next_inline_interaction(app: &mut App) {
     normalize_pending_interaction_queue(app);
     clear_inline_interaction_focus(app);
     set_interaction_focused(app, 0, true);
-    if app.pending_interaction_ids.is_empty() {
+    if app.turn.pending_interaction_ids.is_empty() {
         app.release_focus_target(FocusTarget::Permission);
     } else {
         app.claim_focus_target(FocusTarget::Permission);
@@ -202,7 +202,7 @@ pub(super) fn focus_next_inline_interaction(app: &mut App) {
 }
 
 pub(super) fn normalize_pending_interaction_queue(app: &mut App) {
-    let previous = std::mem::take(&mut app.pending_interaction_ids);
+    let previous = std::mem::take(&mut app.turn.pending_interaction_ids);
     let previous_order = previous.clone();
     let mut queue = Vec::with_capacity(previous.len());
     for id in previous {
@@ -211,16 +211,16 @@ pub(super) fn normalize_pending_interaction_queue(app: &mut App) {
         }
     }
     let changed = queue != previous_order;
-    app.pending_interaction_ids = queue;
+    app.turn.pending_interaction_ids = queue;
 
-    if app.pending_interaction_ids.is_empty() {
+    if app.turn.pending_interaction_ids.is_empty() {
         clear_inline_interaction_focus(app);
         return;
     }
 
     if changed {
         let permission_has_focus = matches!(app.focus_owner(), super::FocusOwner::Permission);
-        for idx in 0..app.pending_interaction_ids.len() {
+        for idx in 0..app.turn.pending_interaction_ids.len() {
             set_interaction_focused(app, idx, permission_has_focus && idx == 0);
         }
     }
@@ -232,7 +232,8 @@ pub(super) fn normalize_pending_interaction_queue(app: &mut App) {
 
 pub(super) fn pop_next_valid_interaction_id(app: &mut App) -> Option<String> {
     normalize_pending_interaction_queue(app);
-    (!app.pending_interaction_ids.is_empty()).then(|| app.pending_interaction_ids.remove(0))
+    (!app.turn.pending_interaction_ids.is_empty())
+        .then(|| app.turn.pending_interaction_ids.remove(0))
 }
 
 pub(super) fn handle_interaction_focus_cycle(
@@ -247,7 +248,7 @@ pub(super) fn handle_interaction_focus_cycle(
     if !matches!(key.code, KeyCode::Up | KeyCode::Down) {
         return None;
     }
-    if app.pending_interaction_ids.len() <= 1 {
+    if app.turn.pending_interaction_ids.len() <= 1 {
         if blocks_vertical_navigation {
             return None;
         }
@@ -257,13 +258,13 @@ pub(super) fn handle_interaction_focus_cycle(
     set_interaction_focused(app, 0, false);
 
     if key.code == KeyCode::Down {
-        let first = app.pending_interaction_ids.remove(0);
-        app.pending_interaction_ids.push(first);
+        let first = app.turn.pending_interaction_ids.remove(0);
+        app.turn.pending_interaction_ids.push(first);
     } else {
-        let Some(last) = app.pending_interaction_ids.pop() else {
+        let Some(last) = app.turn.pending_interaction_ids.pop() else {
             return Some(false);
         };
-        app.pending_interaction_ids.insert(0, last);
+        app.turn.pending_interaction_ids.insert(0, last);
     }
 
     set_interaction_focused(app, 0, true);

--- a/src/app/input_submit.rs
+++ b/src/app/input_submit.rs
@@ -21,7 +21,7 @@ pub(super) fn submit_input(app: &mut App) {
     if text.trim().is_empty() {
         return;
     }
-    app.prompt_suggestion = None;
+    app.session_runtime.prompt_suggestion = None;
 
     // `/cancel` is an explicit control action: execute immediately.
     if slash::is_cancel_command(&text) {
@@ -99,10 +99,10 @@ pub(super) fn request_cancel(app: &mut App, origin: CancelOrigin) -> Result<(), 
         return Ok(());
     }
 
-    let Some(ref conn) = app.conn else {
+    let Some(ref conn) = app.session_runtime.conn else {
         return Err("not connected yet".to_owned());
     };
-    let Some(sid) = app.session_id.clone() else {
+    let Some(sid) = app.session_runtime.session_id.clone() else {
         return Err("no active session".to_owned());
     };
 
@@ -149,8 +149,8 @@ fn dispatch_prompt_turn(app: &mut App, text: String) {
     // so their spinners don't continue during this turn.
     let _ = app.finalize_in_progress_tool_calls(model::ToolCallStatus::Failed);
 
-    let Some(conn) = app.conn.clone() else { return };
-    let Some(sid) = app.session_id.clone() else {
+    let Some(conn) = app.session_runtime.conn.clone() else { return };
+    let Some(sid) = app.session_runtime.session_id.clone() else {
         return;
     };
     let input_chars = text.chars().count();
@@ -204,8 +204,9 @@ mod tests {
     -> (App, tokio::sync::mpsc::UnboundedReceiver<crate::agent::wire::CommandEnvelope>) {
         let mut app = App::test_default();
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-        app.session_id = Some(model::SessionId::new("session-1"));
+        app.session_runtime.conn =
+            Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+        app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
         (app, rx)
     }
 
@@ -479,7 +480,8 @@ mod tests {
     fn dispatch_prompt_turn_without_session_id_leaves_state_unchanged() {
         let mut app = App::test_default();
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+        app.session_runtime.conn =
+            Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
         app.status = AppStatus::Ready;
 
         dispatch_prompt_turn(&mut app, "hello".into());

--- a/src/app/input_submit.rs
+++ b/src/app/input_submit.rs
@@ -333,7 +333,7 @@ mod tests {
     #[test]
     fn supported_advertised_slash_submit_falls_through_to_prompt_turn() {
         let (mut app, mut rx) = app_with_connection();
-        app.available_commands =
+        app.sdk_inventory.available_commands =
             vec![model::AvailableCommand::new("/remote-command", "Remote command")];
         app.input.set_text("/remote-command");
 

--- a/src/app/input_submit.rs
+++ b/src/app/input_submit.rs
@@ -25,9 +25,20 @@ pub(super) fn submit_input(app: &mut App) {
 
     // `/cancel` is an explicit control action: execute immediately.
     if slash::is_cancel_command(&text) {
-        app.pending_auto_submit_after_cancel = false;
+        app.turn.pending_auto_submit_after_cancel = false;
         app.input.clear();
         dispatch_submission(app, text);
+        return;
+    }
+
+    if app.turn.is_compacting {
+        app.turn.pending_auto_submit_after_cancel = false;
+        tracing::debug!(
+            target: crate::logging::targets::APP_INPUT,
+            event_name = "submit_blocked_by_compaction",
+            message = "input submit ignored while compaction is active",
+            outcome = "blocked",
+        );
         return;
     }
 
@@ -36,7 +47,7 @@ pub(super) fn submit_input(app: &mut App) {
     if is_turn_busy(app) {
         match request_cancel(app, CancelOrigin::AutoQueue) {
             Ok(()) => {
-                app.pending_auto_submit_after_cancel = true;
+                app.turn.pending_auto_submit_after_cancel = true;
                 tracing::debug!(
                     target: crate::logging::targets::APP_INPUT,
                     event_name = "submit_deferred_for_cancel",
@@ -45,7 +56,7 @@ pub(super) fn submit_input(app: &mut App) {
                 );
             }
             Err(message) => {
-                app.pending_auto_submit_after_cancel = false;
+                app.turn.pending_auto_submit_after_cancel = false;
                 tracing::error!(
                     target: crate::logging::targets::APP_INPUT,
                     event_name = "cancel_request_failed",
@@ -58,32 +69,32 @@ pub(super) fn submit_input(app: &mut App) {
         return;
     }
 
-    app.pending_auto_submit_after_cancel = false;
+    app.turn.pending_auto_submit_after_cancel = false;
     app.input.clear();
     dispatch_submission(app, text);
 }
 
 fn is_turn_busy(app: &App) -> bool {
     matches!(app.status, AppStatus::Thinking | AppStatus::Running)
-        || app.pending_cancel_origin.is_some()
-        || app.is_compacting
+        || app.turn.pending_cancel_origin.is_some()
+        || app.turn.is_compacting
 }
 
 pub(super) fn request_cancel(app: &mut App, origin: CancelOrigin) -> Result<(), String> {
     if matches!(origin, CancelOrigin::Manual) {
-        app.pending_auto_submit_after_cancel = false;
+        app.turn.pending_auto_submit_after_cancel = false;
     }
 
     if !matches!(app.status, AppStatus::Thinking | AppStatus::Running) {
         return Ok(());
     }
 
-    if let Some(existing_origin) = app.pending_cancel_origin {
+    if let Some(existing_origin) = app.turn.pending_cancel_origin {
         if matches!(existing_origin, CancelOrigin::AutoQueue)
             && matches!(origin, CancelOrigin::Manual)
         {
-            app.pending_cancel_origin = Some(CancelOrigin::Manual);
-            app.cancelled_turn_pending_hint = true;
+            app.turn.pending_cancel_origin = Some(CancelOrigin::Manual);
+            app.turn.cancelled_pending_hint = true;
         }
         return Ok(());
     }
@@ -97,8 +108,8 @@ pub(super) fn request_cancel(app: &mut App, origin: CancelOrigin) -> Result<(), 
 
     let session_id = sid.to_string();
     conn.cancel(session_id.clone()).map_err(|e| e.to_string())?;
-    app.pending_cancel_origin = Some(origin);
-    app.cancelled_turn_pending_hint = matches!(origin, CancelOrigin::Manual);
+    app.turn.pending_cancel_origin = Some(origin);
+    app.turn.cancelled_pending_hint = matches!(origin, CancelOrigin::Manual);
     let _ = app.event_tx.send(ClientEvent::TurnCancelled);
     tracing::info!(
         target: crate::logging::targets::APP_INPUT,
@@ -112,17 +123,17 @@ pub(super) fn request_cancel(app: &mut App, origin: CancelOrigin) -> Result<(), 
 }
 
 pub(super) fn maybe_auto_submit_after_cancel(app: &mut App) {
-    if !app.pending_auto_submit_after_cancel {
+    if !app.turn.pending_auto_submit_after_cancel {
         return;
     }
-    if !matches!(app.status, AppStatus::Ready) || app.pending_cancel_origin.is_some() {
+    if !matches!(app.status, AppStatus::Ready) || app.turn.pending_cancel_origin.is_some() {
         return;
     }
     if app.input.text().trim().is_empty() {
-        app.pending_auto_submit_after_cancel = false;
+        app.turn.pending_auto_submit_after_cancel = false;
         return;
     }
-    app.pending_auto_submit_after_cancel = false;
+    app.turn.pending_auto_submit_after_cancel = false;
     submit_input(app);
 }
 
@@ -207,10 +218,10 @@ mod tests {
         submit_input(&mut app);
 
         assert_eq!(app.input.text(), "queued prompt");
-        assert_eq!(app.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
-        assert!(app.pending_auto_submit_after_cancel);
+        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
+        assert!(app.turn.pending_auto_submit_after_cancel);
         assert!(matches!(app.status, AppStatus::Running));
-        assert!(app.messages.is_empty());
+        assert!(app.transcript.messages.is_empty());
         let envelope = rx.try_recv().expect("cancel command should be sent");
         assert!(matches!(
             envelope.command,
@@ -222,14 +233,14 @@ mod tests {
     fn manual_cancel_promotes_existing_auto_cancel() {
         let (mut app, mut rx) = app_with_connection();
         app.status = AppStatus::Thinking;
-        app.pending_auto_submit_after_cancel = true;
+        app.turn.pending_auto_submit_after_cancel = true;
 
         request_cancel(&mut app, CancelOrigin::AutoQueue).expect("auto cancel request");
         request_cancel(&mut app, CancelOrigin::Manual).expect("manual cancel request");
 
-        assert_eq!(app.pending_cancel_origin, Some(CancelOrigin::Manual));
-        assert!(app.cancelled_turn_pending_hint);
-        assert!(!app.pending_auto_submit_after_cancel);
+        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual));
+        assert!(app.turn.cancelled_pending_hint);
+        assert!(!app.turn.pending_auto_submit_after_cancel);
         let envelope = rx.try_recv().expect("single cancel command should be sent");
         assert!(matches!(
             envelope.command,
@@ -245,24 +256,24 @@ mod tests {
         app.input.set_text("draft");
 
         submit_input(&mut app);
-        assert_eq!(app.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
-        assert!(app.pending_auto_submit_after_cancel);
+        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
+        assert!(app.turn.pending_auto_submit_after_cancel);
         let cancel = rx.try_recv().expect("cancel command should be sent");
         assert!(matches!(
             cancel.command, BridgeCommand::CancelTurn { session_id } if session_id == "session-1"
         ));
 
         request_cancel(&mut app, CancelOrigin::Manual).expect("manual cancel request");
-        assert_eq!(app.pending_cancel_origin, Some(CancelOrigin::Manual));
-        assert!(!app.pending_auto_submit_after_cancel);
+        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual));
+        assert!(!app.turn.pending_auto_submit_after_cancel);
 
         app.status = AppStatus::Ready;
-        app.pending_cancel_origin = None;
+        app.turn.pending_cancel_origin = None;
         maybe_auto_submit_after_cancel(&mut app);
 
         assert_eq!(app.input.text(), "draft");
         assert!(matches!(app.status, AppStatus::Ready));
-        assert!(app.messages.is_empty());
+        assert!(app.transcript.messages.is_empty());
         assert!(rx.try_recv().is_err(), "manual cancel should suppress queued prompt submit");
     }
 
@@ -276,8 +287,8 @@ mod tests {
         submit_input(&mut app);
 
         assert_eq!(app.input.text(), "draft");
-        assert_eq!(app.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
-        assert!(app.pending_auto_submit_after_cancel);
+        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
+        assert!(app.turn.pending_auto_submit_after_cancel);
         let envelope = rx.try_recv().expect("first cancel command should be sent");
         assert!(matches!(
             envelope.command, BridgeCommand::CancelTurn { session_id } if session_id == "session-1"
@@ -294,7 +305,7 @@ mod tests {
         submit_input(&mut app);
 
         assert!(app.input.text().is_empty());
-        assert_eq!(app.pending_cancel_origin, Some(CancelOrigin::Manual));
+        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual));
         let envelope = rx.try_recv().expect("cancel command should be sent");
         assert!(matches!(
             envelope.command,
@@ -312,7 +323,7 @@ mod tests {
 
         assert!(app.surface_dirty.chat.repaint);
         assert!(app.input.text().is_empty());
-        let Some(last) = app.messages.last() else {
+        let Some(last) = app.transcript.messages.last() else {
             panic!("expected docs system message");
         };
         assert!(matches!(last.role, MessageRole::System(Some(super::super::SystemSeverity::Info))));
@@ -329,9 +340,9 @@ mod tests {
 
         assert!(app.input.text().is_empty());
         assert!(matches!(app.status, AppStatus::Thinking));
-        assert_eq!(app.messages.len(), 2);
-        assert!(matches!(app.messages[0].role, MessageRole::User));
-        assert!(matches!(app.messages[1].role, MessageRole::Assistant));
+        assert_eq!(app.transcript.messages.len(), 2);
+        assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
+        assert!(matches!(app.transcript.messages[1].role, MessageRole::Assistant));
         let envelope = rx.try_recv().expect("advertised slash command should be sent");
         match envelope.command {
             BridgeCommand::Prompt { session_id, chunks } => {
@@ -375,7 +386,7 @@ mod tests {
 
         assert!(app.input.text().is_empty());
         assert!(matches!(app.status, AppStatus::Ready));
-        let Some(last) = app.messages.last() else {
+        let Some(last) = app.transcript.messages.last() else {
             panic!("expected /1m-context status message");
         };
         assert!(matches!(last.role, MessageRole::System(Some(super::super::SystemSeverity::Info))));
@@ -391,7 +402,7 @@ mod tests {
 
         assert!(app.input.text().is_empty());
         assert!(matches!(app.status, AppStatus::Ready));
-        let Some(last) = app.messages.last() else {
+        let Some(last) = app.transcript.messages.last() else {
             panic!("expected /login usage message");
         };
         assert!(matches!(
@@ -408,24 +419,24 @@ mod tests {
         app.input.set_text("send after cancel");
 
         submit_input(&mut app);
-        assert!(app.pending_auto_submit_after_cancel);
+        assert!(app.turn.pending_auto_submit_after_cancel);
         let cancel = rx.try_recv().expect("cancel command should be sent");
         assert!(matches!(
             cancel.command, BridgeCommand::CancelTurn { session_id } if session_id == "session-1"
         ));
 
         app.status = AppStatus::Ready;
-        app.pending_cancel_origin = None;
+        app.turn.pending_cancel_origin = None;
         maybe_auto_submit_after_cancel(&mut app);
 
-        assert!(!app.pending_auto_submit_after_cancel);
+        assert!(!app.turn.pending_auto_submit_after_cancel);
         assert!(app.input.text().is_empty());
         assert!(matches!(app.status, AppStatus::Thinking));
-        assert_eq!(app.messages.len(), 2);
+        assert_eq!(app.transcript.messages.len(), 2);
         assert_eq!(app.active_turn_assistant_idx(), Some(1));
-        assert!(matches!(app.messages[0].role, MessageRole::User));
-        assert!(matches!(app.messages[1].role, MessageRole::Assistant));
-        assert!(app.messages[1].blocks.is_empty());
+        assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
+        assert!(matches!(app.transcript.messages[1].role, MessageRole::Assistant));
+        assert!(app.transcript.messages[1].blocks.is_empty());
         let prompt = rx.try_recv().expect("prompt command should be sent");
         assert!(matches!(
             prompt.command,
@@ -446,18 +457,18 @@ mod tests {
 
         assert_eq!(app.surface_mode, SurfaceMode::Chat);
         assert_eq!(app.input.text(), "/config");
-        assert_eq!(app.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
-        assert!(app.pending_auto_submit_after_cancel);
+        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
+        assert!(app.turn.pending_auto_submit_after_cancel);
         let cancel = rx.try_recv().expect("cancel command should be sent");
         assert!(matches!(
             cancel.command, BridgeCommand::CancelTurn { session_id } if session_id == "session-1"
         ));
 
         app.status = AppStatus::Ready;
-        app.pending_cancel_origin = None;
+        app.turn.pending_cancel_origin = None;
         maybe_auto_submit_after_cancel(&mut app);
 
-        assert!(!app.pending_auto_submit_after_cancel);
+        assert!(!app.turn.pending_auto_submit_after_cancel);
         assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::Config));
         assert!(app.input.text().is_empty());
         assert!(matches!(app.status, AppStatus::Ready));
@@ -473,7 +484,7 @@ mod tests {
 
         dispatch_prompt_turn(&mut app, "hello".into());
 
-        assert!(app.messages.is_empty());
+        assert!(app.transcript.messages.is_empty());
         assert!(matches!(app.status, AppStatus::Ready));
     }
 }

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -520,7 +520,7 @@ fn handle_prompt_suggestion(app: &mut App) -> bool {
         return false;
     }
 
-    let Some(suggestion) = app.prompt_suggestion.take() else {
+    let Some(suggestion) = app.session_runtime.prompt_suggestion.take() else {
         return false;
     };
     if suggestion.trim().is_empty() {
@@ -531,7 +531,7 @@ fn handle_prompt_suggestion(app: &mut App) -> bool {
 }
 
 fn handle_mode_cycle(app: &mut App) -> bool {
-    let Some(ref mode) = app.mode else {
+    let Some(ref mode) = app.session_runtime.mode else {
         return true;
     };
     if mode.available_modes.len() <= 1 {
@@ -543,8 +543,8 @@ fn handle_mode_cycle(app: &mut App) -> bool {
     let next_idx = (current_idx + 1) % mode.available_modes.len();
     let next = &mode.available_modes[next_idx];
 
-    if let Some(ref conn) = app.conn
-        && let Some(sid) = app.session_id.clone()
+    if let Some(ref conn) = app.session_runtime.conn
+        && let Some(sid) = app.session_runtime.session_id.clone()
     {
         let mode_id = next.id.clone();
         let conn = Rc::clone(conn);
@@ -568,7 +568,7 @@ fn handle_mode_cycle(app: &mut App) -> bool {
         .iter()
         .map(|m| ModeInfo { id: m.id.clone(), name: m.name.clone() })
         .collect();
-    app.mode = Some(ModeState {
+    app.session_runtime.mode = Some(ModeState {
         current_mode_id: next_id,
         current_mode_name: next_name,
         available_modes: modes,

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -91,9 +91,7 @@ pub(super) fn is_ctrl_char_shortcut(key: KeyEvent, expected: char) -> bool {
 }
 
 pub(super) fn dispatch_key_by_focus(app: &mut App, key: KeyEvent) -> KeyOutcome {
-    if matches!(app.status, AppStatus::Connecting | AppStatus::CommandPending | AppStatus::Error)
-        || app.is_compacting
-    {
+    if matches!(app.status, AppStatus::Connecting | AppStatus::CommandPending | AppStatus::Error) {
         return handle_keymap_context(app, KeyContext::ChatBlocked, key);
     }
 
@@ -185,7 +183,7 @@ fn should_ignore_key_during_paste(app: &mut App, key: KeyEvent) -> bool {
     if app.pending_submit.is_some() && is_editing_like_key(key) {
         app.pending_submit = None;
     }
-    !app.pending_paste_text.is_empty() && is_editing_like_key(key)
+    app.paste.has_pending_text() && is_editing_like_key(key)
 }
 
 fn paste_suppression_bypass_action(app: &App, key: KeyEvent) -> Option<KeyAction> {
@@ -270,7 +268,7 @@ fn execute_app_action(app: &mut App, action: AppAction) -> KeyOutcome {
 fn clear_input_or_quit(app: &mut App) -> bool {
     let has_local_input = !app.input.is_empty()
         || !app.pending_images.is_empty()
-        || !app.pending_paste_text.is_empty()
+        || app.paste.has_pending_text()
         || app.pending_submit.is_some();
     if !has_local_input {
         app.should_quit = true;
@@ -279,9 +277,7 @@ fn clear_input_or_quit(app: &mut App) -> bool {
 
     app.input.clear();
     app.pending_images.clear();
-    app.pending_paste_text.clear();
-    app.pending_paste_session = None;
-    app.active_paste_session = None;
+    app.paste.clear_all_sessions();
     app.pending_submit = None;
     app.request_chat_repaint();
     true
@@ -353,7 +349,7 @@ fn delete_input_word_after(app: &mut App) -> bool {
 }
 
 fn insert_explicit_newline(app: &mut App) -> bool {
-    if app.paste_burst.on_enter(Instant::now()) {
+    if app.paste.burst.on_enter(Instant::now()) {
         tracing::debug!(
             target: crate::logging::targets::APP_INPUT,
             event_name = "enter_routed_to_paste_buffer",
@@ -481,7 +477,7 @@ fn handle_submit(app: &mut App) -> bool {
 
     // During an active burst or the post-burst suppression window, Enter
     // becomes a newline to keep multi-line pastes grouped.
-    if app.paste_burst.on_enter(now) {
+    if app.paste.burst.on_enter(now) {
         tracing::debug!(
             target: crate::logging::targets::APP_INPUT,
             event_name = "enter_routed_to_paste_buffer",
@@ -502,7 +498,7 @@ fn handle_submit(app: &mut App) -> bool {
 }
 
 fn handle_focus_toggle(app: &mut App) -> bool {
-    if app.pending_interaction_ids.is_empty() {
+    if app.turn.pending_interaction_ids.is_empty() {
         false
     } else {
         match app.focus_owner() {
@@ -673,18 +669,7 @@ fn try_delete_input_atom(app: &mut App, direction: AtomicDeleteDirection) -> boo
             app.request_chat_repaint();
         }
         InputAtomKind::PasteBlock { index, .. } => {
-            if app
-                .active_paste_session
-                .is_some_and(|session| session.placeholder_index == Some(index))
-            {
-                app.active_paste_session = None;
-            }
-            if app
-                .pending_paste_session
-                .is_some_and(|session| session.placeholder_index == Some(index))
-            {
-                app.pending_paste_session = None;
-            }
+            app.paste.clear_sessions_for_placeholder(index);
             app.request_chat_repaint();
         }
     }
@@ -694,7 +679,7 @@ fn try_delete_input_atom(app: &mut App, direction: AtomicDeleteDirection) -> boo
 fn handle_printable_key(app: &mut App, key: KeyEvent) -> bool {
     let (KeyCode::Char(c), m) = (key.code, key.modifiers) else {
         // Non-char key: reset burst state to prevent leakage.
-        app.paste_burst.on_non_char_key(Instant::now());
+        app.paste.burst.on_non_char_key(Instant::now());
         return false;
     };
     if !is_printable_text_modifiers(m) {
@@ -703,7 +688,7 @@ fn handle_printable_key(app: &mut App, key: KeyEvent) -> bool {
     reclaim_input_from_inline_prompt_if_needed(app);
 
     let now = Instant::now();
-    match app.paste_burst.on_char(c, now) {
+    match app.paste.burst.on_char(c, now) {
         CharAction::Consumed => {
             // Character absorbed into burst buffer. Don't insert.
             return false;
@@ -922,7 +907,7 @@ mod tests {
     #[test]
     fn queued_paste_still_blocks_overlapping_key_text() {
         let mut app = App::test_default();
-        app.pending_paste_text = "clipboard".to_owned();
+        app.paste.pending_text = "clipboard".to_owned();
 
         let blocked = should_ignore_key_during_paste(
             &mut app,
@@ -934,7 +919,7 @@ mod tests {
     #[test]
     fn queued_paste_allows_app_control_shortcuts() {
         let mut app = App::test_default();
-        app.pending_paste_text = "clipboard".to_owned();
+        app.paste.pending_text = "clipboard".to_owned();
 
         let blocked = should_ignore_key_during_paste(
             &mut app,
@@ -1009,12 +994,12 @@ mod tests {
         app.input.insert_paste_block("a\r\nb\rc");
         app.input.insert_str(" after");
         let _ = app.input.set_cursor_col("before ".chars().count());
-        app.active_paste_session = Some(crate::app::PasteSessionState {
+        app.paste.active_session = Some(crate::app::PasteSessionState {
             id: 1,
             start: crate::app::SelectionPoint { row: 0, col: "before ".chars().count() },
             placeholder_index: Some(0),
         });
-        app.pending_paste_session = app.active_paste_session;
+        app.paste.pending_session = app.paste.active_session;
         app.surface_dirty.chat.repaint = false;
 
         let outcome = execute_key_action(
@@ -1027,8 +1012,8 @@ mod tests {
         assert_eq!(app.input.lines(), vec!["before  after"]);
         assert_eq!(app.input.text(), "before  after");
         assert_eq!(app.input.paste_blocks, vec!["a\nb\nc"]);
-        assert!(app.active_paste_session.is_none());
-        assert!(app.pending_paste_session.is_none());
+        assert!(app.paste.active_session.is_none());
+        assert!(app.paste.pending_session.is_none());
         assert!(app.surface_dirty.chat.repaint);
     }
 
@@ -1141,12 +1126,12 @@ mod tests {
         let mut app = App::test_default();
         let t0 = Instant::now();
 
-        assert_eq!(app.paste_burst.on_char('a', t0), CharAction::Passthrough('a'));
+        assert_eq!(app.paste.burst.on_char('a', t0), CharAction::Passthrough('a'));
         assert_eq!(
-            app.paste_burst.on_char('b', t0 + Duration::from_millis(1)),
+            app.paste.burst.on_char('b', t0 + Duration::from_millis(1)),
             CharAction::Consumed
         );
-        assert!(app.paste_burst.is_buffering());
+        assert!(app.paste.burst.is_buffering());
 
         let blocked = should_ignore_key_during_paste(
             &mut app,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -168,7 +168,7 @@ async fn run_tui_loop(
         // has timed out. EmitChar re-inserts a single held character;
         // EmitPaste feeds the accumulated burst into the paste queue.
         if app.surface_mode == SurfaceMode::Chat
-            && let Some(action) = app.paste_burst.tick(now)
+            && let Some(action) = app.paste.burst.tick(now)
         {
             match action {
                 paste_burst::FlushAction::EmitChar(ch) => {
@@ -181,7 +181,7 @@ async fn run_tui_loop(
         }
 
         // Merge and process `Event::Paste` chunks as one paste action.
-        if app.surface_mode == SurfaceMode::Chat && !app.pending_paste_text.is_empty() {
+        if app.surface_mode == SurfaceMode::Chat && app.paste.has_pending_text() {
             finalize_pending_paste_event(app);
         }
 
@@ -207,7 +207,7 @@ async fn run_tui_loop(
                 | AppStatus::CommandPending
                 | AppStatus::Thinking
                 | AppStatus::Running
-        ) || app.is_compacting;
+        ) || app.turn.is_compacting;
         if is_animating {
             advance_spinner_frame(app, Instant::now());
             tab_title::update_tab_title(&app.status, app.spinner_frame, &app.cwd);
@@ -321,10 +321,10 @@ fn handle_runtime_client_event(
 
 fn finish_run_tui(app: &mut App, terminal_runtime: &mut terminal_runtime::TerminalRuntime) {
     // Dismiss all pending inline permissions (reject via last option)
-    for tool_id in std::mem::take(&mut app.pending_interaction_ids) {
-        if let Some((mi, bi)) = app.tool_call_index.get(&tool_id).copied()
+    for tool_id in std::mem::take(&mut app.turn.pending_interaction_ids) {
+        if let Some((mi, bi)) = app.lookup_tool_call(&tool_id)
             && let Some(MessageBlock::ToolCall(tc)) =
-                app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+                app.transcript.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
         {
             let tc = tc.as_mut();
             if let Some(pending) = tc.pending_permission.take()
@@ -394,20 +394,16 @@ async fn wait_for_shutdown_signal() -> std::io::Result<()> {
 
 /// Finalize queued `Event::Paste` chunks for this drain cycle.
 fn finalize_pending_paste_event(app: &mut App) {
-    let pasted = std::mem::take(&mut app.pending_paste_text);
+    let pasted = app.paste.take_pending_text();
     if pasted.is_empty() {
         return;
     }
     let pasted_chars = pasted.chars().count();
 
-    let session = app.pending_paste_session.take().unwrap_or_else(|| {
-        let id = app.next_paste_session_id;
-        app.next_paste_session_id = app.next_paste_session_id.saturating_add(1);
-        state::PasteSessionState {
-            id,
-            start: SelectionPoint { row: app.input.cursor_row(), col: app.input.cursor_col() },
-            placeholder_index: None,
-        }
+    let session = app.paste.take_pending_session().unwrap_or_else(|| state::PasteSessionState {
+        id: app.paste.allocate_session_id(),
+        start: SelectionPoint { row: app.input.cursor_row(), col: app.input.cursor_col() },
+        placeholder_index: None,
     });
     let session_id = session.id;
 
@@ -427,7 +423,7 @@ fn finalize_pending_paste_event(app: &mut App) {
         .is_some()
         && app.input.append_to_active_paste_block(&pasted);
     if appended {
-        app.active_paste_session = Some(session);
+        app.paste.set_active_session(session);
         app.request_chat_repaint();
         tracing::debug!(
             target: crate::logging::targets::APP_PASTE,
@@ -446,8 +442,8 @@ fn finalize_pending_paste_event(app: &mut App) {
         let idx = app.input.lines().get(app.input.cursor_row()).and_then(|line| {
             input::parse_paste_placeholder_before_cursor(line, app.input.cursor_col())
         });
-        app.active_paste_session =
-            Some(state::PasteSessionState { placeholder_index: idx, ..session });
+        app.paste
+            .set_active_session(state::PasteSessionState { placeholder_index: idx, ..session });
         tracing::debug!(
             target: crate::logging::targets::APP_PASTE,
             event_name = "paste_placeholder_inserted",
@@ -460,7 +456,7 @@ fn finalize_pending_paste_event(app: &mut App) {
         );
     } else {
         app.input.insert_str(&pasted);
-        app.active_paste_session = None;
+        app.paste.clear_active_session();
         tracing::debug!(
             target: crate::logging::targets::APP_PASTE,
             event_name = "paste_inline_inserted",

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -346,8 +346,8 @@ fn finish_run_tui(app: &mut App, terminal_runtime: &mut terminal_runtime::Termin
 
     // Cancel any active turn and give the adapter a moment to clean up
     if matches!(app.status, AppStatus::Thinking | AppStatus::Running)
-        && let Some(ref conn) = app.conn
-        && let Some(sid) = app.session_id.clone()
+        && let Some(ref conn) = app.session_runtime.conn
+        && let Some(sid) = app.session_runtime.session_id.clone()
     {
         let _ = conn.cancel(sid.to_string());
     }

--- a/src/app/permissions.rs
+++ b/src/app/permissions.rs
@@ -187,11 +187,11 @@ fn respond_permission(app: &mut App, override_index: Option<usize>) {
         return;
     };
 
-    let Some((mi, bi)) = app.tool_call_index.get(&tool_id).copied() else {
+    let Some((mi, bi)) = app.lookup_tool_call(&tool_id) else {
         return;
     };
     let Some(MessageBlock::ToolCall(tc)) =
-        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+        app.transcript.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     else {
         return;
     };
@@ -245,11 +245,11 @@ fn respond_permission_cancel(app: &mut App) {
         return;
     };
 
-    let Some((mi, bi)) = app.tool_call_index.get(&tool_id).copied() else {
+    let Some((mi, bi)) = app.lookup_tool_call(&tool_id) else {
         return;
     };
     let Some(MessageBlock::ToolCall(tc)) =
-        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+        app.transcript.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     else {
         return;
     };
@@ -332,13 +332,13 @@ mod tests {
         options: Vec<model::PermissionOption>,
         focused: bool,
     ) -> oneshot::Receiver<model::RequestPermissionResponse> {
-        let msg_idx = app.messages.len();
-        app.messages.push(assistant_tool_msg(test_tool_call(tool_id)));
+        let msg_idx = app.transcript.messages.len();
+        app.transcript.messages.push(assistant_tool_msg(test_tool_call(tool_id)));
         app.index_tool_call(tool_id.to_owned(), msg_idx, 0);
 
         let (tx, rx) = oneshot::channel();
         if let Some(MessageBlock::ToolCall(tc)) =
-            app.messages.get_mut(msg_idx).and_then(|m| m.blocks.get_mut(0))
+            app.transcript.messages.get_mut(msg_idx).and_then(|m| m.blocks.get_mut(0))
         {
             tc.pending_permission = Some(InlinePermission {
                 options,
@@ -349,13 +349,13 @@ mod tests {
                 focused,
             });
         }
-        app.pending_interaction_ids.push(tool_id.to_owned());
+        app.turn.pending_interaction_ids.push(tool_id.to_owned());
         rx
     }
 
     fn add_tool_without_permission(app: &mut App, tool_id: &str) {
-        let msg_idx = app.messages.len();
-        app.messages.push(assistant_tool_msg(test_tool_call(tool_id)));
+        let msg_idx = app.transcript.messages.len();
+        app.transcript.messages.push(assistant_tool_msg(test_tool_call(tool_id)));
         app.index_tool_call(tool_id.to_owned(), msg_idx, 0);
     }
 
@@ -363,7 +363,8 @@ mod tests {
         let Some((mi, bi)) = app.lookup_tool_call(tool_id) else {
             return false;
         };
-        let Some(MessageBlock::ToolCall(tc)) = app.messages.get(mi).and_then(|m| m.blocks.get(bi))
+        let Some(MessageBlock::ToolCall(tc)) =
+            app.transcript.messages.get(mi).and_then(|m| m.blocks.get(bi))
         else {
             return false;
         };
@@ -377,7 +378,7 @@ mod tests {
         let mut rx1 = add_permission(&mut app, "perm-1", allow_options(), true);
         let mut rx2 = add_permission(&mut app, "perm-2", allow_options(), false);
 
-        assert_eq!(app.pending_interaction_ids, vec!["perm-1", "perm-2"]);
+        assert_eq!(app.turn.pending_interaction_ids, vec!["perm-1", "perm-2"]);
         assert!(permission_focused(&app, "perm-1"));
         assert!(!permission_focused(&app, "perm-2"));
 
@@ -387,7 +388,7 @@ mod tests {
             KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
         );
         assert_eq!(consumed, KeyOutcome::Handled(true));
-        assert_eq!(app.pending_interaction_ids, vec!["perm-2", "perm-1"]);
+        assert_eq!(app.turn.pending_interaction_ids, vec!["perm-2", "perm-1"]);
         assert!(permission_focused(&app, "perm-2"));
         assert!(!permission_focused(&app, "perm-1"));
 
@@ -404,7 +405,7 @@ mod tests {
         };
         assert_eq!(sel2.option_id.clone(), "allow-once");
         assert!(matches!(rx1.try_recv(), Err(tokio::sync::oneshot::error::TryRecvError::Empty)));
-        assert_eq!(app.pending_interaction_ids, vec!["perm-1"]);
+        assert_eq!(app.turn.pending_interaction_ids, vec!["perm-1"]);
     }
 
     #[test]
@@ -446,7 +447,7 @@ mod tests {
             KeyOutcome::Ignored
         );
 
-        assert_eq!(app.pending_interaction_ids, vec!["perm-1"]);
+        assert_eq!(app.turn.pending_interaction_ids, vec!["perm-1"]);
         assert!(matches!(rx.try_recv(), Err(tokio::sync::oneshot::error::TryRecvError::Empty)));
     }
 
@@ -454,7 +455,7 @@ mod tests {
     fn keeps_non_tool_blocks_untouched() {
         let app = App::test_default();
         let _ = IncrementalMarkdown::default();
-        assert!(app.messages.is_empty());
+        assert!(app.transcript.messages.is_empty());
     }
 
     #[test]
@@ -500,6 +501,6 @@ mod tests {
             panic!("expected selected permission response");
         };
         assert_eq!(selected.option_id, "allow-once");
-        assert_eq!(app.pending_interaction_ids, Vec::<String>::new());
+        assert_eq!(app.turn.pending_interaction_ids, Vec::<String>::new());
     }
 }

--- a/src/app/plugins/tests.rs
+++ b/src/app/plugins/tests.rs
@@ -10,8 +10,9 @@ fn app_with_connection()
 -> (crate::app::App, tokio::sync::mpsc::UnboundedReceiver<crate::agent::wire::CommandEnvelope>) {
     let mut app = crate::app::App::test_default();
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.conn =
+        Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
     (app, rx)
 }
 

--- a/src/app/questions.rs
+++ b/src/app/questions.rs
@@ -408,11 +408,11 @@ fn respond_question(app: &mut App) {
         return;
     };
 
-    let Some((mi, bi)) = app.tool_call_index.get(&tool_id).copied() else {
+    let Some((mi, bi)) = app.lookup_tool_call(&tool_id) else {
         return;
     };
     let Some(MessageBlock::ToolCall(tc)) =
-        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+        app.transcript.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     else {
         return;
     };
@@ -473,11 +473,11 @@ fn respond_question_cancel(app: &mut App) {
         return;
     };
 
-    let Some((mi, bi)) = app.tool_call_index.get(&tool_id).copied() else {
+    let Some((mi, bi)) = app.lookup_tool_call(&tool_id) else {
         return;
     };
     let Some(MessageBlock::ToolCall(tc)) =
-        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+        app.transcript.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     else {
         return;
     };
@@ -542,13 +542,13 @@ mod tests {
         prompt: model::QuestionPrompt,
         focused: bool,
     ) -> oneshot::Receiver<model::RequestQuestionResponse> {
-        let msg_idx = app.messages.len();
-        app.messages.push(assistant_tool_msg(test_tool_call(tool_id)));
+        let msg_idx = app.transcript.messages.len();
+        app.transcript.messages.push(assistant_tool_msg(test_tool_call(tool_id)));
         app.index_tool_call(tool_id.to_owned(), msg_idx, 0);
 
         let (tx, rx) = oneshot::channel();
         if let Some(MessageBlock::ToolCall(tc)) =
-            app.messages.get_mut(msg_idx).and_then(|m| m.blocks.get_mut(0))
+            app.transcript.messages.get_mut(msg_idx).and_then(|m| m.blocks.get_mut(0))
         {
             tc.pending_question = Some(InlineQuestion {
                 prompt,
@@ -563,7 +563,7 @@ mod tests {
                 total_questions: 1,
             });
         }
-        app.pending_interaction_ids.push(tool_id.to_owned());
+        app.turn.pending_interaction_ids.push(tool_id.to_owned());
         rx
     }
 
@@ -600,7 +600,7 @@ mod tests {
 
         assert_eq!(consumed_right, KeyOutcome::Handled(true));
         assert_eq!(consumed_enter, KeyOutcome::Handled(true));
-        assert!(app.pending_interaction_ids.is_empty());
+        assert!(app.turn.pending_interaction_ids.is_empty());
 
         let resp = rx.try_recv().expect("question should be answered");
         let model::RequestQuestionOutcome::Answered(answered) = resp.outcome else {

--- a/src/app/session_picker.rs
+++ b/src/app/session_picker.rs
@@ -14,7 +14,7 @@ pub(crate) fn picker_session_count(app: &App) -> usize {
 }
 
 pub(crate) fn startup_picker_is_loading(app: &App) -> bool {
-    app.startup.startup_picker_is_loading(app.conn.is_some())
+    app.startup.startup_picker_is_loading(app.session_runtime.conn.is_some())
 }
 
 pub fn handle_key(app: &mut App, key: KeyEvent) {
@@ -62,7 +62,7 @@ fn activate_selection(app: &mut App) {
         return;
     };
     let session_id = session.session_id.clone();
-    let Some(conn) = app.conn.clone() else {
+    let Some(conn) = app.session_runtime.conn.clone() else {
         app.startup.resolve_session_picker();
         view::set_chat_surface(app);
         return;
@@ -139,7 +139,7 @@ mod tests {
         app.startup = crate::app::state::StartupState::new(None, None, true);
         app.startup.request_connection();
         assert!(app.startup.mark_connection_started());
-        app.conn = None;
+        app.session_runtime.conn = None;
 
         handle_key(&mut app, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
 
@@ -162,7 +162,7 @@ mod tests {
     fn enter_triggers_resume() {
         let mut app = picker_app();
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<CommandEnvelope>();
-        app.conn = Some(Rc::new(AgentConnection::new(tx)));
+        app.session_runtime.conn = Some(Rc::new(AgentConnection::new(tx)));
 
         handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 
@@ -194,7 +194,7 @@ mod tests {
         let mut app = picker_app();
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<CommandEnvelope>();
         drop(rx);
-        app.conn = Some(Rc::new(AgentConnection::new(tx)));
+        app.session_runtime.conn = Some(Rc::new(AgentConnection::new(tx)));
 
         handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 

--- a/src/app/session_picker.rs
+++ b/src/app/session_picker.rs
@@ -14,9 +14,7 @@ pub(crate) fn picker_session_count(app: &App) -> usize {
 }
 
 pub(crate) fn startup_picker_is_loading(app: &App) -> bool {
-    app.startup_session_picker_requested
-        && !app.startup_session_picker_resolved
-        && (app.conn.is_none() || !app.startup_recent_sessions_loaded)
+    app.startup.startup_picker_is_loading(app.conn.is_some())
 }
 
 pub fn handle_key(app: &mut App, key: KeyEvent) {
@@ -32,7 +30,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
     let session_count = picker_session_count(app);
     if session_count == 0 {
         if matches!(key.code, KeyCode::Esc | KeyCode::Enter) {
-            app.startup_session_picker_resolved = true;
+            app.startup.resolve_session_picker();
             view::set_chat_surface(app);
         }
         return;
@@ -50,7 +48,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
         (KeyCode::End, _) => app.session_picker.selected = session_count.saturating_sub(1),
         (KeyCode::Enter, KeyModifiers::NONE) => activate_selection(app),
         (KeyCode::Esc, KeyModifiers::NONE) => {
-            app.startup_session_picker_resolved = true;
+            app.startup.resolve_session_picker();
             view::set_chat_surface(app);
         }
         _ => {}
@@ -65,18 +63,18 @@ fn activate_selection(app: &mut App) {
     };
     let session_id = session.session_id.clone();
     let Some(conn) = app.conn.clone() else {
-        app.startup_session_picker_resolved = true;
+        app.startup.resolve_session_picker();
         view::set_chat_surface(app);
         return;
     };
 
-    app.startup_session_picker_resolved = true;
+    app.startup.resolve_session_picker();
     app.status = AppStatus::CommandPending;
-    app.pending_command_label = Some(format!("Resuming session {session_id}..."));
-    app.pending_command_ack = None;
+    app.turn.pending_command_label = Some(format!("Resuming session {session_id}..."));
+    app.turn.pending_command_ack = None;
     if let Err(e) = begin_resume_session(app, &conn, session_id) {
-        app.pending_command_label = None;
-        app.pending_command_ack = None;
+        app.turn.pending_command_label = None;
+        app.turn.pending_command_ack = None;
         app.status = AppStatus::Ready;
         app.resuming_session_id = None;
         push_system_message_with_severity(
@@ -105,6 +103,11 @@ mod tests {
     fn picker_app() -> App {
         let mut app = App::test_default();
         app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::SessionPicker);
+        app.startup = crate::app::state::StartupState::new(None, None, true);
+        app.startup.request_connection();
+        assert!(app.startup.mark_connection_started());
+        app.startup.mark_recent_sessions_loaded();
+        app.startup.resolve_session_picker();
         app.recent_sessions = vec![
             RecentSessionInfo {
                 session_id: "session-1".to_owned(),
@@ -133,8 +136,9 @@ mod tests {
     #[test]
     fn loading_state_ignores_navigation_keys() {
         let mut app = picker_app();
-        app.startup_session_picker_requested = true;
-        app.startup_recent_sessions_loaded = false;
+        app.startup = crate::app::state::StartupState::new(None, None, true);
+        app.startup.request_connection();
+        assert!(app.startup.mark_connection_started());
         app.conn = None;
 
         handle_key(&mut app, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
@@ -182,7 +186,7 @@ mod tests {
         handle_key(&mut app, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
 
         assert_eq!(app.surface_mode, SurfaceMode::Chat);
-        assert!(app.startup_session_picker_resolved);
+        assert!(app.startup.session_picker_resolved());
     }
 
     #[test]
@@ -197,8 +201,8 @@ mod tests {
         assert_eq!(app.surface_mode, SurfaceMode::Chat);
         assert!(matches!(app.status, AppStatus::Ready));
         assert!(app.resuming_session_id.is_none());
-        assert!(app.pending_command_label.is_none());
-        let last = app.messages.last().expect("error message");
+        assert!(app.turn.pending_command_label.is_none());
+        let last = app.transcript.messages.last().expect("error message");
         let text = match last.blocks.first().expect("text block") {
             crate::app::MessageBlock::Text(block) => block.text.as_str(),
             _ => panic!("expected text block"),

--- a/src/app/session_runtime.rs
+++ b/src/app/session_runtime.rs
@@ -113,7 +113,7 @@ pub(crate) fn tick_context_usage_refresh(app: &mut App, now: Instant) {
 }
 
 fn context_usage_refresh_is_active(app: &App) -> bool {
-    matches!(app.status, AppStatus::Thinking | AppStatus::Running) || app.is_compacting
+    matches!(app.status, AppStatus::Thinking | AppStatus::Running) || app.turn.is_compacting
 }
 
 pub(crate) fn request_status_snapshot_refresh(app: &mut App) {

--- a/src/app/session_runtime.rs
+++ b/src/app/session_runtime.rs
@@ -13,10 +13,10 @@ pub(crate) enum RuntimeReloadRequestOutcome {
 }
 
 pub(crate) fn request_runtime_reload(app: &mut App) -> RuntimeReloadRequestOutcome {
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         return RuntimeReloadRequestOutcome::Unavailable;
     };
-    let Some(ref sid) = app.session_id else {
+    let Some(ref sid) = app.session_runtime.session_id else {
         return RuntimeReloadRequestOutcome::Unavailable;
     };
     let session_id = sid.to_string();
@@ -50,25 +50,25 @@ pub(crate) fn request_context_usage_refresh(app: &mut App) {
 }
 
 fn request_context_usage_refresh_at(app: &mut App, now: Instant) {
-    if app.session_usage.context_usage_in_flight {
-        app.session_usage.context_usage_last_requested_at = Some(now);
-        app.session_usage.context_usage_refresh_pending = true;
+    if app.session_runtime.session_usage.context_usage_in_flight {
+        app.session_runtime.session_usage.context_usage_last_requested_at = Some(now);
+        app.session_runtime.session_usage.context_usage_refresh_pending = true;
         return;
     }
 
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         clear_context_usage_refresh_state(app);
         return;
     };
-    let Some(ref sid) = app.session_id else {
+    let Some(ref sid) = app.session_runtime.session_id else {
         clear_context_usage_refresh_state(app);
         return;
     };
 
     let session_id = sid.to_string();
-    app.session_usage.context_usage_last_requested_at = Some(now);
-    app.session_usage.context_usage_in_flight = true;
-    app.session_usage.context_usage_refresh_pending = false;
+    app.session_runtime.session_usage.context_usage_last_requested_at = Some(now);
+    app.session_runtime.session_usage.context_usage_in_flight = true;
+    app.session_runtime.session_usage.context_usage_refresh_pending = false;
     match conn.get_context_usage(session_id.clone()) {
         Ok(()) => tracing::debug!(
             target: crate::logging::targets::APP_SESSION,
@@ -78,7 +78,7 @@ fn request_context_usage_refresh_at(app: &mut App, now: Instant) {
             session_id = %session_id,
         ),
         Err(error) => {
-            app.session_usage.context_usage_in_flight = false;
+            app.session_runtime.session_usage.context_usage_in_flight = false;
             tracing::warn!(
                 target: crate::logging::targets::APP_SESSION,
                 event_name = "context_usage_request_failed",
@@ -95,18 +95,19 @@ pub(crate) fn tick_context_usage_refresh(app: &mut App, now: Instant) {
     if !context_usage_refresh_is_active(app) {
         return;
     }
-    if app.conn.is_none() || app.session_id.is_none() {
+    if app.session_runtime.conn.is_none() || app.session_runtime.session_id.is_none() {
         clear_context_usage_refresh_state(app);
         return;
     }
-    if app.session_usage.context_usage_in_flight {
+    if app.session_runtime.session_usage.context_usage_in_flight {
         return;
     }
 
-    let refresh_due =
-        app.session_usage.context_usage_last_requested_at.is_none_or(|last_requested| {
+    let refresh_due = app.session_runtime.session_usage.context_usage_last_requested_at.is_none_or(
+        |last_requested| {
             now.saturating_duration_since(last_requested) >= CONTEXT_USAGE_REFRESH_INTERVAL
-        });
+        },
+    );
     if refresh_due {
         request_context_usage_refresh_at(app, now);
     }
@@ -117,10 +118,10 @@ fn context_usage_refresh_is_active(app: &App) -> bool {
 }
 
 pub(crate) fn request_status_snapshot_refresh(app: &mut App) {
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         return;
     };
-    let Some(ref sid) = app.session_id else {
+    let Some(ref sid) = app.session_runtime.session_id else {
         return;
     };
 
@@ -145,18 +146,19 @@ pub(crate) fn request_status_snapshot_refresh(app: &mut App) {
 }
 
 pub(crate) fn apply_context_usage_snapshot(app: &mut App, percentage: Option<u8>) {
-    app.session_usage.context_usage_percent = percentage;
-    app.session_usage.context_usage_in_flight = false;
-    let refresh_pending = std::mem::take(&mut app.session_usage.context_usage_refresh_pending);
+    app.session_runtime.session_usage.context_usage_percent = percentage;
+    app.session_runtime.session_usage.context_usage_in_flight = false;
+    let refresh_pending =
+        std::mem::take(&mut app.session_runtime.session_usage.context_usage_refresh_pending);
     if refresh_pending {
         request_context_usage_refresh(app);
     }
 }
 
 fn clear_context_usage_refresh_state(app: &mut App) {
-    app.session_usage.context_usage_in_flight = false;
-    app.session_usage.context_usage_refresh_pending = false;
-    app.session_usage.context_usage_last_requested_at = None;
+    app.session_runtime.session_usage.context_usage_in_flight = false;
+    app.session_runtime.session_usage.context_usage_refresh_pending = false;
+    app.session_runtime.session_usage.context_usage_last_requested_at = None;
 }
 
 #[cfg(test)]
@@ -176,8 +178,9 @@ mod tests {
     -> (App, tokio::sync::mpsc::UnboundedReceiver<crate::agent::wire::CommandEnvelope>) {
         let mut app = App::test_default();
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-        app.session_id = Some(model::SessionId::new("session-1"));
+        app.session_runtime.conn =
+            Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+        app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
         (app, rx)
     }
 
@@ -225,8 +228,8 @@ mod tests {
         request_context_usage_refresh(&mut app);
         request_context_usage_refresh(&mut app);
 
-        assert!(app.session_usage.context_usage_in_flight);
-        assert!(app.session_usage.context_usage_refresh_pending);
+        assert!(app.session_runtime.session_usage.context_usage_in_flight);
+        assert!(app.session_runtime.session_usage.context_usage_refresh_pending);
         expect_context_usage_command(&mut rx);
         assert!(rx.try_recv().is_err(), "coalesced refresh should not send twice");
     }
@@ -240,9 +243,9 @@ mod tests {
 
         apply_context_usage_snapshot(&mut app, Some(62));
 
-        assert_eq!(app.session_usage.context_usage_percent, Some(62));
-        assert!(app.session_usage.context_usage_in_flight);
-        assert!(!app.session_usage.context_usage_refresh_pending);
+        assert_eq!(app.session_runtime.session_usage.context_usage_percent, Some(62));
+        assert!(app.session_runtime.session_usage.context_usage_in_flight);
+        assert!(!app.session_runtime.session_usage.context_usage_refresh_pending);
         expect_context_usage_command(&mut rx);
     }
 
@@ -251,7 +254,7 @@ mod tests {
         let (mut app, mut rx) = app_with_connection();
         let started = Instant::now();
         app.status = AppStatus::Thinking;
-        app.session_usage.context_usage_last_requested_at = Some(started);
+        app.session_runtime.session_usage.context_usage_last_requested_at = Some(started);
 
         tick_context_usage_refresh(&mut app, started + just_before_refresh_interval());
 
@@ -266,7 +269,7 @@ mod tests {
 
         tick_context_usage_refresh(&mut app, now);
 
-        assert_eq!(app.session_usage.context_usage_last_requested_at, Some(now));
+        assert_eq!(app.session_runtime.session_usage.context_usage_last_requested_at, Some(now));
         expect_context_usage_command(&mut rx);
     }
 
@@ -276,11 +279,11 @@ mod tests {
         let started = Instant::now();
         let due = started + CONTEXT_USAGE_REFRESH_INTERVAL;
         app.status = AppStatus::Thinking;
-        app.session_usage.context_usage_last_requested_at = Some(started);
+        app.session_runtime.session_usage.context_usage_last_requested_at = Some(started);
 
         tick_context_usage_refresh(&mut app, due);
 
-        assert_eq!(app.session_usage.context_usage_last_requested_at, Some(due));
+        assert_eq!(app.session_runtime.session_usage.context_usage_last_requested_at, Some(due));
         expect_context_usage_command(&mut rx);
     }
 
@@ -290,7 +293,7 @@ mod tests {
         let started = Instant::now();
         let due = started + CONTEXT_USAGE_REFRESH_INTERVAL;
         app.status = AppStatus::Running;
-        app.session_usage.context_usage_last_requested_at = Some(started);
+        app.session_runtime.session_usage.context_usage_last_requested_at = Some(started);
 
         tick_context_usage_refresh(&mut app, due);
 
@@ -302,7 +305,7 @@ mod tests {
         let (mut app, mut rx) = app_with_connection();
         let started = Instant::now();
         app.status = AppStatus::Ready;
-        app.session_usage.context_usage_last_requested_at = Some(started);
+        app.session_runtime.session_usage.context_usage_last_requested_at = Some(started);
 
         tick_context_usage_refresh(&mut app, started + CONTEXT_USAGE_REFRESH_INTERVAL);
 
@@ -314,13 +317,13 @@ mod tests {
         let (mut app, mut rx) = app_with_connection();
         let started = Instant::now();
         app.status = AppStatus::Running;
-        app.session_usage.context_usage_in_flight = true;
-        app.session_usage.context_usage_last_requested_at = Some(started);
+        app.session_runtime.session_usage.context_usage_in_flight = true;
+        app.session_runtime.session_usage.context_usage_last_requested_at = Some(started);
 
         tick_context_usage_refresh(&mut app, started + CONTEXT_USAGE_REFRESH_INTERVAL);
 
         assert!(rx.try_recv().is_err(), "in-flight refresh should not send another command");
-        assert!(!app.session_usage.context_usage_refresh_pending);
+        assert!(!app.session_runtime.session_usage.context_usage_refresh_pending);
     }
 
     #[test]

--- a/src/app/slash/candidates.rs
+++ b/src/app/slash/candidates.rs
@@ -148,7 +148,8 @@ pub(super) fn detect_slash_at_cursor(
 }
 
 fn advertised_commands(app: &App) -> Vec<String> {
-    app.available_commands
+    app.sdk_inventory
+        .available_commands
         .iter()
         .map(|cmd| normalize_slash_name(&cmd.name))
         .filter(|name| command_spec(name).is_none())
@@ -162,7 +163,10 @@ pub(super) fn find_advertised_command<'a>(
     if command_spec(command_name).is_some() {
         return None;
     }
-    app.available_commands.iter().find(|cmd| normalize_slash_name(&cmd.name) == command_name)
+    app.sdk_inventory
+        .available_commands
+        .iter()
+        .find(|cmd| normalize_slash_name(&cmd.name) == command_name)
 }
 
 fn is_builtin_variable_input_command(command_name: &str) -> bool {
@@ -205,7 +209,7 @@ pub(super) fn supported_command_candidates(app: &App) -> Vec<SlashCandidate> {
         by_name.insert(spec.name.to_owned(), spec.short_description.to_owned());
     }
 
-    for cmd in &app.available_commands {
+    for cmd in &app.sdk_inventory.available_commands {
         let name = normalize_slash_name(&cmd.name);
         if command_spec(&name).is_some() {
             continue;
@@ -305,13 +309,13 @@ fn effort_argument_candidates(app: &App) -> Vec<SlashCandidate> {
 }
 
 fn agent_argument_candidates(app: &App) -> Vec<SlashCandidate> {
-    let mut candidates = Vec::with_capacity(app.available_agents.len() + 1);
+    let mut candidates = Vec::with_capacity(app.sdk_inventory.available_agents.len() + 1);
     candidates.push(SlashCandidate {
         insert_value: "reset".to_owned(),
         primary: "reset".to_owned(),
         secondary: Some("Clear active agent".to_owned()),
     });
-    candidates.extend(app.available_agents.iter().map(|agent| {
+    candidates.extend(app.sdk_inventory.available_agents.iter().map(|agent| {
         let description = agent.description.trim();
         let model = agent.model.as_deref().map(str::trim).filter(|model| !model.is_empty());
         let secondary = match (description.is_empty(), model) {
@@ -398,8 +402,11 @@ pub(super) fn argument_candidates(
             if arg_index == 1 {
                 return rewind_restore_mode_candidates();
             }
-            if app.session_runtime.session_id.as_ref() == app.rewind_targets_session_id.as_ref() {
-                app.rewind_targets
+            if app.session_runtime.session_id.as_ref()
+                == app.sdk_inventory.rewind_targets_session_id.as_ref()
+            {
+                app.sdk_inventory
+                    .rewind_targets
                     .iter()
                     .map(|target| SlashCandidate {
                         insert_value: target.uuid.clone(),
@@ -427,6 +434,7 @@ pub(super) fn argument_candidates(
             })
             .unwrap_or_default(),
         "/model" => app
+            .sdk_inventory
             .available_models
             .iter()
             .map(|model| SlashCandidate {
@@ -460,7 +468,7 @@ fn rewind_restore_mode_candidates() -> Vec<SlashCandidate> {
 }
 
 fn rewind_placeholder(app: &App, query: &str) -> String {
-    if app.rewind_targets_in_flight {
+    if app.sdk_inventory.rewind_targets_in_flight {
         return "Loading messages".to_owned();
     }
 
@@ -468,14 +476,14 @@ fn rewind_placeholder(app: &App, query: &str) -> String {
         return "Connect to load messages".to_owned();
     };
 
-    if app.rewind_targets_session_id.as_ref() != Some(session_id) {
+    if app.sdk_inventory.rewind_targets_session_id.as_ref() != Some(session_id) {
         if app.session_runtime.conn.is_none() {
             return "Connect to load messages".to_owned();
         }
         return "Loading messages".to_owned();
     }
 
-    if app.rewind_targets.is_empty() || query.trim().is_empty() {
+    if app.sdk_inventory.rewind_targets.is_empty() || query.trim().is_empty() {
         "No previous user messages".to_owned()
     } else {
         "No matching messages".to_owned()

--- a/src/app/slash/candidates.rs
+++ b/src/app/slash/candidates.rs
@@ -283,7 +283,7 @@ fn static_argument_candidates(command_name: &str) -> Vec<SlashCandidate> {
 }
 
 fn effort_argument_candidates(app: &App) -> Vec<SlashCandidate> {
-    let mut levels = match app.current_model.as_ref() {
+    let mut levels = match app.session_runtime.current_model.as_ref() {
         Some(model) if !model.supports_effort => Vec::new(),
         Some(model) if !model.supported_effort_levels.is_empty() => {
             model.supported_effort_levels.clone()
@@ -398,7 +398,7 @@ pub(super) fn argument_candidates(
             if arg_index == 1 {
                 return rewind_restore_mode_candidates();
             }
-            if app.session_id.as_ref() == app.rewind_targets_session_id.as_ref() {
+            if app.session_runtime.session_id.as_ref() == app.rewind_targets_session_id.as_ref() {
                 app.rewind_targets
                     .iter()
                     .map(|target| SlashCandidate {
@@ -412,6 +412,7 @@ pub(super) fn argument_candidates(
             }
         }
         "/mode" => app
+            .session_runtime
             .mode
             .as_ref()
             .map(|mode| {
@@ -463,12 +464,12 @@ fn rewind_placeholder(app: &App, query: &str) -> String {
         return "Loading messages".to_owned();
     }
 
-    let Some(session_id) = app.session_id.as_ref() else {
+    let Some(session_id) = app.session_runtime.session_id.as_ref() else {
         return "Connect to load messages".to_owned();
     };
 
     if app.rewind_targets_session_id.as_ref() != Some(session_id) {
-        if app.conn.is_none() {
+        if app.session_runtime.conn.is_none() {
             return "Connect to load messages".to_owned();
         }
         return "Loading messages".to_owned();

--- a/src/app/slash/executors.rs
+++ b/src/app/slash/executors.rs
@@ -714,8 +714,8 @@ fn handle_model_submit(app: &mut App, args: &[&str]) -> bool {
         return true;
     };
 
-    if !app.available_models.is_empty()
-        && !app.available_models.iter().any(|candidate| candidate.id == model_name)
+    if !app.sdk_inventory.available_models.is_empty()
+        && !app.sdk_inventory.available_models.iter().any(|candidate| candidate.id == model_name)
     {
         push_system_message(app, format!("Unknown model: {model_name}"));
         return true;
@@ -806,8 +806,12 @@ fn handle_agent_submit(app: &mut App, args: &[&str]) -> bool {
     let agent = if requested_agent == "reset" {
         None
     } else {
-        if !app.available_agents.is_empty()
-            && !app.available_agents.iter().any(|candidate| candidate.name == requested_agent)
+        if !app.sdk_inventory.available_agents.is_empty()
+            && !app
+                .sdk_inventory
+                .available_agents
+                .iter()
+                .any(|candidate| candidate.name == requested_agent)
         {
             push_system_message(app, format!("Unknown agent: {requested_agent}"));
             return true;
@@ -898,7 +902,9 @@ fn handle_rewind_submit(app: &mut App, args: &[&str]) -> bool {
         push_system_message(app, usage(AppSlashCommand::Rewind));
         return true;
     };
-    let Some(target) = app.rewind_targets.iter().find(|target| target.uuid == target_uuid) else {
+    let Some(target) =
+        app.sdk_inventory.rewind_targets.iter().find(|target| target.uuid == target_uuid)
+    else {
         push_system_message(app, format!("Unknown rewind target: {target_uuid}"));
         return true;
     };
@@ -971,10 +977,11 @@ fn build_docs_mode_markdown(app: &App) -> String {
 }
 
 fn build_docs_models_markdown(app: &App) -> String {
-    let rows = if app.available_models.is_empty() {
+    let rows = if app.sdk_inventory.available_models.is_empty() {
         vec![("Unavailable".to_owned(), "Connect to load advertised models.".to_owned())]
     } else {
-        app.available_models
+        app.sdk_inventory
+            .available_models
             .iter()
             .map(|model| {
                 let name = if model.display_name.trim().is_empty() {

--- a/src/app/slash/executors.rs
+++ b/src/app/slash/executors.rs
@@ -328,7 +328,7 @@ fn handle_compact_submit(app: &mut App, args: &[&str]) -> bool {
         return true;
     }
 
-    app.is_compacting = true;
+    app.turn.is_compacting = true;
     false
 }
 

--- a/src/app/slash/executors.rs
+++ b/src/app/slash/executors.rs
@@ -466,7 +466,7 @@ fn handle_login_submit(app: &mut App, args: &[&str]) -> bool {
     set_command_pending(app, "Authenticating...", None);
 
     let tx = app.event_tx.clone();
-    let conn = app.conn.clone();
+    let conn = app.session_runtime.conn.clone();
     tokio::task::spawn_local(async move {
         tracing::debug!(
             target: crate::logging::targets::APP_AUTH,
@@ -672,7 +672,7 @@ fn handle_mode_submit(app: &mut App, args: &[&str]) -> bool {
         return true;
     };
 
-    if let Some(ref mode) = app.mode
+    if let Some(ref mode) = app.session_runtime.mode
         && !mode.available_modes.iter().any(|m| m.id == requested_mode)
     {
         push_system_message(app, format!("Unknown mode: {requested_mode}"));
@@ -759,7 +759,7 @@ fn handle_effort_submit(app: &mut App, args: &[&str]) -> bool {
         return true;
     };
 
-    if app.current_model.as_ref().is_some_and(|model| !model.supports_effort) {
+    if app.session_runtime.current_model.as_ref().is_some_and(|model| !model.supports_effort) {
         push_system_message(app, "Cannot switch effort: current model does not support effort.");
         return true;
     }
@@ -938,7 +938,7 @@ fn docs_usage() -> &'static str {
 }
 
 fn build_docs_mode_markdown(app: &App) -> String {
-    let rows = app.mode.as_ref().map_or_else(
+    let rows = app.session_runtime.mode.as_ref().map_or_else(
         || vec![("Unavailable".to_owned(), "Connect to load the current session mode.".to_owned())],
         |mode| {
             let mut rows: Vec<(String, String)> = mode

--- a/src/app/slash/mod.rs
+++ b/src/app/slash/mod.rs
@@ -139,8 +139,8 @@ fn require_active_session(
 /// Block the input field while a slash command is in flight.
 fn set_command_pending(app: &mut App, label: &str, ack: Option<super::PendingCommandAck>) {
     app.status = AppStatus::CommandPending;
-    app.pending_command_label = Some(label.to_owned());
-    app.pending_command_ack = ack;
+    app.turn.pending_command_label = Some(label.to_owned());
+    app.turn.pending_command_ack = ack;
 }
 
 #[cfg(test)]

--- a/src/app/slash/mod.rs
+++ b/src/app/slash/mod.rs
@@ -116,7 +116,7 @@ fn require_connection(
     app: &mut App,
     not_connected_msg: &'static str,
 ) -> Option<Rc<crate::agent::client::AgentConnection>> {
-    let Some(conn) = app.conn.as_ref() else {
+    let Some(conn) = app.session_runtime.conn.as_ref() else {
         push_system_message(app, not_connected_msg);
         return None;
     };
@@ -129,7 +129,7 @@ fn require_active_session(
     no_session_msg: &'static str,
 ) -> Option<(Rc<crate::agent::client::AgentConnection>, model::SessionId)> {
     let conn = require_connection(app, not_connected_msg)?;
-    let Some(session_id) = app.session_id.clone() else {
+    let Some(session_id) = app.session_runtime.session_id.clone() else {
         push_system_message(app, no_session_msg);
         return None;
     };

--- a/src/app/slash/navigation.rs
+++ b/src/app/slash/navigation.rs
@@ -69,13 +69,13 @@ fn request_rewind_targets_for_active_argument(app: &mut App) {
     if command != "/rewind" || arg_index != 0 || app.rewind_targets_in_flight {
         return;
     }
-    let Some(session_id) = app.session_id.clone() else {
+    let Some(session_id) = app.session_runtime.session_id.clone() else {
         return;
     };
     if app.rewind_targets_session_id.as_ref() == Some(&session_id) {
         return;
     }
-    let Some(conn) = app.conn.clone() else {
+    let Some(conn) = app.session_runtime.conn.clone() else {
         return;
     };
     let session_id_text = session_id.to_string();

--- a/src/app/slash/navigation.rs
+++ b/src/app/slash/navigation.rs
@@ -66,24 +66,24 @@ fn request_rewind_targets_for_active_argument(app: &mut App) {
     let SlashContext::Argument { command, arg_index, .. } = detection.context else {
         return;
     };
-    if command != "/rewind" || arg_index != 0 || app.rewind_targets_in_flight {
+    if command != "/rewind" || arg_index != 0 || app.sdk_inventory.rewind_targets_in_flight {
         return;
     }
     let Some(session_id) = app.session_runtime.session_id.clone() else {
         return;
     };
-    if app.rewind_targets_session_id.as_ref() == Some(&session_id) {
+    if app.sdk_inventory.rewind_targets_session_id.as_ref() == Some(&session_id) {
         return;
     }
     let Some(conn) = app.session_runtime.conn.clone() else {
         return;
     };
     let session_id_text = session_id.to_string();
-    app.rewind_targets_in_flight = true;
-    app.rewind_targets.clear();
-    app.rewind_targets_session_id = None;
+    app.sdk_inventory.rewind_targets_in_flight = true;
+    app.sdk_inventory.rewind_targets.clear();
+    app.sdk_inventory.rewind_targets_session_id = None;
     if let Err(err) = conn.get_rewind_targets(session_id_text.clone()) {
-        app.rewind_targets_in_flight = false;
+        app.sdk_inventory.rewind_targets_in_flight = false;
         tracing::warn!(
             target: crate::logging::targets::APP_SESSION,
             event_name = "rewind_targets_request_failed",

--- a/src/app/slash/tests.rs
+++ b/src/app/slash/tests.rs
@@ -597,7 +597,7 @@ fn detect_slash_argument_context_after_first_space() {
 #[test]
 fn mode_argument_candidates_are_dynamic() {
     let mut app = App::test_default();
-    app.mode = Some(super::super::ModeState {
+    app.session_runtime.mode = Some(super::super::ModeState {
         current_mode_id: "plan".to_owned(),
         current_mode_name: "Plan".to_owned(),
         available_modes: vec![
@@ -737,7 +737,7 @@ fn agent_argument_candidates_filter_by_query() {
 fn rewind_argument_candidates_use_cached_targets() {
     let mut app = App::test_default();
     let session_id = model::SessionId::new("session-1");
-    app.session_id = Some(session_id.clone());
+    app.session_runtime.session_id = Some(session_id.clone());
     app.rewind_targets_session_id = Some(session_id);
     app.rewind_targets = vec![
         model::RewindTarget {
@@ -778,7 +778,7 @@ fn rewind_argument_candidates_use_cached_targets() {
 #[test]
 fn rewind_argument_candidates_hide_stale_targets() {
     let mut app = App::test_default();
-    app.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
     app.rewind_targets_session_id = Some(model::SessionId::new("old-session"));
     app.rewind_targets = vec![model::RewindTarget {
         uuid: "user-1".to_owned(),
@@ -797,8 +797,9 @@ fn rewind_argument_candidates_hide_stale_targets() {
 fn rewind_argument_context_requests_targets_when_cache_is_stale() {
     let mut app = App::test_default();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.conn =
+        Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
     app.input.set_text("/rewind ");
     let _ = app.input.set_cursor(0, "/rewind ".chars().count());
 
@@ -817,8 +818,9 @@ fn rewind_argument_context_requests_targets_when_cache_is_stale() {
 fn rewind_argument_context_shows_loading_while_request_is_in_flight() {
     let mut app = App::test_default();
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.conn =
+        Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
     app.input.set_text("/rewind ");
     let _ = app.input.set_cursor(0, "/rewind ".chars().count());
 
@@ -833,7 +835,7 @@ fn rewind_argument_context_shows_loading_while_request_is_in_flight() {
 fn rewind_argument_context_shows_no_previous_messages_when_loaded_empty() {
     let mut app = App::test_default();
     let session_id = model::SessionId::new("session-1");
-    app.session_id = Some(session_id.clone());
+    app.session_runtime.session_id = Some(session_id.clone());
     app.rewind_targets_session_id = Some(session_id);
     app.input.set_text("/rewind ");
     let _ = app.input.set_cursor(0, "/rewind ".chars().count());
@@ -848,7 +850,7 @@ fn rewind_argument_context_shows_no_previous_messages_when_loaded_empty() {
 fn rewind_argument_context_shows_no_matching_messages_for_filtered_empty_result() {
     let mut app = App::test_default();
     let session_id = model::SessionId::new("session-1");
-    app.session_id = Some(session_id.clone());
+    app.session_runtime.session_id = Some(session_id.clone());
     app.rewind_targets_session_id = Some(session_id);
     app.rewind_targets = vec![model::RewindTarget {
         uuid: "user-1".to_owned(),
@@ -869,7 +871,7 @@ fn rewind_argument_context_shows_no_matching_messages_for_filtered_empty_result(
 #[test]
 fn effort_argument_candidates_include_session_only_max() {
     let mut app = App::test_default();
-    app.current_model = Some(
+    app.session_runtime.current_model = Some(
         crate::agent::model::CurrentModel::new("opus", "Opus", "Opus")
             .supports_effort(true)
             .supported_effort_levels(vec![
@@ -895,7 +897,7 @@ fn effort_argument_candidates_include_session_only_max() {
 #[test]
 fn effort_argument_candidates_filter_by_query() {
     let mut app = App::test_default();
-    app.current_model = Some(
+    app.session_runtime.current_model = Some(
         crate::agent::model::CurrentModel::new("opus", "Opus", "Opus")
             .supports_effort(true)
             .supported_effort_levels(crate::agent::model::EffortLevel::ALL.to_vec()),
@@ -1073,7 +1075,7 @@ fn non_variable_command_argument_mode_is_disabled() {
 #[test]
 fn variable_command_argument_mode_stays_active_without_matches() {
     let mut app = App::test_default();
-    app.mode = Some(super::super::ModeState {
+    app.session_runtime.mode = Some(super::super::ModeState {
         current_mode_id: "plan".to_owned(),
         current_mode_name: "Plan".to_owned(),
         available_modes: vec![super::super::ModeInfo {
@@ -1219,8 +1221,9 @@ fn rewind_with_cached_target_requires_connection() {
 fn rewind_with_cached_target_sends_bridge_command() {
     let mut app = App::test_default();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.conn =
+        Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
     app.rewind_targets = vec![model::RewindTarget {
         uuid: "user-1".to_owned(),
         first_text: "first prompt".to_owned(),
@@ -1272,7 +1275,8 @@ async fn resume_sets_command_pending_when_connected() {
         .run_until(async {
             let mut app = App::test_default();
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+            app.session_runtime.conn =
+                Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
 
             let consumed = try_handle_submit(&mut app, "/resume abc-123");
             assert!(consumed);
@@ -1291,9 +1295,10 @@ async fn mode_sets_command_pending_and_mode_update_restores_ready() {
         .run_until(async {
             let mut app = App::test_default();
             let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-            app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-            app.session_id = Some("sess-1".into());
-            app.mode = Some(super::super::ModeState {
+            app.session_runtime.conn =
+                Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+            app.session_runtime.session_id = Some("sess-1".into());
+            app.session_runtime.mode = Some(super::super::ModeState {
                 current_mode_id: "code".to_owned(),
                 current_mode_name: "Code".to_owned(),
                 available_modes: vec![
@@ -1336,9 +1341,10 @@ async fn model_sets_command_pending_and_current_model_ack_updates_model_and_rest
         .run_until(async {
             let mut app = App::test_default();
             let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-            app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-            app.session_id = Some("sess-1".into());
-            app.current_model = Some(
+            app.session_runtime.conn =
+                Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+            app.session_runtime.session_id = Some("sess-1".into());
+            app.session_runtime.current_model = Some(
                 crate::agent::model::CurrentModel::new("old-model", "old-model", "old-model")
                     .authoritative(true),
             );
@@ -1352,7 +1358,7 @@ async fn model_sets_command_pending_and_current_model_ack_updates_model_and_rest
             );
             assert_eq!(app.turn.pending_command_label.as_deref(), Some("Switching model..."));
             assert_eq!(
-                app.current_model.as_ref().map(|model| model.resolved_id.as_str()),
+                app.session_runtime.current_model.as_ref().map(|model| model.resolved_id.as_str()),
                 Some("old-model")
             );
 
@@ -1373,7 +1379,7 @@ async fn model_sets_command_pending_and_current_model_ack_updates_model_and_rest
                 app.status
             );
             assert_eq!(
-                app.current_model.as_ref().map(|model| model.resolved_id.as_str()),
+                app.session_runtime.current_model.as_ref().map(|model| model.resolved_id.as_str()),
                 Some("sonnet")
             );
             assert!(app.turn.pending_command_label.is_none());
@@ -1387,9 +1393,10 @@ async fn effort_sets_command_pending_and_config_option_ack_restores_ready() {
         .run_until(async {
             let mut app = App::test_default();
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-            app.session_id = Some("sess-1".into());
-            app.current_model = Some(
+            app.session_runtime.conn =
+                Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+            app.session_runtime.session_id = Some("sess-1".into());
+            app.session_runtime.current_model = Some(
                 crate::agent::model::CurrentModel::new("opus", "Opus", "Opus")
                     .supports_effort(true)
                     .supported_effort_levels(crate::agent::model::EffortLevel::ALL.to_vec()),
@@ -1427,7 +1434,10 @@ async fn effort_sets_command_pending_and_config_option_ack_restores_ready() {
                 ),
             );
             assert!(matches!(app.status, AppStatus::Ready));
-            assert_eq!(app.config_options.get("effortLevel"), Some(&serde_json::json!("xhigh")));
+            assert_eq!(
+                app.session_runtime.config_options.get("effortLevel"),
+                Some(&serde_json::json!("xhigh"))
+            );
             assert_eq!(
                 app.session_thinking_effort_effective(),
                 crate::agent::model::EffortLevel::XHigh
@@ -1442,9 +1452,10 @@ async fn effort_accepts_session_only_max() {
         .run_until(async {
             let mut app = App::test_default();
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-            app.session_id = Some("sess-1".into());
-            app.current_model = Some(
+            app.session_runtime.conn =
+                Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+            app.session_runtime.session_id = Some("sess-1".into());
+            app.session_runtime.current_model = Some(
                 crate::agent::model::CurrentModel::new("opus", "Opus", "Opus")
                     .supports_effort(true)
                     .supported_effort_levels(vec![
@@ -1476,8 +1487,9 @@ async fn agent_sets_command_pending_and_config_option_ack_restores_ready() {
         .run_until(async {
             let mut app = App::test_default();
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-            app.session_id = Some("sess-1".into());
+            app.session_runtime.conn =
+                Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+            app.session_runtime.session_id = Some("sess-1".into());
             app.available_agents =
                 vec![crate::agent::model::AvailableAgent::new("reviewer", "Review code")];
 
@@ -1513,7 +1525,10 @@ async fn agent_sets_command_pending_and_config_option_ack_restores_ready() {
                 ),
             );
             assert!(matches!(app.status, AppStatus::Ready));
-            assert_eq!(app.config_options.get("agent"), Some(&serde_json::json!("reviewer")));
+            assert_eq!(
+                app.session_runtime.config_options.get("agent"),
+                Some(&serde_json::json!("reviewer"))
+            );
         })
         .await;
 }
@@ -1524,8 +1539,9 @@ async fn agent_reset_sends_null_agent() {
         .run_until(async {
             let mut app = App::test_default();
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-            app.session_id = Some("sess-1".into());
+            app.session_runtime.conn =
+                Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+            app.session_runtime.session_id = Some("sess-1".into());
 
             let consumed = try_handle_submit(&mut app, "/agent reset");
             assert!(consumed);
@@ -1549,8 +1565,9 @@ async fn agent_allows_unadvertised_name_when_agent_catalog_is_empty() {
         .run_until(async {
             let mut app = App::test_default();
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-            app.session_id = Some("sess-1".into());
+            app.session_runtime.conn =
+                Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+            app.session_runtime.session_id = Some("sess-1".into());
 
             let consumed = try_handle_submit(&mut app, "/agent custom-agent");
             assert!(consumed);
@@ -1572,8 +1589,9 @@ async fn agent_allows_unadvertised_name_when_agent_catalog_is_empty() {
 fn agent_rejects_unknown_when_available_agents_are_populated() {
     let mut app = App::test_default();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some("sess-1".into());
+    app.session_runtime.conn =
+        Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some("sess-1".into());
     app.available_agents =
         vec![crate::agent::model::AvailableAgent::new("reviewer", "Review code")];
 
@@ -1633,9 +1651,10 @@ fn effort_invalid_arguments_return_usage() {
 fn effort_rejects_models_without_effort_support() {
     let mut app = App::test_default();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some("sess-1".into());
-    app.current_model = Some(
+    app.session_runtime.conn =
+        Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some("sess-1".into());
+    app.session_runtime.current_model = Some(
         crate::agent::model::CurrentModel::new("haiku", "Haiku", "Haiku").supports_effort(false),
     );
 
@@ -1658,7 +1677,8 @@ async fn new_session_sets_command_pending() {
         .run_until(async {
             let mut app = App::test_default();
             let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-            app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+            app.session_runtime.conn =
+                Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
 
             let consumed = try_handle_submit(&mut app, "/new-session");
             assert!(consumed);
@@ -1693,8 +1713,9 @@ fn compact_without_connection_is_handled_locally() {
 fn compact_with_active_session_sets_compacting_without_success_pending() {
     let mut app = App::test_default();
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.conn =
+        Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
 
     let consumed = try_handle_submit(&mut app, "/compact");
     assert!(!consumed);

--- a/src/app/slash/tests.rs
+++ b/src/app/slash/tests.rs
@@ -33,7 +33,7 @@ fn unsupported_command_is_handled_locally() {
 #[test]
 fn advertised_command_is_forwarded() {
     let mut app = App::test_default();
-    app.available_commands =
+    app.sdk_inventory.available_commands =
         vec![model::AvailableCommand::new("/remote-command", "Remote command")];
     let consumed = try_handle_submit(&mut app, "/remote-command");
     assert!(!consumed);
@@ -85,7 +85,7 @@ fn app_config_shadows_advertised_config_command() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut app = App::test_default();
     app.settings_home_override = Some(dir.path().to_path_buf());
-    app.available_commands =
+    app.sdk_inventory.available_commands =
         vec![model::AvailableCommand::new("/config", "SDK config command").input_hint("<setting>")];
 
     let consumed = try_handle_submit(&mut app, "/config");
@@ -100,7 +100,7 @@ fn app_config_shadows_advertised_config_command() {
 #[test]
 fn app_config_candidate_ignores_advertised_config_metadata() {
     let mut app = App::test_default();
-    app.available_commands =
+    app.sdk_inventory.available_commands =
         vec![model::AvailableCommand::new("/config", "SDK config command").input_hint("<setting>")];
     app.input.set_text("/config");
     let _ = app.input.set_cursor(0, "/config".chars().count());
@@ -116,7 +116,7 @@ fn app_config_candidate_ignores_advertised_config_metadata() {
 #[test]
 fn app_config_does_not_enter_advertised_argument_mode() {
     let mut app = App::test_default();
-    app.available_commands =
+    app.sdk_inventory.available_commands =
         vec![model::AvailableCommand::new("/config", "SDK config command").input_hint("<setting>")];
     app.input.set_text("/config ");
     let _ = app.input.set_cursor(0, "/config ".chars().count());
@@ -616,7 +616,7 @@ fn mode_argument_candidates_are_dynamic() {
 #[test]
 fn model_argument_candidates_are_dynamic() {
     let mut app = App::test_default();
-    app.available_models = vec![
+    app.sdk_inventory.available_models = vec![
         crate::agent::model::AvailableModel::new("sonnet", "Claude Sonnet")
             .description("Balanced coding model"),
         crate::agent::model::AvailableModel::new("opus", "Claude Opus"),
@@ -631,7 +631,7 @@ fn model_argument_candidates_are_dynamic() {
 #[test]
 fn model_argument_candidates_include_sdk_default_option() {
     let mut app = App::test_default();
-    app.available_models = vec![
+    app.sdk_inventory.available_models = vec![
         crate::agent::model::AvailableModel::new("default", "Default")
             .description("Default (recommended)"),
         crate::agent::model::AvailableModel::new("sonnet", "Claude Sonnet"),
@@ -655,7 +655,7 @@ fn model_argument_candidates_rewrite_opus_secondary_from_project_pin() {
             "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-5-20251101"
         }
     });
-    app.available_models = vec![
+    app.sdk_inventory.available_models = vec![
         crate::agent::model::AvailableModel::new("opus", "Opus")
             .description("Opus 4.7 · Most capable for complex work"),
     ];
@@ -673,7 +673,7 @@ fn model_argument_candidates_rewrite_opus_secondary_from_project_pin() {
 #[test]
 fn model_argument_candidates_keep_sdk_opus_description_when_unpinned() {
     let mut app = App::test_default();
-    app.available_models = vec![
+    app.sdk_inventory.available_models = vec![
         crate::agent::model::AvailableModel::new("opus", "Opus")
             .description("Opus 4.7 · Most capable for complex work"),
     ];
@@ -691,7 +691,7 @@ fn model_argument_candidates_keep_sdk_opus_description_when_unpinned() {
 #[test]
 fn agent_argument_candidates_include_reset_and_available_agents() {
     let mut app = App::test_default();
-    app.available_agents = vec![
+    app.sdk_inventory.available_agents = vec![
         crate::agent::model::AvailableAgent::new("reviewer", "Review code").model("claude-opus"),
         crate::agent::model::AvailableAgent::new("planner", "Plan work"),
     ];
@@ -713,7 +713,7 @@ fn agent_argument_candidates_include_reset_and_available_agents() {
 #[test]
 fn agent_argument_candidates_filter_by_query() {
     let mut app = App::test_default();
-    app.available_agents = vec![
+    app.sdk_inventory.available_agents = vec![
         crate::agent::model::AvailableAgent::new("reviewer", "Review code"),
         crate::agent::model::AvailableAgent::new("planner", "Plan work"),
     ];
@@ -738,8 +738,8 @@ fn rewind_argument_candidates_use_cached_targets() {
     let mut app = App::test_default();
     let session_id = model::SessionId::new("session-1");
     app.session_runtime.session_id = Some(session_id.clone());
-    app.rewind_targets_session_id = Some(session_id);
-    app.rewind_targets = vec![
+    app.sdk_inventory.rewind_targets_session_id = Some(session_id);
+    app.sdk_inventory.rewind_targets = vec![
         model::RewindTarget {
             uuid: "user-1".to_owned(),
             first_text: "first prompt".to_owned(),
@@ -779,8 +779,8 @@ fn rewind_argument_candidates_use_cached_targets() {
 fn rewind_argument_candidates_hide_stale_targets() {
     let mut app = App::test_default();
     app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
-    app.rewind_targets_session_id = Some(model::SessionId::new("old-session"));
-    app.rewind_targets = vec![model::RewindTarget {
+    app.sdk_inventory.rewind_targets_session_id = Some(model::SessionId::new("old-session"));
+    app.sdk_inventory.rewind_targets = vec![model::RewindTarget {
         uuid: "user-1".to_owned(),
         first_text: "first prompt".to_owned(),
         input_text: "first prompt".to_owned(),
@@ -805,7 +805,7 @@ fn rewind_argument_context_requests_targets_when_cache_is_stale() {
 
     sync_with_cursor(&mut app);
 
-    assert!(app.rewind_targets_in_flight);
+    assert!(app.sdk_inventory.rewind_targets_in_flight);
     let envelope = rx.try_recv().expect("rewind target request");
     assert!(matches!(
         envelope.command,
@@ -836,7 +836,7 @@ fn rewind_argument_context_shows_no_previous_messages_when_loaded_empty() {
     let mut app = App::test_default();
     let session_id = model::SessionId::new("session-1");
     app.session_runtime.session_id = Some(session_id.clone());
-    app.rewind_targets_session_id = Some(session_id);
+    app.sdk_inventory.rewind_targets_session_id = Some(session_id);
     app.input.set_text("/rewind ");
     let _ = app.input.set_cursor(0, "/rewind ".chars().count());
 
@@ -851,8 +851,8 @@ fn rewind_argument_context_shows_no_matching_messages_for_filtered_empty_result(
     let mut app = App::test_default();
     let session_id = model::SessionId::new("session-1");
     app.session_runtime.session_id = Some(session_id.clone());
-    app.rewind_targets_session_id = Some(session_id);
-    app.rewind_targets = vec![model::RewindTarget {
+    app.sdk_inventory.rewind_targets_session_id = Some(session_id);
+    app.sdk_inventory.rewind_targets = vec![model::RewindTarget {
         uuid: "user-1".to_owned(),
         first_text: "first prompt".to_owned(),
         input_text: "first prompt".to_owned(),
@@ -946,7 +946,7 @@ fn docs_without_args_returns_usage() {
 #[test]
 fn docs_models_show_advertised_effort_levels() {
     let mut app = App::test_default();
-    app.available_models = vec![
+    app.sdk_inventory.available_models = vec![
         crate::agent::model::AvailableModel::new("sonnet", "Claude Sonnet")
             .description("Balanced model")
             .supports_effort(true)
@@ -975,7 +975,8 @@ fn docs_models_show_advertised_effort_levels() {
 #[test]
 fn docs_commands_reuse_help_rows() {
     let mut app = App::test_default();
-    app.available_commands = vec![crate::agent::model::AvailableCommand::new("/help", "Open help")];
+    app.sdk_inventory.available_commands =
+        vec![crate::agent::model::AvailableCommand::new("/help", "Open help")];
 
     let consumed = try_handle_submit(&mut app, "/docs commands");
 
@@ -1002,7 +1003,7 @@ fn docs_commands_reuse_help_rows() {
 #[test]
 fn docs_commands_do_not_show_advertised_command_shadowed_by_app_command() {
     let mut app = App::test_default();
-    app.available_commands = vec![
+    app.sdk_inventory.available_commands = vec![
         crate::agent::model::AvailableCommand::new("/config", "SDK config command")
             .input_hint("<setting>"),
     ];
@@ -1123,7 +1124,8 @@ async fn login_is_handled_as_builtin_even_when_advertised() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let mut app = App::test_default();
-            app.available_commands = vec![model::AvailableCommand::new("/login", "Login")];
+            app.sdk_inventory.available_commands =
+                vec![model::AvailableCommand::new("/login", "Login")];
 
             let consumed = try_handle_submit(&mut app, "/login");
             assert!(consumed, "/login should be handled locally even when SDK advertises it");
@@ -1196,7 +1198,7 @@ fn rewind_with_missing_target_returns_usage() {
 #[test]
 fn rewind_with_cached_target_requires_connection() {
     let mut app = App::test_default();
-    app.rewind_targets = vec![model::RewindTarget {
+    app.sdk_inventory.rewind_targets = vec![model::RewindTarget {
         uuid: "user-1".to_owned(),
         first_text: "first prompt".to_owned(),
         input_text: "first prompt".to_owned(),
@@ -1224,7 +1226,7 @@ fn rewind_with_cached_target_sends_bridge_command() {
     app.session_runtime.conn =
         Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
     app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
-    app.rewind_targets = vec![model::RewindTarget {
+    app.sdk_inventory.rewind_targets = vec![model::RewindTarget {
         uuid: "user-1".to_owned(),
         first_text: "first prompt".to_owned(),
         input_text: "first prompt".to_owned(),
@@ -1490,7 +1492,7 @@ async fn agent_sets_command_pending_and_config_option_ack_restores_ready() {
             app.session_runtime.conn =
                 Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
             app.session_runtime.session_id = Some("sess-1".into());
-            app.available_agents =
+            app.sdk_inventory.available_agents =
                 vec![crate::agent::model::AvailableAgent::new("reviewer", "Review code")];
 
             let consumed = try_handle_submit(&mut app, "/agent reviewer");
@@ -1592,7 +1594,7 @@ fn agent_rejects_unknown_when_available_agents_are_populated() {
     app.session_runtime.conn =
         Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
     app.session_runtime.session_id = Some("sess-1".into());
-    app.available_agents =
+    app.sdk_inventory.available_agents =
         vec![crate::agent::model::AvailableAgent::new("reviewer", "Review code")];
 
     let consumed = try_handle_submit(&mut app, "/agent planner");

--- a/src/app/slash/tests.rs
+++ b/src/app/slash/tests.rs
@@ -24,7 +24,7 @@ fn unsupported_command_is_handled_locally() {
     let mut app = App::test_default();
     let consumed = try_handle_submit(&mut app, "/definitely-unknown");
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system message");
     };
     assert!(matches!(last.role, MessageRole::System(_)));
@@ -147,7 +147,7 @@ fn config_with_extra_args_returns_usage_message() {
     let consumed = try_handle_submit(&mut app, "/config extra");
 
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -169,7 +169,7 @@ fn one_m_context_disable_persists_folder_local_override_and_hints_new_session() 
     let settings_path = dir.path().join(".claude").join("settings.local.json");
     let raw = std::fs::read_to_string(settings_path).expect("read settings.local.json");
     assert!(raw.contains("\"CLAUDE_CODE_DISABLE_1M_CONTEXT\": \"1\""));
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected success message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -199,7 +199,7 @@ fn one_m_context_enable_removes_folder_local_override_and_hints_new_session() {
     let raw = std::fs::read_to_string(local_settings).expect("read settings.local.json");
     assert!(!raw.contains("CLAUDE_CODE_DISABLE_1M_CONTEXT"));
     assert!(raw.contains("\"KEEP_ME\": \"yes\""));
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected success message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -226,7 +226,7 @@ fn one_m_context_status_reports_disabled_folder_local_override() {
     let consumed = try_handle_submit(&mut app, "/1m-context status");
 
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected status message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -278,7 +278,7 @@ fn opus_version_45_persists_folder_local_override_and_hints_new_session() {
     let settings_path = dir.path().join(".claude").join("settings.local.json");
     let raw = std::fs::read_to_string(settings_path).expect("read settings.local.json");
     assert!(raw.contains("\"ANTHROPIC_DEFAULT_OPUS_MODEL\": \"claude-opus-4-5-20251101\""));
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected success message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -353,7 +353,7 @@ fn opus_version_default_removes_folder_local_override_and_preserves_neighbor_key
     let raw = std::fs::read_to_string(local_settings).expect("read settings.local.json");
     assert!(!raw.contains("ANTHROPIC_DEFAULT_OPUS_MODEL"));
     assert!(raw.contains("\"KEEP_ME\": \"yes\""));
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected success message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -380,7 +380,7 @@ fn opus_version_status_reports_known_folder_local_override() {
     let consumed = try_handle_submit(&mut app, "/opus-version status");
 
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected status message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -400,7 +400,7 @@ fn opus_version_status_reports_default_when_unset() {
     let consumed = try_handle_submit(&mut app, "/opus-version status");
 
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected status message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -415,7 +415,7 @@ fn opus_version_with_missing_arg_returns_usage_message() {
 
     let consumed = try_handle_submit(&mut app, "/opus-version");
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -430,7 +430,7 @@ fn opus_version_with_extra_args_returns_usage_message() {
 
     let consumed = try_handle_submit(&mut app, "/opus-version 4.7 extra");
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -445,7 +445,7 @@ fn opus_version_with_unknown_arg_returns_usage_message() {
 
     let consumed = try_handle_submit(&mut app, "/opus-version 9.9");
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -462,7 +462,7 @@ fn opus_version_requires_trusted_project_for_mutation() {
     let consumed = try_handle_submit(&mut app, "/opus-version 4.7");
 
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected error message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -510,7 +510,7 @@ fn mcp_with_extra_args_returns_usage() {
     let consumed = try_handle_submit(&mut app, "/mcp extra");
 
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -573,7 +573,7 @@ fn login_rejects_extra_args() {
     let mut app = App::test_default();
     let consumed = try_handle_submit(&mut app, "/login somearg");
     assert!(consumed);
-    let last = app.messages.last().expect("expected system message");
+    let last = app.transcript.messages.last().expect("expected system message");
     assert!(matches!(last.role, MessageRole::System(_)));
 }
 
@@ -934,7 +934,7 @@ fn docs_without_args_returns_usage() {
     let consumed = try_handle_submit(&mut app, "/docs");
 
     assert!(consumed);
-    let last = app.messages.last().expect("expected system message");
+    let last = app.transcript.messages.last().expect("expected system message");
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
         panic!("expected text block");
     };
@@ -961,7 +961,7 @@ fn docs_models_show_advertised_effort_levels() {
     let consumed = try_handle_submit(&mut app, "/docs models");
 
     assert!(consumed);
-    let last = app.messages.last().expect("expected system message");
+    let last = app.transcript.messages.last().expect("expected system message");
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
         panic!("expected text block");
     };
@@ -978,7 +978,7 @@ fn docs_commands_reuse_help_rows() {
     let consumed = try_handle_submit(&mut app, "/docs commands");
 
     assert!(consumed);
-    let last = app.messages.last().expect("expected system message");
+    let last = app.transcript.messages.last().expect("expected system message");
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
         panic!("expected text block");
     };
@@ -1008,7 +1008,7 @@ fn docs_commands_do_not_show_advertised_command_shadowed_by_app_command() {
     let consumed = try_handle_submit(&mut app, "/docs commands");
 
     assert!(consumed);
-    let last = app.messages.last().expect("expected system message");
+    let last = app.transcript.messages.last().expect("expected system message");
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
         panic!("expected text block");
     };
@@ -1023,7 +1023,7 @@ fn docs_shortcuts_use_live_help_state() {
     let consumed = try_handle_submit(&mut app, "/docs shortcuts");
 
     assert!(consumed);
-    let last = app.messages.last().expect("expected system message");
+    let last = app.transcript.messages.last().expect("expected system message");
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
         panic!("expected text block");
     };
@@ -1039,7 +1039,7 @@ fn docs_with_unknown_topic_returns_usage() {
     let consumed = try_handle_submit(&mut app, "/docs nope");
 
     assert!(consumed);
-    let last = app.messages.last().expect("expected system message");
+    let last = app.transcript.messages.last().expect("expected system message");
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
         panic!("expected text block");
     };
@@ -1054,7 +1054,7 @@ fn docs_with_extra_args_returns_usage() {
     let consumed = try_handle_submit(&mut app, "/docs commands extra");
 
     assert!(consumed);
-    let last = app.messages.last().expect("expected system message");
+    let last = app.transcript.messages.last().expect("expected system message");
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
         panic!("expected text block");
     };
@@ -1135,9 +1135,9 @@ fn new_session_command_is_rendered_as_user_message() {
 
     let consumed = try_handle_submit(&mut app, "/new-session");
     assert!(consumed);
-    assert!(app.messages.len() >= 2);
+    assert!(app.transcript.messages.len() >= 2);
 
-    let Some(first) = app.messages.first() else {
+    let Some(first) = app.transcript.messages.first() else {
         panic!("expected first message");
     };
     assert!(matches!(first.role, MessageRole::User));
@@ -1152,7 +1152,7 @@ fn resume_with_missing_id_returns_usage() {
     let mut app = App::test_default();
     let consumed = try_handle_submit(&mut app, "/resume");
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -1166,7 +1166,7 @@ fn resume_with_extra_args_returns_usage() {
     let mut app = App::test_default();
     let consumed = try_handle_submit(&mut app, "/resume abc-123 extra");
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -1182,7 +1182,7 @@ fn rewind_with_missing_target_returns_usage() {
     let consumed = try_handle_submit(&mut app, "/rewind");
 
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -1205,7 +1205,7 @@ fn rewind_with_cached_target_requires_connection() {
     let consumed = try_handle_submit(&mut app, "/rewind user-1 conversation");
 
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected selection message");
     };
     assert!(matches!(last.role, MessageRole::System(Some(SystemSeverity::Error))));
@@ -1232,7 +1232,7 @@ fn rewind_with_cached_target_sends_bridge_command() {
     let consumed = try_handle_submit(&mut app, "/rewind user-1 conversation");
 
     assert!(consumed);
-    assert_eq!(app.pending_command_label.as_deref(), Some("Rewinding conversation..."));
+    assert_eq!(app.turn.pending_command_label.as_deref(), Some("Rewinding conversation..."));
     let envelope = rx.try_recv().expect("rewind command");
     let crate::agent::wire::BridgeCommand::Rewind {
         session_id,
@@ -1254,9 +1254,9 @@ fn resume_command_is_rendered_as_user_message() {
 
     let consumed = try_handle_submit(&mut app, "/resume abc-123");
     assert!(consumed);
-    assert!(app.messages.len() >= 2);
+    assert!(app.transcript.messages.len() >= 2);
 
-    let Some(first) = app.messages.first() else {
+    let Some(first) = app.transcript.messages.first() else {
         panic!("expected user message");
     };
     assert!(matches!(first.role, MessageRole::User));
@@ -1309,7 +1309,7 @@ async fn mode_sets_command_pending_and_mode_update_restores_ready() {
                 "expected CommandPending, got {:?}",
                 app.status
             );
-            assert_eq!(app.pending_command_label.as_deref(), Some("Switching mode..."));
+            assert_eq!(app.turn.pending_command_label.as_deref(), Some("Switching mode..."));
 
             // Simulate mode-update ack arriving from bridge.
             super::super::events::handle_client_event(
@@ -1325,7 +1325,7 @@ async fn mode_sets_command_pending_and_mode_update_restores_ready() {
                 "expected Ready after CurrentModeUpdate ack, got {:?}",
                 app.status
             );
-            assert!(app.pending_command_label.is_none());
+            assert!(app.turn.pending_command_label.is_none());
         })
         .await;
 }
@@ -1350,7 +1350,7 @@ async fn model_sets_command_pending_and_current_model_ack_updates_model_and_rest
                 "expected CommandPending, got {:?}",
                 app.status
             );
-            assert_eq!(app.pending_command_label.as_deref(), Some("Switching model..."));
+            assert_eq!(app.turn.pending_command_label.as_deref(), Some("Switching model..."));
             assert_eq!(
                 app.current_model.as_ref().map(|model| model.resolved_id.as_str()),
                 Some("old-model")
@@ -1376,7 +1376,7 @@ async fn model_sets_command_pending_and_current_model_ack_updates_model_and_rest
                 app.current_model.as_ref().map(|model| model.resolved_id.as_str()),
                 Some("sonnet")
             );
-            assert!(app.pending_command_label.is_none());
+            assert!(app.turn.pending_command_label.is_none());
         })
         .await;
 }
@@ -1398,9 +1398,9 @@ async fn effort_sets_command_pending_and_config_option_ack_restores_ready() {
             let consumed = try_handle_submit(&mut app, "/effort xhigh");
             assert!(consumed);
             assert!(matches!(app.status, AppStatus::CommandPending));
-            assert_eq!(app.pending_command_label.as_deref(), Some("Switching effort..."));
+            assert_eq!(app.turn.pending_command_label.as_deref(), Some("Switching effort..."));
             assert!(matches!(
-                app.pending_command_ack.as_ref(),
+                app.turn.pending_command_ack.as_ref(),
                 Some(super::super::PendingCommandAck::ConfigOption { option_id })
                     if option_id == "effortLevel"
             ));
@@ -1484,9 +1484,9 @@ async fn agent_sets_command_pending_and_config_option_ack_restores_ready() {
             let consumed = try_handle_submit(&mut app, "/agent reviewer");
             assert!(consumed);
             assert!(matches!(app.status, AppStatus::CommandPending));
-            assert_eq!(app.pending_command_label.as_deref(), Some("Switching agent..."));
+            assert_eq!(app.turn.pending_command_label.as_deref(), Some("Switching agent..."));
             assert!(matches!(
-                app.pending_command_ack.as_ref(),
+                app.turn.pending_command_ack.as_ref(),
                 Some(super::super::PendingCommandAck::ConfigOption { option_id })
                     if option_id == "agent"
             ));
@@ -1582,7 +1582,7 @@ fn agent_rejects_unknown_when_available_agents_are_populated() {
     assert!(consumed);
     assert!(rx.try_recv().is_err());
     assert!(!matches!(app.status, AppStatus::CommandPending));
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -1599,7 +1599,7 @@ fn agent_invalid_arguments_return_usage() {
         let consumed = try_handle_submit(&mut app, input);
 
         assert!(consumed);
-        let Some(last) = app.messages.last() else {
+        let Some(last) = app.transcript.messages.last() else {
             panic!("expected system usage message for {input}");
         };
         let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -1618,7 +1618,7 @@ fn effort_invalid_arguments_return_usage() {
         let consumed = try_handle_submit(&mut app, input);
 
         assert!(consumed);
-        let Some(last) = app.messages.last() else {
+        let Some(last) = app.transcript.messages.last() else {
             panic!("expected system usage message for {input}");
         };
         let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -1643,7 +1643,7 @@ fn effort_rejects_models_without_effort_support() {
 
     assert!(consumed);
     assert!(rx.try_recv().is_err());
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -1667,7 +1667,7 @@ async fn new_session_sets_command_pending() {
                 "expected CommandPending, got {:?}",
                 app.status
             );
-            assert_eq!(app.pending_command_label.as_deref(), Some("Starting new session..."));
+            assert_eq!(app.turn.pending_command_label.as_deref(), Some("Starting new session..."));
         })
         .await;
 }
@@ -1678,8 +1678,8 @@ fn compact_without_connection_is_handled_locally() {
 
     let consumed = try_handle_submit(&mut app, "/compact");
     assert!(consumed);
-    assert!(!app.pending_compact_clear);
-    let Some(last) = app.messages.last() else {
+    assert!(!app.turn.pending_compact_clear);
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system message");
     };
     assert!(matches!(last.role, MessageRole::System(_)));
@@ -1698,14 +1698,14 @@ fn compact_with_active_session_sets_compacting_without_success_pending() {
 
     let consumed = try_handle_submit(&mut app, "/compact");
     assert!(!consumed);
-    assert!(!app.pending_compact_clear);
-    assert!(app.is_compacting);
+    assert!(!app.turn.pending_compact_clear);
+    assert!(app.turn.is_compacting);
 }
 
 #[test]
 fn compact_with_args_returns_usage_message() {
     let mut app = App::test_default();
-    app.messages.push(ChatMessage::new(
+    app.transcript.messages.push(ChatMessage::new(
         MessageRole::User,
         vec![MessageBlock::Text(TextBlock::from_complete("keep"))],
         None,
@@ -1713,8 +1713,8 @@ fn compact_with_args_returns_usage_message() {
 
     let consumed = try_handle_submit(&mut app, "/compact now");
     assert!(consumed);
-    assert!(app.messages.len() >= 2);
-    let Some(last) = app.messages.last() else {
+    assert!(app.transcript.messages.len() >= 2);
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system usage message");
     };
     assert!(matches!(last.role, MessageRole::System(_)));
@@ -1730,7 +1730,7 @@ fn mode_with_extra_args_returns_usage_message() {
 
     let consumed = try_handle_submit(&mut app, "/mode plan extra");
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system usage message");
     };
     assert!(matches!(last.role, MessageRole::System(_)));
@@ -1746,7 +1746,7 @@ fn model_with_missing_id_returns_usage_message() {
 
     let consumed = try_handle_submit(&mut app, "/model");
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -1761,7 +1761,7 @@ fn model_with_extra_args_returns_usage_message() {
 
     let consumed = try_handle_submit(&mut app, "/model sonnet extra");
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected system usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -1905,7 +1905,7 @@ fn status_with_extra_args_returns_usage() {
     let consumed = try_handle_submit(&mut app, "/status extra");
 
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -1921,7 +1921,7 @@ fn usage_with_extra_args_returns_usage() {
     let consumed = try_handle_submit(&mut app, "/usage extra");
 
     assert!(consumed);
-    let Some(last) = app.messages.last() else {
+    let Some(last) = app.transcript.messages.last() else {
         panic!("expected usage message");
     };
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {

--- a/src/app/state/app.rs
+++ b/src/app/state/app.rs
@@ -12,6 +12,7 @@ pub struct App {
     pub trust: TrustState,
     pub settings_home_override: Option<PathBuf>,
     pub transcript: Transcript,
+    pub session_runtime: SessionRuntimeState,
     pub input: InputState,
     pub status: AppStatus,
     /// Session id currently being resumed via `/resume`.
@@ -21,20 +22,9 @@ pub struct App {
     pub should_quit: bool,
     /// Optional fatal app error that should be surfaced at CLI boundary.
     pub exit_error: Option<crate::error::AppError>,
-    pub session_id: Option<model::SessionId>,
-    /// Agent connection handle. `None` while connecting (before bridge is ready).
-    pub conn: Option<Rc<crate::agent::client::AgentConnection>>,
-    /// Monotonic session authority epoch used to ignore stale async view data.
-    pub session_scope_epoch: u64,
-    pub current_model: Option<model::CurrentModel>,
     pub cwd: String,
     pub cwd_raw: String,
     pub files_accessed: usize,
-    pub mode: Option<ModeState>,
-    /// Latest config options observed from bridge `config_option_update` events.
-    pub config_options: BTreeMap<String, serde_json::Value>,
-    /// Login hint shown when authentication is required. Rendered above the input field.
-    pub login_hint: Option<LoginHint>,
     /// State scoped to the currently active turn (command spinner, cancel
     /// bookkeeping, inline interactions, turn-local notices).
     pub turn: TurnState,
@@ -99,22 +89,10 @@ pub struct App {
     pub(crate) git_context: GitContextState,
     /// Update availability state for the current app lifetime.
     pub update_notice: Option<UpdateNoticeState>,
-    /// Session-wide usage and cost telemetry from the bridge.
-    pub session_usage: SessionUsageState,
     /// Config > Usage snapshot and refresh lifecycle.
     pub usage: UsageState,
     /// Config > MCP live server snapshot and refresh lifecycle.
     pub mcp: McpState,
-    /// Fast mode state telemetry from the SDK.
-    pub fast_mode_state: model::FastModeState,
-    /// Latest SDK runtime liveness state.
-    pub runtime_session_state: Option<model::RuntimeSessionState>,
-    /// Latest prompt suggestion from the SDK, shown in the input hint band.
-    pub prompt_suggestion: Option<String>,
-    /// Latest rate-limit telemetry from the SDK.
-    pub last_rate_limit_update: Option<model::RateLimitUpdate>,
-    /// Account info from the bridge status snapshot (email, org, subscription).
-    pub account_info: Option<model::AccountInfo>,
 
     /// Central notification manager (bell + desktop toast when unfocused).
     pub notifications: notify::NotificationManager,
@@ -143,7 +121,8 @@ pub struct App {
 impl App {
     #[must_use]
     pub fn session_thinking_effort_effective(&self) -> model::EffortLevel {
-        self.config_options
+        self.session_runtime
+            .config_options
             .get("effortLevel")
             .and_then(serde_json::Value::as_str)
             .and_then(model::EffortLevel::from_stored)
@@ -191,6 +170,7 @@ impl App {
             trust: TrustState::default(),
             settings_home_override: None,
             transcript: Transcript::default(),
+            session_runtime: SessionRuntimeState::test_default(),
             input: InputState::new(),
             status: AppStatus::Ready,
             resuming_session_id: None,
@@ -198,19 +178,9 @@ impl App {
             turn: TurnState::default(),
             should_quit: false,
             exit_error: None,
-            session_id: None,
-            conn: None,
-            session_scope_epoch: 0,
-            current_model: Some(
-                model::CurrentModel::new("test-model", "test-model", "test-model")
-                    .authoritative(true),
-            ),
             cwd: "/test".into(),
             cwd_raw: "/test".into(),
             files_accessed: 0,
-            mode: None,
-            config_options: BTreeMap::new(),
-            login_hint: None,
             event_tx: tx,
             event_rx: rx,
             file_index_event_tx: file_index_tx,
@@ -241,14 +211,8 @@ impl App {
             pending_images: Vec::new(),
             git_context: GitContextState::default(),
             update_notice: None,
-            session_usage: SessionUsageState::default(),
             usage: UsageState::default(),
             mcp: McpState::default(),
-            fast_mode_state: model::FastModeState::Off,
-            runtime_session_state: None,
-            prompt_suggestion: None,
-            last_rate_limit_update: None,
-            account_info: None,
             notifications: notify::NotificationManager::new(),
             perf: None,
             render_cache_budget: RenderCacheBudget::default(),

--- a/src/app/state/app.rs
+++ b/src/app/state/app.rs
@@ -11,21 +11,13 @@ pub struct App {
     pub config: ConfigState,
     pub trust: TrustState,
     pub settings_home_override: Option<PathBuf>,
-    pub messages: Vec<ChatMessage>,
-    /// Cached approximate retained bytes for each message, parallel to `messages`.
-    pub message_retained_bytes: Vec<usize>,
-    /// Rolling total of `message_retained_bytes`.
-    pub retained_history_bytes: usize,
+    pub transcript: Transcript,
     pub input: InputState,
     pub status: AppStatus,
     /// Session id currently being resumed via `/resume`.
     pub resuming_session_id: Option<String>,
     /// Whether the synthetic session overview is eligible for chat transcript output.
     pub show_session_overview: bool,
-    /// Spinner label shown while a slash command is in flight (`CommandPending`).
-    pub pending_command_label: Option<String>,
-    /// Ack marker required to clear `CommandPending` for strict completion semantics.
-    pub pending_command_ack: Option<PendingCommandAck>,
     pub should_quit: bool,
     /// Optional fatal app error that should be surfaced at CLI boundary.
     pub exit_error: Option<crate::error::AppError>,
@@ -43,40 +35,20 @@ pub struct App {
     pub config_options: BTreeMap<String, serde_json::Value>,
     /// Login hint shown when authentication is required. Rendered above the input field.
     pub login_hint: Option<LoginHint>,
-    /// When true, the current/next turn completion should clear local conversation history.
-    /// Set by `/compact` once the command is accepted for bridge forwarding.
-    pub pending_compact_clear: bool,
-    /// Tool call IDs with pending inline interactions, ordered by arrival.
-    /// The first entry is the focused interaction that receives keyboard input.
-    /// Up / Down arrow keys cycle focus through the list.
-    pub pending_interaction_ids: Vec<String>,
-    /// Set when a cancel notification succeeds; consumed on `TurnComplete`
-    /// to render a red interruption hint in chat.
-    pub cancelled_turn_pending_hint: bool,
-    /// Origin of the in-flight cancellation request, if any.
-    pub pending_cancel_origin: Option<CancelOrigin>,
-    /// Auto-submit the current input draft once cancellation transitions the app
-    /// back to `Ready`.
-    pub pending_auto_submit_after_cancel: bool,
+    /// State scoped to the currently active turn (command spinner, cancel
+    /// bookkeeping, inline interactions, turn-local notices).
+    pub turn: TurnState,
     pub event_tx: mpsc::UnboundedSender<ClientEvent>,
     pub event_rx: mpsc::UnboundedReceiver<ClientEvent>,
     pub file_index_event_tx: std_mpsc::Sender<file_index::FileIndexEvent>,
     pub file_index_event_rx: std_mpsc::Receiver<file_index::FileIndexEvent>,
     pub spinner_frame: usize,
     pub spinner_last_advance_at: Option<Instant>,
-    /// Message index that owns the current main-assistant turn indicators.
-    pub active_turn_assistant_message_idx: Option<usize>,
-    /// IDs of root Task/Agent tool calls currently `InProgress`.
-    /// Use `insert_active_task()`, `remove_active_task()`.
-    pub active_task_ids: HashSet<String>,
     /// Tool scope keyed by tool call ID; used to distinguish main-agent, subagent roots,
     /// and explicitly owned subagent child tools.
     pub tool_call_scopes: HashMap<String, ToolCallScope>,
     /// Shared terminal process map - used to snapshot output on completion.
     pub terminals: crate::agent::events::TerminalMap,
-    /// O(1) lookup: `tool_call_id` -> `(message_index, block_index)`.
-    /// Use `lookup_tool_call()`, `index_tool_call()`.
-    pub tool_call_index: HashMap<String, (usize, usize)>,
     /// Current SDK task state from `TaskCreate`/`TaskUpdate`/`TaskGet`/`TaskList`.
     pub tasks: Vec<model::TaskItem>,
     /// Focus manager for directional/navigation key ownership.
@@ -117,20 +89,8 @@ pub struct App {
     /// If another editing-like event or a paste payload arrives in the same
     /// drain cycle, this is cleared and no submit occurs.
     pub pending_submit: Option<InputSnapshot>,
-    /// Timing-based paste burst detector. Detects rapid character streams
-    /// (paste delivered as individual key events) and buffers them into a
-    /// single paste payload. Fallback for terminals without bracketed paste.
-    pub paste_burst: paste_burst::PasteBurstDetector,
-    /// Buffered `Event::Paste` payload for this drain cycle.
-    /// Some terminals split one clipboard paste into multiple chunks; we merge
-    /// them and apply placeholder threshold to the merged content once per cycle.
-    pub pending_paste_text: String,
-    /// Pending paste session metadata for the currently queued `Event::Paste` payload.
-    pub pending_paste_session: Option<PasteSessionState>,
-    /// Most recent active placeholder paste session, used for safe chunk continuation.
-    pub active_paste_session: Option<PasteSessionState>,
-    /// Monotonic counter for paste session identifiers.
-    pub next_paste_session_id: u64,
+    /// Paste ingestion state: burst detection, queued chunks, session tracking.
+    pub paste: PasteState,
     /// Pending image attachments accumulated via Ctrl+V clipboard reads and
     /// consumed on submit. No cap on count — this is a developer tool, so
     /// users are trusted to attach as many images as they need.
@@ -153,18 +113,9 @@ pub struct App {
     pub prompt_suggestion: Option<String>,
     /// Latest rate-limit telemetry from the SDK.
     pub last_rate_limit_update: Option<model::RateLimitUpdate>,
-    /// Turn-local inline/system notices that may upgrade in place during the active turn.
-    pub turn_notice_refs: Vec<TurnNoticeRef>,
-    /// True while the SDK reports active compaction.
-    pub is_compacting: bool,
     /// Account info from the bridge status snapshot (email, org, subscription).
     pub account_info: Option<model::AccountInfo>,
 
-    /// Indexed terminal tool calls for per-frame terminal snapshot updates.
-    /// Avoids O(n*m) scan of all messages/blocks every frame.
-    pub terminal_tool_calls: Vec<TerminalToolCallRef>,
-    /// Membership index for `terminal_tool_calls`, used to avoid linear duplicate checks.
-    pub terminal_tool_call_membership: HashSet<TerminalToolCallRef>,
     /// Central notification manager (bell + desktop toast when unfocused).
     pub notifications: notify::NotificationManager,
     /// Performance logger. Present only when built with `--features perf`.
@@ -173,17 +124,6 @@ pub struct App {
     pub perf: Option<crate::perf::PerfLogger>,
     /// Global in-memory budget for rendered block and message caches.
     pub render_cache_budget: RenderCacheBudget,
-    /// Cached render-cache slot metadata parallel to `messages[*].blocks[*]`
-    /// plus one synthetic per-message slot at the tail of each row.
-    pub(crate) render_cache_slots: Vec<Vec<render_budget::RenderCacheSlotState>>,
-    /// Rolling total of cached render bytes across blocks and message-level caches.
-    pub(crate) render_cache_total_bytes: usize,
-    /// Rolling total of cached render bytes currently excluded from the budget.
-    pub(crate) render_cache_protected_bytes: usize,
-    /// Evictable cached blocks ordered by LRU and size tie-breaker.
-    pub(crate) render_cache_evictable: BTreeSet<render_budget::RenderCacheEvictionKey>,
-    /// Last message index currently protected as the streaming tail, if any.
-    pub(crate) render_cache_tail_msg_idx: Option<usize>,
     /// Byte budget for source conversation history retained in memory.
     pub history_retention: HistoryRetentionPolicy,
     /// Last history-retention enforcement statistics.
@@ -196,14 +136,8 @@ pub struct App {
     pub last_frame_at: Option<Instant>,
     /// Last emitted chat render trace snapshot to suppress identical per-frame summaries.
     pub last_chat_render_trace_state: Option<ChatRenderTraceState>,
-    pub startup_connection_requested: bool,
-    pub connection_started: bool,
-    pub startup_bridge_script: Option<PathBuf>,
-    pub startup_resume_id: Option<String>,
-    pub startup_resume_requested: bool,
-    pub startup_session_picker_requested: bool,
-    pub startup_recent_sessions_loaded: bool,
-    pub startup_session_picker_resolved: bool,
+    /// Bootstrap sequencing state resolved from CLI flags at launch.
+    pub startup: StartupState,
 }
 
 impl App {
@@ -256,15 +190,12 @@ impl App {
             config: ConfigState::default(),
             trust: TrustState::default(),
             settings_home_override: None,
-            messages: Vec::new(),
-            message_retained_bytes: Vec::new(),
-            retained_history_bytes: 0,
+            transcript: Transcript::default(),
             input: InputState::new(),
             status: AppStatus::Ready,
             resuming_session_id: None,
             show_session_overview: true,
-            pending_command_label: None,
-            pending_command_ack: None,
+            turn: TurnState::default(),
             should_quit: false,
             exit_error: None,
             session_id: None,
@@ -280,22 +211,14 @@ impl App {
             mode: None,
             config_options: BTreeMap::new(),
             login_hint: None,
-            pending_compact_clear: false,
-            pending_interaction_ids: Vec::new(),
-            cancelled_turn_pending_hint: false,
-            pending_cancel_origin: None,
-            pending_auto_submit_after_cancel: false,
             event_tx: tx,
             event_rx: rx,
             file_index_event_tx: file_index_tx,
             file_index_event_rx: file_index_rx,
             spinner_frame: 0,
             spinner_last_advance_at: None,
-            active_turn_assistant_message_idx: None,
-            active_task_ids: HashSet::default(),
             tool_call_scopes: HashMap::default(),
             terminals: std::rc::Rc::default(),
-            tool_call_index: HashMap::default(),
             tasks: Vec::new(),
             focus: FocusManager::default(),
             keymap: ResolvedKeymap::defaults(),
@@ -314,11 +237,7 @@ impl App {
             slash: None,
             subagent: None,
             pending_submit: None,
-            paste_burst: paste_burst::PasteBurstDetector::new(),
-            pending_paste_text: String::new(),
-            pending_paste_session: None,
-            active_paste_session: None,
-            next_paste_session_id: 1,
+            paste: PasteState::default(),
             pending_images: Vec::new(),
             git_context: GitContextState::default(),
             update_notice: None,
@@ -329,33 +248,22 @@ impl App {
             runtime_session_state: None,
             prompt_suggestion: None,
             last_rate_limit_update: None,
-            turn_notice_refs: Vec::new(),
-            is_compacting: false,
             account_info: None,
-            terminal_tool_calls: Vec::new(),
-            terminal_tool_call_membership: HashSet::new(),
             notifications: notify::NotificationManager::new(),
             perf: None,
             render_cache_budget: RenderCacheBudget::default(),
-            render_cache_slots: Vec::new(),
-            render_cache_total_bytes: 0,
-            render_cache_protected_bytes: 0,
-            render_cache_evictable: BTreeSet::new(),
-            render_cache_tail_msg_idx: None,
             history_retention: HistoryRetentionPolicy::default(),
             history_retention_stats: HistoryRetentionStats::default(),
             cache_metrics: CacheMetrics::default(),
             fps_ema: None,
             last_frame_at: None,
             last_chat_render_trace_state: None,
-            startup_connection_requested: false,
-            connection_started: false,
-            startup_bridge_script: None,
-            startup_resume_id: None,
-            startup_resume_requested: false,
-            startup_session_picker_requested: false,
-            startup_recent_sessions_loaded: false,
-            startup_session_picker_resolved: false,
+            startup: StartupState::default(),
         }
+    }
+
+    #[cfg(test)]
+    pub fn test_request_startup_session_picker(&mut self) {
+        self.startup = StartupState::new(None, None, true);
     }
 }

--- a/src/app/state/app.rs
+++ b/src/app/state/app.rs
@@ -13,6 +13,7 @@ pub struct App {
     pub settings_home_override: Option<PathBuf>,
     pub transcript: Transcript,
     pub session_runtime: SessionRuntimeState,
+    pub sdk_inventory: SdkInventoryState,
     pub input: InputState,
     pub status: AppStatus,
     /// Session id currently being resumed via `/resume`.
@@ -39,26 +40,12 @@ pub struct App {
     pub tool_call_scopes: HashMap<String, ToolCallScope>,
     /// Shared terminal process map - used to snapshot output on completion.
     pub terminals: crate::agent::events::TerminalMap,
-    /// Current SDK task state from `TaskCreate`/`TaskUpdate`/`TaskGet`/`TaskList`.
-    pub tasks: Vec<model::TaskItem>,
     /// Focus manager for directional/navigation key ownership.
     pub focus: FocusManager,
     /// Resolved keyboard bindings used by chat-surface dispatch.
     pub keymap: ResolvedKeymap,
-    /// Commands advertised by the agent via `AvailableCommandsUpdate`.
-    pub available_commands: Vec<model::AvailableCommand>,
-    /// Rewind candidates loaded from persisted SDK session history.
-    pub rewind_targets: Vec<model::RewindTarget>,
-    /// Session id that owns `rewind_targets`.
-    pub rewind_targets_session_id: Option<model::SessionId>,
-    /// True while a rewind target refresh request is in flight.
-    pub rewind_targets_in_flight: bool,
     /// Plugin inventory and UI state for the Config > Plugins view.
     pub plugins: PluginsState,
-    /// Subagents advertised by the agent via `AvailableAgentsUpdate`.
-    pub available_agents: Vec<model::AvailableAgent>,
-    /// Models advertised by the agent SDK for the active session.
-    pub available_models: Vec<model::AvailableModel>,
     /// Recently persisted session IDs discovered at startup.
     pub recent_sessions: Vec<RecentSessionInfo>,
     /// Selection state for the startup session picker screen.
@@ -171,6 +158,7 @@ impl App {
             settings_home_override: None,
             transcript: Transcript::default(),
             session_runtime: SessionRuntimeState::test_default(),
+            sdk_inventory: SdkInventoryState::default(),
             input: InputState::new(),
             status: AppStatus::Ready,
             resuming_session_id: None,
@@ -189,16 +177,9 @@ impl App {
             spinner_last_advance_at: None,
             tool_call_scopes: HashMap::default(),
             terminals: std::rc::Rc::default(),
-            tasks: Vec::new(),
             focus: FocusManager::default(),
             keymap: ResolvedKeymap::defaults(),
-            available_commands: Vec::new(),
-            rewind_targets: Vec::new(),
-            rewind_targets_session_id: None,
-            rewind_targets_in_flight: false,
             plugins: PluginsState::default(),
-            available_agents: Vec::new(),
-            available_models: Vec::new(),
             recent_sessions: Vec::new(),
             session_picker: SessionPickerState::default(),
             chat_render: ChatRenderState::default(),

--- a/src/app/state/focus_runtime.rs
+++ b/src/app/state/focus_runtime.rs
@@ -22,7 +22,7 @@ impl App {
 
         self.normalize_focus_stack();
 
-        if self.pending_interaction_ids.is_empty() {
+        if self.turn.pending_interaction_ids.is_empty() {
             clear_inline_interaction_focus(self);
         } else if self.focus_owner() == FocusOwner::Permission || !self.has_draft_input_for_focus()
         {
@@ -63,7 +63,7 @@ impl App {
     fn focus_context(&self) -> FocusContext {
         FocusContext::new(
             self.autocomplete_focus_available(),
-            !self.pending_interaction_ids.is_empty(),
+            !self.turn.pending_interaction_ids.is_empty(),
         )
     }
 }

--- a/src/app/state/history_retention.rs
+++ b/src/app/state/history_retention.rs
@@ -34,7 +34,7 @@ impl super::App {
 
     fn sync_after_message_topology_change(&mut self, start_idx: usize) {
         self.rebuild_tool_indices_and_terminal_refs();
-        if self.messages.is_empty() {
+        if self.transcript.messages.is_empty() {
             return;
         }
         self.invalidate_layout(InvalidationLevel::MessagesFrom(start_idx));
@@ -220,53 +220,59 @@ impl super::App {
     /// Measure the total in-memory byte footprint of all retained messages.
     #[must_use]
     pub fn measure_history_bytes(&self) -> usize {
-        self.messages.iter().map(Self::measure_message_bytes).sum()
+        self.transcript.messages.iter().map(Self::measure_message_bytes).sum()
     }
 
     pub(crate) fn rebuild_history_retention_accounting(&mut self) {
-        self.message_retained_bytes.clear();
-        self.message_retained_bytes.reserve(self.messages.len());
-        self.retained_history_bytes = 0;
+        self.transcript.message_retained_bytes.clear();
+        self.transcript.message_retained_bytes.reserve(self.transcript.messages.len());
+        self.transcript.retained_history_bytes = 0;
 
-        for msg in &self.messages {
+        for msg in &self.transcript.messages {
             let bytes = Self::measure_message_bytes(msg);
-            self.message_retained_bytes.push(bytes);
-            self.retained_history_bytes = self.retained_history_bytes.saturating_add(bytes);
+            self.transcript.message_retained_bytes.push(bytes);
+            self.transcript.retained_history_bytes =
+                self.transcript.retained_history_bytes.saturating_add(bytes);
         }
     }
 
     pub(crate) fn ensure_history_retention_accounting(&mut self) {
-        if self.message_retained_bytes.len() != self.messages.len() {
+        if self.transcript.message_retained_bytes.len() != self.transcript.messages.len() {
             self.rebuild_history_retention_accounting();
         }
     }
 
     pub(crate) fn push_message_tracked(&mut self, msg: ChatMessage) {
-        let previous_tail = self.messages.len().checked_sub(1);
+        let previous_tail = self.transcript.messages.len().checked_sub(1);
         let bytes = Self::measure_message_bytes(&msg);
-        self.messages.push(msg);
-        self.message_retained_bytes.push(bytes);
-        self.retained_history_bytes = self.retained_history_bytes.saturating_add(bytes);
+        self.transcript.messages.push(msg);
+        self.transcript.message_retained_bytes.push(bytes);
+        self.transcript.retained_history_bytes =
+            self.transcript.retained_history_bytes.saturating_add(bytes);
         self.rebuild_render_cache_accounting();
-        self.invalidate_tail_transition(previous_tail, self.messages.len().checked_sub(1));
+        self.invalidate_tail_transition(
+            previous_tail,
+            self.transcript.messages.len().checked_sub(1),
+        );
         self.request_chat_repaint();
     }
 
     pub(crate) fn insert_message_tracked(&mut self, idx: usize, msg: ChatMessage) {
         self.ensure_history_retention_accounting();
-        let insert_idx = idx.min(self.messages.len());
-        let appended_at_tail = insert_idx == self.messages.len();
+        let insert_idx = idx.min(self.transcript.messages.len());
+        let appended_at_tail = insert_idx == self.transcript.messages.len();
         if !appended_at_tail {
             self.shift_active_turn_assistant_for_insert(insert_idx);
             self.shift_turn_notice_refs_for_insert(insert_idx);
         }
         let bytes = Self::measure_message_bytes(&msg);
-        self.messages.insert(insert_idx, msg);
-        self.message_retained_bytes.insert(insert_idx, bytes);
-        self.retained_history_bytes = self.retained_history_bytes.saturating_add(bytes);
+        self.transcript.messages.insert(insert_idx, msg);
+        self.transcript.message_retained_bytes.insert(insert_idx, bytes);
+        self.transcript.retained_history_bytes =
+            self.transcript.retained_history_bytes.saturating_add(bytes);
         self.rebuild_render_cache_accounting();
         if appended_at_tail {
-            let new_tail = self.messages.len().checked_sub(1);
+            let new_tail = self.transcript.messages.len().checked_sub(1);
             self.invalidate_tail_transition(
                 new_tail.and_then(|tail| tail.checked_sub(1)),
                 new_tail,
@@ -279,21 +285,22 @@ impl super::App {
 
     pub(crate) fn remove_message_tracked(&mut self, idx: usize) -> Option<ChatMessage> {
         self.ensure_history_retention_accounting();
-        let old_len = self.messages.len();
+        let old_len = self.transcript.messages.len();
         if idx >= old_len {
             return None;
         }
         let removed_tail = idx + 1 == old_len;
         self.shift_active_turn_assistant_for_remove(idx);
         self.shift_turn_notice_refs_for_remove(idx);
-        let removed = self.messages.remove(idx);
-        let removed_bytes = self.message_retained_bytes.remove(idx);
-        self.retained_history_bytes = self.retained_history_bytes.saturating_sub(removed_bytes);
+        let removed = self.transcript.messages.remove(idx);
+        let removed_bytes = self.transcript.message_retained_bytes.remove(idx);
+        self.transcript.retained_history_bytes =
+            self.transcript.retained_history_bytes.saturating_sub(removed_bytes);
         self.rebuild_render_cache_accounting();
         self.rebuild_tool_indices_and_terminal_refs();
         if removed_tail {
-            self.invalidate_tail_transition(None, self.messages.len().checked_sub(1));
-        } else if !self.messages.is_empty() {
+            self.invalidate_tail_transition(None, self.transcript.messages.len().checked_sub(1));
+        } else if !self.transcript.messages.is_empty() {
             self.invalidate_layout(InvalidationLevel::MessagesFrom(idx));
         }
         self.request_chat_repaint();
@@ -301,9 +308,9 @@ impl super::App {
     }
 
     pub(crate) fn clear_messages_tracked(&mut self) {
-        self.messages.clear();
-        self.message_retained_bytes.clear();
-        self.retained_history_bytes = 0;
+        self.transcript.messages.clear();
+        self.transcript.message_retained_bytes.clear();
+        self.transcript.retained_history_bytes = 0;
         self.clear_active_turn_assistant();
         self.clear_turn_notice_refs();
         self.rebuild_render_cache_accounting();
@@ -313,33 +320,36 @@ impl super::App {
 
     pub(crate) fn recompute_message_retained_bytes(&mut self, idx: usize) {
         self.ensure_history_retention_accounting();
-        let Some(msg) = self.messages.get(idx) else {
+        let Some(msg) = self.transcript.messages.get(idx) else {
             return;
         };
         let new_bytes = Self::measure_message_bytes(msg);
-        let Some(old_bytes) = self.message_retained_bytes.get_mut(idx) else {
+        let Some(old_bytes) = self.transcript.message_retained_bytes.get_mut(idx) else {
             self.rebuild_history_retention_accounting();
             return;
         };
-        self.retained_history_bytes =
-            self.retained_history_bytes.saturating_sub(*old_bytes).saturating_add(new_bytes);
+        self.transcript.retained_history_bytes = self
+            .transcript
+            .retained_history_bytes
+            .saturating_sub(*old_bytes)
+            .saturating_add(new_bytes);
         *old_bytes = new_bytes;
     }
 
     pub(crate) fn rebuild_tool_indices_and_terminal_refs(&mut self) {
-        self.tool_call_index.clear();
+        self.transcript.tool_call_index.clear();
         self.clear_terminal_tool_call_tracking();
-        self.active_task_ids.clear();
+        self.turn.active_task_ids.clear();
 
         let mut pending_interaction_ids = Vec::new();
         let mut terminal_tool_call_membership = HashSet::new();
         let mut terminal_tool_calls = Vec::new();
-        for (msg_idx, msg) in self.messages.iter_mut().enumerate() {
+        for (msg_idx, msg) in self.transcript.messages.iter_mut().enumerate() {
             for (block_idx, block) in msg.blocks.iter_mut().enumerate() {
                 match block {
                     MessageBlock::ToolCall(tc) => {
                         let tc = tc.as_mut();
-                        self.tool_call_index.insert(tc.id.clone(), (msg_idx, block_idx));
+                        self.transcript.tool_call_index.insert(tc.id.clone(), (msg_idx, block_idx));
                         if let Some(terminal_id) = Self::tracked_terminal_id_for_tool(tc) {
                             let entry =
                                 super::TerminalToolCallRef::new(terminal_id, msg_idx, block_idx);
@@ -357,7 +367,8 @@ impl super::App {
                         }
                     }
                     MessageBlock::UserDialog(dialog) => {
-                        self.tool_call_index
+                        self.transcript
+                            .tool_call_index
                             .insert(dialog.request_id.clone(), (msg_idx, block_idx));
                         if !dialog.answered {
                             dialog.focused = false;
@@ -368,10 +379,15 @@ impl super::App {
                 }
             }
         }
-        self.terminal_tool_calls = terminal_tool_calls;
-        self.terminal_tool_call_membership = terminal_tool_call_membership;
-        self.tool_call_scopes.retain(|id, _| self.tool_call_index.contains_key(id));
-        for msg in &self.messages {
+        self.transcript.terminal_tool_calls = terminal_tool_calls;
+        self.transcript.terminal_tool_call_membership = terminal_tool_call_membership;
+        self.rebuild_active_task_tracking_from_tool_scopes();
+        self.sync_pending_interaction_focus(pending_interaction_ids);
+    }
+
+    fn rebuild_active_task_tracking_from_tool_scopes(&mut self) {
+        self.tool_call_scopes.retain(|id, _| self.transcript.tool_call_index.contains_key(id));
+        for msg in &self.transcript.messages {
             for block in &msg.blocks {
                 let MessageBlock::ToolCall(tc) = block else {
                     continue;
@@ -384,7 +400,7 @@ impl super::App {
                 }
                 match self.tool_call_scopes.get(&tc.id) {
                     Some(super::ToolCallScope::SubagentRoot) => {
-                        self.active_task_ids.insert(tc.id.clone());
+                        self.turn.active_task_ids.insert(tc.id.clone());
                     }
                     Some(
                         super::ToolCallScope::SubagentChild { .. }
@@ -394,21 +410,26 @@ impl super::App {
                 }
             }
         }
+    }
 
+    fn sync_pending_interaction_focus(&mut self, pending_interaction_ids: Vec<String>) {
         let interaction_set: HashSet<&str> =
             pending_interaction_ids.iter().map(String::as_str).collect();
-        self.pending_interaction_ids.retain(|id| interaction_set.contains(id.as_str()));
+        self.turn.pending_interaction_ids.retain(|id| interaction_set.contains(id.as_str()));
         for id in pending_interaction_ids {
-            if !self.pending_interaction_ids.iter().any(|existing| existing == &id) {
-                self.pending_interaction_ids.push(id);
+            if !self.turn.pending_interaction_ids.iter().any(|existing| existing == &id) {
+                self.turn.pending_interaction_ids.push(id);
             }
         }
 
-        if let Some(first_id) = self.pending_interaction_ids.first().cloned() {
+        if let Some(first_id) = self.turn.pending_interaction_ids.first().cloned() {
             self.claim_focus_target(super::super::focus::FocusTarget::Permission);
             if let Some((msg_idx, block_idx)) = self.lookup_tool_call(&first_id)
-                && let Some(block) =
-                    self.messages.get_mut(msg_idx).and_then(|m| m.blocks.get_mut(block_idx))
+                && let Some(block) = self
+                    .transcript
+                    .messages
+                    .get_mut(msg_idx)
+                    .and_then(|m| m.blocks.get_mut(block_idx))
             {
                 match block {
                     MessageBlock::ToolCall(tc) => {
@@ -451,7 +472,8 @@ impl super::App {
 
     fn upsert_history_hidden_marker(&mut self) {
         self.ensure_history_retention_accounting();
-        let marker_idx = self.messages.iter().position(Self::is_history_hidden_marker_message);
+        let marker_idx =
+            self.transcript.messages.iter().position(Self::is_history_hidden_marker_message);
         if self.history_retention_stats.total_dropped_messages == 0 {
             if let Some(idx) = marker_idx {
                 self.remove_message_tracked(idx);
@@ -466,7 +488,7 @@ impl super::App {
 
         if let Some(idx) = marker_idx {
             if let Some(MessageBlock::Text(block)) =
-                self.messages.get_mut(idx).and_then(|m| m.blocks.get_mut(0))
+                self.transcript.messages.get_mut(idx).and_then(|m| m.blocks.get_mut(0))
                 && block.text != marker_text
             {
                 block.text.clone_from(&marker_text);
@@ -480,7 +502,10 @@ impl super::App {
         }
 
         let insert_idx = usize::from(
-            self.messages.first().is_some_and(|msg| matches!(msg.role, MessageRole::Welcome)),
+            self.transcript
+                .messages
+                .first()
+                .is_some_and(|msg| matches!(msg.role, MessageRole::Welcome)),
         );
         self.insert_message_tracked(
             insert_idx,
@@ -497,19 +522,20 @@ impl super::App {
         let mut stats = HistoryRetentionStats::default();
         let max_bytes = self.history_retention.max_bytes.max(1);
         let active_turn_owner = self.active_turn_assistant_idx();
-        stats.total_before_bytes = self.retained_history_bytes;
+        stats.total_before_bytes = self.transcript.retained_history_bytes;
         stats.total_after_bytes = stats.total_before_bytes;
 
         if stats.total_before_bytes > max_bytes {
             let mut candidates = Vec::new();
-            for (msg_idx, msg) in self.messages.iter().enumerate() {
+            for (msg_idx, msg) in self.transcript.messages.iter().enumerate() {
                 if Self::is_history_hidden_marker_message(msg)
                     || Self::is_history_protected_message(msg)
                     || active_turn_owner == Some(msg_idx)
                 {
                     continue;
                 }
-                let bytes = self.message_retained_bytes.get(msg_idx).copied().unwrap_or(0);
+                let bytes =
+                    self.transcript.message_retained_bytes.get(msg_idx).copied().unwrap_or(0);
                 if bytes == 0 {
                     continue;
                 }
@@ -544,7 +570,7 @@ impl super::App {
 
         self.upsert_history_hidden_marker();
 
-        stats.total_after_bytes = self.retained_history_bytes;
+        stats.total_after_bytes = self.transcript.retained_history_bytes;
         self.history_retention_stats.total_after_bytes = stats.total_after_bytes;
         self.history_retention_stats.dropped_messages = stats.dropped_messages;
         self.history_retention_stats.dropped_bytes = stats.dropped_bytes;
@@ -569,27 +595,29 @@ impl super::App {
         let drop_set: HashSet<usize> =
             drop_candidates.iter().map(|candidate| candidate.msg_idx).collect();
 
-        let mut retained = Vec::with_capacity(self.messages.len().saturating_sub(drop_set.len()));
+        let mut retained =
+            Vec::with_capacity(self.transcript.messages.len().saturating_sub(drop_set.len()));
         let mut retained_bytes = Vec::with_capacity(retained.capacity());
-        let old_messages = std::mem::take(&mut self.messages);
-        let old_bytes = std::mem::take(&mut self.message_retained_bytes);
+        let old_messages = std::mem::take(&mut self.transcript.messages);
+        let old_bytes = std::mem::take(&mut self.transcript.message_retained_bytes);
         let mut old_to_new = vec![None; old_messages.len()];
         let mut remapped_active_turn_owner = None;
-        self.retained_history_bytes = 0;
+        self.transcript.retained_history_bytes = 0;
         for (msg_idx, (msg, bytes)) in old_messages.into_iter().zip(old_bytes).enumerate() {
             if !drop_set.contains(&msg_idx) {
                 if active_turn_owner == Some(msg_idx) {
                     remapped_active_turn_owner = Some(retained.len());
                 }
                 old_to_new[msg_idx] = Some(retained.len());
-                self.retained_history_bytes = self.retained_history_bytes.saturating_add(bytes);
+                self.transcript.retained_history_bytes =
+                    self.transcript.retained_history_bytes.saturating_add(bytes);
                 retained.push(msg);
                 retained_bytes.push(bytes);
             }
         }
-        self.messages = retained;
-        self.message_retained_bytes = retained_bytes;
-        self.active_turn_assistant_message_idx = remapped_active_turn_owner;
+        self.transcript.messages = retained;
+        self.transcript.message_retained_bytes = retained_bytes;
+        self.turn.assistant_message_idx = remapped_active_turn_owner;
         self.remap_turn_notice_refs_after_message_drop(&old_to_new);
     }
 }

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -16,6 +16,7 @@ mod focus_runtime;
 mod git_runtime;
 mod paste;
 mod repaint;
+mod sdk_inventory;
 mod session_identity;
 mod session_runtime;
 mod startup;
@@ -43,6 +44,7 @@ pub use messages::{
 pub use paste::PasteState;
 pub use repaint::LayoutInvalidation as InvalidationLevel;
 pub use repaint::{ChatRenderTraceState, LayoutInvalidation};
+pub use sdk_inventory::SdkInventoryState;
 pub use session_runtime::SessionRuntimeState;
 pub use startup::StartupState;
 pub use tool_call_info::{
@@ -74,6 +76,7 @@ mod prelude {
     pub(super) use super::render_budget;
     pub(super) use super::repaint::LayoutInvalidation as InvalidationLevel;
     pub(super) use super::repaint::{ChatRenderTraceState, LayoutInvalidation};
+    pub(super) use super::sdk_inventory::SdkInventoryState;
     pub(super) use super::session_runtime::SessionRuntimeState;
     pub(super) use super::startup::StartupState;
     pub(super) use super::tool_call_info::ToolCallInfo;

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -17,6 +17,7 @@ mod git_runtime;
 mod paste;
 mod repaint;
 mod session_identity;
+mod session_runtime;
 mod startup;
 mod tool_tracking;
 mod transcript;
@@ -42,6 +43,7 @@ pub use messages::{
 pub use paste::PasteState;
 pub use repaint::LayoutInvalidation as InvalidationLevel;
 pub use repaint::{ChatRenderTraceState, LayoutInvalidation};
+pub use session_runtime::SessionRuntimeState;
 pub use startup::StartupState;
 pub use tool_call_info::{
     InlinePermission, InlineQuestion, SubagentPermissionContext, TerminalSnapshotMode,
@@ -72,6 +74,7 @@ mod prelude {
     pub(super) use super::render_budget;
     pub(super) use super::repaint::LayoutInvalidation as InvalidationLevel;
     pub(super) use super::repaint::{ChatRenderTraceState, LayoutInvalidation};
+    pub(super) use super::session_runtime::SessionRuntimeState;
     pub(super) use super::startup::StartupState;
     pub(super) use super::tool_call_info::ToolCallInfo;
     pub(super) use super::tool_tracking::TerminalToolCallRef;

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -17,7 +17,10 @@ mod git_runtime;
 mod paste;
 mod repaint;
 mod session_identity;
+mod startup;
 mod tool_tracking;
+mod transcript;
+mod turn;
 mod turn_notices;
 mod welcome;
 
@@ -36,13 +39,17 @@ pub use messages::{
     SystemSeverity, TextBlock, TextBlockSpacing, UserDialogBlock, WelcomeBlock,
     hash_text_block_content, hash_welcome_block_content,
 };
+pub use paste::PasteState;
 pub use repaint::LayoutInvalidation as InvalidationLevel;
 pub use repaint::{ChatRenderTraceState, LayoutInvalidation};
+pub use startup::StartupState;
 pub use tool_call_info::{
     InlinePermission, InlineQuestion, SubagentPermissionContext, TerminalSnapshotMode,
     ToolCallInfo, is_execute_tool_name,
 };
 pub use tool_tracking::TerminalToolCallRef;
+pub use transcript::Transcript;
+pub use turn::TurnState;
 pub use turn_notices::{NoticeStage, TurnNoticeLocation, TurnNoticeRef};
 pub use types::{
     AppStatus, CancelOrigin, ExtraUsage, HistoryRetentionPolicy, HistoryRetentionStats, LoginHint,
@@ -61,11 +68,15 @@ mod prelude {
     pub(super) use super::messages::{
         ChatMessage, MessageBlock, MessageRole, NoticeDedupKey, WelcomeBlock,
     };
+    pub(super) use super::paste::PasteState;
     pub(super) use super::render_budget;
     pub(super) use super::repaint::LayoutInvalidation as InvalidationLevel;
     pub(super) use super::repaint::{ChatRenderTraceState, LayoutInvalidation};
+    pub(super) use super::startup::StartupState;
     pub(super) use super::tool_call_info::ToolCallInfo;
     pub(super) use super::tool_tracking::TerminalToolCallRef;
+    pub(super) use super::transcript::Transcript;
+    pub(super) use super::turn::TurnState;
     pub(super) use super::turn_notices::{NoticeStage, TurnNoticeLocation, TurnNoticeRef};
     pub(super) use super::types::{
         AppStatus, CancelOrigin, HistoryRetentionPolicy, HistoryRetentionStats, LoginHint,

--- a/src/app/state/paste.rs
+++ b/src/app/state/paste.rs
@@ -3,6 +3,87 @@
 
 use super::prelude::*;
 
+/// Paste ingestion state: burst detection, queued chunks, and paste-session
+/// tracking for placeholder continuation.
+pub struct PasteState {
+    /// Timing-based paste burst detector. Detects rapid character streams
+    /// (paste delivered as individual key events) and buffers them into a
+    /// single paste payload. Fallback for terminals without bracketed paste.
+    pub burst: paste_burst::PasteBurstDetector,
+    /// Buffered `Event::Paste` payload for this drain cycle.
+    /// Some terminals split one clipboard paste into multiple chunks; we merge
+    /// them and apply placeholder threshold to the merged content once per cycle.
+    pub pending_text: String,
+    /// Pending paste session metadata for the currently queued `Event::Paste` payload.
+    pub pending_session: Option<PasteSessionState>,
+    /// Most recent active placeholder paste session, used for safe chunk continuation.
+    pub active_session: Option<PasteSessionState>,
+    /// Monotonic counter for paste session identifiers. Private so IDs can only
+    /// be handed out via [`PasteState::allocate_session_id`].
+    next_session_id: u64,
+}
+
+impl PasteState {
+    #[must_use]
+    pub fn has_pending_text(&self) -> bool {
+        !self.pending_text.is_empty()
+    }
+
+    /// Hand out the next paste session ID; IDs are unique per app lifetime.
+    pub fn allocate_session_id(&mut self) -> u64 {
+        let id = self.next_session_id;
+        self.next_session_id = self.next_session_id.saturating_add(1);
+        id
+    }
+
+    pub fn take_pending_text(&mut self) -> String {
+        std::mem::take(&mut self.pending_text)
+    }
+
+    pub fn take_pending_session(&mut self) -> Option<PasteSessionState> {
+        self.pending_session.take()
+    }
+
+    pub fn set_active_session(&mut self, session: PasteSessionState) {
+        self.active_session = Some(session);
+    }
+
+    pub fn clear_active_session(&mut self) {
+        self.active_session = None;
+    }
+
+    pub fn clear_pending_queue(&mut self) {
+        self.pending_text.clear();
+        self.pending_session = None;
+    }
+
+    pub fn clear_all_sessions(&mut self) {
+        self.clear_pending_queue();
+        self.clear_active_session();
+    }
+
+    pub fn clear_sessions_for_placeholder(&mut self, index: usize) {
+        if self.active_session.is_some_and(|session| session.placeholder_index == Some(index)) {
+            self.active_session = None;
+        }
+        if self.pending_session.is_some_and(|session| session.placeholder_index == Some(index)) {
+            self.pending_session = None;
+        }
+    }
+}
+
+impl Default for PasteState {
+    fn default() -> Self {
+        Self {
+            burst: paste_burst::PasteBurstDetector::new(),
+            pending_text: String::new(),
+            pending_session: None,
+            active_session: None,
+            next_session_id: 1,
+        }
+    }
+}
+
 impl App {
     /// Queue a paste payload for drain-cycle finalization.
     ///
@@ -14,26 +95,23 @@ impl App {
         let chunk_chars = text.chars().count();
         let had_pending_submit = self.pending_submit.is_some();
         self.pending_submit = None;
-        if self.pending_paste_text.is_empty() {
-            let continued_session = self.active_paste_session.and_then(|session| {
+        if self.paste.pending_text.is_empty() {
+            let continued_session = self.paste.active_session.and_then(|session| {
                 let current_line = self.input.lines().get(self.input.cursor_row())?;
                 let idx =
                     parse_paste_placeholder_before_cursor(current_line, self.input.cursor_col())?;
                 (session.placeholder_index == Some(idx)).then_some(session)
             });
-            self.pending_paste_session = Some(continued_session.unwrap_or_else(|| {
-                let id = self.next_paste_session_id;
-                self.next_paste_session_id = self.next_paste_session_id.saturating_add(1);
-                PasteSessionState {
-                    id,
+            self.paste.pending_session =
+                Some(continued_session.unwrap_or_else(|| PasteSessionState {
+                    id: self.paste.allocate_session_id(),
                     start: SelectionPoint {
                         row: self.input.cursor_row(),
                         col: self.input.cursor_col(),
                     },
                     placeholder_index: None,
-                }
-            }));
-            if let Some(session) = self.pending_paste_session {
+                }));
+            if let Some(session) = self.paste.pending_session {
                 tracing::debug!(
                     target: crate::logging::targets::APP_PASTE,
                     event_name = "paste_queue_opened",
@@ -48,14 +126,14 @@ impl App {
                 );
             }
         }
-        self.pending_paste_text.push_str(text);
+        self.paste.pending_text.push_str(text);
         tracing::debug!(
             target: crate::logging::targets::APP_PASTE,
             event_name = "paste_queue_updated",
             message = "paste queue updated",
             outcome = "success",
             chunk_chars,
-            pending_chars = self.pending_paste_text.chars().count(),
+            pending_chars = self.paste.pending_text.chars().count(),
             had_pending_submit,
         );
     }

--- a/src/app/state/render_budget.rs
+++ b/src/app/state/render_budget.rs
@@ -37,7 +37,7 @@ impl super::App {
         if !self.is_streaming_tail_protected() {
             return None;
         }
-        self.active_turn_assistant_idx().or_else(|| self.messages.len().checked_sub(1))
+        self.active_turn_assistant_idx().or_else(|| self.transcript.messages.len().checked_sub(1))
     }
 
     #[must_use]
@@ -55,7 +55,8 @@ impl super::App {
     #[must_use]
     fn is_render_cache_block_protected(&self, msg_idx: usize, block_idx: usize) -> bool {
         let tail_protected = self.protected_streaming_message_idx() == Some(msg_idx);
-        let Some(block) = self.messages.get(msg_idx).and_then(|msg| msg.blocks.get(block_idx))
+        let Some(block) =
+            self.transcript.messages.get(msg_idx).and_then(|msg| msg.blocks.get(block_idx))
         else {
             return false;
         };
@@ -86,23 +87,24 @@ impl super::App {
 
     #[must_use]
     fn render_cache_slots_match_messages(&self) -> bool {
-        self.render_cache_slots.len() == self.messages.len()
+        self.transcript.render_cache_slots.len() == self.transcript.messages.len()
             && self
+                .transcript
                 .render_cache_slots
                 .iter()
-                .zip(&self.messages)
+                .zip(&self.transcript.messages)
                 .all(|(slots, msg)| slots.len() == Self::render_cache_slot_count_for_message(msg))
     }
 
     pub(crate) fn rebuild_render_cache_accounting(&mut self) {
-        self.render_cache_slots.clear();
-        self.render_cache_slots.reserve(self.messages.len());
-        self.render_cache_total_bytes = 0;
-        self.render_cache_protected_bytes = 0;
-        self.render_cache_evictable.clear();
+        self.transcript.render_cache_slots.clear();
+        self.transcript.render_cache_slots.reserve(self.transcript.messages.len());
+        self.transcript.render_cache_total_bytes = 0;
+        self.transcript.render_cache_protected_bytes = 0;
+        self.transcript.render_cache_evictable.clear();
 
         let protected_tail = self.protected_streaming_message_idx();
-        for (msg_idx, msg) in self.messages.iter().enumerate() {
+        for (msg_idx, msg) in self.transcript.messages.iter().enumerate() {
             let mut slots = Vec::with_capacity(Self::render_cache_slot_count_for_message(msg));
             for (block_idx, block) in msg.blocks.iter().enumerate() {
                 let cache = Self::block_cache(block);
@@ -121,19 +123,19 @@ impl super::App {
                     last_access_tick: cache.last_access_tick(),
                     protected,
                 };
-                self.render_cache_total_bytes =
-                    self.render_cache_total_bytes.saturating_add(cached_bytes);
+                self.transcript.render_cache_total_bytes =
+                    self.transcript.render_cache_total_bytes.saturating_add(cached_bytes);
                 if protected {
-                    self.render_cache_protected_bytes =
-                        self.render_cache_protected_bytes.saturating_add(cached_bytes);
+                    self.transcript.render_cache_protected_bytes =
+                        self.transcript.render_cache_protected_bytes.saturating_add(cached_bytes);
                 } else if let Some(key) = Self::render_cache_slot_key(msg_idx, block_idx, &slot) {
-                    self.render_cache_evictable.insert(key);
+                    self.transcript.render_cache_evictable.insert(key);
                 }
                 slots.push(slot);
             }
-            self.render_cache_slots.push(slots);
+            self.transcript.render_cache_slots.push(slots);
         }
-        self.render_cache_tail_msg_idx = protected_tail;
+        self.transcript.render_cache_tail_msg_idx = protected_tail;
     }
 
     pub(crate) fn ensure_render_cache_accounting(&mut self) {
@@ -144,24 +146,29 @@ impl super::App {
 
     pub(crate) fn sync_render_cache_slot(&mut self, msg_idx: usize, block_idx: usize) {
         self.ensure_render_cache_accounting();
-        let Some(old_slot) =
-            self.render_cache_slots.get(msg_idx).and_then(|slots| slots.get(block_idx)).copied()
+        let Some(old_slot) = self
+            .transcript
+            .render_cache_slots
+            .get(msg_idx)
+            .and_then(|slots| slots.get(block_idx))
+            .copied()
         else {
             self.rebuild_render_cache_accounting();
             return;
         };
 
         if let Some(old_key) = Self::render_cache_slot_key(msg_idx, block_idx, &old_slot) {
-            self.render_cache_evictable.remove(&old_key);
+            self.transcript.render_cache_evictable.remove(&old_key);
         }
-        self.render_cache_total_bytes =
-            self.render_cache_total_bytes.saturating_sub(old_slot.cached_bytes);
+        self.transcript.render_cache_total_bytes =
+            self.transcript.render_cache_total_bytes.saturating_sub(old_slot.cached_bytes);
         if old_slot.protected {
-            self.render_cache_protected_bytes =
-                self.render_cache_protected_bytes.saturating_sub(old_slot.cached_bytes);
+            self.transcript.render_cache_protected_bytes =
+                self.transcript.render_cache_protected_bytes.saturating_sub(old_slot.cached_bytes);
         }
 
-        let Some(block) = self.messages.get(msg_idx).and_then(|msg| msg.blocks.get(block_idx))
+        let Some(block) =
+            self.transcript.messages.get(msg_idx).and_then(|msg| msg.blocks.get(block_idx))
         else {
             self.rebuild_render_cache_accounting();
             return;
@@ -172,7 +179,7 @@ impl super::App {
             last_access_tick: cache.last_access_tick(),
             protected: self.is_render_cache_block_protected(msg_idx, block_idx),
         };
-        if let Some(slots) = self.render_cache_slots.get_mut(msg_idx) {
+        if let Some(slots) = self.transcript.render_cache_slots.get_mut(msg_idx) {
             if let Some(slot) = slots.get_mut(block_idx) {
                 *slot = new_slot;
             } else {
@@ -184,25 +191,27 @@ impl super::App {
             return;
         }
 
-        self.render_cache_total_bytes =
-            self.render_cache_total_bytes.saturating_add(new_slot.cached_bytes);
+        self.transcript.render_cache_total_bytes =
+            self.transcript.render_cache_total_bytes.saturating_add(new_slot.cached_bytes);
         if new_slot.protected {
-            self.render_cache_protected_bytes =
-                self.render_cache_protected_bytes.saturating_add(new_slot.cached_bytes);
+            self.transcript.render_cache_protected_bytes =
+                self.transcript.render_cache_protected_bytes.saturating_add(new_slot.cached_bytes);
         } else if let Some(new_key) = Self::render_cache_slot_key(msg_idx, block_idx, &new_slot) {
-            self.render_cache_evictable.insert(new_key);
+            self.transcript.render_cache_evictable.insert(new_key);
         }
     }
 
     pub(crate) fn sync_render_cache_message(&mut self, msg_idx: usize) {
         self.ensure_render_cache_accounting();
-        let Some(msg) = self.messages.get(msg_idx) else {
+        let Some(msg) = self.transcript.messages.get(msg_idx) else {
             self.rebuild_render_cache_accounting();
             return;
         };
         let block_count = msg.blocks.len();
         let slot_count = Self::render_cache_slot_count_for_message(msg);
-        if self.render_cache_slots.get(msg_idx).map_or(usize::MAX, Vec::len) != slot_count {
+        if self.transcript.render_cache_slots.get(msg_idx).map_or(usize::MAX, Vec::len)
+            != slot_count
+        {
             self.rebuild_render_cache_accounting();
             return;
         }
@@ -214,12 +223,12 @@ impl super::App {
     fn refresh_tail_message_cache_protection(&mut self) {
         self.ensure_render_cache_accounting();
         let next_tail = self.protected_streaming_message_idx();
-        if self.render_cache_tail_msg_idx == next_tail {
+        if self.transcript.render_cache_tail_msg_idx == next_tail {
             return;
         }
 
-        let previous_tail = self.render_cache_tail_msg_idx;
-        self.render_cache_tail_msg_idx = next_tail;
+        let previous_tail = self.transcript.render_cache_tail_msg_idx;
+        self.transcript.render_cache_tail_msg_idx = next_tail;
 
         if let Some(msg_idx) = previous_tail {
             self.sync_render_cache_message(msg_idx);
@@ -237,9 +246,9 @@ impl super::App {
 
     fn refresh_render_cache_eviction_order(&mut self) {
         self.ensure_render_cache_accounting();
-        self.render_cache_evictable.clear();
+        self.transcript.render_cache_evictable.clear();
 
-        for (msg_idx, msg) in self.messages.iter().enumerate() {
+        for (msg_idx, msg) in self.transcript.messages.iter().enumerate() {
             for (block_idx, block) in msg.blocks.iter().enumerate() {
                 let cache = Self::block_cache(block);
                 let protected = self.is_render_cache_block_protected(msg_idx, block_idx);
@@ -248,14 +257,14 @@ impl super::App {
                     last_access_tick: cache.last_access_tick(),
                     protected,
                 };
-                if let Some(slots) = self.render_cache_slots.get_mut(msg_idx)
+                if let Some(slots) = self.transcript.render_cache_slots.get_mut(msg_idx)
                     && let Some(existing) = slots.get_mut(block_idx)
                 {
                     existing.last_access_tick = slot.last_access_tick;
                     existing.protected = slot.protected;
                 }
                 if let Some(key) = Self::render_cache_slot_key(msg_idx, block_idx, &slot) {
-                    self.render_cache_evictable.insert(key);
+                    self.transcript.render_cache_evictable.insert(key);
                 }
             }
         }
@@ -264,8 +273,8 @@ impl super::App {
     pub fn enforce_render_cache_budget(&mut self) -> CacheBudgetEnforceStats {
         let mut stats = CacheBudgetEnforceStats::default();
         self.refresh_tail_message_cache_protection();
-        stats.total_before_bytes = self.render_cache_total_bytes;
-        stats.protected_bytes = self.render_cache_protected_bytes;
+        stats.total_before_bytes = self.transcript.render_cache_total_bytes;
+        stats.protected_bytes = self.transcript.render_cache_protected_bytes;
 
         // Budget comparison uses only non-protected (evictable) bytes.
         let budgeted_bytes = stats.total_before_bytes.saturating_sub(stats.protected_bytes);
@@ -281,11 +290,11 @@ impl super::App {
         let mut current_budgeted = budgeted_bytes;
         stats.total_after_bytes = stats.total_before_bytes;
 
-        while let Some(slot) = self.render_cache_evictable.first().copied() {
+        while let Some(slot) = self.transcript.render_cache_evictable.first().copied() {
             if current_budgeted <= self.render_cache_budget.max_bytes {
                 break;
             }
-            self.render_cache_evictable.remove(&slot);
+            self.transcript.render_cache_evictable.remove(&slot);
             let removed = self.evict_cache_slot(slot.msg_idx, slot.block_idx);
             if removed == 0 {
                 continue;
@@ -305,7 +314,7 @@ impl super::App {
     }
 
     fn evict_cache_slot(&mut self, msg_idx: usize, block_idx: usize) -> usize {
-        let Some(msg) = self.messages.get_mut(msg_idx) else {
+        let Some(msg) = self.transcript.messages.get_mut(msg_idx) else {
             return 0;
         };
         let Some(block) = msg.blocks.get_mut(block_idx) else {

--- a/src/app/state/repaint.rs
+++ b/src/app/state/repaint.rs
@@ -102,7 +102,7 @@ impl App {
         I: IntoIterator<Item = usize>,
     {
         let unique: BTreeSet<_> =
-            indices.into_iter().filter(|&idx| idx < self.messages.len()).collect();
+            indices.into_iter().filter(|&idx| idx < self.transcript.messages.len()).collect();
         if !unique.is_empty() {
             self.invalidate_layout(LayoutInvalidation::Global);
         }

--- a/src/app/state/sdk_inventory.rs
+++ b/src/app/state/sdk_inventory.rs
@@ -1,0 +1,31 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::agent::model;
+
+/// SDK-provided inventories and session-history caches surfaced by the app.
+#[derive(Default)]
+pub struct SdkInventoryState {
+    /// Current SDK task state from `TaskCreate`/`TaskUpdate`/`TaskGet`/`TaskList`.
+    pub tasks: Vec<model::TaskItem>,
+    /// Commands advertised by the agent via `AvailableCommandsUpdate`.
+    pub available_commands: Vec<model::AvailableCommand>,
+    /// Rewind candidates loaded from persisted SDK session history.
+    pub rewind_targets: Vec<model::RewindTarget>,
+    /// Session id that owns `rewind_targets`.
+    pub rewind_targets_session_id: Option<model::SessionId>,
+    /// True while a rewind target refresh request is in flight.
+    pub rewind_targets_in_flight: bool,
+    /// Subagents advertised by the agent via `AvailableAgentsUpdate`.
+    pub available_agents: Vec<model::AvailableAgent>,
+    /// Models advertised by the agent SDK for the active session.
+    pub available_models: Vec<model::AvailableModel>,
+}
+
+impl SdkInventoryState {
+    pub fn clear_rewind_targets(&mut self) {
+        self.rewind_targets.clear();
+        self.rewind_targets_session_id = None;
+        self.rewind_targets_in_flight = false;
+    }
+}

--- a/src/app/state/session_identity.rs
+++ b/src/app/state/session_identity.rs
@@ -36,15 +36,11 @@ impl App {
     }
 
     pub fn bump_session_scope_epoch(&mut self) {
-        self.session_scope_epoch = self.session_scope_epoch.saturating_add(1);
+        self.session_runtime.bump_session_scope_epoch();
     }
 
     pub fn clear_session_runtime_identity(&mut self) {
-        self.session_id = None;
-        self.current_model = None;
-        self.mode = None;
-        self.fast_mode_state = model::FastModeState::Off;
-        self.session_usage = SessionUsageState::default();
+        self.session_runtime.clear_identity();
         self.rewind_targets.clear();
         self.rewind_targets_session_id = None;
         self.rewind_targets_in_flight = false;

--- a/src/app/state/session_identity.rs
+++ b/src/app/state/session_identity.rs
@@ -6,13 +6,17 @@ use super::prelude::*;
 impl App {
     #[must_use]
     pub fn active_turn_assistant_idx(&self) -> Option<usize> {
-        self.active_turn_assistant_message_idx.filter(|&idx| {
-            self.messages.get(idx).is_some_and(|msg| matches!(msg.role, MessageRole::Assistant))
+        self.turn.assistant_message_idx.filter(|&idx| {
+            self.transcript
+                .messages
+                .get(idx)
+                .is_some_and(|msg| matches!(msg.role, MessageRole::Assistant))
         })
     }
 
     pub fn bind_active_turn_assistant(&mut self, idx: usize) {
-        self.active_turn_assistant_message_idx = self
+        self.turn.assistant_message_idx = self
+            .transcript
             .messages
             .get(idx)
             .is_some_and(|msg| matches!(msg.role, MessageRole::Assistant))
@@ -20,7 +24,7 @@ impl App {
     }
 
     pub fn bind_active_turn_assistant_to_tail(&mut self) {
-        if let Some(idx) = self.messages.len().checked_sub(1) {
+        if let Some(idx) = self.transcript.messages.len().checked_sub(1) {
             self.bind_active_turn_assistant(idx);
         } else {
             self.clear_active_turn_assistant();
@@ -28,7 +32,7 @@ impl App {
     }
 
     pub fn clear_active_turn_assistant(&mut self) {
-        self.active_turn_assistant_message_idx = None;
+        self.turn.assistant_message_idx = None;
     }
 
     pub fn bump_session_scope_epoch(&mut self) {
@@ -70,18 +74,18 @@ impl App {
     }
 
     pub(crate) fn shift_active_turn_assistant_for_insert(&mut self, idx: usize) {
-        if let Some(owner_idx) = self.active_turn_assistant_message_idx
+        if let Some(owner_idx) = self.turn.assistant_message_idx
             && idx <= owner_idx
         {
-            self.active_turn_assistant_message_idx = Some(owner_idx.saturating_add(1));
+            self.turn.assistant_message_idx = Some(owner_idx.saturating_add(1));
         }
     }
 
     pub(crate) fn shift_active_turn_assistant_for_remove(&mut self, idx: usize) {
-        let Some(owner_idx) = self.active_turn_assistant_message_idx else {
+        let Some(owner_idx) = self.turn.assistant_message_idx else {
             return;
         };
-        self.active_turn_assistant_message_idx = match idx.cmp(&owner_idx) {
+        self.turn.assistant_message_idx = match idx.cmp(&owner_idx) {
             std::cmp::Ordering::Less => Some(owner_idx.saturating_sub(1)),
             std::cmp::Ordering::Equal => None,
             std::cmp::Ordering::Greater => Some(owner_idx),

--- a/src/app/state/session_identity.rs
+++ b/src/app/state/session_identity.rs
@@ -41,9 +41,7 @@ impl App {
 
     pub fn clear_session_runtime_identity(&mut self) {
         self.session_runtime.clear_identity();
-        self.rewind_targets.clear();
-        self.rewind_targets_session_id = None;
-        self.rewind_targets_in_flight = false;
+        self.sdk_inventory.clear_rewind_targets();
     }
 
     pub fn reconcile_trust_state_from_preferences_and_cwd(&mut self) {

--- a/src/app/state/session_runtime.rs
+++ b/src/app/state/session_runtime.rs
@@ -1,0 +1,80 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::agent::client::AgentConnection;
+use crate::agent::model;
+use crate::app::state::{LoginHint, ModeState, SessionUsageState};
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+/// State owned by the active SDK session/runtime boundary.
+pub struct SessionRuntimeState {
+    pub session_id: Option<model::SessionId>,
+    /// Agent connection handle. `None` while connecting (before bridge is ready).
+    pub conn: Option<Rc<AgentConnection>>,
+    /// Monotonic session authority epoch used to ignore stale async view data.
+    pub session_scope_epoch: u64,
+    pub current_model: Option<model::CurrentModel>,
+    pub mode: Option<ModeState>,
+    /// Latest config options observed from bridge `config_option_update` events.
+    pub config_options: BTreeMap<String, serde_json::Value>,
+    /// Login hint shown when authentication is required. Rendered above the input field.
+    pub login_hint: Option<LoginHint>,
+    /// Session-wide usage and cost telemetry from the bridge.
+    pub session_usage: SessionUsageState,
+    /// Fast mode state telemetry from the SDK.
+    pub fast_mode_state: model::FastModeState,
+    /// Latest SDK runtime liveness state.
+    pub runtime_session_state: Option<model::RuntimeSessionState>,
+    /// Latest prompt suggestion from the SDK, shown in the input hint band.
+    pub prompt_suggestion: Option<String>,
+    /// Latest rate-limit telemetry from the SDK.
+    pub last_rate_limit_update: Option<model::RateLimitUpdate>,
+    /// Account info from the bridge status snapshot (email, org, subscription).
+    pub account_info: Option<model::AccountInfo>,
+}
+
+impl Default for SessionRuntimeState {
+    fn default() -> Self {
+        Self {
+            session_id: None,
+            conn: None,
+            session_scope_epoch: 0,
+            current_model: None,
+            mode: None,
+            config_options: BTreeMap::new(),
+            login_hint: None,
+            session_usage: SessionUsageState::default(),
+            fast_mode_state: model::FastModeState::Off,
+            runtime_session_state: None,
+            prompt_suggestion: None,
+            last_rate_limit_update: None,
+            account_info: None,
+        }
+    }
+}
+
+impl SessionRuntimeState {
+    #[must_use]
+    pub fn test_default() -> Self {
+        Self {
+            current_model: Some(
+                model::CurrentModel::new("test-model", "test-model", "test-model")
+                    .authoritative(true),
+            ),
+            ..Self::default()
+        }
+    }
+
+    pub fn bump_session_scope_epoch(&mut self) {
+        self.session_scope_epoch = self.session_scope_epoch.saturating_add(1);
+    }
+
+    pub fn clear_identity(&mut self) {
+        self.session_id = None;
+        self.current_model = None;
+        self.mode = None;
+        self.fast_mode_state = model::FastModeState::Off;
+        self.session_usage = SessionUsageState::default();
+    }
+}

--- a/src/app/state/startup.rs
+++ b/src/app/state/startup.rs
@@ -1,0 +1,180 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+/// Bootstrap state resolved from CLI flags and consumed while the app
+/// transitions from launch to a connected session.
+///
+/// CLI launch intent is immutable after construction. Runtime sequencing moves
+/// through [`StartupPhase`], so callers cannot represent conflicting states
+/// such as "connection started but not requested".
+#[derive(Debug, Default)]
+pub struct StartupState {
+    /// Explicit bridge script path from `--bridge-script`.
+    bridge_script: Option<PathBuf>,
+    launch: StartupLaunch,
+    phase: StartupPhase,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum StartupLaunch {
+    #[default]
+    NewSession,
+    ResumeSession {
+        session_id: String,
+    },
+    SessionPicker,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StartupPhase {
+    /// Waiting for trust resolution before a bridge connection may be started.
+    #[default]
+    AwaitingConnection,
+    /// Trust is resolved and the bridge connection may be spawned.
+    ConnectionRequested,
+    /// The bridge task has been spawned. If startup requested the picker, the
+    /// picker sub-phase tracks list loading and resolution.
+    ConnectionStarted(StartupConnectionPhase),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupConnectionPhase {
+    Running,
+    PickerPending { recent_sessions_loaded: bool },
+    PickerResolved,
+}
+
+impl StartupState {
+    #[must_use]
+    pub fn new(
+        bridge_script: Option<PathBuf>,
+        resume_id: Option<String>,
+        session_picker_requested: bool,
+    ) -> Self {
+        let launch = if session_picker_requested {
+            StartupLaunch::SessionPicker
+        } else if let Some(session_id) = resume_id {
+            StartupLaunch::ResumeSession { session_id }
+        } else {
+            StartupLaunch::NewSession
+        };
+
+        Self { bridge_script, launch, phase: StartupPhase::AwaitingConnection }
+    }
+
+    #[must_use]
+    pub fn bridge_script(&self) -> Option<&PathBuf> {
+        self.bridge_script.as_ref()
+    }
+
+    #[must_use]
+    pub fn resume_id(&self) -> Option<&str> {
+        match &self.launch {
+            StartupLaunch::ResumeSession { session_id } => Some(session_id.as_str()),
+            StartupLaunch::NewSession | StartupLaunch::SessionPicker => None,
+        }
+    }
+
+    #[must_use]
+    pub fn resume_requested(&self) -> bool {
+        matches!(self.launch, StartupLaunch::ResumeSession { .. })
+    }
+
+    #[must_use]
+    pub fn session_picker_requested(&self) -> bool {
+        matches!(self.launch, StartupLaunch::SessionPicker)
+    }
+
+    #[must_use]
+    pub fn connection_requested(&self) -> bool {
+        matches!(self.phase, StartupPhase::ConnectionRequested | StartupPhase::ConnectionStarted(_))
+    }
+
+    #[must_use]
+    pub fn connection_started(&self) -> bool {
+        matches!(self.phase, StartupPhase::ConnectionStarted(_))
+    }
+
+    pub fn request_connection(&mut self) {
+        if matches!(self.phase, StartupPhase::AwaitingConnection) {
+            self.phase = StartupPhase::ConnectionRequested;
+        }
+    }
+
+    /// Mark the bridge connection as spawned.
+    ///
+    /// Returns `true` only for the valid transition from requested to started.
+    pub fn mark_connection_started(&mut self) -> bool {
+        if !matches!(self.phase, StartupPhase::ConnectionRequested) {
+            return false;
+        }
+
+        self.phase = StartupPhase::ConnectionStarted(if self.session_picker_requested() {
+            StartupConnectionPhase::PickerPending { recent_sessions_loaded: false }
+        } else {
+            StartupConnectionPhase::Running
+        });
+        true
+    }
+
+    pub fn mark_recent_sessions_loaded(&mut self) {
+        if let StartupPhase::ConnectionStarted(StartupConnectionPhase::PickerPending {
+            recent_sessions_loaded,
+        }) = &mut self.phase
+        {
+            *recent_sessions_loaded = true;
+        }
+    }
+
+    #[must_use]
+    pub fn recent_sessions_loaded(&self) -> bool {
+        matches!(
+            self.phase,
+            StartupPhase::ConnectionStarted(
+                StartupConnectionPhase::PickerPending { recent_sessions_loaded: true }
+                    | StartupConnectionPhase::PickerResolved
+            )
+        )
+    }
+
+    #[must_use]
+    pub fn session_picker_resolved(&self) -> bool {
+        matches!(
+            self.phase,
+            StartupPhase::ConnectionStarted(StartupConnectionPhase::PickerResolved)
+        )
+    }
+
+    #[must_use]
+    pub fn startup_picker_is_loading(&self, connection_ready: bool) -> bool {
+        matches!(
+            self.phase,
+            StartupPhase::ConnectionStarted(StartupConnectionPhase::PickerPending {
+                recent_sessions_loaded: false
+            })
+        ) || (self.session_picker_requested()
+            && !self.session_picker_resolved()
+            && !connection_ready)
+    }
+
+    #[must_use]
+    pub fn startup_picker_is_ready(&self) -> bool {
+        matches!(
+            self.phase,
+            StartupPhase::ConnectionStarted(StartupConnectionPhase::PickerPending {
+                recent_sessions_loaded: true
+            })
+        )
+    }
+
+    pub fn resolve_session_picker(&mut self) {
+        if matches!(
+            self.phase,
+            StartupPhase::ConnectionStarted(StartupConnectionPhase::PickerPending { .. })
+        ) {
+            self.phase = StartupPhase::ConnectionStarted(StartupConnectionPhase::PickerResolved);
+        }
+    }
+}

--- a/src/app/state/tests.rs
+++ b/src/app/state/tests.rs
@@ -181,28 +181,28 @@ fn cache_height_invalidated_returns_none() {
 #[test]
 fn clear_session_runtime_identity_resets_session_usage() {
     let mut app = App::test_default();
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
-    app.current_model = Some(
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.current_model = Some(
         crate::agent::model::CurrentModel::new("sonnet", "Claude Sonnet", "Claude Sonnet")
             .authoritative(true),
     );
-    app.mode = Some(crate::app::ModeState {
+    app.session_runtime.mode = Some(crate::app::ModeState {
         current_mode_id: "plan".to_owned(),
         current_mode_name: "Plan".to_owned(),
         available_modes: Vec::new(),
     });
-    app.session_usage.context_usage_percent = Some(62);
-    app.session_usage.context_usage_in_flight = true;
-    app.session_usage.context_usage_refresh_pending = true;
-    app.session_usage.context_usage_last_requested_at = Some(Instant::now());
-    app.session_usage.last_compaction_pre_tokens = Some(123_456);
+    app.session_runtime.session_usage.context_usage_percent = Some(62);
+    app.session_runtime.session_usage.context_usage_in_flight = true;
+    app.session_runtime.session_usage.context_usage_refresh_pending = true;
+    app.session_runtime.session_usage.context_usage_last_requested_at = Some(Instant::now());
+    app.session_runtime.session_usage.last_compaction_pre_tokens = Some(123_456);
 
     app.clear_session_runtime_identity();
 
-    assert!(app.session_id.is_none());
-    assert!(app.current_model.is_none());
-    assert!(app.mode.is_none());
-    assert_eq!(app.session_usage, SessionUsageState::default());
+    assert!(app.session_runtime.session_id.is_none());
+    assert!(app.session_runtime.current_model.is_none());
+    assert!(app.session_runtime.mode.is_none());
+    assert_eq!(app.session_runtime.session_usage, SessionUsageState::default());
 }
 
 #[test]
@@ -319,7 +319,7 @@ fn user_text_image_message(text: &str, image_count: usize) -> ChatMessage {
 }
 
 fn set_account_subscription(app: &mut App, subscription: &str) {
-    app.account_info = Some(crate::agent::model::AccountInfo {
+    app.session_runtime.account_info = Some(crate::agent::model::AccountInfo {
         subscription_type: Some(subscription.to_owned()),
         ..Default::default()
     });
@@ -361,7 +361,7 @@ fn sync_welcome_snapshot_updates_canonical_welcome_message() {
     let mut app = make_test_app();
     app.ensure_welcome_message();
 
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     set_account_subscription(&mut app, "Pro");
 
     app.sync_welcome_snapshot();
@@ -378,7 +378,7 @@ fn sync_welcome_snapshot_updates_canonical_welcome_message() {
 fn sync_welcome_snapshot_updates_existing_canonical_welcome_in_place() {
     let mut app = make_test_app();
     app.ensure_welcome_message();
-    app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
     set_account_subscription(&mut app, "Pro");
     app.sync_welcome_snapshot();
 

--- a/src/app/state/tests.rs
+++ b/src/app/state/tests.rs
@@ -332,9 +332,9 @@ fn push_message_tracked_appends_user_message_and_requests_repaint() {
 
     app.push_message_tracked(user_text_message("hello"));
 
-    assert_eq!(app.messages.len(), 1);
-    assert!(matches!(app.messages[0].role, MessageRole::User));
-    let MessageBlock::Text(text) = &app.messages[0].blocks[0] else {
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
+    let MessageBlock::Text(text) = &app.transcript.messages[0].blocks[0] else {
         panic!("expected text block");
     };
     assert_eq!(text.text, "hello");
@@ -348,9 +348,12 @@ fn push_message_tracked_preserves_message_order() {
     app.push_message_tracked(user_text_message("first"));
     app.push_message_tracked(system_text_message("second"));
 
-    assert_eq!(app.messages.len(), 2);
-    assert!(matches!(app.messages[0].role, MessageRole::User));
-    assert!(matches!(app.messages[1].role, MessageRole::System(Some(SystemSeverity::Info))));
+    assert_eq!(app.transcript.messages.len(), 2);
+    assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
+    assert!(matches!(
+        app.transcript.messages[1].role,
+        MessageRole::System(Some(SystemSeverity::Info))
+    ));
 }
 
 #[test]
@@ -364,7 +367,7 @@ fn sync_welcome_snapshot_updates_canonical_welcome_message() {
     app.sync_welcome_snapshot();
     app.sync_welcome_snapshot();
 
-    let MessageBlock::Welcome(welcome) = &app.messages[0].blocks[0] else {
+    let MessageBlock::Welcome(welcome) = &app.transcript.messages[0].blocks[0] else {
         panic!("expected welcome block");
     };
     assert_eq!(welcome.subscription, "Pro");
@@ -382,10 +385,10 @@ fn sync_welcome_snapshot_updates_existing_canonical_welcome_in_place() {
     set_account_subscription(&mut app, "Claude Max");
     app.sync_welcome_snapshot();
 
-    let MessageBlock::Welcome(welcome) = &app.messages[0].blocks[0] else {
+    let MessageBlock::Welcome(welcome) = &app.transcript.messages[0].blocks[0] else {
         panic!("expected welcome block");
     };
-    assert_eq!(app.messages.len(), 1);
+    assert_eq!(app.transcript.messages.len(), 1);
     assert_eq!(welcome.subscription, "Claude Max");
 }
 
@@ -395,13 +398,13 @@ fn push_message_tracked_preserves_user_image_attachment_block() {
 
     app.push_message_tracked(user_text_image_message("see attached", 2));
 
-    assert_eq!(app.messages.len(), 1);
-    assert!(matches!(app.messages[0].role, MessageRole::User));
-    let MessageBlock::Text(text) = &app.messages[0].blocks[0] else {
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
+    let MessageBlock::Text(text) = &app.transcript.messages[0].blocks[0] else {
         panic!("expected text block");
     };
     assert_eq!(text.text, "see attached");
-    let MessageBlock::ImageAttachment(image) = &app.messages[0].blocks[1] else {
+    let MessageBlock::ImageAttachment(image) = &app.transcript.messages[0].blocks[1] else {
         panic!("expected image attachment block");
     };
     assert_eq!(image.count, 2);
@@ -544,18 +547,18 @@ fn pending_user_dialog_message(request_id: &str) -> ChatMessage {
 #[test]
 fn enforce_render_cache_budget_evicts_lru_block() {
     let mut app = make_test_app();
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::new(MessageRole::Assistant, vec![assistant_text_block("a")], None),
         ChatMessage::new(MessageRole::Assistant, vec![assistant_text_block("b")], None),
     ];
 
-    let bytes_a = if let MessageBlock::Text(block) = &mut app.messages[0].blocks[0] {
+    let bytes_a = if let MessageBlock::Text(block) = &mut app.transcript.messages[0].blocks[0] {
         block.cache.store(vec![Line::from("x".repeat(2200))]);
         block.cache.cached_bytes()
     } else {
         0
     };
-    let bytes_b = if let MessageBlock::Text(block) = &mut app.messages[1].blocks[0] {
+    let bytes_b = if let MessageBlock::Text(block) = &mut app.transcript.messages[1].blocks[0] {
         block.cache.store(vec![Line::from("y".repeat(2200))]);
         let _ = block.cache.get();
         block.cache.cached_bytes()
@@ -570,12 +573,12 @@ fn enforce_render_cache_budget_evicts_lru_block() {
     assert!(stats.total_after_bytes <= app.render_cache_budget.max_bytes);
     assert_eq!(stats.protected_bytes, 0);
 
-    if let MessageBlock::Text(block) = &app.messages[0].blocks[0] {
+    if let MessageBlock::Text(block) = &app.transcript.messages[0].blocks[0] {
         assert_eq!(block.cache.cached_bytes(), 0);
     } else {
         panic!("expected text block");
     }
-    if let MessageBlock::Text(block) = &app.messages[1].blocks[0] {
+    if let MessageBlock::Text(block) = &app.transcript.messages[1].blocks[0] {
         assert_eq!(block.cache.cached_bytes(), bytes_b);
     } else {
         panic!("expected text block");
@@ -586,13 +589,13 @@ fn enforce_render_cache_budget_evicts_lru_block() {
 fn enforce_render_cache_budget_protects_streaming_tail_message() {
     let mut app = make_test_app();
     app.status = AppStatus::Thinking;
-    app.messages = vec![ChatMessage::new(
+    app.transcript.messages = vec![ChatMessage::new(
         MessageRole::Assistant,
         vec![assistant_text_block("streaming tail")],
         None,
     )];
 
-    let before = if let MessageBlock::Text(block) = &mut app.messages[0].blocks[0] {
+    let before = if let MessageBlock::Text(block) = &mut app.transcript.messages[0].blocks[0] {
         block.cache.store(vec![Line::from("z".repeat(4096))]);
         block.cache.cached_bytes()
     } else {
@@ -604,7 +607,7 @@ fn enforce_render_cache_budget_protects_streaming_tail_message() {
     assert_eq!(stats.evicted_bytes, 0);
     assert_eq!(stats.protected_bytes, before);
 
-    if let MessageBlock::Text(block) = &app.messages[0].blocks[0] {
+    if let MessageBlock::Text(block) = &app.transcript.messages[0].blocks[0] {
         assert_eq!(block.cache.cached_bytes(), before);
     } else {
         panic!("expected text block");
@@ -615,7 +618,7 @@ fn enforce_render_cache_budget_protects_streaming_tail_message() {
 fn enforce_render_cache_budget_excludes_protected_from_budget() {
     let mut app = make_test_app();
     app.status = AppStatus::Running;
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::new(MessageRole::Assistant, vec![assistant_text_block("old message")], None),
         ChatMessage::new(
             MessageRole::Assistant,
@@ -624,13 +627,13 @@ fn enforce_render_cache_budget_excludes_protected_from_budget() {
         ),
     ];
 
-    let bytes_a = if let MessageBlock::Text(block) = &mut app.messages[0].blocks[0] {
+    let bytes_a = if let MessageBlock::Text(block) = &mut app.transcript.messages[0].blocks[0] {
         block.cache.store(vec![Line::from("x".repeat(2200))]);
         block.cache.cached_bytes()
     } else {
         0
     };
-    let bytes_b = if let MessageBlock::Text(block) = &mut app.messages[1].blocks[0] {
+    let bytes_b = if let MessageBlock::Text(block) = &mut app.transcript.messages[1].blocks[0] {
         block.cache.store(vec![Line::from("y".repeat(5000))]);
         block.cache.cached_bytes()
     } else {
@@ -649,7 +652,7 @@ fn enforce_render_cache_budget_excludes_protected_from_budget() {
     assert_eq!(stats.evicted_blocks, 0);
     assert_eq!(stats.evicted_bytes, 0);
     // Old message cache intact.
-    if let MessageBlock::Text(block) = &app.messages[0].blocks[0] {
+    if let MessageBlock::Text(block) = &app.transcript.messages[0].blocks[0] {
         assert_eq!(block.cache.cached_bytes(), bytes_a);
     } else {
         panic!("expected text block");
@@ -660,7 +663,7 @@ fn enforce_render_cache_budget_excludes_protected_from_budget() {
 fn enforce_render_cache_budget_protects_active_streaming_owner_not_physical_tail() {
     let mut app = make_test_app();
     app.status = AppStatus::Running;
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::new(MessageRole::Assistant, vec![assistant_text_block("old message")], None),
         ChatMessage::new(
             MessageRole::Assistant,
@@ -675,16 +678,17 @@ fn enforce_render_cache_budget_protects_active_streaming_owner_not_physical_tail
     ];
     app.bind_active_turn_assistant(1);
 
-    if let MessageBlock::Text(block) = &mut app.messages[0].blocks[0] {
+    if let MessageBlock::Text(block) = &mut app.transcript.messages[0].blocks[0] {
         block.cache.store(vec![Line::from("x".repeat(2000))]);
     }
-    let protected_bytes = if let MessageBlock::Text(block) = &mut app.messages[1].blocks[0] {
-        block.cache.store(vec![Line::from("y".repeat(4000))]);
-        block.cache.cached_bytes()
-    } else {
-        0
-    };
-    if let MessageBlock::Text(block) = &mut app.messages[2].blocks[0] {
+    let protected_bytes =
+        if let MessageBlock::Text(block) = &mut app.transcript.messages[1].blocks[0] {
+            block.cache.store(vec![Line::from("y".repeat(4000))]);
+            block.cache.cached_bytes()
+        } else {
+            0
+        };
+    if let MessageBlock::Text(block) = &mut app.transcript.messages[2].blocks[0] {
         block.cache.store(vec![Line::from("z".repeat(5000))]);
     }
 
@@ -698,24 +702,24 @@ fn enforce_render_cache_budget_protects_active_streaming_owner_not_physical_tail
 fn enforce_render_cache_budget_evicts_when_budgeted_over_limit() {
     let mut app = make_test_app();
     app.status = AppStatus::Running;
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::new(MessageRole::Assistant, vec![assistant_text_block("old-a")], None),
         ChatMessage::new(MessageRole::Assistant, vec![assistant_text_block("old-b")], None),
         ChatMessage::new(MessageRole::Assistant, vec![assistant_text_block("streaming")], None),
     ];
 
     // Populate caches: messages 0 and 1 evictable, message 2 protected.
-    if let MessageBlock::Text(block) = &mut app.messages[0].blocks[0] {
+    if let MessageBlock::Text(block) = &mut app.transcript.messages[0].blocks[0] {
         block.cache.store(vec![Line::from("x".repeat(3000))]);
     }
-    let bytes_b = if let MessageBlock::Text(block) = &mut app.messages[1].blocks[0] {
+    let bytes_b = if let MessageBlock::Text(block) = &mut app.transcript.messages[1].blocks[0] {
         block.cache.store(vec![Line::from("y".repeat(3000))]);
         let _ = block.cache.get(); // touch to make more recently accessed
         block.cache.cached_bytes()
     } else {
         0
     };
-    let bytes_c = if let MessageBlock::Text(block) = &mut app.messages[2].blocks[0] {
+    let bytes_c = if let MessageBlock::Text(block) = &mut app.transcript.messages[2].blocks[0] {
         block.cache.store(vec![Line::from("z".repeat(5000))]);
         block.cache.cached_bytes()
     } else {
@@ -730,7 +734,7 @@ fn enforce_render_cache_budget_evicts_when_budgeted_over_limit() {
     assert_eq!(stats.protected_bytes, bytes_c);
     assert!(stats.evicted_blocks >= 1); // message A evicted (older access)
     // Message B should survive (more recent access).
-    if let MessageBlock::Text(block) = &app.messages[1].blocks[0] {
+    if let MessageBlock::Text(block) = &app.transcript.messages[1].blocks[0] {
         assert_eq!(block.cache.cached_bytes(), bytes_b);
     } else {
         panic!("expected text block");
@@ -741,10 +745,10 @@ fn enforce_render_cache_budget_evicts_when_budgeted_over_limit() {
 fn enforce_render_cache_budget_protected_bytes_zero_when_not_streaming() {
     let mut app = make_test_app();
     app.status = AppStatus::Ready;
-    app.messages =
+    app.transcript.messages =
         vec![ChatMessage::new(MessageRole::Assistant, vec![assistant_text_block("done")], None)];
 
-    if let MessageBlock::Text(block) = &mut app.messages[0].blocks[0] {
+    if let MessageBlock::Text(block) = &mut app.transcript.messages[0].blocks[0] {
         block.cache.store(vec![Line::from("x".repeat(2000))]);
     }
     app.render_cache_budget.max_bytes = usize::MAX;
@@ -756,7 +760,7 @@ fn enforce_render_cache_budget_protected_bytes_zero_when_not_streaming() {
 #[test]
 fn enforce_history_retention_noop_under_budget() {
     let mut app = make_test_app();
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
         user_text_message("small message"),
         user_text_message("another message"),
@@ -766,13 +770,13 @@ fn enforce_history_retention_noop_under_budget() {
     let stats = app.enforce_history_retention();
     assert_eq!(stats.dropped_messages, 0);
     assert_eq!(stats.total_dropped_messages, 0);
-    assert!(!app.messages.iter().any(App::is_history_hidden_marker_message));
+    assert!(!app.transcript.messages.iter().any(App::is_history_hidden_marker_message));
 }
 
 #[test]
 fn enforce_history_retention_drops_oldest_and_adds_marker() {
     let mut app = make_test_app();
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
         user_text_message("first old message"),
         user_text_message("second old message"),
@@ -782,15 +786,15 @@ fn enforce_history_retention_drops_oldest_and_adds_marker() {
 
     let stats = app.enforce_history_retention();
     assert_eq!(stats.dropped_messages, 3);
-    assert!(matches!(app.messages[0].role, MessageRole::Welcome));
-    assert!(app.messages.iter().any(App::is_history_hidden_marker_message));
-    assert_eq!(app.messages.len(), 2);
+    assert!(matches!(app.transcript.messages[0].role, MessageRole::Welcome));
+    assert!(app.transcript.messages.iter().any(App::is_history_hidden_marker_message));
+    assert_eq!(app.transcript.messages.len(), 2);
 }
 
 #[test]
 fn enforce_history_retention_preserves_in_progress_tool_message() {
     let mut app = make_test_app();
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
         user_text_message("droppable"),
         assistant_tool_message("tool-keep", model::ToolCallStatus::InProgress),
@@ -799,7 +803,7 @@ fn enforce_history_retention_preserves_in_progress_tool_message() {
 
     let stats = app.enforce_history_retention();
     assert_eq!(stats.dropped_messages, 1);
-    assert!(app.messages.iter().any(|msg| {
+    assert!(app.transcript.messages.iter().any(|msg| {
         msg.blocks.iter().any(|block| {
             matches!(
                 block,
@@ -813,7 +817,7 @@ fn enforce_history_retention_preserves_in_progress_tool_message() {
 #[test]
 fn enforce_history_retention_preserves_pending_tool_message() {
     let mut app = make_test_app();
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
         user_text_message("droppable"),
         assistant_tool_message("tool-pending", model::ToolCallStatus::Pending),
@@ -822,7 +826,7 @@ fn enforce_history_retention_preserves_pending_tool_message() {
 
     let stats = app.enforce_history_retention();
     assert_eq!(stats.dropped_messages, 1);
-    assert!(app.messages.iter().any(|msg| {
+    assert!(app.transcript.messages.iter().any(|msg| {
         msg.blocks
             .iter()
             .any(|block| matches!(block, MessageBlock::ToolCall(tc) if tc.id == "tool-pending"))
@@ -832,7 +836,7 @@ fn enforce_history_retention_preserves_pending_tool_message() {
 #[test]
 fn enforce_history_retention_preserves_permission_tool_message() {
     let mut app = make_test_app();
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
         user_text_message("droppable"),
         assistant_tool_message_with_pending_permission("tool-perm"),
@@ -841,7 +845,7 @@ fn enforce_history_retention_preserves_permission_tool_message() {
 
     let stats = app.enforce_history_retention();
     assert_eq!(stats.dropped_messages, 1);
-    assert!(app.messages.iter().any(|msg| {
+    assert!(app.transcript.messages.iter().any(|msg| {
         msg.blocks
             .iter()
             .any(|block| matches!(block, MessageBlock::ToolCall(tc) if tc.id == "tool-perm"))
@@ -851,25 +855,25 @@ fn enforce_history_retention_preserves_permission_tool_message() {
 #[test]
 fn enforce_history_retention_preserves_and_rebuilds_pending_user_dialog() {
     let mut app = make_test_app();
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
         user_text_message("droppable"),
         pending_user_dialog_message("dialog-1"),
     ];
     app.index_tool_call("dialog-1".to_owned(), 99, 99);
-    app.pending_interaction_ids = vec!["stale-dialog".to_owned(), "dialog-1".to_owned()];
+    app.turn.pending_interaction_ids = vec!["stale-dialog".to_owned(), "dialog-1".to_owned()];
     app.history_retention.max_bytes = 1;
 
     let stats = app.enforce_history_retention();
 
     assert_eq!(stats.dropped_messages, 1);
     assert_eq!(app.lookup_tool_call("dialog-1"), Some((2, 0)));
-    assert_eq!(app.pending_interaction_ids, vec!["dialog-1".to_owned()]);
+    assert_eq!(app.turn.pending_interaction_ids, vec!["dialog-1".to_owned()]);
     let Some((msg_idx, block_idx)) = app.lookup_tool_call("dialog-1") else {
         panic!("expected rebuilt dialog index");
     };
     let Some(MessageBlock::UserDialog(dialog)) =
-        app.messages.get(msg_idx).and_then(|msg| msg.blocks.get(block_idx))
+        app.transcript.messages.get(msg_idx).and_then(|msg| msg.blocks.get(block_idx))
     else {
         panic!("expected user dialog block");
     };
@@ -880,7 +884,7 @@ fn enforce_history_retention_preserves_and_rebuilds_pending_user_dialog() {
 #[test]
 fn enforce_history_retention_rebuilds_tool_index_after_prune() {
     let mut app = make_test_app();
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
         user_text_message("drop this"),
         assistant_bash_tool_message("tool-idx", model::ToolCallStatus::InProgress, "term-1"),
@@ -891,18 +895,17 @@ fn enforce_history_retention_rebuilds_tool_index_after_prune() {
 
     let _ = app.enforce_history_retention();
     assert_eq!(app.lookup_tool_call("tool-idx"), Some((2, 0)));
-    assert_eq!(app.terminal_tool_calls.len(), 1);
-    assert_eq!(app.terminal_tool_call_membership.len(), 1);
-    assert_eq!(app.terminal_tool_calls[0].terminal_id, "term-1");
-    assert_eq!(app.terminal_tool_calls[0].msg_idx, 2);
-    assert_eq!(app.terminal_tool_calls[0].block_idx, 0);
+    assert_eq!(app.terminal_tool_calls().len(), 1);
+    assert_eq!(app.terminal_tool_calls()[0].terminal_id, "term-1");
+    assert_eq!(app.terminal_tool_calls()[0].msg_idx, 2);
+    assert_eq!(app.terminal_tool_calls()[0].block_idx, 0);
 }
 
 #[test]
 fn enforce_history_retention_preserves_active_turn_assistant_message() {
     let mut app = make_test_app();
     app.status = AppStatus::Thinking;
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
         user_text_message("drop this"),
         ChatMessage::new(MessageRole::Assistant, Vec::new(), None),
@@ -914,14 +917,14 @@ fn enforce_history_retention_preserves_active_turn_assistant_message() {
 
     assert_eq!(stats.dropped_messages, 1);
     assert_eq!(app.active_turn_assistant_idx(), Some(2));
-    assert!(matches!(app.messages[2].role, MessageRole::Assistant));
+    assert!(matches!(app.transcript.messages[2].role, MessageRole::Assistant));
 }
 
 #[test]
 fn enforce_history_retention_remaps_active_turn_assistant_after_prune() {
     let mut app = make_test_app();
     app.status = AppStatus::Thinking;
-    app.messages = vec![
+    app.transcript.messages = vec![
         user_text_message("drop this"),
         ChatMessage::new(
             MessageRole::Assistant,
@@ -930,20 +933,20 @@ fn enforce_history_retention_remaps_active_turn_assistant_after_prune() {
         ),
     ];
     app.bind_active_turn_assistant(1);
-    app.history_retention.max_bytes = App::measure_message_bytes(&app.messages[1]);
+    app.history_retention.max_bytes = App::measure_message_bytes(&app.transcript.messages[1]);
 
     let stats = app.enforce_history_retention();
 
     assert_eq!(stats.dropped_messages, 1);
     assert_eq!(app.active_turn_assistant_idx(), Some(1));
-    assert!(App::is_history_hidden_marker_message(&app.messages[0]));
-    assert!(matches!(app.messages[1].role, MessageRole::Assistant));
+    assert!(App::is_history_hidden_marker_message(&app.transcript.messages[0]));
+    assert!(matches!(app.transcript.messages[1].role, MessageRole::Assistant));
 }
 
 #[test]
 fn enforce_history_retention_keeps_single_marker_on_repeat() {
     let mut app = make_test_app();
-    app.messages = vec![
+    app.transcript.messages = vec![
         ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-"),
         user_text_message("drop me"),
     ];
@@ -951,8 +954,12 @@ fn enforce_history_retention_keeps_single_marker_on_repeat() {
 
     let first = app.enforce_history_retention();
     let second = app.enforce_history_retention();
-    let marker_count =
-        app.messages.iter().filter(|msg| App::is_history_hidden_marker_message(msg)).count();
+    let marker_count = app
+        .transcript
+        .messages
+        .iter()
+        .filter(|msg| App::is_history_hidden_marker_message(msg))
+        .count();
 
     assert_eq!(first.dropped_messages, 1);
     assert_eq!(second.dropped_messages, 0);
@@ -1021,16 +1028,16 @@ fn index_unicode_id() {
 fn active_task_insert_remove() {
     let mut app = make_test_app();
     app.insert_active_task("task-1".into());
-    assert!(app.active_task_ids.contains("task-1"));
+    assert!(app.turn.active_task_ids.contains("task-1"));
     app.remove_active_task("task-1");
-    assert!(!app.active_task_ids.contains("task-1"));
+    assert!(!app.turn.active_task_ids.contains("task-1"));
 }
 
 #[test]
 fn remove_nonexistent_task_is_noop() {
     let mut app = make_test_app();
     app.remove_active_task("does-not-exist");
-    assert!(app.active_task_ids.is_empty());
+    assert!(app.turn.active_task_ids.is_empty());
 }
 
 // active_task_ids
@@ -1041,9 +1048,9 @@ fn active_task_insert_duplicate() {
     let mut app = make_test_app();
     app.insert_active_task("task-1".into());
     app.insert_active_task("task-1".into());
-    assert_eq!(app.active_task_ids.len(), 1);
+    assert_eq!(app.turn.active_task_ids.len(), 1);
     app.remove_active_task("task-1");
-    assert!(app.active_task_ids.is_empty());
+    assert!(app.turn.active_task_ids.is_empty());
 }
 
 /// Insert many tasks, remove in different order.
@@ -1053,12 +1060,12 @@ fn active_task_insert_many_remove_out_of_order() {
     for i in 0..100 {
         app.insert_active_task(format!("task-{i}"));
     }
-    assert_eq!(app.active_task_ids.len(), 100);
+    assert_eq!(app.turn.active_task_ids.len(), 100);
     // Remove in reverse order
     for i in (0..100).rev() {
         app.remove_active_task(&format!("task-{i}"));
     }
-    assert!(app.active_task_ids.is_empty());
+    assert!(app.turn.active_task_ids.is_empty());
 }
 
 /// Mixed insert/remove interleaving.
@@ -1069,10 +1076,10 @@ fn active_task_interleaved_insert_remove() {
     app.insert_active_task("b".into());
     app.remove_active_task("a");
     app.insert_active_task("c".into());
-    assert!(!app.active_task_ids.contains("a"));
-    assert!(app.active_task_ids.contains("b"));
-    assert!(app.active_task_ids.contains("c"));
-    assert_eq!(app.active_task_ids.len(), 2);
+    assert!(!app.turn.active_task_ids.contains("a"));
+    assert!(app.turn.active_task_ids.contains("b"));
+    assert!(app.turn.active_task_ids.contains("c"));
+    assert_eq!(app.turn.active_task_ids.len(), 2);
 }
 
 /// Remove from empty set multiple times - no panic.
@@ -1082,7 +1089,7 @@ fn active_task_remove_from_empty_repeatedly() {
     for i in 0..100 {
         app.remove_active_task(&format!("ghost-{i}"));
     }
-    assert!(app.active_task_ids.is_empty());
+    assert!(app.turn.active_task_ids.is_empty());
 }
 
 /// `clear_tool_scope_tracking` must also clear `active_task_ids`.
@@ -1092,15 +1099,15 @@ fn active_task_remove_from_empty_repeatedly() {
 fn clear_tool_scope_tracking_also_clears_active_task_ids() {
     let mut app = make_test_app();
     app.insert_active_task("task-leaked".into());
-    assert!(!app.active_task_ids.is_empty());
+    assert!(!app.turn.active_task_ids.is_empty());
     app.clear_tool_scope_tracking();
-    assert!(app.active_task_ids.is_empty(), "active_task_ids must be cleared at turn end");
+    assert!(app.turn.active_task_ids.is_empty(), "active_task_ids must be cleared at turn end");
 }
 
 #[test]
 fn finalize_in_progress_tool_calls_detaches_execute_terminal_refs() {
     let mut app = make_test_app();
-    app.messages.push(assistant_bash_tool_message(
+    app.transcript.messages.push(assistant_bash_tool_message(
         "bash-1",
         model::ToolCallStatus::InProgress,
         "term-1",
@@ -1111,9 +1118,8 @@ fn finalize_in_progress_tool_calls_detaches_execute_terminal_refs() {
     let changed = app.finalize_in_progress_tool_calls(model::ToolCallStatus::Completed);
 
     assert_eq!(changed, 1);
-    assert!(app.terminal_tool_calls.is_empty());
-    assert!(app.terminal_tool_call_membership.is_empty());
-    let MessageBlock::ToolCall(tc) = &app.messages[0].blocks[0] else {
+    assert!(app.terminal_tool_calls().is_empty());
+    let MessageBlock::ToolCall(tc) = &app.transcript.messages[0].blocks[0] else {
         panic!("expected tool call");
     };
     assert_eq!(tc.status, model::ToolCallStatus::Completed);
@@ -1123,8 +1129,10 @@ fn finalize_in_progress_tool_calls_detaches_execute_terminal_refs() {
 #[test]
 fn remove_message_tracked_tail_removes_orphaned_tool_indices() {
     let mut app = make_test_app();
-    app.messages.push(user_text_message("before"));
-    app.messages.push(assistant_tool_message("tool-1", model::ToolCallStatus::Completed));
+    app.transcript.messages.push(user_text_message("before"));
+    app.transcript
+        .messages
+        .push(assistant_tool_message("tool-1", model::ToolCallStatus::Completed));
     app.index_tool_call("tool-1".to_owned(), 1, 0);
 
     let removed = app.remove_message_tracked(1);
@@ -1136,7 +1144,9 @@ fn remove_message_tracked_tail_removes_orphaned_tool_indices() {
 #[test]
 fn remove_message_tracked_prunes_tool_scope_entries() {
     let mut app = make_test_app();
-    app.messages.push(assistant_tool_message("tool-1", model::ToolCallStatus::Completed));
+    app.transcript
+        .messages
+        .push(assistant_tool_message("tool-1", model::ToolCallStatus::Completed));
     app.index_tool_call("tool-1".to_owned(), 0, 0);
     app.register_tool_call_scope(
         "tool-1".to_owned(),
@@ -1152,28 +1162,27 @@ fn remove_message_tracked_prunes_tool_scope_entries() {
 #[test]
 fn clear_messages_tracked_clears_tool_and_terminal_tracking() {
     let mut app = make_test_app();
-    app.messages.push(assistant_bash_tool_message(
+    app.transcript.messages.push(assistant_bash_tool_message(
         "bash-1",
         model::ToolCallStatus::InProgress,
         "term-1",
     ));
     app.index_tool_call("bash-1".to_owned(), 0, 0);
     app.sync_terminal_tool_call("term-1".to_owned(), 0, 0);
-    app.pending_interaction_ids.push("bash-1".into());
+    app.turn.pending_interaction_ids.push("bash-1".into());
 
     app.clear_messages_tracked();
 
-    assert!(app.messages.is_empty());
-    assert!(app.tool_call_index.is_empty());
-    assert!(app.terminal_tool_calls.is_empty());
-    assert!(app.terminal_tool_call_membership.is_empty());
-    assert!(app.pending_interaction_ids.is_empty());
+    assert!(app.transcript.messages.is_empty());
+    assert!(app.transcript.tool_call_index.is_empty());
+    assert!(app.terminal_tool_calls().is_empty());
+    assert!(app.turn.pending_interaction_ids.is_empty());
 }
 
 #[test]
 fn rebuild_tool_indices_skips_completed_terminal_refs() {
     let mut app = make_test_app();
-    app.messages.push(assistant_bash_tool_message(
+    app.transcript.messages.push(assistant_bash_tool_message(
         "bash-1",
         model::ToolCallStatus::Completed,
         "term-1",
@@ -1183,8 +1192,7 @@ fn rebuild_tool_indices_skips_completed_terminal_refs() {
 
     app.rebuild_tool_indices_and_terminal_refs();
 
-    assert!(app.terminal_tool_calls.is_empty());
-    assert!(app.terminal_tool_call_membership.is_empty());
+    assert!(app.terminal_tool_calls().is_empty());
 }
 
 // IncrementalMarkdown
@@ -1313,7 +1321,7 @@ fn incr_streaming_simulation() {
 
 fn focus_test_app_with_available_targets() -> App {
     let mut app = make_test_app();
-    app.pending_interaction_ids.push("perm-1".into());
+    app.turn.pending_interaction_ids.push("perm-1".into());
     app.slash = Some(SlashState {
         trigger_row: 0,
         trigger_col: 0,

--- a/src/app/state/tool_tracking.rs
+++ b/src/app/state/tool_tracking.rs
@@ -20,12 +20,12 @@ impl TerminalToolCallRef {
 impl App {
     /// Track a Task/Agent tool call as active (in-progress subagent).
     pub fn insert_active_task(&mut self, id: String) {
-        self.active_task_ids.insert(id);
+        self.turn.active_task_ids.insert(id);
     }
 
     /// Remove a Task/Agent tool call from the active set (completed/failed).
     pub fn remove_active_task(&mut self, id: &str) {
-        self.active_task_ids.remove(id);
+        self.turn.active_task_ids.remove(id);
     }
 
     pub fn register_tool_call_scope(&mut self, id: String, scope: ToolCallScope) {
@@ -50,18 +50,37 @@ impl App {
 
     pub fn clear_tool_scope_tracking(&mut self) {
         self.tool_call_scopes.clear();
-        self.active_task_ids.clear();
+        self.turn.active_task_ids.clear();
     }
 
     /// Look up the (`message_index`, `block_index`) for a tool call ID.
     #[must_use]
     pub fn lookup_tool_call(&self, id: &str) -> Option<(usize, usize)> {
-        self.tool_call_index.get(id).copied()
+        self.transcript.tool_call_index.get(id).copied()
     }
 
     /// Register a tool call's position in the message/block arrays.
     pub fn index_tool_call(&mut self, id: String, msg_idx: usize, block_idx: usize) {
-        self.tool_call_index.insert(id, (msg_idx, block_idx));
+        self.transcript.tool_call_index.insert(id, (msg_idx, block_idx));
+    }
+
+    pub fn clear_tool_call_index(&mut self) {
+        self.transcript.tool_call_index.clear();
+    }
+
+    #[must_use]
+    pub(crate) fn terminal_tool_calls(&self) -> &[TerminalToolCallRef] {
+        &self.transcript.terminal_tool_calls
+    }
+
+    #[must_use]
+    pub fn has_tool_call(&self, id: &str) -> bool {
+        self.lookup_tool_call(id).is_some()
+    }
+
+    #[must_use]
+    pub fn tool_call_index_len(&self) -> usize {
+        self.transcript.tool_call_index.len()
     }
 
     pub(crate) fn sync_terminal_tool_call(
@@ -71,16 +90,17 @@ impl App {
         block_idx: usize,
     ) {
         let desired = TerminalToolCallRef::new(terminal_id, msg_idx, block_idx);
-        if self.terminal_tool_call_membership.contains(&desired) {
+        if self.transcript.terminal_tool_call_membership.contains(&desired) {
             return;
         }
         self.untrack_terminal_tool_call(msg_idx, block_idx);
-        self.terminal_tool_call_membership.insert(desired.clone());
-        self.terminal_tool_calls.push(desired);
+        self.transcript.terminal_tool_call_membership.insert(desired.clone());
+        self.transcript.terminal_tool_calls.push(desired);
     }
 
     pub(crate) fn untrack_terminal_tool_call(&mut self, msg_idx: usize, block_idx: usize) {
         let removed: Vec<_> = self
+            .transcript
             .terminal_tool_calls
             .iter()
             .filter(|entry| entry.msg_idx == msg_idx && entry.block_idx == block_idx)
@@ -89,16 +109,17 @@ impl App {
         if removed.is_empty() {
             return;
         }
-        self.terminal_tool_calls
+        self.transcript
+            .terminal_tool_calls
             .retain(|entry| entry.msg_idx != msg_idx || entry.block_idx != block_idx);
         for entry in removed {
-            self.terminal_tool_call_membership.remove(&entry);
+            self.transcript.terminal_tool_call_membership.remove(&entry);
         }
     }
 
     pub(crate) fn clear_terminal_tool_call_tracking(&mut self) {
-        self.terminal_tool_calls.clear();
-        self.terminal_tool_call_membership.clear();
+        self.transcript.terminal_tool_calls.clear();
+        self.transcript.terminal_tool_call_membership.clear();
     }
 
     pub(crate) fn sync_after_message_blocks_changed(&mut self, msg_idx: usize) {
@@ -117,7 +138,7 @@ impl App {
         let mut changed_slots = Vec::new();
         let mut detached_terminal = false;
 
-        for (msg_idx, msg) in self.messages.iter_mut().enumerate() {
+        for (msg_idx, msg) in self.transcript.messages.iter_mut().enumerate() {
             for (block_idx, block) in msg.blocks.iter_mut().enumerate() {
                 if let MessageBlock::ToolCall(tc) = block {
                     let tc = tc.as_mut();
@@ -160,7 +181,7 @@ impl App {
 
         if changed > 0 || cleared_interaction {
             self.invalidate_message_set(changed_message_indices.iter().copied());
-            self.pending_interaction_ids.clear();
+            self.turn.pending_interaction_ids.clear();
             self.release_focus_target(FocusTarget::Permission);
         }
 
@@ -174,7 +195,7 @@ impl App {
         let mut changed_message_indices = Vec::new();
         let mut changed_slots = Vec::new();
 
-        for (msg_idx, msg) in self.messages.iter_mut().enumerate() {
+        for (msg_idx, msg) in self.transcript.messages.iter_mut().enumerate() {
             for (block_idx, block) in msg.blocks.iter_mut().enumerate() {
                 let MessageBlock::ToolCall(tc) = block else {
                     continue;
@@ -211,8 +232,8 @@ impl App {
             self.invalidate_message_set(changed_message_indices.iter().copied());
         }
 
-        if changed > 0 || !self.pending_interaction_ids.is_empty() {
-            self.pending_interaction_ids.clear();
+        if changed > 0 || !self.turn.pending_interaction_ids.is_empty() {
+            self.turn.pending_interaction_ids.clear();
             self.release_focus_target(FocusTarget::Permission);
         }
 

--- a/src/app/state/transcript.rs
+++ b/src/app/state/transcript.rs
@@ -1,0 +1,41 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use super::messages::ChatMessage;
+use super::render_budget;
+use super::tool_tracking::TerminalToolCallRef;
+
+#[derive(Default)]
+pub struct Transcript {
+    pub messages: Vec<ChatMessage>,
+    /// Cached approximate retained bytes for each message, parallel to `messages`.
+    pub(super) message_retained_bytes: Vec<usize>,
+    /// Rolling total of `message_retained_bytes`.
+    pub(super) retained_history_bytes: usize,
+    /// O(1) lookup: `tool_call_id` -> `(message_index, block_index)`.
+    pub(super) tool_call_index: HashMap<String, (usize, usize)>,
+    /// Indexed terminal tool calls for per-frame terminal snapshot updates.
+    /// Avoids O(n*m) scan of all messages/blocks every frame.
+    pub(super) terminal_tool_calls: Vec<TerminalToolCallRef>,
+    /// Membership index for `terminal_tool_calls`, used to avoid linear duplicate checks.
+    pub(super) terminal_tool_call_membership: HashSet<TerminalToolCallRef>,
+    /// Cached render-cache slot metadata parallel to `messages[*].blocks[*]`.
+    pub(super) render_cache_slots: Vec<Vec<render_budget::RenderCacheSlotState>>,
+    /// Rolling total of cached render bytes across blocks and message-level caches.
+    pub(super) render_cache_total_bytes: usize,
+    /// Rolling total of cached render bytes currently excluded from the budget.
+    pub(super) render_cache_protected_bytes: usize,
+    /// Evictable cached blocks ordered by LRU and size tie-breaker.
+    pub(super) render_cache_evictable: BTreeSet<render_budget::RenderCacheEvictionKey>,
+    /// Last message index currently protected as the streaming tail, if any.
+    pub(super) render_cache_tail_msg_idx: Option<usize>,
+}
+
+impl Transcript {
+    #[must_use]
+    pub fn new(messages: Vec<ChatMessage>) -> Self {
+        Self { messages, ..Self::default() }
+    }
+}

--- a/src/app/state/turn.rs
+++ b/src/app/state/turn.rs
@@ -1,0 +1,76 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use super::prelude::*;
+
+/// State scoped to the currently active turn: in-flight command tracking,
+/// cancellation bookkeeping, inline interactions, and turn-local notices.
+///
+/// Everything here resets at turn or session boundaries; grouping it makes
+/// those reset contracts explicit instead of scattering them across `App`.
+// The bools are independent latches consumed at different turn-lifecycle
+// points, not an encodable state machine.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Default)]
+pub struct TurnState {
+    /// Spinner label shown while a slash command is in flight (`CommandPending`).
+    pub pending_command_label: Option<String>,
+    /// Ack marker required to clear `CommandPending` for strict completion semantics.
+    pub pending_command_ack: Option<PendingCommandAck>,
+    /// When true, the current/next turn completion should clear local conversation history.
+    /// Set by `/compact` once the command is accepted for bridge forwarding.
+    pub pending_compact_clear: bool,
+    /// Tool call IDs with pending inline interactions, ordered by arrival.
+    /// The first entry is the focused interaction that receives keyboard input.
+    /// Up / Down arrow keys cycle focus through the list.
+    pub pending_interaction_ids: Vec<String>,
+    /// Set when a cancel notification succeeds; consumed on `TurnComplete`
+    /// to render a red interruption hint in chat.
+    pub cancelled_pending_hint: bool,
+    /// Origin of the in-flight cancellation request, if any.
+    pub pending_cancel_origin: Option<CancelOrigin>,
+    /// Auto-submit the current input draft once cancellation transitions the app
+    /// back to `Ready`.
+    pub pending_auto_submit_after_cancel: bool,
+    /// Message index that owns the current main-assistant turn indicators.
+    pub assistant_message_idx: Option<usize>,
+    /// IDs of root Task/Agent tool calls currently `InProgress`.
+    /// Use `App::insert_active_task()`, `App::remove_active_task()`.
+    pub active_task_ids: HashSet<String>,
+    /// True while the SDK reports active compaction.
+    pub is_compacting: bool,
+    /// Turn-local inline/system notices that may upgrade in place during the active turn.
+    pub notice_refs: Vec<TurnNoticeRef>,
+}
+
+impl TurnState {
+    /// Clear all cancellation bookkeeping (after a cancel resolves or on
+    /// session reset). Keeps the three cancel flags from drifting apart.
+    pub fn clear_cancel_state(&mut self) {
+        self.cancelled_pending_hint = false;
+        self.pending_cancel_origin = None;
+        self.pending_auto_submit_after_cancel = false;
+    }
+
+    /// Clear turn-local tracking that must not survive a completed or failed
+    /// turn. Message-index fields are reset here; topology reindexing methods
+    /// handle index shifts while a turn is still active.
+    pub fn reset_for_turn_exit(&mut self) {
+        self.pending_command_label = None;
+        self.pending_command_ack = None;
+        self.pending_compact_clear = false;
+        self.pending_interaction_ids.clear();
+        self.cancelled_pending_hint = false;
+        self.pending_cancel_origin = None;
+        self.assistant_message_idx = None;
+        self.active_task_ids.clear();
+        self.is_compacting = false;
+        self.notice_refs.clear();
+    }
+
+    /// Clear all state scoped to the active session/turn lifecycle.
+    pub fn reset_for_new_session(&mut self) {
+        self.reset_for_turn_exit();
+        self.pending_auto_submit_after_cancel = false;
+    }
+}

--- a/src/app/state/turn_notices.rs
+++ b/src/app/state/turn_notices.rs
@@ -25,11 +25,11 @@ pub struct TurnNoticeRef {
 
 impl App {
     pub(crate) fn clear_turn_notice_refs(&mut self) {
-        self.turn_notice_refs.clear();
+        self.turn.notice_refs.clear();
     }
 
     pub(crate) fn shift_turn_notice_refs_for_insert(&mut self, idx: usize) {
-        for notice_ref in &mut self.turn_notice_refs {
+        for notice_ref in &mut self.turn.notice_refs {
             match &mut notice_ref.location {
                 TurnNoticeLocation::Inline { msg_idx, .. }
                 | TurnNoticeLocation::Standalone { msg_idx }
@@ -43,7 +43,7 @@ impl App {
     }
 
     pub(crate) fn shift_turn_notice_refs_for_remove(&mut self, idx: usize) {
-        self.turn_notice_refs.retain_mut(|notice_ref| match &mut notice_ref.location {
+        self.turn.notice_refs.retain_mut(|notice_ref| match &mut notice_ref.location {
             TurnNoticeLocation::Inline { msg_idx, .. }
             | TurnNoticeLocation::Standalone { msg_idx } => match idx.cmp(msg_idx) {
                 std::cmp::Ordering::Less => {
@@ -60,7 +60,7 @@ impl App {
         &mut self,
         old_to_new: &[Option<usize>],
     ) {
-        self.turn_notice_refs.retain_mut(|notice_ref| match &mut notice_ref.location {
+        self.turn.notice_refs.retain_mut(|notice_ref| match &mut notice_ref.location {
             TurnNoticeLocation::Inline { msg_idx, .. }
             | TurnNoticeLocation::Standalone { msg_idx } => {
                 let Some(new_idx) = old_to_new.get(*msg_idx).copied().flatten() else {

--- a/src/app/state/welcome.rs
+++ b/src/app/state/welcome.rs
@@ -6,7 +6,8 @@ use super::prelude::*;
 impl App {
     /// Ensure the synthetic welcome message exists at index 0.
     pub fn ensure_welcome_message(&mut self) {
-        if self.messages.first().is_some_and(|m| matches!(m.role, MessageRole::Welcome)) {
+        if self.transcript.messages.first().is_some_and(|m| matches!(m.role, MessageRole::Welcome))
+        {
             return;
         }
         self.insert_message_tracked(0, self.build_welcome_message());
@@ -52,7 +53,7 @@ impl App {
 
     #[must_use]
     pub(crate) fn current_welcome_tip_seed(&self) -> Option<u64> {
-        let first = self.messages.first()?;
+        let first = self.transcript.messages.first()?;
         let MessageBlock::Welcome(welcome) = first.blocks.first()? else {
             return None;
         };
@@ -72,7 +73,7 @@ impl App {
         let subscription = self.welcome_subscription_display().to_owned();
         let cwd = self.welcome_cwd_display().to_owned();
         let session_id = self.welcome_session_id_display();
-        let Some(first) = self.messages.first() else {
+        let Some(first) = self.transcript.messages.first() else {
             return;
         };
         if !matches!(first.role, MessageRole::Welcome) {
@@ -80,7 +81,7 @@ impl App {
         }
         let mut changed = false;
         {
-            let Some(first) = self.messages.first_mut() else {
+            let Some(first) = self.transcript.messages.first_mut() else {
                 return;
             };
             let Some(MessageBlock::Welcome(welcome)) = first.blocks.first_mut() else {

--- a/src/app/state/welcome.rs
+++ b/src/app/state/welcome.rs
@@ -15,7 +15,8 @@ impl App {
 
     #[must_use]
     fn welcome_subscription_display(&self) -> &str {
-        self.account_info
+        self.session_runtime
+            .account_info
             .as_ref()
             .and_then(|account| account.subscription_type.as_deref())
             .map(str::trim)
@@ -31,7 +32,8 @@ impl App {
 
     #[must_use]
     fn welcome_session_id_display(&self) -> String {
-        self.session_id
+        self.session_runtime
+            .session_id
             .as_ref()
             .map(std::string::ToString::to_string)
             .map(|value| value.trim().to_owned())

--- a/src/app/subagent.rs
+++ b/src/app/subagent.rs
@@ -122,7 +122,7 @@ fn build_subagent_state(app: &App) -> Option<SubagentState> {
         app.input.cursor_row(),
         app.input.cursor_col(),
     )?;
-    let candidates = filter_candidates(&app.available_agents, &detection.query);
+    let candidates = filter_candidates(&app.sdk_inventory.available_agents, &detection.query);
     if candidates.is_empty() {
         return None;
     }
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn sync_with_cursor_activates_when_subagent_token_is_valid() {
         let mut app = App::test_default();
-        app.available_agents = vec![
+        app.sdk_inventory.available_agents = vec![
             crate::agent::model::AvailableAgent::new("reviewer", "Review code"),
             crate::agent::model::AvailableAgent::new("explore", "Explore codebase"),
         ];
@@ -331,7 +331,7 @@ mod tests {
     #[test]
     fn sync_with_cursor_activates_on_bare_ampersand_at_line_end() {
         let mut app = App::test_default();
-        app.available_agents =
+        app.sdk_inventory.available_agents =
             vec![crate::agent::model::AvailableAgent::new("reviewer", "Review code")];
         app.input.set_text("&");
 

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -6,12 +6,12 @@ use crate::agent::model;
 use std::collections::{BTreeSet, HashSet};
 
 pub(super) fn apply_task_state_update(app: &mut App, update: model::TaskStateUpdate) {
-    let previous_tasks = app.tasks.clone();
+    let previous_tasks = app.sdk_inventory.tasks.clone();
     let removed: HashSet<&str> =
         update.removed_task_ids.iter().map(std::string::String::as_str).collect();
 
     if update.is_complete_snapshot {
-        app.tasks = update
+        app.sdk_inventory.tasks = update
             .tasks
             .into_iter()
             .filter(|task| !removed.contains(task.task_id.as_str()))
@@ -21,7 +21,7 @@ pub(super) fn apply_task_state_update(app: &mut App, update: model::TaskStateUpd
     }
 
     if !removed.is_empty() {
-        app.tasks.retain(|task| !removed.contains(task.task_id.as_str()));
+        app.sdk_inventory.tasks.retain(|task| !removed.contains(task.task_id.as_str()));
     }
 
     for task in update.tasks {
@@ -29,18 +29,18 @@ pub(super) fn apply_task_state_update(app: &mut App, update: model::TaskStateUpd
             continue;
         }
         if let Some(existing) =
-            app.tasks.iter_mut().find(|existing| existing.task_id == task.task_id)
+            app.sdk_inventory.tasks.iter_mut().find(|existing| existing.task_id == task.task_id)
         {
             *existing = task;
         } else {
-            app.tasks.push(task);
+            app.sdk_inventory.tasks.push(task);
         }
     }
     refresh_task_tool_displays_with_previous(app, &previous_tasks);
 }
 
 pub(super) fn refresh_task_tool_displays(app: &mut App) -> bool {
-    let previous_tasks = app.tasks.clone();
+    let previous_tasks = app.sdk_inventory.tasks.clone();
     refresh_task_tool_displays_with_previous(app, &previous_tasks)
 }
 
@@ -48,7 +48,7 @@ fn refresh_task_tool_displays_with_previous(
     app: &mut App,
     previous_tasks: &[model::TaskItem],
 ) -> bool {
-    let current_tasks = app.tasks.clone();
+    let current_tasks = app.sdk_inventory.tasks.clone();
     let mut dirty_blocks = Vec::new();
 
     for (message_idx, message) in app.transcript.messages.iter_mut().enumerate() {
@@ -287,7 +287,7 @@ mod tests {
     #[test]
     fn singular_updates_merge_by_task_id() {
         let mut app = App::test_default();
-        app.tasks.push(task("task-1", "old", model::TaskStatus::Pending));
+        app.sdk_inventory.tasks.push(task("task-1", "old", model::TaskStatus::Pending));
 
         apply_task_state_update(
             &mut app,
@@ -298,16 +298,16 @@ mod tests {
             )]),
         );
 
-        assert_eq!(app.tasks.len(), 1);
-        assert_eq!(app.tasks[0].subject, "new");
-        assert_eq!(app.tasks[0].status, model::TaskStatus::InProgress);
+        assert_eq!(app.sdk_inventory.tasks.len(), 1);
+        assert_eq!(app.sdk_inventory.tasks[0].subject, "new");
+        assert_eq!(app.sdk_inventory.tasks[0].status, model::TaskStatus::InProgress);
     }
 
     #[test]
     fn removed_task_ids_remove_state() {
         let mut app = App::test_default();
-        app.tasks.push(task("task-1", "one", model::TaskStatus::Pending));
-        app.tasks.push(task("task-2", "two", model::TaskStatus::Pending));
+        app.sdk_inventory.tasks.push(task("task-1", "one", model::TaskStatus::Pending));
+        app.sdk_inventory.tasks.push(task("task-2", "two", model::TaskStatus::Pending));
 
         apply_task_state_update(
             &mut app,
@@ -315,15 +315,15 @@ mod tests {
                 .removed_task_ids(vec!["task-1".to_owned()]),
         );
 
-        assert_eq!(app.tasks.len(), 1);
-        assert_eq!(app.tasks[0].task_id, "task-2");
+        assert_eq!(app.sdk_inventory.tasks.len(), 1);
+        assert_eq!(app.sdk_inventory.tasks[0].task_id, "task-2");
     }
 
     #[test]
     fn complete_snapshot_replaces_membership() {
         let mut app = App::test_default();
-        app.tasks.push(task("task-1", "one", model::TaskStatus::Pending));
-        app.tasks.push(task("task-2", "two", model::TaskStatus::Pending));
+        app.sdk_inventory.tasks.push(task("task-1", "one", model::TaskStatus::Pending));
+        app.sdk_inventory.tasks.push(task("task-2", "two", model::TaskStatus::Pending));
 
         apply_task_state_update(
             &mut app,
@@ -332,9 +332,9 @@ mod tests {
                 .complete_snapshot(true),
         );
 
-        assert_eq!(app.tasks.len(), 1);
-        assert_eq!(app.tasks[0].task_id, "task-2");
-        assert_eq!(app.tasks[0].subject, "two updated");
+        assert_eq!(app.sdk_inventory.tasks.len(), 1);
+        assert_eq!(app.sdk_inventory.tasks[0].task_id, "task-2");
+        assert_eq!(app.sdk_inventory.tasks[0].subject, "two updated");
     }
 
     #[test]
@@ -371,7 +371,7 @@ mod tests {
     #[test]
     fn in_progress_update_uses_task_subject_and_activity() {
         let mut app = App::test_default();
-        app.tasks.push(
+        app.sdk_inventory.tasks.push(
             task("1", "Scaffold Next.js 15 app via create-next-app", model::TaskStatus::Pending)
                 .active_form("Scaffolding Next.js app"),
         );
@@ -396,7 +396,7 @@ mod tests {
     #[test]
     fn completed_update_clears_redundant_activity_content() {
         let mut app = App::test_default();
-        app.tasks.push(task(
+        app.sdk_inventory.tasks.push(task(
             "1",
             "Scaffold Next.js 15 app via create-next-app",
             model::TaskStatus::Completed,
@@ -424,7 +424,11 @@ mod tests {
     #[test]
     fn deleted_update_uses_previous_task_subject_after_removal() {
         let mut app = App::test_default();
-        app.tasks.push(task("1", "Remove temporary files", model::TaskStatus::Pending));
+        app.sdk_inventory.tasks.push(task(
+            "1",
+            "Remove temporary files",
+            model::TaskStatus::Pending,
+        ));
         insert_tool_call(
             &mut app,
             task_tool_call(
@@ -442,7 +446,7 @@ mod tests {
                 .removed_task_ids(vec!["1".to_owned()]),
         );
 
-        assert!(app.tasks.is_empty());
+        assert!(app.sdk_inventory.tasks.is_empty());
         assert_eq!(only_tool_call(&app).title, "Delete task #1: Remove temporary files");
     }
 }

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -51,7 +51,7 @@ fn refresh_task_tool_displays_with_previous(
     let current_tasks = app.tasks.clone();
     let mut dirty_blocks = Vec::new();
 
-    for (message_idx, message) in app.messages.iter_mut().enumerate() {
+    for (message_idx, message) in app.transcript.messages.iter_mut().enumerate() {
         for (block_idx, block) in message.blocks.iter_mut().enumerate() {
             let MessageBlock::ToolCall(tool_call) = block else {
                 continue;
@@ -252,7 +252,7 @@ mod tests {
 
     fn insert_tool_call(app: &mut App, tool_call: ToolCallInfo) {
         let id = tool_call.id.clone();
-        let message_idx = app.messages.len();
+        let message_idx = app.transcript.messages.len();
         app.push_message_tracked(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(tool_call))],
@@ -262,7 +262,7 @@ mod tests {
     }
 
     fn only_tool_call(app: &App) -> &ToolCallInfo {
-        let MessageBlock::ToolCall(tool_call) = &app.messages[0].blocks[0] else {
+        let MessageBlock::ToolCall(tool_call) = &app.transcript.messages[0].blocks[0] else {
             panic!("expected task tool call");
         };
         tool_call

--- a/src/app/terminal.rs
+++ b/src/app/terminal.rs
@@ -64,11 +64,13 @@ pub(super) fn update_terminal_outputs(app: &mut App) -> bool {
     let mut dirty_slots = Vec::new();
 
     // Use the indexed terminal tool calls instead of scanning all messages/blocks.
-    for terminal_ref in &app.terminal_tool_calls {
+    let terminal_tool_calls = app.terminal_tool_calls().to_vec();
+    for terminal_ref in terminal_tool_calls {
         let Some(terminal) = terminals.get(terminal_ref.terminal_id.as_str()) else {
             continue;
         };
         let Some(MessageBlock::ToolCall(tc)) = app
+            .transcript
             .messages
             .get_mut(terminal_ref.msg_idx)
             .and_then(|m| m.blocks.get_mut(terminal_ref.block_idx))
@@ -187,7 +189,7 @@ mod tests {
     #[test]
     fn terminal_output_poll_updates_canonical_tool_output() {
         let mut app = App::test_default();
-        app.messages.push(bash_tool_message("bash-1", "term-1"));
+        app.transcript.messages.push(bash_tool_message("bash-1", "term-1"));
         app.bind_active_turn_assistant(0);
         app.index_tool_call("bash-1".to_owned(), 0, 0);
         app.sync_terminal_tool_call("term-1".to_owned(), 0, 0);
@@ -202,7 +204,7 @@ mod tests {
 
         assert!(update_terminal_outputs(&mut app));
 
-        let Some(MessageBlock::ToolCall(tool)) = app.messages[0].blocks.first() else {
+        let Some(MessageBlock::ToolCall(tool)) = app.transcript.messages[0].blocks.first() else {
             panic!("expected tool call block");
         };
         assert_eq!(tool.terminal_output.as_deref(), Some("alpha\n"));

--- a/src/app/terminal.rs
+++ b/src/app/terminal.rs
@@ -115,7 +115,7 @@ pub(super) fn update_terminal_outputs(app: &mut App) -> bool {
                 event_name = "terminal_output_summary",
                 message = "terminal output updated",
                 outcome = "success",
-                session_id = %app.session_id.as_ref().map_or_else(String::new, ToString::to_string),
+                session_id = %app.session_runtime.session_id.as_ref().map_or_else(String::new, ToString::to_string),
                 tool_call_id = %tc.id,
                 terminal_id = %terminal_ref.terminal_id,
                 terminal_update_mode = update_mode,

--- a/src/app/terminal_runtime/chat_session.rs
+++ b/src/app/terminal_runtime/chat_session.rs
@@ -1142,7 +1142,7 @@ fn log_inline_chat_draw(summary: &InlineChatDrawSummary<'_>) {
         message = "inline chat draw payload prepared",
         outcome = "prepared",
         status = ?summary.app.status,
-        mode = summary.app.mode.as_ref().map_or_else(|| "none".to_owned(), |mode| mode.current_mode_name.clone()),
+        mode = summary.app.session_runtime.mode.as_ref().map_or_else(|| "none".to_owned(), |mode| mode.current_mode_name.clone()),
         terminal_width = summary.app.chat_render.terminal_width,
         terminal_height = summary.app.chat_render.terminal_height,
         anchor_valid = summary.app.chat_render.live_region.anchor_valid,

--- a/src/app/terminal_runtime/chat_session.rs
+++ b/src/app/terminal_runtime/chat_session.rs
@@ -1330,7 +1330,7 @@ mod tests {
         );
         let message_id = message.id;
         let mut app = App::test_default();
-        app.messages.push(message);
+        app.transcript.messages.push(message);
 
         let serialized =
             serialize_live_rows_with_boundaries_excluding(&mut app, 120, &BTreeSet::new());
@@ -1364,7 +1364,7 @@ mod tests {
             "| Scrollback destroyed |  | #42002 |\n",
         );
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![
+        app.transcript.messages.push(assistant_blocks_message(vec![
             MessageBlock::Text(TextBlock::from_complete(table)),
             MessageBlock::Text(TextBlock::from_complete("streaming tail remains mutable")),
         ]));

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -410,7 +410,7 @@ fn mode_selection_then_second_enter_arms_submit() {
 #[test]
 fn model_selection_then_second_enter_arms_submit() {
     let mut app = App::test_default();
-    app.available_models = vec![
+    app.sdk_inventory.available_models = vec![
         model::AvailableModel::new("sonnet", "Claude Sonnet"),
         model::AvailableModel::new("haiku", "Claude Haiku"),
     ];

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -23,7 +23,7 @@ fn pending_paste_chunks_are_merged_before_threshold_check() {
 
     // Not applied until post-drain finalization.
     assert!(app.input.is_empty());
-    assert!(!app.pending_paste_text.is_empty());
+    assert!(!app.paste.pending_text.is_empty());
 
     finalize_pending_paste_event(&mut app);
 
@@ -35,13 +35,13 @@ fn pending_paste_chunks_are_merged_before_threshold_check() {
 fn pending_paste_chunk_appends_to_same_session_placeholder() {
     let mut app = App::test_default();
     app.input.insert_paste_block("a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk");
-    app.active_paste_session = Some(state::PasteSessionState {
+    app.paste.active_session = Some(state::PasteSessionState {
         id: 7,
         start: SelectionPoint { row: 0, col: 0 },
         placeholder_index: Some(0),
     });
-    app.pending_paste_session = app.active_paste_session;
-    app.pending_paste_text = "\nl\nm".to_owned();
+    app.paste.pending_session = app.paste.active_session;
+    app.paste.pending_text = "\nl\nm".to_owned();
 
     finalize_pending_paste_event(&mut app);
 
@@ -52,7 +52,7 @@ fn pending_paste_chunk_appends_to_same_session_placeholder() {
 #[test]
 fn pending_paste_exact_1000_chars_stays_inline() {
     let mut app = App::test_default();
-    app.pending_paste_text = "x".repeat(1000);
+    app.paste.pending_text = "x".repeat(1000);
 
     finalize_pending_paste_event(&mut app);
 
@@ -63,7 +63,7 @@ fn pending_paste_exact_1000_chars_stays_inline() {
 fn pending_paste_finalization_marks_redraw() {
     let mut app = App::test_default();
     app.surface_dirty.chat.repaint = false;
-    app.pending_paste_text = "hello\nworld".to_owned();
+    app.paste.pending_text = "hello\nworld".to_owned();
 
     finalize_pending_paste_event(&mut app);
 
@@ -76,21 +76,21 @@ fn suppressed_enter_preserves_multiline_inline_paste() {
     let mut app = App::test_default();
     let t0 = Instant::now();
 
-    assert_eq!(app.paste_burst.on_char('a', t0), paste_burst::CharAction::Passthrough('a'));
+    assert_eq!(app.paste.burst.on_char('a', t0), paste_burst::CharAction::Passthrough('a'));
     let _ = app.input.textarea_insert_char('a');
     assert_eq!(
-        app.paste_burst.on_char('b', t0 + Duration::from_millis(2)),
+        app.paste.burst.on_char('b', t0 + Duration::from_millis(2)),
         paste_burst::CharAction::Consumed
     );
     assert_eq!(
-        app.paste_burst.on_char('c', t0 + Duration::from_millis(4)),
+        app.paste.burst.on_char('c', t0 + Duration::from_millis(4)),
         paste_burst::CharAction::RetroCapture(1)
     );
     let _ = app.input.textarea_delete_char_before();
 
     let t_flush = t0 + Duration::from_millis(200);
     assert_eq!(
-        app.paste_burst.tick(t_flush),
+        app.paste.burst.tick(t_flush),
         Some(paste_burst::FlushAction::EmitPaste("abc".to_owned()))
     );
     app.queue_paste_text("abc");
@@ -98,23 +98,23 @@ fn suppressed_enter_preserves_multiline_inline_paste() {
     assert_eq!(app.input.text(), "abc");
 
     let t_enter = t_flush + Duration::from_millis(10);
-    assert!(app.paste_burst.on_enter(t_enter));
+    assert!(app.paste.burst.on_enter(t_enter));
     assert_eq!(
-        app.paste_burst.on_char('d', t_enter + Duration::from_millis(1)),
+        app.paste.burst.on_char('d', t_enter + Duration::from_millis(1)),
         paste_burst::CharAction::Consumed
     );
     assert_eq!(
-        app.paste_burst.on_char('e', t_enter + Duration::from_millis(2)),
+        app.paste.burst.on_char('e', t_enter + Duration::from_millis(2)),
         paste_burst::CharAction::Consumed
     );
     assert_eq!(
-        app.paste_burst.on_char('f', t_enter + Duration::from_millis(3)),
+        app.paste.burst.on_char('f', t_enter + Duration::from_millis(3)),
         paste_burst::CharAction::Consumed
     );
 
     let t_second_flush = t_enter + Duration::from_millis(200);
     assert_eq!(
-        app.paste_burst.tick(t_second_flush),
+        app.paste.burst.tick(t_second_flush),
         Some(paste_burst::FlushAction::EmitPaste("\ndef".to_owned()))
     );
     app.queue_paste_text("\ndef");
@@ -127,7 +127,7 @@ fn suppressed_enter_preserves_multiline_inline_paste() {
 #[test]
 fn pending_paste_1001_chars_becomes_placeholder() {
     let mut app = App::test_default();
-    app.pending_paste_text = "x".repeat(1001);
+    app.paste.pending_text = "x".repeat(1001);
 
     finalize_pending_paste_event(&mut app);
 
@@ -138,7 +138,7 @@ fn pending_paste_1001_chars_becomes_placeholder() {
 #[test]
 fn pending_paste_session_isolation_prevents_unintended_append() {
     let mut app = App::test_default();
-    app.pending_paste_text = "a".repeat(1001);
+    app.paste.pending_text = "a".repeat(1001);
     finalize_pending_paste_event(&mut app);
     events::handle_terminal_event(
         &mut app,
@@ -148,7 +148,7 @@ fn pending_paste_session_isolation_prevents_unintended_append() {
         )),
     );
 
-    app.pending_paste_text = "b".repeat(1001);
+    app.paste.pending_text = "b".repeat(1001);
     finalize_pending_paste_event(&mut app);
 
     assert_eq!(app.input.lines(), vec!["[Pasted Text 1 - 1001 chars][Pasted Text 2 - 1001 chars]"]);
@@ -174,10 +174,10 @@ fn plain_enter_preserves_single_line_draft_before_submit() {
 
     assert!(app.pending_submit.is_none());
     assert!(app.input.text().is_empty());
-    assert_eq!(app.messages.len(), 2);
-    assert!(matches!(app.messages[0].role, MessageRole::User));
+    assert_eq!(app.transcript.messages.len(), 2);
+    assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
     assert!(matches!(
-        app.messages[0].blocks.as_slice(),
+        app.transcript.messages[0].blocks.as_slice(),
         [MessageBlock::Text(block)] if block.text == "hello world"
     ));
     let envelope = rx.try_recv().expect("prompt command should be sent");
@@ -185,6 +185,43 @@ fn plain_enter_preserves_single_line_draft_before_submit() {
         envelope.command,
         BridgeCommand::Prompt { session_id, .. } if session_id == "session-1"
     ));
+}
+
+#[test]
+fn compaction_allows_drafting_but_blocks_submit() {
+    let (mut app, mut rx) = app_with_connection();
+    app.turn.is_compacting = true;
+    app.input.set_text("draft");
+
+    events::handle_terminal_event(
+        &mut app,
+        Event::Key(KeyEvent::new(KeyCode::Char('!'), KeyModifiers::NONE)),
+    );
+
+    assert_eq!(app.input.text(), "draft!");
+
+    events::handle_terminal_event(
+        &mut app,
+        Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+    );
+    assert!(app.pending_submit.is_some());
+
+    finalize_deferred_submit(&mut app);
+
+    assert!(app.pending_submit.is_none());
+    assert_eq!(app.input.text(), "draft!");
+    assert!(app.transcript.messages.is_empty());
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn compaction_allows_paste_drafting() {
+    let (mut app, _rx) = app_with_connection();
+    app.turn.is_compacting = true;
+
+    events::handle_terminal_event(&mut app, Event::Paste(" pasted".into()));
+
+    assert_eq!(app.paste.pending_text, " pasted");
 }
 
 #[test]
@@ -206,7 +243,7 @@ fn plain_enter_preserves_multiline_draft_with_mid_buffer_cursor() {
 
     assert!(app.pending_submit.is_none());
     assert!(matches!(
-        app.messages[0].blocks.as_slice(),
+        app.transcript.messages[0].blocks.as_slice(),
         [MessageBlock::Text(block)] if block.text == "alpha beta\ngamma"
     ));
     let envelope = rx.try_recv().expect("prompt command should be sent");
@@ -238,7 +275,7 @@ fn sending_lone_question_mark_submits_as_prompt() {
     assert!(app.pending_submit.is_none());
     assert!(app.input.text().is_empty());
     assert!(matches!(
-        app.messages[0].blocks.as_slice(),
+        app.transcript.messages[0].blocks.as_slice(),
         [MessageBlock::Text(block)] if block.text == "?"
     ));
     let envelope = rx.try_recv().expect("prompt command should be sent");
@@ -277,7 +314,7 @@ fn docs_topic_selected_with_enter_then_second_enter_submits() {
     finalize_deferred_submit(&mut app);
 
     assert!(app.pending_submit.is_none());
-    let last = app.messages.last().expect("expected docs system message");
+    let last = app.transcript.messages.last().expect("expected docs system message");
     assert!(matches!(last.role, MessageRole::System(_)));
     assert!(matches!(
         last.blocks.as_slice(),
@@ -330,7 +367,7 @@ fn docs_command_selection_then_topic_selection_then_submit_works_with_enter_only
 
     finalize_deferred_submit(&mut app);
 
-    let last = app.messages.last().expect("expected docs system message");
+    let last = app.transcript.messages.last().expect("expected docs system message");
     assert!(matches!(
         last.blocks.as_slice(),
         [MessageBlock::Text(block)] if block.text.contains("| Command | Description |")
@@ -445,7 +482,7 @@ fn paste_event_cancels_deferred_submit_snapshot() {
     events::handle_terminal_event(&mut app, Event::Paste("pasted".into()));
 
     assert!(app.pending_submit.is_none());
-    assert_eq!(app.pending_paste_text, "pasted");
+    assert_eq!(app.paste.pending_text, "pasted");
     assert_eq!(app.input.text(), "draft");
 }
 
@@ -468,7 +505,7 @@ fn esc_cancels_deferred_submit_snapshot_before_finalize() {
     assert!(app.pending_submit.is_none());
     finalize_deferred_submit(&mut app);
     assert_eq!(app.input.text(), "draft");
-    assert!(app.messages.is_empty());
+    assert!(app.transcript.messages.is_empty());
     assert!(rx.try_recv().is_err(), "Esc should prevent deferred submit dispatch");
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8,8 +8,9 @@ fn app_with_connection()
 -> (App, tokio::sync::mpsc::UnboundedReceiver<crate::agent::wire::CommandEnvelope>) {
     let mut app = App::test_default();
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-    app.session_id = Some(model::SessionId::new("session-1"));
+    app.session_runtime.conn =
+        Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+    app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
     (app, rx)
 }
 
@@ -377,7 +378,7 @@ fn docs_command_selection_then_topic_selection_then_submit_works_with_enter_only
 #[test]
 fn mode_selection_then_second_enter_arms_submit() {
     let mut app = App::test_default();
-    app.mode = Some(ModeState {
+    app.session_runtime.mode = Some(ModeState {
         current_mode_id: "code".to_owned(),
         current_mode_name: "Code".to_owned(),
         available_modes: vec![

--- a/src/app/trust/mod.rs
+++ b/src/app/trust/mod.rs
@@ -47,9 +47,11 @@ pub fn initialize(app: &mut App) {
             .clone()
             .unwrap_or_else(|| "Trust preferences path is not available".to_owned())
     });
-    app.startup_connection_requested = app.trust.is_trusted();
     if app.trust.is_trusted() {
-        let next_view = if app.startup_session_picker_requested {
+        app.startup.request_connection();
+    }
+    if app.trust.is_trusted() {
+        let next_view = if app.startup.session_picker_requested() {
             SurfaceMode::Fullscreen(FullscreenView::SessionPicker)
         } else {
             SurfaceMode::Chat
@@ -95,8 +97,8 @@ pub fn accept(app: &mut App) -> Result<(), String> {
     app.config.committed_preferences_document = next_document;
     app.trust.status = TrustStatus::Trusted;
     app.trust.last_error = None;
-    app.startup_connection_requested = true;
-    let next_view = if app.startup_session_picker_requested {
+    app.startup.request_connection();
+    let next_view = if app.startup.session_picker_requested() {
         SurfaceMode::Fullscreen(FullscreenView::SessionPicker)
     } else {
         SurfaceMode::Chat

--- a/src/app/trust/tests.rs
+++ b/src/app/trust/tests.rs
@@ -19,7 +19,7 @@ fn initialize_routes_untrusted_projects_to_trusted_view() {
     assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::Trusted));
     assert!(!app.is_project_trusted());
     assert_eq!(app.trust.selection, TrustSelection::Yes);
-    assert!(!app.startup_connection_requested);
+    assert!(!app.startup.connection_requested());
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn initialize_allows_trusted_projects_into_chat() {
 
     assert_eq!(app.surface_mode, SurfaceMode::Chat);
     assert!(app.is_project_trusted());
-    assert!(app.startup_connection_requested);
+    assert!(app.startup.connection_requested());
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn accept_persists_trust_and_switches_to_chat() {
     assert!(raw.contains("\"hasTrustDialogAccepted\": true"));
     assert_eq!(app.surface_mode, SurfaceMode::Chat);
     assert!(app.is_project_trusted());
-    assert!(app.startup_connection_requested);
+    assert!(app.startup.connection_requested());
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn initialize_routes_trusted_resume_picker_startup_to_picker_view() {
 
     let mut app = App::test_default();
     app.cwd_raw = project_path.to_owned();
-    app.startup_session_picker_requested = true;
+    app.startup = crate::app::state::StartupState::new(None, None, true);
     app.config.preferences_path = Some(std::path::PathBuf::from("prefs.json"));
     let mut prefs = json!({ "projects": {} });
     prefs["projects"][project_path] = json!({
@@ -81,7 +81,7 @@ fn initialize_routes_trusted_resume_picker_startup_to_picker_view() {
     initialize(&mut app);
 
     assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::SessionPicker));
-    assert!(app.startup_connection_requested);
+    assert!(app.startup.connection_requested());
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn accept_routes_resume_picker_startup_to_picker_view() {
 
     let mut app = App::test_default();
     app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::Trusted);
-    app.startup_session_picker_requested = true;
+    app.startup = crate::app::state::StartupState::new(None, None, true);
     app.cwd_raw = dir.path().join("project").to_string_lossy().to_string();
     app.config.preferences_path = Some(path);
     app.trust.status = TrustStatus::Untrusted;
@@ -101,7 +101,7 @@ fn accept_routes_resume_picker_startup_to_picker_view() {
     accept(&mut app).expect("accept");
 
     assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::SessionPicker));
-    assert!(app.startup_connection_requested);
+    assert!(app.startup.connection_requested());
 }
 
 #[test]

--- a/src/app/usage/mod.rs
+++ b/src/app/usage/mod.rs
@@ -30,7 +30,7 @@ pub(crate) fn request_refresh(app: &mut App) {
     apply_refresh_started(app);
 
     let event_tx = app.event_tx.clone();
-    let epoch = app.session_scope_epoch;
+    let epoch = app.session_runtime.session_scope_epoch;
     let source_mode = app.usage.active_source;
     let cwd_raw = app.cwd_raw.clone();
 

--- a/src/app/user_dialog.rs
+++ b/src/app/user_dialog.rs
@@ -59,7 +59,7 @@ pub(super) fn execute_user_dialog_action(
 
 fn focused_dialog_slot(app: &App) -> Option<(usize, usize)> {
     let tool_id = focused_interaction_id(app)?;
-    app.tool_call_index.get(tool_id).copied()
+    app.lookup_tool_call(tool_id)
 }
 
 fn move_dialog_selection(app: &mut App, delta: i32) {
@@ -68,7 +68,7 @@ fn move_dialog_selection(app: &mut App, delta: i32) {
     };
     let mut changed = false;
     if let Some(MessageBlock::UserDialog(dialog)) =
-        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+        app.transcript.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     {
         if dialog.options.is_empty() {
             return;
@@ -103,11 +103,11 @@ fn respond_dialog(app: &mut App, resolution: DialogResolution) {
     let Some(tool_id) = pop_next_valid_interaction_id(app) else {
         return;
     };
-    let Some((mi, bi)) = app.tool_call_index.get(&tool_id).copied() else {
+    let Some((mi, bi)) = app.lookup_tool_call(&tool_id) else {
         return;
     };
     let Some(MessageBlock::UserDialog(dialog)) =
-        app.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
+        app.transcript.messages.get_mut(mi).and_then(|m| m.blocks.get_mut(bi))
     else {
         return;
     };
@@ -167,7 +167,7 @@ fn respond_dialog(app: &mut App, resolution: DialogResolution) {
 }
 
 fn repopulate_composer_from_last_user_message(app: &mut App) {
-    let last_user_text = app.messages.iter().rev().find_map(|message| {
+    let last_user_text = app.transcript.messages.iter().rev().find_map(|message| {
         if !matches!(message.role, MessageRole::User) {
             return None;
         }
@@ -212,17 +212,17 @@ mod tests {
         request_id: &str,
         focused: bool,
     ) -> oneshot::Receiver<model::RequestUserDialogResponse> {
-        let msg_idx = app.messages.len();
+        let msg_idx = app.transcript.messages.len();
         let (tx, rx) = oneshot::channel();
         let mut block = UserDialogBlock::new(dialog_request(request_id), tx);
         block.focused = focused;
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::System(Some(SystemSeverity::Warning)),
             vec![MessageBlock::UserDialog(block)],
             None,
         ));
         app.index_tool_call(request_id.to_owned(), msg_idx, 0);
-        app.pending_interaction_ids.push(request_id.to_owned());
+        app.turn.pending_interaction_ids.push(request_id.to_owned());
         rx
     }
 
@@ -245,14 +245,14 @@ mod tests {
             panic!("expected a selected outcome");
         };
         assert_eq!(selected.option_id, "retry_fallback");
-        assert!(!app.pending_interaction_ids.iter().any(|id| id == "dialog-1"));
+        assert!(!app.turn.pending_interaction_ids.iter().any(|id| id == "dialog-1"));
     }
 
     #[test]
     fn move_next_then_confirm_sends_edit_prompt_and_repopulates_composer() {
         let mut app = App::test_default();
         app.status = AppStatus::Ready;
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::User,
             vec![MessageBlock::Text(TextBlock::from_complete("original prompt text"))],
             None,
@@ -288,7 +288,7 @@ mod tests {
         let response = rx.try_recv().expect("dialog should receive a response");
         assert!(matches!(response.outcome, model::RequestUserDialogOutcome::Cancelled));
         assert!(app.input.text().is_empty());
-        assert!(!app.pending_interaction_ids.iter().any(|id| id == "dialog-1"));
+        assert!(!app.turn.pending_interaction_ids.iter().any(|id| id == "dialog-1"));
     }
 
     #[test]
@@ -304,7 +304,7 @@ mod tests {
 
         let (mi, bi) = app.lookup_tool_call("dialog-1").expect("indexed dialog");
         let Some(MessageBlock::UserDialog(dialog)) =
-            app.messages.get(mi).and_then(|m| m.blocks.get(bi))
+            app.transcript.messages.get(mi).and_then(|m| m.blocks.get(bi))
         else {
             panic!("expected user dialog block");
         };

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -56,9 +56,7 @@ pub fn set_chat_surface(app: &mut App) {
 }
 
 fn clear_transient_view_state(app: &mut App) {
-    app.active_paste_session = None;
-    app.pending_paste_session = None;
-    app.pending_paste_text.clear();
+    app.paste.clear_all_sessions();
     app.pending_submit = None;
     app.mention = None;
     app.slash = None;
@@ -67,7 +65,7 @@ fn clear_transient_view_state(app: &mut App) {
         app.config.clear_overlay();
     }
     app.release_focus_target(crate::app::FocusTarget::Mention);
-    app.paste_burst.on_non_char_key(Instant::now());
+    app.paste.burst.on_non_char_key(Instant::now());
 }
 
 #[cfg(test)]

--- a/src/app/view/tests.rs
+++ b/src/app/view/tests.rs
@@ -12,13 +12,13 @@ fn busy_view_test_app() -> App {
     let mut app = App::test_default();
     app.input.set_text("draft");
     app.pending_submit = Some(app.input.snapshot());
-    app.pending_paste_text = "blocked".to_owned();
-    app.pending_paste_session = Some(PasteSessionState {
+    app.paste.pending_text = "blocked".to_owned();
+    app.paste.pending_session = Some(PasteSessionState {
         id: 1,
         start: SelectionPoint { row: 0, col: 0 },
         placeholder_index: Some(0),
     });
-    app.active_paste_session = Some(PasteSessionState {
+    app.paste.active_session = Some(PasteSessionState {
         id: 2,
         start: SelectionPoint { row: 0, col: 0 },
         placeholder_index: Some(1),
@@ -40,7 +40,7 @@ fn busy_view_test_app() -> App {
         candidates: vec![],
         dialog: DialogState::default(),
     });
-    app.pending_interaction_ids.push("perm-1".to_owned());
+    app.turn.pending_interaction_ids.push("perm-1".to_owned());
     app.claim_focus_target(FocusTarget::Permission);
     app
 }
@@ -58,9 +58,9 @@ fn set_surface_mode_clears_transient_chat_state_but_keeps_draft() {
     assert!(app.mention.is_none());
     assert!(app.slash.is_none());
     assert!(app.subagent.is_none());
-    assert!(app.pending_paste_text.is_empty());
-    assert!(app.pending_paste_session.is_none());
-    assert!(app.active_paste_session.is_none());
+    assert!(app.paste.pending_text.is_empty());
+    assert!(app.paste.pending_session.is_none());
+    assert!(app.paste.active_session.is_none());
     assert!(app.pending_submit.is_none());
     assert!(!app.chat_render.live_region.anchor_valid);
     assert_eq!(app.chat_render.live_region.last_rendered_rows, 0);
@@ -74,7 +74,7 @@ fn set_surface_mode_switches_to_config_from_trusted() {
     set_surface_mode(&mut app, SurfaceMode::Fullscreen(FullscreenView::Config));
 
     assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::Config));
-    assert!(app.pending_paste_text.is_empty());
+    assert!(app.paste.pending_text.is_empty());
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn set_surface_mode_same_view_is_noop() {
 
     assert_eq!(app.surface_mode, SurfaceMode::Chat);
     assert!(app.mention.is_some());
-    assert!(!app.pending_paste_text.is_empty());
+    assert!(!app.paste.pending_text.is_empty());
     assert!(app.pending_submit.is_some());
     assert!(!app.surface_dirty.chat.repaint);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ fn maybe_print_resume_hint(app: &claude_code_rust::app::App, success: bool) {
     if !success {
         return;
     }
-    let Some(session_id) = app.session_id.as_ref() else {
+    let Some(session_id) = app.session_runtime.session_id.as_ref() else {
         return;
     };
     let mut stderr = std::io::stderr().lock();

--- a/src/ui/autocomplete.rs
+++ b/src/ui/autocomplete.rs
@@ -393,8 +393,9 @@ mod tests {
     fn slash_empty_state_renders_command_placeholder() {
         let mut app = App::test_default();
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        app.conn = Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
-        app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+        app.session_runtime.conn =
+            Some(std::rc::Rc::new(crate::agent::client::AgentConnection::new(tx)));
+        app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
         app.input.set_text("/rewind ");
         let _ = app.input.set_cursor(0, "/rewind ".chars().count());
         slash::sync_with_cursor(&mut app);

--- a/src/ui/autocomplete.rs
+++ b/src/ui/autocomplete.rs
@@ -410,7 +410,7 @@ mod tests {
     #[test]
     fn bare_subagent_trigger_renders_single_placeholder_row() {
         let mut app = App::test_default();
-        app.available_agents =
+        app.sdk_inventory.available_agents =
             vec![crate::agent::model::AvailableAgent::new("reviewer", "Review code")];
         app.input.set_text("&");
         let _ = app.input.set_cursor(0, 1);

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -128,7 +128,7 @@ fn config_help_text(app: &App) -> String {
                 .to_owned()
         }
         ConfigTab::Status => {
-            if app.session_id.is_some() {
+            if app.session_runtime.session_id.is_some() {
                 "g generate | r rename | Tab next tab | Shift+Tab prev tab | Enter close | Esc close"
                     .to_owned()
             } else {
@@ -2395,7 +2395,7 @@ mod tests {
         let mut app = App::test_default();
         app.surface_mode = crate::app::SurfaceMode::Fullscreen(crate::app::FullscreenView::Config);
         app.config.active_tab = crate::app::ConfigTab::Status;
-        app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+        app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
 
         terminal
             .draw(|frame| {

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -1229,7 +1229,7 @@ mod tests {
     #[test]
     fn model_overlay_scroll_keeps_selected_multiline_model_visible() {
         let mut app = App::test_default();
-        app.available_models = vec![
+        app.sdk_inventory.available_models = vec![
             AvailableModel::new("opus", "Opus")
                 .description("Opus 4.7")
                 .supports_effort(true)
@@ -1267,7 +1267,7 @@ mod tests {
     #[test]
     fn model_overlay_scroll_accounts_for_wrapped_lines() {
         let mut app = App::test_default();
-        app.available_models = vec![
+        app.sdk_inventory.available_models = vec![
             AvailableModel::new("opus", "Opus")
                 .description("1234567890")
                 .supports_effort(true)
@@ -1290,7 +1290,7 @@ mod tests {
     #[test]
     fn model_overlay_scroll_accounts_for_badge_padding_width() {
         let mut app = App::test_default();
-        app.available_models = vec![
+        app.sdk_inventory.available_models = vec![
             AvailableModel::new("opus", "Opus")
                 .description("Frontier")
                 .supports_effort(true)
@@ -1323,7 +1323,7 @@ mod tests {
     #[test]
     fn effort_overlay_filters_session_only_max_from_persisted_settings() {
         let mut app = App::test_default();
-        app.available_models = vec![
+        app.sdk_inventory.available_models = vec![
             AvailableModel::new("opus", "Opus")
                 .supports_effort(true)
                 .supported_effort_levels(EffortLevel::ALL.to_vec()),
@@ -1353,7 +1353,7 @@ mod tests {
     #[test]
     fn model_overlay_lines_show_positive_capability_badges_only() {
         let mut app = App::test_default();
-        app.available_models = vec![
+        app.sdk_inventory.available_models = vec![
             AvailableModel::new("sonnet", "Sonnet")
                 .description("Everyday tasks")
                 .supports_effort(true)

--- a/src/ui/config/mcp.rs
+++ b/src/ui/config/mcp.rs
@@ -31,7 +31,7 @@ pub(super) fn render(frame: &mut Frame, area: Rect, app: &App) {
         .split(content_area);
     frame.render_widget(Paragraph::new(summary).wrap(Wrap { trim: false }), sections[0]);
 
-    if app.session_id.is_none() {
+    if app.session_runtime.session_id.is_none() {
         render_message(
             frame,
             sections[1],
@@ -884,7 +884,7 @@ mod tests {
     #[test]
     fn renders_live_server_snapshot_as_list_only() {
         let mut app = App::test_default();
-        app.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+        app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
         app.mcp.servers = vec![
             McpServerStatus {
                 name: "notion".to_owned(),

--- a/src/ui/config/status.rs
+++ b/src/ui/config/status.rs
@@ -26,6 +26,7 @@ pub(crate) fn status_lines(app: &App) -> Vec<Line<'static>> {
     kv_line(&mut lines, "Session name", &derive_session_name(app));
 
     let session_id_str = app
+        .session_runtime
         .session_id
         .as_ref()
         .map_or_else(|| "(none)".to_owned(), std::string::ToString::to_string);
@@ -40,7 +41,7 @@ pub(crate) fn status_lines(app: &App) -> Vec<Line<'static>> {
     lines.push(Line::default());
 
     // ---- Account ----
-    if let Some(ref account) = app.account_info {
+    if let Some(ref account) = app.session_runtime.account_info {
         section_header(&mut lines, "Account");
         kv_line(&mut lines, "Login method", &login_method_label(account));
         if let Some(ref provider) = account.api_provider {
@@ -67,7 +68,7 @@ pub(crate) fn status_lines(app: &App) -> Vec<Line<'static>> {
     // ---- Model ----
     section_header(&mut lines, "Model");
     kv_line(&mut lines, "Model", &model_display(app));
-    if let Some(current_model) = app.current_model.as_ref() {
+    if let Some(current_model) = app.session_runtime.current_model.as_ref() {
         kv_line(&mut lines, "Resolved model ID", &current_model.resolved_id);
         if let Some(requested_id) = current_model.requested_id.as_deref()
             && requested_id != current_model.resolved_id
@@ -76,7 +77,7 @@ pub(crate) fn status_lines(app: &App) -> Vec<Line<'static>> {
         }
     }
 
-    if let Some(ref mode) = app.mode {
+    if let Some(ref mode) = app.session_runtime.mode {
         kv_line(&mut lines, "Mode", &mode.current_mode_name);
     }
 
@@ -109,7 +110,7 @@ fn kv_line(lines: &mut Vec<Line<'static>>, key: &str, value: &str) {
 }
 
 fn derive_session_name(app: &App) -> String {
-    if let Some(ref sid) = app.session_id {
+    if let Some(ref sid) = app.session_runtime.session_id {
         let sid_str = sid.to_string();
         if let Some(session) = app.recent_sessions.iter().find(|s| s.session_id == sid_str) {
             if let Some(ref title) = session.custom_title
@@ -140,7 +141,7 @@ fn derive_session_name(app: &App) -> String {
 }
 
 fn model_display(app: &App) -> String {
-    let Some(current_model) = app.current_model.as_ref() else {
+    let Some(current_model) = app.session_runtime.current_model.as_ref() else {
         return "(not set)".to_owned();
     };
     current_model.display_name_long.clone()
@@ -205,7 +206,7 @@ mod tests {
     #[test]
     fn status_lines_shows_model() {
         let mut app = App::test_default();
-        app.current_model = Some(
+        app.session_runtime.current_model = Some(
             crate::agent::model::CurrentModel::new("claude-sonnet-4-7", "Sonnet", "Sonnet 4.7")
                 .authoritative(true),
         );
@@ -223,7 +224,7 @@ mod tests {
     #[test]
     fn status_lines_uses_custom_title() {
         let mut app = App::test_default();
-        app.session_id = Some(crate::agent::model::SessionId::new("test-sess-1"));
+        app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("test-sess-1"));
         app.recent_sessions = vec![crate::app::RecentSessionInfo {
             session_id: "test-sess-1".to_owned(),
             summary: String::new(),
@@ -290,7 +291,7 @@ mod tests {
     #[test]
     fn status_lines_render_api_provider() {
         let mut app = App::test_default();
-        app.account_info = Some(crate::agent::model::AccountInfo {
+        app.session_runtime.account_info = Some(crate::agent::model::AccountInfo {
             api_provider: Some(crate::agent::model::AccountApiProvider::Gateway),
             ..Default::default()
         });

--- a/src/ui/footer_rows.rs
+++ b/src/ui/footer_rows.rs
@@ -64,7 +64,7 @@ fn footer_mcp_auth_hint(app: &App) -> FooterItem {
 }
 
 fn footer_context_usage_hint(app: &App) -> FooterItem {
-    app.session_usage.context_usage_percent.map(|percentage| {
+    app.session_runtime.session_usage.context_usage_percent.map(|percentage| {
         let remaining = 100_u8.saturating_sub(percentage);
         (format!("{remaining}%"), FOOTER_CONTEXT_VALUE)
     })
@@ -139,9 +139,10 @@ fn compose_footer_row(
 }
 
 fn build_primary_line(app: &App) -> Line<'static> {
-    if let Some(ref mode) = app.mode {
+    if let Some(ref mode) = app.session_runtime.mode {
         let color = mode_color(&mode.current_mode_id);
-        let (fast_mode_text, fast_mode_color) = fast_mode_badge(app.fast_mode_state);
+        let (fast_mode_text, fast_mode_color) =
+            fast_mode_badge(app.session_runtime.fast_mode_state);
         let mut spans = Vec::new();
         push_badge(&mut spans, mode.current_mode_name.clone(), color);
         if let Some(model_badge) = footer_model_badge(app) {
@@ -152,7 +153,8 @@ fn build_primary_line(app: &App) -> Line<'static> {
         push_badge(&mut spans, fast_mode_text.to_owned(), fast_mode_color);
         Line::from(spans)
     } else {
-        let (fast_mode_text, fast_mode_color) = fast_mode_badge(app.fast_mode_state);
+        let (fast_mode_text, fast_mode_color) =
+            fast_mode_badge(app.session_runtime.fast_mode_state);
         let mut spans = Vec::new();
         if let Some((status_text, status_color)) = startup_status_badge(app) {
             push_badge(&mut spans, status_text.to_owned(), status_color);
@@ -170,7 +172,7 @@ fn push_badge(spans: &mut Vec<Span<'static>>, text: String, color: Color) {
 }
 
 fn footer_model_badge(app: &App) -> Option<String> {
-    let current_model = app.current_model.as_ref()?;
+    let current_model = app.session_runtime.current_model.as_ref()?;
     let mut badge = current_model.display_name_short.clone();
     if current_model.supports_effort {
         badge.push('/');
@@ -465,7 +467,7 @@ mod tests {
 
     fn app_with_mode() -> App {
         let mut app = App::test_default();
-        app.mode = Some(ModeState {
+        app.session_runtime.mode = Some(ModeState {
             current_mode_id: "default".to_owned(),
             current_mode_name: "default".to_owned(),
             available_modes: Vec::new(),
@@ -592,7 +594,7 @@ mod tests {
     #[test]
     fn mcp_auth_hint_wins_over_context_usage_on_second_row() {
         let mut app = App::test_default();
-        app.session_usage.context_usage_percent = Some(62);
+        app.session_runtime.session_usage.context_usage_percent = Some(62);
         app.mcp.servers.push(McpServerStatus {
             name: "filesystem".to_owned(),
             status: McpServerConnectionStatus::NeedsAuth,

--- a/src/ui/footer_rows.rs
+++ b/src/ui/footer_rows.rs
@@ -341,14 +341,15 @@ fn fit_footer_suffix_text(text: &str, max_width: usize) -> Option<String> {
 }
 
 fn pending_permission_request_count(app: &App) -> usize {
-    app.pending_interaction_ids
+    app.turn
+        .pending_interaction_ids
         .iter()
         .filter(|tool_id| {
             let Some((mi, bi)) = app.lookup_tool_call(tool_id) else {
                 return false;
             };
             matches!(
-                app.messages.get(mi).and_then(|msg| msg.blocks.get(bi)),
+                app.transcript.messages.get(mi).and_then(|msg| msg.blocks.get(bi)),
                 Some(MessageBlock::ToolCall(tc)) if tc.pending_permission.is_some()
             )
         })
@@ -366,7 +367,8 @@ fn mcp_needs_auth_count(app: &App) -> usize {
 }
 
 fn should_show_startup_mcp_hint(app: &App) -> bool {
-    !app.messages
+    !app.transcript
+        .messages
         .iter()
         .any(|message| matches!(message.role, MessageRole::User | MessageRole::Assistant))
 }
@@ -545,7 +547,7 @@ mod tests {
     fn pending_permission_hint_wins_on_first_row() {
         let mut app = App::test_default();
         let (response_tx, _response_rx) = oneshot::channel();
-        app.messages.push(ChatMessage::new(
+        app.transcript.messages.push(ChatMessage::new(
             MessageRole::Assistant,
             vec![MessageBlock::ToolCall(Box::new(ToolCallInfo {
                 id: "perm-1".into(),
@@ -580,7 +582,7 @@ mod tests {
             None,
         ));
         app.index_tool_call("perm-1".into(), 0, 0);
-        app.pending_interaction_ids.push("perm-1".into());
+        app.turn.pending_interaction_ids.push("perm-1".into());
 
         let serialized = serialize_footer_rows(&app, 80);
         let text = line_text(&serialized.rows[0]);

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -47,7 +47,7 @@ fn build_key_help_items(app: &App) -> Vec<(String, String)> {
 
     let context = active_key_help_context(app);
     let mut items = keymap_help_rows(app, context);
-    if app.is_compacting {
+    if app.turn.is_compacting {
         items.push(("Status".to_owned(), "Compacting context".to_owned()));
     }
     items.push(("Mouse wheel".to_owned(), "Scroll chat".to_owned()));
@@ -89,7 +89,7 @@ fn keymap_help_rows(app: &App, context: KeyContext) -> Vec<(String, String)> {
 fn should_show_help_binding(app: &App, context: KeyContext, binding: &ResolvedHelpBinding) -> bool {
     if context == KeyContext::ChatInput
         && matches!(binding.action, KeyAction::App(AppAction::FocusPromptOrAcceptSuggestion))
-        && app.pending_interaction_ids.is_empty()
+        && app.turn.pending_interaction_ids.is_empty()
     {
         return false;
     }
@@ -105,7 +105,7 @@ fn help_action_label(app: &App, action: KeyAction) -> &'static str {
         }
         KeyAction::App(AppAction::CancelTurn) => "Clear pending input state",
         KeyAction::App(AppAction::FocusPromptOrAcceptSuggestion)
-            if !app.pending_interaction_ids.is_empty() =>
+            if !app.turn.pending_interaction_ids.is_empty() =>
         {
             "Focus pending prompt"
         }
@@ -128,14 +128,14 @@ fn active_key_help_context(app: &App) -> KeyContext {
 }
 
 fn focused_question_prompt(app: &App) -> bool {
-    let Some(tool_id) = app.pending_interaction_ids.first() else {
+    let Some(tool_id) = app.turn.pending_interaction_ids.first() else {
         return false;
     };
     let Some((mi, bi)) = app.lookup_tool_call(tool_id) else {
         return false;
     };
     let Some(crate::app::MessageBlock::ToolCall(tc)) =
-        app.messages.get(mi).and_then(|message| message.blocks.get(bi))
+        app.transcript.messages.get(mi).and_then(|message| message.blocks.get(bi))
     else {
         return false;
     };
@@ -192,7 +192,7 @@ fn format_help_key_code(code: KeyCodeSpec) -> String {
 }
 
 fn pending_command_help_label(app: &App) -> String {
-    app.pending_command_label.clone().unwrap_or_else(|| "Processing command...".to_owned())
+    app.turn.pending_command_label.clone().unwrap_or_else(|| "Processing command...".to_owned())
 }
 
 fn build_slash_help_items(app: &App) -> Vec<(String, String)> {

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -217,7 +217,7 @@ fn build_slash_command_items(app: &App) -> Vec<(String, String)> {
         .map(|spec| (spec.name.to_owned(), spec.long_description.to_owned()))
         .collect();
 
-    for cmd in &app.available_commands {
+    for cmd in &app.sdk_inventory.available_commands {
         let name =
             if cmd.name.starts_with('/') { cmd.name.clone() } else { format!("/{}", cmd.name) };
         if crate::app::slash::app_owned_command_name(&name).is_some() {
@@ -255,6 +255,7 @@ fn build_subagent_help_items(app: &App) -> Vec<(String, String)> {
     }
 
     let mut agents: Vec<(String, String)> = app
+        .sdk_inventory
         .available_agents
         .iter()
         .filter(|agent| !agent.name.trim().is_empty())

--- a/src/ui/inline_chat_rows.rs
+++ b/src/ui/inline_chat_rows.rs
@@ -170,7 +170,8 @@ pub(crate) fn serialize_live_rows_with_boundaries_excluding(
     width: u16,
     excluded_ids: &BTreeSet<HistoryOutputId>,
 ) -> SerializedLiveRows {
-    let current_mode_id = app.mode.as_ref().map(|mode| mode.current_mode_id.clone());
+    let current_mode_id =
+        app.session_runtime.mode.as_ref().map(|mode| mode.current_mode_id.clone());
     let active_msg_idx = app.active_turn_assistant_idx();
     let runtime_indicator = sync_runtime_indicator(app);
     let mut rows = Vec::new();

--- a/src/ui/inline_chat_rows.rs
+++ b/src/ui/inline_chat_rows.rs
@@ -177,8 +177,8 @@ pub(crate) fn serialize_live_rows_with_boundaries_excluding(
     let mut row_boundaries = Vec::new();
     let mut previous_block_kind = None;
 
-    for msg_idx in 0..app.messages.len() {
-        let role = app.messages[msg_idx].role.clone();
+    for msg_idx in 0..app.transcript.messages.len() {
+        let role = app.transcript.messages[msg_idx].role.clone();
         let block_kind = message_block_kind(&role);
         let rendered_message = render_live_message_rows(
             app,
@@ -250,8 +250,8 @@ fn render_welcome_live_rows(
     width: u16,
     excluded_ids: &BTreeSet<HistoryOutputId>,
 ) -> RenderedMessageRows {
-    let ids = welcome_output_ids(&app.messages[msg_idx]);
-    let commit_ready = message_commit_ready(&app.messages[msg_idx]);
+    let ids = welcome_output_ids(&app.transcript.messages[msg_idx]);
+    let commit_ready = message_commit_ready(&app.transcript.messages[msg_idx]);
     if ids_are_excluded(&ids, excluded_ids) {
         return RenderedMessageRows::skipped_transcript_content();
     }
@@ -276,7 +276,7 @@ fn render_user_system_live_rows(
     width: u16,
     excluded_ids: &BTreeSet<HistoryOutputId>,
 ) -> RenderedMessageRows {
-    let ids = vec![HistoryOutputId::Message(app.messages[msg_idx].id)];
+    let ids = vec![HistoryOutputId::Message(app.transcript.messages[msg_idx].id)];
     if ids_are_excluded(&ids, excluded_ids) {
         return RenderedMessageRows::skipped_transcript_content();
     }
@@ -284,9 +284,9 @@ fn render_user_system_live_rows(
     // A message hosting an unanswered user dialog must stay in the live
     // (mutable) region so its chooser re-renders on focus/selection changes;
     // committing it would freeze it in immutable scrollback.
-    let commit_ready = !message_has_pending_user_dialog(&app.messages[msg_idx]);
+    let commit_ready = !message_has_pending_user_dialog(&app.transcript.messages[msg_idx]);
     let rendered = build_user_system_message_rows(
-        &mut app.messages[msg_idx],
+        &mut app.transcript.messages[msg_idx],
         message_render_context(current_mode_id, width),
     );
     RenderedMessageRows::message(
@@ -319,8 +319,11 @@ fn render_assistant_live_rows(
     excluded_ids: &BTreeSet<HistoryOutputId>,
 ) -> RenderedMessageRows {
     let active_mutable = active_assistant_message_is_mutable(app, msg_idx);
-    let items =
-        assistant_render_items_from_message(&app.messages[msg_idx], msg_idx, active_mutable);
+    let items = assistant_render_items_from_message(
+        &app.transcript.messages[msg_idx],
+        msg_idx,
+        active_mutable,
+    );
     let selection = select_unexcluded_assistant_items(items, excluded_ids);
     let indicator = assistant_runtime_indicator(msg_idx, active_msg_idx, runtime_indicator);
     if selection.items.is_empty() && indicator.is_none() {
@@ -331,7 +334,7 @@ fn render_assistant_live_rows(
         };
     }
 
-    let message_id = app.messages[msg_idx].id;
+    let message_id = app.transcript.messages[msg_idx].id;
     let label_ids = vec![HistoryOutputId::AssistantLabel(message_id)];
     let show_label = !ids_are_excluded(&label_ids, excluded_ids);
     let skipped_static_body = selection.skipped_body_before_rendered_content;
@@ -352,7 +355,7 @@ fn render_assistant_live_rows(
     tracing::debug!(
         target: crate::logging::targets::APP_RENDER,
         event_name = "inline_chat_assistant_block_built",
-        message = "assistant message block rendered from canonical app.messages",
+        message = "assistant message block rendered from canonical app.transcript.messages",
         outcome = "success",
         assistant_turn_id = tracing::field::Empty,
         show_label,
@@ -468,7 +471,7 @@ fn serialize_welcome_message(app: &App, msg_idx: usize, width: u16) -> Vec<Line<
     if !app.show_session_overview {
         return Vec::new();
     }
-    let Some(message) = app.messages.get(msg_idx) else {
+    let Some(message) = app.transcript.messages.get(msg_idx) else {
         return Vec::new();
     };
     let Some(MessageBlock::Welcome(welcome)) =
@@ -518,7 +521,7 @@ fn welcome_value_ready(value: &str) -> bool {
 }
 
 fn sync_runtime_indicator(app: &mut App) -> Option<AssistantRuntimeIndicator> {
-    if app.is_compacting {
+    if app.turn.is_compacting {
         app.chat_render.thinking_verb = None;
         return Some(AssistantRuntimeIndicator::Compacting);
     }
@@ -527,7 +530,7 @@ fn sync_runtime_indicator(app: &mut App) -> Option<AssistantRuntimeIndicator> {
         || (matches!(app.status, crate::app::AppStatus::Running)
             && app
                 .active_turn_assistant_idx()
-                .and_then(|idx| app.messages.get(idx))
+                .and_then(|idx| app.transcript.messages.get(idx))
                 .is_some_and(|msg| msg.blocks.is_empty()));
 
     if thinking {
@@ -627,7 +630,8 @@ impl RenderedMessageRows {
 
 fn active_assistant_message_is_mutable(app: &App, msg_idx: usize) -> bool {
     app.active_turn_assistant_idx() == Some(msg_idx)
-        && (app.is_compacting || matches!(app.status, AppStatus::Thinking | AppStatus::Running))
+        && (app.turn.is_compacting
+            || matches!(app.status, AppStatus::Thinking | AppStatus::Running))
 }
 
 struct PendingAssistantTextRun {
@@ -1253,8 +1257,11 @@ fn render_canonical_tool_rows(
     render_context: MessageRenderContext<'_>,
     spinner: SpinnerState,
 ) -> Vec<Line<'static>> {
-    let Some(MessageBlock::ToolCall(tc)) =
-        app.messages.get_mut(msg_idx).and_then(|message| message.blocks.get_mut(block_idx))
+    let Some(MessageBlock::ToolCall(tc)) = app
+        .transcript
+        .messages
+        .get_mut(msg_idx)
+        .and_then(|message| message.blocks.get_mut(block_idx))
     else {
         return Vec::new();
     };
@@ -1610,7 +1617,7 @@ mod tests {
     #[test]
     fn live_rows_do_not_start_with_synthetic_blank_row() {
         let mut app = App::test_default();
-        app.messages.push(assistant_text_message("hi"));
+        app.transcript.messages.push(assistant_text_message("hi"));
 
         let rows = serialize_live_rows(&mut app, 120);
 
@@ -1622,7 +1629,7 @@ mod tests {
     fn live_rows_render_user_row_while_assistant_streams() {
         let mut app = App::test_default();
         app.push_message_tracked(user_text_message("hello"));
-        app.messages.push(assistant_text_message("still streaming"));
+        app.transcript.messages.push(assistant_text_message("still streaming"));
 
         let rows = serialize_live_rows(&mut app, 120);
         let text = line_texts(&rows);
@@ -1637,8 +1644,8 @@ mod tests {
             "Resize should rebuild canonical user prose from messages with enough words to wrap \
              differently at narrow widths.",
         ));
-        app.messages.push(assistant_text_message(
-            "Assistant rows also come directly from app.messages, so changing width changes \
+        app.transcript.messages.push(assistant_text_message(
+            "Assistant rows also come directly from app.transcript.messages, so changing width changes \
              physical row count without changing semantic text.",
         ));
 
@@ -1662,7 +1669,7 @@ mod tests {
     fn live_row_boundaries_stop_stable_prefix_before_active_assistant() {
         let mut app = App::test_default();
         app.push_message_tracked(user_text_message("hello"));
-        app.messages.push(assistant_text_message("still streaming"));
+        app.transcript.messages.push(assistant_text_message("still streaming"));
         app.bind_active_turn_assistant(1);
         app.status = AppStatus::Running;
 
@@ -1674,7 +1681,7 @@ mod tests {
     #[test]
     fn active_assistant_commits_completed_text_before_streaming_tail() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![
+        app.transcript.messages.push(assistant_blocks_message(vec![
             MessageBlock::Text(TextBlock::from_complete("prefix")),
             MessageBlock::Text(TextBlock::from_complete("tail")),
         ]));
@@ -1692,7 +1699,7 @@ mod tests {
     #[test]
     fn active_assistant_commits_completed_tool_before_pending_permission_tool() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![
+        app.transcript.messages.push(assistant_blocks_message(vec![
             tool_call_block("done-tool", false),
             tool_call_block_with_status_interaction(
                 "pending-tool",
@@ -1718,7 +1725,9 @@ mod tests {
     #[test]
     fn active_assistant_completed_tool_is_commit_ready() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![tool_call_block("done-tool", false)]));
+        app.transcript
+            .messages
+            .push(assistant_blocks_message(vec![tool_call_block("done-tool", false)]));
         app.bind_active_turn_assistant(0);
         app.status = AppStatus::Running;
 
@@ -1730,13 +1739,15 @@ mod tests {
     #[test]
     fn active_assistant_in_progress_tool_keeps_label_mutable() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![tool_call_block_with_status_interaction(
-            "running-tool",
-            model::ToolCallStatus::InProgress,
-            false,
-            false,
-            false,
-        )]));
+        app.transcript.messages.push(assistant_blocks_message(vec![
+            tool_call_block_with_status_interaction(
+                "running-tool",
+                model::ToolCallStatus::InProgress,
+                false,
+                false,
+                false,
+            ),
+        ]));
         app.bind_active_turn_assistant(0);
         app.status = AppStatus::Running;
 
@@ -1752,7 +1763,7 @@ mod tests {
     #[test]
     fn live_rows_render_committed_assistant_prefix_before_live_tail() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![
+        app.transcript.messages.push(assistant_blocks_message(vec![
             MessageBlock::Text(TextBlock::from_complete("prefix")),
             MessageBlock::Text(TextBlock::from_complete("tail")),
         ]));
@@ -1766,7 +1777,7 @@ mod tests {
     #[test]
     fn live_adjacent_text_blocks_preserve_paragraph_gap() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![
+        app.transcript.messages.push(assistant_blocks_message(vec![
             MessageBlock::Text(
                 TextBlock::from_complete("line 1: ready\n\n")
                     .with_trailing_spacing(TextBlockSpacing::ParagraphBreak),
@@ -1782,7 +1793,7 @@ mod tests {
     #[test]
     fn live_assistant_text_suppresses_paragraph_gap_before_list_block() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![
+        app.transcript.messages.push(assistant_blocks_message(vec![
             MessageBlock::Text(
                 TextBlock::from_complete("Intro\n\n")
                     .with_trailing_spacing(TextBlockSpacing::ParagraphBreak),
@@ -1798,7 +1809,7 @@ mod tests {
     #[test]
     fn live_assistant_text_suppresses_paragraph_gap_after_list_block() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![
+        app.transcript.messages.push(assistant_blocks_message(vec![
             MessageBlock::Text(
                 TextBlock::from_complete("- One\n- Two\n\n")
                     .with_trailing_spacing(TextBlockSpacing::ParagraphBreak),
@@ -1814,7 +1825,9 @@ mod tests {
     #[test]
     fn live_assistant_text_preserves_single_newline_rows() {
         let mut app = App::test_default();
-        app.messages.push(assistant_text_message("line 1: ready\nline 2: ready\nline 3: ready"));
+        app.transcript
+            .messages
+            .push(assistant_text_message("line 1: ready\nline 2: ready\nline 3: ready"));
 
         let rows = serialize_live_rows(&mut app, 120);
 
@@ -1827,7 +1840,7 @@ mod tests {
     #[test]
     fn live_rows_render_assistant_notice_from_messages() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![MessageBlock::Notice(
+        app.transcript.messages.push(assistant_blocks_message(vec![MessageBlock::Notice(
             NoticeBlock::from_complete(crate::app::SystemSeverity::Warning, "watch this"),
         )]));
 
@@ -1840,7 +1853,9 @@ mod tests {
     #[test]
     fn live_rows_render_visible_tool_from_canonical_message_block() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![tool_call_block("tool-1", false)]));
+        app.transcript
+            .messages
+            .push(assistant_blocks_message(vec![tool_call_block("tool-1", false)]));
 
         let rows = serialize_live_rows(&mut app, 120);
         let text = line_texts(&rows);
@@ -1860,7 +1875,7 @@ mod tests {
             assistant_blocks_message(vec![MessageBlock::Text(first), MessageBlock::Text(second)]);
         let message_id = message.id;
         let mut app = App::test_default();
-        app.messages.push(message);
+        app.transcript.messages.push(message);
         let excluded_ids = BTreeSet::from([
             HistoryOutputId::AssistantLabel(message_id),
             HistoryOutputId::Block(first_id),
@@ -1896,7 +1911,7 @@ mod tests {
             "| Slow startup | Startup output lands after a long delay | #42002 |\n",
         );
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![
+        app.transcript.messages.push(assistant_blocks_message(vec![
             MessageBlock::Text(first),
             MessageBlock::Text(second),
         ]));
@@ -1948,7 +1963,7 @@ mod tests {
         let message = assistant_blocks_message(vec![done, running]);
         let message_id = message.id;
         let mut app = App::test_default();
-        app.messages.push(message);
+        app.transcript.messages.push(message);
         app.bind_active_turn_assistant(0);
         app.status = AppStatus::Running;
         let excluded_ids = BTreeSet::from([
@@ -1973,7 +1988,7 @@ mod tests {
     #[test]
     fn empty_active_assistant_renders_thinking_from_runtime_state() {
         let mut app = App::test_default();
-        app.messages.push(assistant_message());
+        app.transcript.messages.push(assistant_message());
         app.bind_active_turn_assistant(0);
         app.status = AppStatus::Thinking;
         app.chat_render.thinking_verb = Some("Pondering");
@@ -1988,7 +2003,7 @@ mod tests {
     #[test]
     fn thinking_remains_render_only_across_width_rebuilds() {
         let mut app = App::test_default();
-        app.messages.push(assistant_message());
+        app.transcript.messages.push(assistant_message());
         app.bind_active_turn_assistant(0);
         app.status = AppStatus::Thinking;
         app.chat_render.thinking_verb = Some("Pondering");
@@ -2003,8 +2018,8 @@ mod tests {
                 "thinking indicator missing at width {width}: {text:?}"
             );
             assert!(
-                app.messages[0].blocks.is_empty(),
-                "thinking indicator must not be persisted into app.messages"
+                app.transcript.messages[0].blocks.is_empty(),
+                "thinking indicator must not be persisted into app.transcript.messages"
             );
         }
     }
@@ -2012,7 +2027,7 @@ mod tests {
     #[test]
     fn live_rows_keep_system_row_after_active_assistant_turn() {
         let mut app = App::test_default();
-        app.messages.push(assistant_text_message("streaming"));
+        app.transcript.messages.push(assistant_text_message("streaming"));
         app.push_message_tracked(system_text_message("during turn"));
 
         let rows = serialize_live_rows(&mut app, 120);
@@ -2026,7 +2041,12 @@ mod tests {
     #[test]
     fn live_rows_render_welcome_once() {
         let mut app = App::test_default();
-        app.messages.push(ChatMessage::welcome("1.2.3", "Pro", "/workspace/demo", "session-123"));
+        app.transcript.messages.push(ChatMessage::welcome(
+            "1.2.3",
+            "Pro",
+            "/workspace/demo",
+            "session-123",
+        ));
 
         let rows = serialize_live_rows(&mut app, 120);
         let text = line_texts(&rows);
@@ -2037,7 +2057,12 @@ mod tests {
     #[test]
     fn welcome_renders_once_across_repeated_width_rebuilds() {
         let mut app = App::test_default();
-        app.messages.push(ChatMessage::welcome("1.2.3", "Pro", "/workspace/demo", "session-123"));
+        app.transcript.messages.push(ChatMessage::welcome(
+            "1.2.3",
+            "Pro",
+            "/workspace/demo",
+            "session-123",
+        ));
 
         for width in [36, 120, 36] {
             let rows = serialize_live_rows(&mut app, width);
@@ -2069,7 +2094,12 @@ mod tests {
     #[test]
     fn finalized_welcome_rows_are_commit_ready() {
         let mut app = App::test_default();
-        app.messages.push(ChatMessage::welcome("1.2.3", "Pro", "/workspace/demo", "session-123"));
+        app.transcript.messages.push(ChatMessage::welcome(
+            "1.2.3",
+            "Pro",
+            "/workspace/demo",
+            "session-123",
+        ));
 
         let serialized = serialize_all_rows_with_boundaries(&mut app, 120);
 
@@ -2081,7 +2111,7 @@ mod tests {
     fn live_rows_render_uncommitted_loading_welcome() {
         let mut app = App::test_default();
         app.status = AppStatus::Connecting;
-        app.messages.push(ChatMessage::welcome("1.2.3", "-", "/workspace/demo", "-"));
+        app.transcript.messages.push(ChatMessage::welcome("1.2.3", "-", "/workspace/demo", "-"));
 
         let rows = serialize_live_rows(&mut app, 120);
         let text = line_texts(&rows);
@@ -2096,7 +2126,7 @@ mod tests {
     fn loading_welcome_rows_are_not_commit_ready() {
         let mut app = App::test_default();
         app.status = AppStatus::Connecting;
-        app.messages.push(ChatMessage::welcome("1.2.3", "-", "/workspace/demo", "-"));
+        app.transcript.messages.push(ChatMessage::welcome("1.2.3", "-", "/workspace/demo", "-"));
 
         let serialized = serialize_all_rows_with_boundaries(&mut app, 120);
 
@@ -2108,7 +2138,7 @@ mod tests {
     fn loading_welcome_blocks_later_stable_rows_from_scrollback() {
         let mut app = App::test_default();
         app.status = AppStatus::Connecting;
-        app.messages.push(ChatMessage::welcome("1.2.3", "-", "/workspace/demo", "-"));
+        app.transcript.messages.push(ChatMessage::welcome("1.2.3", "-", "/workspace/demo", "-"));
         app.push_message_tracked(user_text_message("queued while connecting"));
 
         let serialized = serialize_all_rows_with_boundaries(&mut app, 120);
@@ -2120,7 +2150,9 @@ mod tests {
     #[test]
     fn hidden_canonical_tool_renders_no_rows_or_label() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![tool_call_block("child-1", true)]));
+        app.transcript
+            .messages
+            .push(assistant_blocks_message(vec![tool_call_block("child-1", true)]));
 
         for width in [32, 120, 32] {
             let rows = serialize_live_rows(&mut app, width);
@@ -2132,9 +2164,9 @@ mod tests {
     #[test]
     fn hidden_canonical_tool_with_focused_permission_without_subagent_context_has_no_header() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![tool_call_block_with_interaction(
-            "child-1", true, true, false,
-        )]));
+        app.transcript.messages.push(assistant_blocks_message(vec![
+            tool_call_block_with_interaction("child-1", true, true, false),
+        ]));
 
         for width in [32, 120, 32] {
             let rows = serialize_live_rows(&mut app, width);
@@ -2159,9 +2191,9 @@ mod tests {
     #[test]
     fn hidden_canonical_tool_with_unfocused_permission_renders_interaction_rows() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![tool_call_block_with_pending_permission(
-            "child-1", true, false,
-        )]));
+        app.transcript.messages.push(assistant_blocks_message(vec![
+            tool_call_block_with_pending_permission("child-1", true, false),
+        ]));
 
         for width in [32, 120, 32] {
             let rows = serialize_live_rows(&mut app, width);
@@ -2190,7 +2222,7 @@ mod tests {
     #[test]
     fn hidden_canonical_tool_with_subagent_permission_prefixes_child_tool_title() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![
+        app.transcript.messages.push(assistant_blocks_message(vec![
             tool_call_block_with_subagent_pending_permission("child-1"),
         ]));
 
@@ -2227,9 +2259,9 @@ mod tests {
     #[test]
     fn hidden_canonical_tool_with_focused_question_renders_interaction_rows() {
         let mut app = App::test_default();
-        app.messages.push(assistant_blocks_message(vec![tool_call_block_with_interaction(
-            "child-1", true, false, true,
-        )]));
+        app.transcript.messages.push(assistant_blocks_message(vec![
+            tool_call_block_with_interaction("child-1", true, false, true),
+        ]));
 
         for width in [32, 120, 32] {
             let rows = serialize_live_rows(&mut app, width);

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -47,7 +47,7 @@ fn has_login_hint(app: &App) -> bool {
 }
 
 fn has_cancel_hint(app: &App) -> bool {
-    app.pending_cancel_origin.is_some()
+    app.turn.pending_cancel_origin.is_some()
 }
 
 fn has_prompt_suggestion_hint(app: &App) -> bool {
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     fn visual_line_count_includes_cancel_hint_row() {
         let mut app = App::test_default();
-        app.pending_cancel_origin = Some(CancelOrigin::AutoQueue);
+        app.turn.pending_cancel_origin = Some(CancelOrigin::AutoQueue);
         assert_eq!(visual_line_count(&mut app, 80), CANCEL_HINT_LINES + 1);
     }
 
@@ -284,7 +284,7 @@ mod tests {
     fn visual_line_count_hides_prompt_suggestion_hint_when_input_lacks_focus() {
         let mut app = App::test_default();
         app.prompt_suggestion = Some("Write tests for the retry flow".to_owned());
-        app.pending_interaction_ids.push("perm-1".to_owned());
+        app.turn.pending_interaction_ids.push("perm-1".to_owned());
         app.claim_focus_target(FocusTarget::Permission);
         assert_eq!(visual_line_count(&mut app, 80), 1);
     }

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -43,7 +43,7 @@ pub(crate) struct InputRenderGeometry {
 
 /// Whether a login hint banner is active.
 fn has_login_hint(app: &App) -> bool {
-    app.login_hint.is_some()
+    app.session_runtime.login_hint.is_some()
 }
 
 fn has_cancel_hint(app: &App) -> bool {
@@ -54,7 +54,11 @@ fn has_prompt_suggestion_hint(app: &App) -> bool {
     app.input.is_empty()
         && app.focus_owner() == FocusOwner::Input
         && !autocomplete::is_active(app)
-        && app.prompt_suggestion.as_deref().is_some_and(|suggestion| !suggestion.trim().is_empty())
+        && app
+            .session_runtime
+            .prompt_suggestion
+            .as_deref()
+            .is_some_and(|suggestion| !suggestion.trim().is_empty())
 }
 
 pub(crate) fn hint_line_count(app: &App) -> u16 {
@@ -241,7 +245,7 @@ mod tests {
     #[test]
     fn visual_line_count_includes_login_hint_rows() {
         let mut app = App::test_default();
-        app.login_hint = Some(LoginHint {
+        app.session_runtime.login_hint = Some(LoginHint {
             method_name: "oauth".to_owned(),
             method_description: "Sign in".to_owned(),
         });
@@ -258,7 +262,7 @@ mod tests {
     #[test]
     fn visual_line_count_includes_prompt_suggestion_hint_row() {
         let mut app = App::test_default();
-        app.prompt_suggestion = Some("Write tests for the retry flow".to_owned());
+        app.session_runtime.prompt_suggestion = Some("Write tests for the retry flow".to_owned());
         assert_eq!(visual_line_count(&mut app, 80), PROMPT_SUGGESTION_HINT_LINES + 1);
     }
 
@@ -275,7 +279,7 @@ mod tests {
     #[test]
     fn visual_line_count_hides_prompt_suggestion_hint_when_input_not_empty() {
         let mut app = App::test_default();
-        app.prompt_suggestion = Some("Write tests for the retry flow".to_owned());
+        app.session_runtime.prompt_suggestion = Some("Write tests for the retry flow".to_owned());
         app.input.set_text("draft");
         assert_eq!(visual_line_count(&mut app, 80), 1);
     }
@@ -283,7 +287,7 @@ mod tests {
     #[test]
     fn visual_line_count_hides_prompt_suggestion_hint_when_input_lacks_focus() {
         let mut app = App::test_default();
-        app.prompt_suggestion = Some("Write tests for the retry flow".to_owned());
+        app.session_runtime.prompt_suggestion = Some("Write tests for the retry flow".to_owned());
         app.turn.pending_interaction_ids.push("perm-1".to_owned());
         app.claim_focus_target(FocusTarget::Permission);
         assert_eq!(visual_line_count(&mut app, 80), 1);

--- a/src/ui/input_rows.rs
+++ b/src/ui/input_rows.rs
@@ -25,12 +25,23 @@ pub(crate) fn build_composer_hint_rows(app: &App) -> Vec<Line<'static>> {
         )));
     }
 
-    if app.pending_cancel_origin.is_some() {
+    if app.turn.pending_cancel_origin.is_some() {
         let spinner_ch = SPINNER_FRAMES[app.spinner_frame % SPINNER_FRAMES.len()];
         rows.push(Line::from(vec![
             Span::styled(format!("{spinner_ch} "), Style::default().fg(theme::DIM)),
             Span::styled(
                 "Cancelling current turn... draft will auto-submit when ready.",
+                Style::default().fg(theme::DIM),
+            ),
+        ]));
+    }
+
+    if app.turn.is_compacting {
+        let spinner_ch = SPINNER_FRAMES[app.spinner_frame % SPINNER_FRAMES.len()];
+        rows.push(Line::from(vec![
+            Span::styled(format!("{spinner_ch} "), Style::default().fg(theme::DIM)),
+            Span::styled(
+                "Compacting session... you can draft, submit is paused.",
                 Style::default().fg(theme::DIM),
             ),
         ]));
@@ -67,7 +78,8 @@ pub(crate) fn blocked_input_lines(app: &App) -> Vec<Line<'static>> {
         }
         AppStatus::CommandPending => {
             let spinner_ch = SPINNER_FRAMES[app.spinner_frame % SPINNER_FRAMES.len()];
-            let label = app.pending_command_label.as_deref().unwrap_or("Processing command...");
+            let label =
+                app.turn.pending_command_label.as_deref().unwrap_or("Processing command...");
             vec![Line::from(vec![
                 Span::styled(format!("{spinner_ch} "), Style::default().fg(theme::DIM)),
                 Span::styled(label.to_owned(), Style::default().fg(theme::DIM)),
@@ -112,13 +124,25 @@ mod tests {
     #[test]
     fn build_composer_hint_rows_preserves_cancel_and_suggestion_rows() {
         let mut app = App::test_default();
-        app.pending_cancel_origin = Some(CancelOrigin::AutoQueue);
+        app.turn.pending_cancel_origin = Some(CancelOrigin::AutoQueue);
         app.prompt_suggestion = Some("Write tests".to_owned());
 
         let rows = build_composer_hint_rows(&app);
         assert_eq!(rows.len(), 2);
         assert!(line_text(&rows[0]).contains("Cancelling current turn"));
         assert!(line_text(&rows[1]).contains("Suggestion: Write tests"));
+    }
+
+    #[test]
+    fn build_composer_hint_rows_shows_compaction_draft_hint() {
+        let mut app = App::test_default();
+        app.turn.is_compacting = true;
+
+        let rows = build_composer_hint_rows(&app);
+
+        assert_eq!(rows.len(), 1);
+        assert!(line_text(&rows[0]).contains("Compacting session"));
+        assert!(line_text(&rows[0]).contains("you can draft"));
     }
 
     #[test]
@@ -140,7 +164,7 @@ mod tests {
     fn prompt_suggestion_hint_requires_input_focus() {
         let mut app = App::test_default();
         app.prompt_suggestion = Some("Write tests".to_owned());
-        app.pending_interaction_ids.push("perm-1".to_owned());
+        app.turn.pending_interaction_ids.push("perm-1".to_owned());
         app.claim_focus_target(FocusTarget::Permission);
 
         let rows = build_composer_hint_rows(&app);
@@ -163,7 +187,7 @@ mod tests {
     fn blocked_input_lines_shows_pending_command_label() {
         let mut app = App::test_default();
         app.status = AppStatus::CommandPending;
-        app.pending_command_label = Some("Switching model...".to_owned());
+        app.turn.pending_command_label = Some("Switching model...".to_owned());
 
         let rows = blocked_input_lines(&app);
 

--- a/src/ui/input_rows.rs
+++ b/src/ui/input_rows.rs
@@ -14,7 +14,7 @@ const SPINNER_FRAMES: &[char] = &[
 pub(crate) fn build_composer_hint_rows(app: &App) -> Vec<Line<'static>> {
     let mut rows = Vec::new();
 
-    if let Some(hint) = &app.login_hint {
+    if let Some(hint) = &app.session_runtime.login_hint {
         rows.push(Line::from(Span::styled(
             format!("Authentication required: {} -- {}", hint.method_name, hint.method_description),
             Style::default().fg(ratatui::style::Color::Yellow),
@@ -51,7 +51,7 @@ pub(crate) fn build_composer_hint_rows(app: &App) -> Vec<Line<'static>> {
         rows.extend(autocomplete::composer_hint_rows(app));
     } else if app.input.is_empty()
         && app.focus_owner() == FocusOwner::Input
-        && let Some(suggestion) = app.prompt_suggestion.as_deref()
+        && let Some(suggestion) = app.session_runtime.prompt_suggestion.as_deref()
         && !suggestion.trim().is_empty()
     {
         rows.push(Line::from(vec![
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn build_composer_hint_rows_preserves_login_hint_content() {
         let mut app = App::test_default();
-        app.login_hint = Some(LoginHint {
+        app.session_runtime.login_hint = Some(LoginHint {
             method_name: "oauth".to_owned(),
             method_description: "Sign in".to_owned(),
         });
@@ -125,7 +125,7 @@ mod tests {
     fn build_composer_hint_rows_preserves_cancel_and_suggestion_rows() {
         let mut app = App::test_default();
         app.turn.pending_cancel_origin = Some(CancelOrigin::AutoQueue);
-        app.prompt_suggestion = Some("Write tests".to_owned());
+        app.session_runtime.prompt_suggestion = Some("Write tests".to_owned());
 
         let rows = build_composer_hint_rows(&app);
         assert_eq!(rows.len(), 2);
@@ -150,7 +150,7 @@ mod tests {
         let mut app = App::test_default();
         app.input.set_text("@");
         let _ = app.input.set_cursor(0, 1);
-        app.prompt_suggestion = Some("Write tests".to_owned());
+        app.session_runtime.prompt_suggestion = Some("Write tests".to_owned());
         crate::app::mention::activate(&mut app);
 
         let rows = build_composer_hint_rows(&app);
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn prompt_suggestion_hint_requires_input_focus() {
         let mut app = App::test_default();
-        app.prompt_suggestion = Some("Write tests".to_owned());
+        app.session_runtime.prompt_suggestion = Some("Write tests".to_owned());
         app.turn.pending_interaction_ids.push("perm-1".to_owned());
         app.claim_focus_target(FocusTarget::Permission);
 

--- a/src/ui/session_picker.rs
+++ b/src/ui/session_picker.rs
@@ -235,7 +235,7 @@ mod tests {
     fn renders_loading_state_before_sessions_are_ready() {
         let mut app = App::test_default();
         app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::SessionPicker);
-        app.startup_session_picker_requested = true;
+        app.test_request_startup_session_picker();
 
         let text = draw_text(&mut app);
 

--- a/tests/config_flow.rs
+++ b/tests/config_flow.rs
@@ -53,14 +53,14 @@ fn config_ignores_paste_until_returning_to_chat() {
 
     handle_terminal_event(&mut app, Event::Paste("blocked".into()));
 
-    assert!(app.pending_paste_text.is_empty());
+    assert!(app.paste.pending_text.is_empty());
     assert!(app.input.is_empty());
 
     handle_terminal_event(&mut app, Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)));
     handle_terminal_event(&mut app, Event::Paste("allowed".into()));
 
     assert_eq!(app.surface_mode, SurfaceMode::Chat);
-    assert_eq!(app.pending_paste_text, "allowed");
+    assert_eq!(app.paste.pending_text, "allowed");
 }
 
 #[test]

--- a/tests/integration/permissions.rs
+++ b/tests/integration/permissions.rs
@@ -61,12 +61,12 @@ async fn permission_request_attaches_to_tool_call() {
     let mut app = test_app();
     let _rx = setup_permission(&mut app, "tc-perm-1", allow_deny_options());
 
-    assert_eq!(app.pending_interaction_ids.len(), 1);
-    assert_eq!(app.pending_interaction_ids[0], "tc-perm-1");
+    assert_eq!(app.turn.pending_interaction_ids.len(), 1);
+    assert_eq!(app.turn.pending_interaction_ids[0], "tc-perm-1");
 
     // The tool call should have a pending_permission
-    let (mi, bi) = app.tool_call_index["tc-perm-1"];
-    if let MessageBlock::ToolCall(tc) = &app.messages[mi].blocks[bi] {
+    let (mi, bi) = app.lookup_tool_call("tc-perm-1").expect("tc-perm-1 indexed");
+    if let MessageBlock::ToolCall(tc) = &app.transcript.messages[mi].blocks[bi] {
         assert!(tc.pending_permission.is_some());
         let perm = tc.pending_permission.as_ref().unwrap();
         assert_eq!(perm.options.len(), 2);
@@ -92,7 +92,7 @@ async fn permission_for_unknown_tool_call_auto_rejects() {
     send_client_event(&mut app, ClientEvent::PermissionRequest { request, response_tx });
 
     // Should NOT be in pending queue
-    assert!(app.pending_interaction_ids.is_empty());
+    assert!(app.turn.pending_interaction_ids.is_empty());
 
     // The response should have been sent (auto-reject with last option = "deny")
     let response = response_rx.try_recv();
@@ -113,17 +113,17 @@ async fn multiple_permissions_queue_in_order() {
     let _rx1 = setup_permission(&mut app, "tc-q1", allow_deny_options());
     let _rx2 = setup_permission(&mut app, "tc-q2", allow_deny_options());
 
-    assert_eq!(app.pending_interaction_ids.len(), 2);
-    assert_eq!(app.pending_interaction_ids[0], "tc-q1");
-    assert_eq!(app.pending_interaction_ids[1], "tc-q2");
+    assert_eq!(app.turn.pending_interaction_ids.len(), 2);
+    assert_eq!(app.turn.pending_interaction_ids[0], "tc-q1");
+    assert_eq!(app.turn.pending_interaction_ids[1], "tc-q2");
 
     // First should be focused, second should not
-    let (mi1, bi1) = app.tool_call_index["tc-q1"];
-    if let MessageBlock::ToolCall(tc) = &app.messages[mi1].blocks[bi1] {
+    let (mi1, bi1) = app.lookup_tool_call("tc-q1").expect("tc-q1 indexed");
+    if let MessageBlock::ToolCall(tc) = &app.transcript.messages[mi1].blocks[bi1] {
         assert!(tc.pending_permission.as_ref().unwrap().focused);
     }
-    let (mi2, bi2) = app.tool_call_index["tc-q2"];
-    if let MessageBlock::ToolCall(tc) = &app.messages[mi2].blocks[bi2] {
+    let (mi2, bi2) = app.lookup_tool_call("tc-q2").expect("tc-q2 indexed");
+    if let MessageBlock::ToolCall(tc) = &app.transcript.messages[mi2].blocks[bi2] {
         assert!(!tc.pending_permission.as_ref().unwrap().focused);
     }
 }
@@ -143,7 +143,7 @@ async fn duplicate_permission_request_is_rejected_without_duplicate_queue_entry(
     );
     send_client_event(&mut app, ClientEvent::PermissionRequest { request, response_tx });
 
-    assert_eq!(app.pending_interaction_ids, vec!["tc-dup"]);
+    assert_eq!(app.turn.pending_interaction_ids, vec!["tc-dup"]);
     assert!(matches!(first_rx.try_recv(), Err(tokio::sync::oneshot::error::TryRecvError::Empty)));
 
     let resp = duplicate_rx.try_recv().expect("duplicate permission should be auto-rejected");
@@ -168,7 +168,7 @@ async fn turn_complete_resets_transient_state() {
     assert_eq!(app.files_accessed, 0, "files_accessed should reset");
     // spinner_frame is a UI detail, not reset by TurnComplete (it's driven by tick)
     // pending_interaction_ids should be empty (no permissions were pending)
-    assert!(app.pending_interaction_ids.is_empty());
+    assert!(app.turn.pending_interaction_ids.is_empty());
 }
 
 #[tokio::test]
@@ -181,11 +181,11 @@ async fn turn_complete_does_not_clear_messages() {
         &mut app,
         ClientEvent::SessionUpdate(model::SessionUpdate::AgentMessageChunk(chunk)),
     );
-    assert_eq!(app.messages.len(), 1);
+    assert_eq!(app.transcript.messages.len(), 1);
 
     send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
-    assert_eq!(app.messages.len(), 1, "messages should persist across turns");
+    assert_eq!(app.transcript.messages.len(), 1, "messages should persist across turns");
 }
 
 #[tokio::test]
@@ -195,14 +195,11 @@ async fn turn_complete_does_not_clear_tool_call_index() {
     let tc =
         model::ToolCall::new("tc-persist", "Read file").status(model::ToolCallStatus::InProgress);
     send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
-    assert!(app.tool_call_index.contains_key("tc-persist"));
+    assert!(app.has_tool_call("tc-persist"));
 
     send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
-    assert!(
-        app.tool_call_index.contains_key("tc-persist"),
-        "tool_call_index should persist across turns"
-    );
+    assert!(app.has_tool_call("tc-persist"), "tool_call_index should persist across turns");
 }
 
 #[tokio::test]

--- a/tests/integration/permissions.rs
+++ b/tests/integration/permissions.rs
@@ -206,11 +206,11 @@ async fn turn_complete_does_not_clear_tool_call_index() {
 async fn turn_complete_does_not_clear_tasks() {
     let mut app = test_app();
 
-    app.tasks.push(task_item("task-1", "Test task", model::TaskStatus::InProgress));
+    app.sdk_inventory.tasks.push(task_item("task-1", "Test task", model::TaskStatus::InProgress));
 
     send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
-    assert_eq!(app.tasks.len(), 1, "tasks should persist across turns");
+    assert_eq!(app.sdk_inventory.tasks.len(), 1, "tasks should persist across turns");
 }
 
 #[tokio::test]

--- a/tests/integration/permissions.rs
+++ b/tests/integration/permissions.rs
@@ -217,7 +217,7 @@ async fn turn_complete_does_not_clear_tasks() {
 async fn turn_complete_does_not_affect_mode() {
     let mut app = test_app();
 
-    app.mode = Some(claude_code_rust::app::ModeState {
+    app.session_runtime.mode = Some(claude_code_rust::app::ModeState {
         current_mode_id: "plan".into(),
         current_mode_name: "Plan".into(),
         available_modes: vec![claude_code_rust::app::ModeInfo {
@@ -228,5 +228,5 @@ async fn turn_complete_does_not_affect_mode() {
 
     send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
 
-    assert!(app.mode.is_some(), "mode should persist across turns");
+    assert!(app.session_runtime.mode.is_some(), "mode should persist across turns");
 }

--- a/tests/integration/state_transitions.rs
+++ b/tests/integration/state_transitions.rs
@@ -135,7 +135,7 @@ async fn todowrite_tool_call_does_not_update_task_state() {
         .meta(meta);
     send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
 
-    assert!(app.tasks.is_empty(), "TodoWrite must not hydrate SDK task state");
+    assert!(app.sdk_inventory.tasks.is_empty(), "TodoWrite must not hydrate SDK task state");
     assert!(app.has_tool_call("todo-1"));
 }
 
@@ -390,7 +390,7 @@ async fn available_commands_update_replaces_previous() {
         &mut app,
         ClientEvent::SessionUpdate(model::SessionUpdate::AvailableCommandsUpdate(update1)),
     );
-    assert_eq!(app.available_commands.len(), 2);
+    assert_eq!(app.sdk_inventory.available_commands.len(), 2);
 
     // New update replaces, not appends
     let cmd3 = model::AvailableCommand::new("/commit", "Commit");
@@ -399,7 +399,7 @@ async fn available_commands_update_replaces_previous() {
         &mut app,
         ClientEvent::SessionUpdate(model::SessionUpdate::AvailableCommandsUpdate(update2)),
     );
-    assert_eq!(app.available_commands.len(), 1, "replaced, not appended");
+    assert_eq!(app.sdk_inventory.available_commands.len(), 1, "replaced, not appended");
 }
 
 #[tokio::test]

--- a/tests/integration/state_transitions.rs
+++ b/tests/integration/state_transitions.rs
@@ -261,7 +261,7 @@ async fn stress_many_tool_calls_in_one_turn() {
 async fn mode_updates_switch_known_modes_fall_back_for_unknown_ids_and_noop_without_state() {
     let mut app = test_app();
 
-    app.mode = Some(claude_code_rust::app::ModeState {
+    app.session_runtime.mode = Some(claude_code_rust::app::ModeState {
         current_mode_id: "code".into(),
         current_mode_name: "Code".into(),
         available_modes: vec![
@@ -276,7 +276,7 @@ async fn mode_updates_switch_known_modes_fall_back_for_unknown_ids_and_noop_with
             model::CurrentModeUpdate::new("plan"),
         )),
     );
-    let mode = app.mode.as_ref().expect("mode should still exist");
+    let mode = app.session_runtime.mode.as_ref().expect("mode should still exist");
     assert_eq!(mode.current_mode_id, "plan");
     assert_eq!(mode.current_mode_name, "Plan");
 
@@ -286,7 +286,7 @@ async fn mode_updates_switch_known_modes_fall_back_for_unknown_ids_and_noop_with
             model::CurrentModeUpdate::new("unknown-mode"),
         )),
     );
-    let mode = app.mode.as_ref().expect("mode should still exist");
+    let mode = app.session_runtime.mode.as_ref().expect("mode should still exist");
     assert_eq!(mode.current_mode_id, "unknown-mode");
     assert_eq!(mode.current_mode_name, "unknown-mode");
 
@@ -297,7 +297,10 @@ async fn mode_updates_switch_known_modes_fall_back_for_unknown_ids_and_noop_with
             model::CurrentModeUpdate::new("plan-mode"),
         )),
     );
-    assert!(no_mode_app.mode.is_none(), "update without existing mode state is a no-op");
+    assert!(
+        no_mode_app.session_runtime.mode.is_none(),
+        "update without existing mode state is a no-op"
+    );
 }
 
 // --- Edge cases: interleaved events ---

--- a/tests/integration/state_transitions.rs
+++ b/tests/integration/state_transitions.rs
@@ -17,7 +17,7 @@ use crate::helpers::{send_client_event, test_app};
 #[tokio::test]
 async fn agent_thought_chunk_sets_thinking_without_writing_transcript() {
     let mut app = test_app();
-    let original_message_count = app.messages.len();
+    let original_message_count = app.transcript.messages.len();
     let thought_text = "Planning...";
     let thought =
         model::ContentChunk::new(model::ContentBlock::Text(model::TextContent::new(thought_text)));
@@ -28,9 +28,9 @@ async fn agent_thought_chunk_sets_thinking_without_writing_transcript() {
     );
 
     assert!(matches!(app.status, AppStatus::Thinking));
-    assert_eq!(app.messages.len(), original_message_count);
+    assert_eq!(app.transcript.messages.len(), original_message_count);
     assert!(
-        !app.messages.iter().any(|message| {
+        !app.transcript.messages.iter().any(|message| {
             message.blocks.iter().any(|block| match block {
                 MessageBlock::Text(text) => text.text.contains(thought_text),
                 _ => false,
@@ -67,7 +67,7 @@ async fn full_turn_lifecycle_text_only() {
     // Turn completes
     send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
     assert!(matches!(app.status, AppStatus::Ready));
-    assert_eq!(app.messages.len(), 1);
+    assert_eq!(app.transcript.messages.len(), 1);
 }
 
 #[tokio::test]
@@ -136,7 +136,7 @@ async fn todowrite_tool_call_does_not_update_task_state() {
     send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
 
     assert!(app.tasks.is_empty(), "TodoWrite must not hydrate SDK task state");
-    assert!(app.tool_call_index.contains_key("todo-1"));
+    assert!(app.has_tool_call("todo-1"));
 }
 
 // --- Error recovery ---
@@ -179,7 +179,7 @@ async fn chunks_across_turns_append_to_last_assistant_message() {
         ClientEvent::SessionUpdate(model::SessionUpdate::AgentMessageChunk(c1)),
     );
     send_client_event(&mut app, ClientEvent::TurnComplete { terminal_reason: None });
-    assert_eq!(app.messages.len(), 1);
+    assert_eq!(app.transcript.messages.len(), 1);
 
     // Second turn: chunks append to the last assistant message (no user message between turns)
     let c2 = model::ContentChunk::new(model::ContentBlock::Text(model::TextContent::new("Turn 2")));
@@ -189,9 +189,9 @@ async fn chunks_across_turns_append_to_last_assistant_message() {
     );
 
     // Still one message - consecutive assistant chunks always merge
-    assert_eq!(app.messages.len(), 1);
+    assert_eq!(app.transcript.messages.len(), 1);
     if let MessageBlock::Text(block) =
-        &app.messages.last().expect("message").blocks.last().expect("block")
+        &app.transcript.messages.last().expect("message").blocks.last().expect("block")
     {
         assert!(block.text.contains("Turn 1"), "first turn text present");
         assert!(block.text.contains("Turn 2"), "second turn text appended");
@@ -218,8 +218,8 @@ async fn tool_call_content_update() {
         )),
     );
 
-    let (mi, bi) = app.tool_call_index["tc-content"];
-    if let MessageBlock::ToolCall(tc) = &app.messages[mi].blocks[bi] {
+    let (mi, bi) = app.lookup_tool_call("tc-content").expect("tc-content indexed");
+    if let MessageBlock::ToolCall(tc) = &app.transcript.messages[mi].blocks[bi] {
         assert!(!tc.content.is_empty(), "content should be set");
     } else {
         panic!("expected ToolCall block");
@@ -239,7 +239,7 @@ async fn stress_many_tool_calls_in_one_turn() {
         send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
     }
 
-    assert_eq!(app.tool_call_index.len(), 50);
+    assert_eq!(app.tool_call_index_len(), 50);
 
     // Complete all
     for i in 0..50 {
@@ -336,13 +336,13 @@ async fn text_between_tool_calls_creates_separate_blocks() {
     );
 
     // Should be: Text, ToolCall, Text, ToolCall, Text = 5 blocks
-    assert_eq!(app.messages.len(), 1);
-    assert_eq!(app.messages[0].blocks.len(), 5);
-    assert!(matches!(app.messages[0].blocks[0], MessageBlock::Text(..)));
-    assert!(matches!(app.messages[0].blocks[1], MessageBlock::ToolCall(_)));
-    assert!(matches!(app.messages[0].blocks[2], MessageBlock::Text(..)));
-    assert!(matches!(app.messages[0].blocks[3], MessageBlock::ToolCall(_)));
-    assert!(matches!(app.messages[0].blocks[4], MessageBlock::Text(..)));
+    assert_eq!(app.transcript.messages.len(), 1);
+    assert_eq!(app.transcript.messages[0].blocks.len(), 5);
+    assert!(matches!(app.transcript.messages[0].blocks[0], MessageBlock::Text(..)));
+    assert!(matches!(app.transcript.messages[0].blocks[1], MessageBlock::ToolCall(_)));
+    assert!(matches!(app.transcript.messages[0].blocks[2], MessageBlock::Text(..)));
+    assert!(matches!(app.transcript.messages[0].blocks[3], MessageBlock::ToolCall(_)));
+    assert!(matches!(app.transcript.messages[0].blocks[4], MessageBlock::Text(..)));
 }
 
 #[tokio::test]
@@ -423,18 +423,18 @@ async fn error_during_tool_calls_leaves_tool_calls_intact() {
 
     assert!(matches!(app.status, AppStatus::Error));
     // Tool call should remain indexed and preserved in the original assistant message.
-    assert!(app.tool_call_index.contains_key("tc-err"));
-    assert_eq!(app.messages.len(), 2, "assistant message + system error message");
-    assert!(matches!(app.messages[0].role, MessageRole::Assistant));
-    assert_eq!(app.messages[0].blocks.len(), 2, "text + tool call preserved");
-    let Some(MessageBlock::ToolCall(tc)) = app.messages[0].blocks.get(1) else {
+    assert!(app.has_tool_call("tc-err"));
+    assert_eq!(app.transcript.messages.len(), 2, "assistant message + system error message");
+    assert!(matches!(app.transcript.messages[0].role, MessageRole::Assistant));
+    assert_eq!(app.transcript.messages[0].blocks.len(), 2, "text + tool call preserved");
+    let Some(MessageBlock::ToolCall(tc)) = app.transcript.messages[0].blocks.get(1) else {
         panic!("expected preserved tool call block");
     };
     assert_eq!(tc.id, "tc-err");
     assert_eq!(tc.status, model::ToolCallStatus::Failed, "in-progress tool should be failed");
 
-    assert!(matches!(app.messages[1].role, MessageRole::System(_)));
-    let Some(MessageBlock::Text(block)) = app.messages[1].blocks.first() else {
+    assert!(matches!(app.transcript.messages[1].role, MessageRole::System(_)));
+    let Some(MessageBlock::Text(block)) = app.transcript.messages[1].blocks.first() else {
         panic!("expected system error text block");
     };
     assert!(block.text.contains("Turn failed: crashed"));

--- a/tests/integration/tool_lifecycle.rs
+++ b/tests/integration/tool_lifecycle.rs
@@ -40,8 +40,9 @@ fn claude_meta(
 
 #[allow(clippy::expect_used)]
 fn tool_call_block<'a>(app: &'a App, id: &str) -> &'a ToolCallInfo {
-    let (message_index, block_index) = app.tool_call_index[id];
-    app.messages
+    let (message_index, block_index) = app.lookup_tool_call(id).expect("tool call indexed");
+    app.transcript
+        .messages
         .get(message_index)
         .and_then(|message| message.blocks.get(block_index))
         .and_then(|block| match block {
@@ -170,7 +171,7 @@ async fn task_tool_calls_leave_active_set_only_on_terminal_statuses() {
         .status(model::ToolCallStatus::InProgress)
         .meta(task_meta());
     send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
-    assert!(app.active_task_ids.contains("task-pend"), "new Task should be tracked");
+    assert!(app.turn.active_task_ids.contains("task-pend"), "new Task should be tracked");
 
     let fields = model::ToolCallUpdateFields::new().status(model::ToolCallStatus::Pending);
     send_client_event(
@@ -179,7 +180,7 @@ async fn task_tool_calls_leave_active_set_only_on_terminal_statuses() {
             model::ToolCallUpdate::new("task-pend", fields),
         )),
     );
-    assert!(app.active_task_ids.contains("task-pend"), "Pending should stay active");
+    assert!(app.turn.active_task_ids.contains("task-pend"), "Pending should stay active");
 
     let fields = model::ToolCallUpdateFields::new().status(model::ToolCallStatus::Completed);
     send_client_event(
@@ -188,14 +189,14 @@ async fn task_tool_calls_leave_active_set_only_on_terminal_statuses() {
             model::ToolCallUpdate::new("task-pend", fields),
         )),
     );
-    assert!(!app.active_task_ids.contains("task-pend"), "completed Task should be removed");
+    assert!(!app.turn.active_task_ids.contains("task-pend"), "completed Task should be removed");
 
     let tc = model::ToolCall::new("task-fail", "Subtask")
         .kind(model::ToolKind::Think)
         .status(model::ToolCallStatus::InProgress)
         .meta(task_meta());
     send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
-    assert!(app.active_task_ids.contains("task-fail"));
+    assert!(app.turn.active_task_ids.contains("task-fail"));
 
     let fields = model::ToolCallUpdateFields::new().status(model::ToolCallStatus::Failed);
     send_client_event(
@@ -204,7 +205,7 @@ async fn task_tool_calls_leave_active_set_only_on_terminal_statuses() {
             model::ToolCallUpdate::new("task-fail", fields),
         )),
     );
-    assert!(!app.active_task_ids.contains("task-fail"), "failed Task should also be removed");
+    assert!(!app.turn.active_task_ids.contains("task-fail"), "failed Task should also be removed");
 }
 
 #[tokio::test]
@@ -303,10 +304,10 @@ async fn multiple_tool_calls_independently_indexed() {
         send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
     }
 
-    assert_eq!(app.tool_call_index.len(), 5);
+    assert_eq!(app.tool_call_index_len(), 5);
     for i in 0..5 {
         let key = format!("tc-{i}");
-        assert!(app.tool_call_index.contains_key(&key), "missing {key}");
+        assert!(app.has_tool_call(&key), "missing {key}");
     }
 }
 
@@ -329,8 +330,8 @@ async fn tool_call_update_via_meta_sets_sdk_tool_name() {
         ClientEvent::SessionUpdate(model::SessionUpdate::ToolCallUpdate(update)),
     );
 
-    let (mi, bi) = app.tool_call_index["tc-meta"];
-    if let MessageBlock::ToolCall(tc) = &app.messages[mi].blocks[bi] {
+    let (mi, bi) = app.lookup_tool_call("tc-meta").expect("tc-meta indexed");
+    if let MessageBlock::ToolCall(tc) = &app.transcript.messages[mi].blocks[bi] {
         assert_eq!(tc.sdk_tool_name, "WebSearch");
     } else {
         panic!("expected ToolCall block");
@@ -373,8 +374,8 @@ async fn title_shortened_relative_to_cwd() {
         .status(model::ToolCallStatus::InProgress);
     send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
 
-    let (mi, bi) = app.tool_call_index["tc-shorten"];
-    if let MessageBlock::ToolCall(tc) = &app.messages[mi].blocks[bi] {
+    let (mi, bi) = app.lookup_tool_call("tc-shorten").expect("tc-shorten indexed");
+    if let MessageBlock::ToolCall(tc) = &app.transcript.messages[mi].blocks[bi] {
         assert_eq!(tc.title, "Read src/main.rs", "absolute path shortened to relative");
     } else {
         panic!("expected ToolCall block");
@@ -405,8 +406,11 @@ async fn tool_call_update_locations_replace_metadata_and_invalidate_render_cache
         .content(vec![model::ToolCallContent::from("fn main() {}\n".to_owned())]);
     send_client_event(&mut app, ClientEvent::SessionUpdate(model::SessionUpdate::ToolCall(tc)));
 
-    let (message_index, block_index) = app.tool_call_index["tc-location-update"];
-    if let MessageBlock::ToolCall(tc) = &mut app.messages[message_index].blocks[block_index] {
+    let (message_index, block_index) =
+        app.lookup_tool_call("tc-location-update").expect("tc-location-update indexed");
+    if let MessageBlock::ToolCall(tc) =
+        &mut app.transcript.messages[message_index].blocks[block_index]
+    {
         tc.cache.store(vec![Line::from("cached body")]);
         assert!(tc.cache.get().is_some());
     } else {

--- a/tests/integration/tool_lifecycle.rs
+++ b/tests/integration/tool_lifecycle.rs
@@ -360,7 +360,7 @@ async fn todowrite_update_raw_input_does_not_mutate_task_state() {
         ClientEvent::SessionUpdate(model::SessionUpdate::ToolCallUpdate(update)),
     );
 
-    assert!(app.tasks.is_empty(), "TodoWrite must not hydrate SDK task state");
+    assert!(app.sdk_inventory.tasks.is_empty(), "TodoWrite must not hydrate SDK task state");
     let tc = tool_call_block(&app, "tc-todo-up");
     assert_eq!(tc.sdk_tool_name, "TodoWrite");
 }


### PR DESCRIPTION
## Summary

- Extract app-owned state into focused state modules for transcript storage, turn lifecycle, SDK inventory, session runtime, startup sequencing, and paste handling.
- Update app, event, view, config, slash, session picker, and integration call sites to use the new state boundaries while preserving existing behavior.
- Refresh the bundled bridge runtime handling so npm installs record the copied Node runtime version and the launcher can replace stale bridge runtime copies after Node upgrades.

## Why

The `App` struct had accumulated unrelated lifecycle, transcript, runtime, and SDK inventory fields in one large state surface. Splitting those fields into named state groups makes reset contracts and ownership boundaries explicit, especially around active-turn cleanup, session replacement, startup session picker flow, transcript cache metadata, and SDK-provided inventories.

The bridge runtime copy is created during package installation, but users may upgrade Node after install. Recording the copied runtime version and refreshing it from the launcher keeps the packaged bridge runtime aligned with the Node version actually launching `claude-rs`.

Closes #

## Validation

- Automated:
  - `cargo check`
  - `cargo test`
  - `cargo clippy --all-targets --all-features -- -D warnings`
- Manual:
  - Reviewed the clean `refactor/app-state-transcript` branch diff against `main`.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
