### PR TITLE
fix(release): publish npm tarballs from explicit local paths

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -404,7 +404,12 @@ jobs:
             local package_name="$1"
             local filename="${package_name#@}"
             filename="${filename/\//-}-${VERSION}.tgz"
-            npm publish "dist-pack/$filename" --access public
+            local tarball="./dist-pack/$filename"
+            if [ ! -f "$tarball" ]; then
+              echo "::error::Missing npm package tarball: $tarball"
+              exit 1
+            fi
+            npm publish "$tarball" --access public
           }
           publish_package "@srothgan/claude-code-rust-darwin-arm64"
           publish_package "@srothgan/claude-code-rust-darwin-x64"
@@ -438,4 +443,11 @@ jobs:
           npm --version
 
       - name: Publish root tarball
-        run: npm publish "dist-pack/claude-code-rust-${{ needs.verify.outputs.version }}.tgz" --access public
+        run: |
+          set -euo pipefail
+          tarball="./dist-pack/claude-code-rust-${{ needs.verify.outputs.version }}.tgz"
+          if [ ! -f "$tarball" ]; then
+            echo "::error::Missing npm package tarball: $tarball"
+            exit 1
+          fi
+          npm publish "$tarball" --access public


### PR DESCRIPTION
## Summary

Fix the npm release workflow so package publication uses explicit local tarball paths from `dist-pack`.

## Why

The failed `0.13.1` release reached the platform package publish job, but npm interpreted `dist-pack/<tarball>.tgz` as a GitHub shorthand package spec instead of a local file path. That made npm try `git ls-remote ssh://git@github.com/dist-pack/...`, which failed with `Permission denied (publickey)`.

This change prefixes release tarball paths with `./` and checks that each tarball exists before calling `npm publish`, so missing artifacts fail with a clear workflow error instead of being reinterpreted by npm.

Closes #

## Validation

- Automated: `git diff --check -- .github/workflows/release-npm.yml pr.md`
- Manual: Compared against `copilot-suggestion.md`; kept the workflow publish fix because the failed job was `Publish platform npm packages`, not the smoke-test install job.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Recovery note: the failed GitHub-only `v0.13.1` release/tag should be deleted before rerunning the fixed release workflow, because npm did not publish any `0.13.1` packages.
