### PR TITLE
test(agent-sdk): add SDK and bridge confidence checks

### DIFF
--- a/.github/workflows/agent-sdk-update-monitor.yml
+++ b/.github/workflows/agent-sdk-update-monitor.yml
@@ -29,8 +29,25 @@ jobs:
           set -euo pipefail
 
           package='@anthropic-ai/claude-agent-sdk'
-          root_version="$(node -p "require('./package.json').dependencies['${package}']")"
-          bridge_version="$(node -p "require('./agent-sdk/package.json').dependencies['${package}']")"
+          bridge_stack=(
+            '@anthropic-ai/claude-agent-sdk'
+            '@anthropic-ai/sdk'
+            '@modelcontextprotocol/sdk'
+            'zod'
+          )
+
+          package_version() {
+            local package_name="$1"
+            local package_json="$2"
+            PACKAGE_NAME="${package_name}" PACKAGE_JSON="${package_json}" node -e '
+              const pkg = require(process.env.PACKAGE_JSON);
+              const version = pkg.dependencies?.[process.env.PACKAGE_NAME];
+              process.stdout.write(version ?? "<missing>");
+            '
+          }
+
+          root_version="$(package_version "${package}" "./package.json")"
+          bridge_version="$(package_version "${package}" "./agent-sdk/package.json")"
           latest_version="$(npm view "${package}" version)"
 
           echo "Root package version: ${root_version}"
@@ -47,17 +64,33 @@ jobs:
           cat > "${issue_file}" <<EOF
           A newer \`${package}\` version is available.
 
-          | Surface | Version |
-          | --- | --- |
-          | Root package | \`${root_version}\` |
-          | Bridge package | \`${bridge_version}\` |
-          | Latest npm | \`${latest_version}\` |
+          | Package | Root package | Bridge package | Latest npm |
+          | --- | --- | --- | --- |
+          EOF
+
+          for stack_package in "${bridge_stack[@]}"; do
+            stack_root_version="$(package_version "${stack_package}" "./package.json")"
+            stack_bridge_version="$(package_version "${stack_package}" "./agent-sdk/package.json")"
+            stack_latest_version="$(npm view "${stack_package}" version)"
+            {
+              printf '| `%s` | `%s` | `%s` | `%s` |\n' \
+                "${stack_package}" \
+                "${stack_root_version}" \
+                "${stack_bridge_version}" \
+                "${stack_latest_version}"
+            } >> "${issue_file}"
+          done
+
+          cat >> "${issue_file}" <<EOF
 
           Suggested next steps:
 
           - Review the upstream release notes between \`${root_version}\`/\`${bridge_version}\` and \`${latest_version}\`.
-          - Compare release notes and tarball diffs before changing package pins.
-          - Update the pins in \`package.json\` and \`agent-sdk/package.json\`, then rebuild the bridge.
+          - Review the bridge dependency stack together before changing package pins.
+          - Compare release notes and tarball diffs before accepting the migration.
+          - Update accepted dependency pins in both \`package.json\` and \`agent-sdk/package.json\`, then rebuild the bridge.
+          - Run the bridge build, test, lint, knip, audit, and Rust compatibility checks before merging.
+          - Do not auto-publish from SDK migration work.
 
           This issue was opened or refreshed by \`${GITHUB_WORKFLOW}\`.
           EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,32 @@ jobs:
       - name: Check lockfile
         run: cargo fetch --locked
 
+  direct-binary-smoke:
+    name: Direct Binary Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build release binary
+        run: cargo build --release --locked --bin claude-rs
+      - name: Smoke-test version startup (Unix)
+        if: runner.os != 'Windows'
+        run: ./target/release/claude-rs --version
+      - name: Smoke-test help startup (Unix)
+        if: runner.os != 'Windows'
+        run: ./target/release/claude-rs --help
+      - name: Smoke-test version startup (Windows)
+        if: runner.os == 'Windows'
+        run: .\target\release\claude-rs.exe --version
+      - name: Smoke-test help startup (Windows)
+        if: runner.os == 'Windows'
+        run: .\target\release\claude-rs.exe --help
+
   npm-package-layout:
     name: npm Package Layout
     runs-on: ubuntu-latest

--- a/agent-sdk/src/bridge.contract.test.ts
+++ b/agent-sdk/src/bridge.contract.test.ts
@@ -1,0 +1,261 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import readline from "node:readline";
+import { fileURLToPath } from "node:url";
+
+type BridgeEnvelope = Record<string, unknown>;
+
+const bridgePath = join(dirname(fileURLToPath(import.meta.url)), "bridge.js");
+
+class SpawnedBridge {
+  readonly child: ChildProcessWithoutNullStreams;
+  readonly stderrLines: string[] = [];
+
+  #stdoutQueue: BridgeEnvelope[] = [];
+  #stdoutWaiters: Array<{
+    resolve: (envelope: BridgeEnvelope) => void;
+    reject: (error: Error) => void;
+  }> = [];
+  #exitCode: number | null | undefined;
+
+  constructor(env: NodeJS.ProcessEnv = {}) {
+    this.child = spawn(process.execPath, [bridgePath], {
+      env: {
+        ...process.env,
+        CLAUDE_RS_BRIDGE_DIAGNOSTICS: "1",
+        ...env,
+      },
+      stdio: "pipe",
+      windowsHide: true,
+    });
+
+    const stdout = readline.createInterface({ input: this.child.stdout });
+    stdout.on("line", (line) => {
+      let envelope: BridgeEnvelope;
+      try {
+        envelope = JSON.parse(line) as BridgeEnvelope;
+      } catch (error) {
+        this.#rejectWaiters(
+          error instanceof Error
+            ? error
+            : new Error(`failed to parse bridge stdout line: ${String(error)}`),
+        );
+        return;
+      }
+      const waiter = this.#stdoutWaiters.shift();
+      if (waiter) {
+        waiter.resolve(envelope);
+      } else {
+        this.#stdoutQueue.push(envelope);
+      }
+    });
+
+    const stderr = readline.createInterface({ input: this.child.stderr });
+    stderr.on("line", (line) => {
+      this.stderrLines.push(line);
+    });
+
+    this.child.once("exit", (code) => {
+      this.#exitCode = code;
+      this.#rejectWaiters(new Error(`bridge exited before next protocol event: ${code}`));
+    });
+  }
+
+  writeCommand(command: BridgeEnvelope): void {
+    this.writeRaw(`${JSON.stringify(command)}\n`);
+  }
+
+  writeRaw(line: string): void {
+    this.child.stdin.write(line);
+  }
+
+  nextEnvelope(timeoutMs = 2_000): Promise<BridgeEnvelope> {
+    const queued = this.#stdoutQueue.shift();
+    if (queued) {
+      return Promise.resolve(queued);
+    }
+    if (this.#exitCode !== undefined) {
+      return Promise.reject(new Error(`bridge already exited: ${this.#exitCode}`));
+    }
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const index = this.#stdoutWaiters.findIndex((waiter) => waiter.resolve === resolve);
+        if (index >= 0) {
+          this.#stdoutWaiters.splice(index, 1);
+        }
+        reject(new Error("timed out waiting for bridge protocol event"));
+      }, timeoutMs);
+
+      this.#stdoutWaiters.push({
+        resolve: (envelope) => {
+          clearTimeout(timeout);
+          resolve(envelope);
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+      });
+    });
+  }
+
+  async waitForExit(timeoutMs = 2_000): Promise<number | null> {
+    if (this.#exitCode !== undefined) {
+      return this.#exitCode;
+    }
+    return await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error("timed out waiting for bridge exit"));
+      }, timeoutMs);
+      this.child.once("exit", (code) => {
+        clearTimeout(timeout);
+        resolve(code);
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.#exitCode !== undefined) {
+      return;
+    }
+    this.child.kill();
+    await this.waitForExit().catch(() => undefined);
+  }
+
+  #rejectWaiters(error: Error): void {
+    const waiters = this.#stdoutWaiters.splice(0);
+    for (const waiter of waiters) {
+      waiter.reject(error);
+    }
+  }
+}
+
+function assertProtocolEvent(
+  envelope: BridgeEnvelope,
+  eventName: string,
+): asserts envelope is BridgeEnvelope & { event: string } {
+  assert.equal(envelope.event, eventName);
+}
+
+test("bridge process emits connection_failed for malformed JSON", async () => {
+  const bridge = new SpawnedBridge();
+  try {
+    bridge.writeRaw("{ not-json\n");
+
+    const envelope = await bridge.nextEnvelope();
+
+    assertProtocolEvent(envelope, "connection_failed");
+    assert.match(String(envelope.message), /invalid command envelope/);
+    assert.equal("schema" in envelope, false);
+  } finally {
+    await bridge.stop();
+  }
+});
+
+test("bridge process initializes with stable capability envelope", async () => {
+  const bridge = new SpawnedBridge();
+  try {
+    bridge.writeCommand({
+      request_id: "req-init",
+      command: "initialize",
+      cwd: process.cwd(),
+    });
+
+    const envelope = await bridge.nextEnvelope();
+
+    assertProtocolEvent(envelope, "initialized");
+    assert.equal(envelope.request_id, "req-init");
+    assert.deepEqual(envelope.result, {
+      agent_name: "claude-rs-agent-bridge",
+      agent_version: "0.1.0",
+      auth_methods: [
+        {
+          id: "claude-login",
+          name: "Log in with Claude",
+          description: "Run `claude /login` in a terminal",
+        },
+      ],
+      capabilities: {
+        prompt_image: true,
+        prompt_embedded_context: true,
+        supports_session_listing: true,
+        supports_resume_session: true,
+      },
+    });
+    assert.ok(
+      bridge.stderrLines.every((line) => {
+        const parsed = JSON.parse(line) as { schema?: unknown };
+        return parsed.schema === "claude-rs-log/v1";
+      }),
+    );
+  } finally {
+    await bridge.stop();
+  }
+});
+
+test("bridge process preserves request_id for unsupported commands", async () => {
+  const bridge = new SpawnedBridge();
+  try {
+    bridge.writeCommand({
+      request_id: "req-unsupported",
+      command: "future_command",
+    });
+
+    const envelope = await bridge.nextEnvelope();
+
+    assertProtocolEvent(envelope, "connection_failed");
+    assert.equal(envelope.request_id, "req-unsupported");
+    assert.match(String(envelope.message), /unsupported command: future_command/);
+  } finally {
+    await bridge.stop();
+  }
+});
+
+test("bridge process exits cleanly on shutdown", async () => {
+  const bridge = new SpawnedBridge();
+  try {
+    bridge.writeCommand({ command: "shutdown" });
+
+    assert.equal(await bridge.waitForExit(), 0);
+  } finally {
+    await bridge.stop();
+  }
+});
+
+test("bridge process reports actionable session initialization failure", async () => {
+  const missingClaudeExecutable = join(
+    tmpdir(),
+    `claude-rs-missing-claude-code-${process.pid}`,
+  );
+  const bridge = new SpawnedBridge({
+    CLAUDE_CODE_EXECUTABLE: missingClaudeExecutable,
+  });
+  try {
+    bridge.writeCommand({
+      request_id: "req-init",
+      command: "initialize",
+      cwd: process.cwd(),
+    });
+    assertProtocolEvent(await bridge.nextEnvelope(), "initialized");
+
+    bridge.writeCommand({
+      request_id: "req-create",
+      command: "create_session",
+      cwd: process.cwd(),
+      launch_settings: {},
+    });
+
+    const envelope = await bridge.nextEnvelope();
+
+    assertProtocolEvent(envelope, "connection_failed");
+    assert.equal(envelope.request_id, "req-create");
+    assert.match(String(envelope.message), /bridge command failed \(create_session\)/);
+    assert.match(String(envelope.message), /CLAUDE_CODE_EXECUTABLE does not exist/);
+  } finally {
+    await bridge.stop();
+  }
+});

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -452,6 +452,19 @@ function emitRewindResult(
   );
 }
 
+function requestIdFromCommandLine(line: string): string | undefined {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const requestId = (parsed as Record<string, unknown>).request_id;
+    return typeof requestId === "string" ? requestId : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function replaceConversationForRewind(
   command: Extract<BridgeCommand, { command: "rewind" }>,
   session: SessionState,
@@ -1418,11 +1431,13 @@ function main(): void {
         parsed = parseCommandEnvelope(line);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+        const requestId = requestIdFromCommandLine(line);
         bridgeLogger.error({
           target: LOG_TARGETS.BRIDGE_PROTOCOL,
           eventName: "bridge_command_decode_failed",
           message: "failed to decode bridge command envelope",
           outcome: "failure",
+          ...(requestId ? { requestId } : {}),
           sizeBytes: Buffer.byteLength(line),
           fields: {
             preview: line.slice(0, 240),
@@ -1430,7 +1445,7 @@ function main(): void {
             error_message: message,
           },
         });
-        failConnection(`invalid command envelope: ${message}`);
+        failConnection(`invalid command envelope: ${message}`, requestId);
         return;
       }
 

--- a/src/app/connect/bridge_lifecycle.rs
+++ b/src/app/connect/bridge_lifecycle.rs
@@ -301,7 +301,25 @@ pub(super) async fn wait_for_bridge_initialized(
     connected_once: &mut bool,
     resume_requested: bool,
 ) -> Result<(), AppError> {
-    let timeout = Duration::from_secs(10);
+    wait_for_bridge_initialized_with_timeout(
+        bridge,
+        event_tx,
+        cmd_tx,
+        connected_once,
+        resume_requested,
+        Duration::from_secs(10),
+    )
+    .await
+}
+
+async fn wait_for_bridge_initialized_with_timeout(
+    bridge: &mut BridgeClient,
+    event_tx: &mpsc::UnboundedSender<ClientEvent>,
+    cmd_tx: &mpsc::UnboundedSender<CommandEnvelope>,
+    connected_once: &mut bool,
+    resume_requested: bool,
+    timeout: Duration,
+) -> Result<(), AppError> {
     let timeout_ms = u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX);
     let initialize_span = info_span!(
         target: crate::logging::targets::BRIDGE_LIFECYCLE,
@@ -356,4 +374,247 @@ pub(super) async fn wait_for_bridge_initialized(
     }
     .instrument(initialize_span)
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wait_for_bridge_initialized_with_timeout;
+    use crate::agent::bridge::BridgeLauncher;
+    use crate::agent::client::BridgeClient;
+    use crate::agent::events::ClientEvent;
+    use crate::agent::wire::{BridgeEvent, CommandEnvelope};
+    use crate::error::AppError;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn bridge_client_recv_returns_none_when_stdout_closes() {
+        let fixture = RuntimeFixture::new(exit_success_script()).expect("runtime fixture");
+        let mut bridge = BridgeClient::spawn(&fixture.launcher()).expect("spawn bridge");
+
+        let event = bridge.recv().await.expect("recv should not fail");
+
+        assert_eq!(event, None);
+        let status = bridge.wait().await.expect("wait for bridge");
+        assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn bridge_client_recv_reports_malformed_event_json() {
+        let fixture = RuntimeFixture::new(malformed_stdout_script()).expect("runtime fixture");
+        let mut bridge = BridgeClient::spawn(&fixture.launcher()).expect("spawn bridge");
+
+        let err = bridge.recv().await.expect_err("malformed event should fail");
+
+        assert!(
+            err.to_string().contains("failed to decode bridge event json"),
+            "unexpected error: {err:#}"
+        );
+        let _ = bridge.wait().await;
+    }
+
+    #[tokio::test]
+    async fn bridge_client_reads_protocol_after_child_stderr_output() {
+        let fixture =
+            RuntimeFixture::new(stderr_then_initialized_script()).expect("runtime fixture");
+        let mut bridge = BridgeClient::spawn(&fixture.launcher()).expect("spawn bridge");
+
+        let event = bridge.recv().await.expect("recv should parse initialized event");
+
+        assert!(matches!(
+            event.map(|envelope| envelope.event),
+            Some(BridgeEvent::Initialized { .. })
+        ));
+        let status = bridge.wait().await.expect("wait for bridge");
+        assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn bridge_initialization_fails_when_process_exits_before_protocol_ready() {
+        let fixture = RuntimeFixture::new(exit_failure_script()).expect("runtime fixture");
+        let mut bridge = BridgeClient::spawn(&fixture.launcher()).expect("spawn bridge");
+        let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel::<ClientEvent>();
+        let (cmd_tx, _cmd_rx) = tokio::sync::mpsc::unbounded_channel::<CommandEnvelope>();
+        let mut connected_once = false;
+
+        let err = wait_for_bridge_initialized_with_timeout(
+            &mut bridge,
+            &event_tx,
+            &cmd_tx,
+            &mut connected_once,
+            false,
+            Duration::from_secs(1),
+        )
+        .await
+        .expect_err("closed stdout should fail initialization");
+
+        assert_eq!(err, AppError::ConnectionFailed);
+        let status = bridge.wait().await.expect("wait for bridge");
+        assert!(!status.success());
+    }
+
+    #[tokio::test]
+    async fn bridge_initialization_timeout_is_deterministic() {
+        let fixture = RuntimeFixture::new(delayed_no_output_script()).expect("runtime fixture");
+        let mut bridge = BridgeClient::spawn(&fixture.launcher()).expect("spawn bridge");
+        let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel::<ClientEvent>();
+        let (cmd_tx, _cmd_rx) = tokio::sync::mpsc::unbounded_channel::<CommandEnvelope>();
+        let mut connected_once = false;
+
+        let err = wait_for_bridge_initialized_with_timeout(
+            &mut bridge,
+            &event_tx,
+            &cmd_tx,
+            &mut connected_once,
+            false,
+            Duration::from_millis(50),
+        )
+        .await
+        .expect_err("missing initialized event should time out");
+
+        assert_eq!(err, AppError::ConnectionFailed);
+        let _ = bridge.wait().await;
+    }
+
+    #[tokio::test]
+    async fn bridge_initialization_succeeds_after_initialized_event() {
+        let fixture = RuntimeFixture::new(initialized_stdout_script()).expect("runtime fixture");
+        let mut bridge = BridgeClient::spawn(&fixture.launcher()).expect("spawn bridge");
+        let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel::<ClientEvent>();
+        let (cmd_tx, _cmd_rx) = tokio::sync::mpsc::unbounded_channel::<CommandEnvelope>();
+        let mut connected_once = false;
+
+        wait_for_bridge_initialized_with_timeout(
+            &mut bridge,
+            &event_tx,
+            &cmd_tx,
+            &mut connected_once,
+            false,
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("initialized event should complete handshake");
+
+        let status = bridge.wait().await.expect("wait for bridge");
+        assert!(status.success());
+    }
+
+    struct RuntimeFixture {
+        _dir: TempDir,
+        runtime_path: PathBuf,
+        script_path: PathBuf,
+    }
+
+    impl RuntimeFixture {
+        fn new(runtime_contents: impl AsRef<str>) -> std::io::Result<Self> {
+            let dir = tempfile::tempdir()?;
+            let runtime_path = dir.path().join(runtime_name());
+            let script_path = dir.path().join("bridge.js");
+            fs::write(&runtime_path, runtime_contents.as_ref())?;
+            fs::write(&script_path, "// fake bridge script\n")?;
+            make_executable(&runtime_path)?;
+            Ok(Self { _dir: dir, runtime_path, script_path })
+        }
+
+        fn launcher(&self) -> BridgeLauncher {
+            BridgeLauncher {
+                runtime_path: self.runtime_path.clone(),
+                script_path: self.script_path.clone(),
+            }
+        }
+    }
+
+    fn initialized_event_json() -> &'static str {
+        r#"{"event":"initialized","result":{"agent_name":"test","agent_version":"0","auth_methods":[],"capabilities":{"prompt_image":false,"prompt_embedded_context":false,"supports_session_listing":false,"supports_resume_session":false}}}"#
+    }
+
+    #[cfg(windows)]
+    fn runtime_name() -> &'static str {
+        "fake_bridge.cmd"
+    }
+
+    #[cfg(not(windows))]
+    fn runtime_name() -> &'static str {
+        "fake_bridge.sh"
+    }
+
+    #[cfg(windows)]
+    fn exit_success_script() -> &'static str {
+        "@echo off\r\nexit /b 0\r\n"
+    }
+
+    #[cfg(not(windows))]
+    fn exit_success_script() -> &'static str {
+        "#!/bin/sh\nexit 0\n"
+    }
+
+    #[cfg(windows)]
+    fn exit_failure_script() -> &'static str {
+        "@echo off\r\nexit /b 7\r\n"
+    }
+
+    #[cfg(not(windows))]
+    fn exit_failure_script() -> &'static str {
+        "#!/bin/sh\nexit 7\n"
+    }
+
+    #[cfg(windows)]
+    fn malformed_stdout_script() -> String {
+        "@echo off\r\necho not-json\r\n".to_owned()
+    }
+
+    #[cfg(not(windows))]
+    fn malformed_stdout_script() -> String {
+        "#!/bin/sh\nprintf 'not-json\\n'\n".to_owned()
+    }
+
+    #[cfg(windows)]
+    fn initialized_stdout_script() -> String {
+        format!("@echo off\r\necho {}\r\n", initialized_event_json())
+    }
+
+    #[cfg(not(windows))]
+    fn initialized_stdout_script() -> String {
+        format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", initialized_event_json())
+    }
+
+    #[cfg(windows)]
+    fn stderr_then_initialized_script() -> String {
+        format!("@echo off\r\necho bridge diagnostic 1>&2\r\necho {}\r\n", initialized_event_json())
+    }
+
+    #[cfg(not(windows))]
+    fn stderr_then_initialized_script() -> String {
+        format!(
+            "#!/bin/sh\nprintf 'bridge diagnostic\\n' >&2\nprintf '%s\\n' '{}'\n",
+            initialized_event_json()
+        )
+    }
+
+    #[cfg(windows)]
+    fn delayed_no_output_script() -> &'static str {
+        "@echo off\r\npowershell -NoProfile -Command \"Start-Sleep -Milliseconds 500\"\r\n"
+    }
+
+    #[cfg(not(windows))]
+    fn delayed_no_output_script() -> &'static str {
+        "#!/bin/sh\nsleep 0.5\n"
+    }
+
+    #[cfg(unix)]
+    fn make_executable(path: &Path) -> std::io::Result<()> {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let mut permissions = fs::metadata(path)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions)
+    }
+
+    #[cfg(not(unix))]
+    #[allow(clippy::unnecessary_wraps)]
+    fn make_executable(_path: &Path) -> std::io::Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

Adds SDK and bridge confidence coverage across update governance, the Node bridge protocol, Rust bridge failure handling, and direct binary startup CI.

## Why

The Rust UI depends on a Node-based Agent SDK bridge. SDK changes, bridge protocol drift, or binary startup regressions should fail in deterministic checks before they reach users.

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `cargo check --offline`
  - `npm.cmd ci`
  - `npm.cmd ci --prefix agent-sdk`
  - `npm.cmd --prefix agent-sdk run test`
  - `npm.cmd --prefix agent-sdk run lint`
  - `npm.cmd --prefix agent-sdk run knip`
  - `npm.cmd --prefix agent-sdk run audit`
- Manual:
  - `cargo build --release --locked --bin claude-rs`
  - `.\target\release\claude-rs.exe --version`
  - `.\target\release\claude-rs.exe --help`
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
