### PR TITLE
feat(cli): add supportability commands and redacted config inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- **Supportability commands** (#235, @srothgan): Add `claude-rs doctor`, `logs`, redacted debug bundles, crash and bridge failure reports, and read-only redacted config inspection/export commands for installation and runtime diagnostics.
+
 ## [0.13.1] - 2026-07-02 [Changes][v0.13.1]
 
 ### Release and Packaging

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,7 @@ dependencies = [
  "unicode-width",
  "uuid",
  "which",
+ "zip",
 ]
 
 [[package]]
@@ -1066,6 +1067,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3628,6 +3630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -3938,6 +3941,12 @@ dependencies = [
  "serde_derive",
  "syntect",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -5003,10 +5012,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "time",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ unicode-segmentation = "1.13.3"
 unicode-width = "0.2.2"
 uuid = { version = "1.23.2", features = ["v4"] }
 which = "8.0.2"
+zip = { version = "8.6.0", default-features = false, features = ["deflate", "time"] }
 
 [features]
 perf = []

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -114,9 +114,16 @@ The bundle includes:
 - selected recent runtime logs
 - the legacy log if present
 - bridge diagnostics extracted from structured log records
+- `last-crash.json` when the previous run crashed
 - diagnostics paths
 
 The bundle excludes full config files, Claude credentials, environment dumps, and arbitrary project files. Redaction removes obvious credentials, but logs can still contain private conversation text, local file paths, command output, or project-specific context. Review a bundle before sharing it publicly.
+
+## Failure Reports
+
+Top-level failures print a short issue-friendly report to stderr with a category, exit code, version, platform, latest discovered log path, and one next-step command. Bridge failures are categorized as spawn, initialization, stdout close, SDK/protocol failure, or timeout so support output points at the likely failing boundary.
+
+Unexpected Rust panics install a local panic hook. The hook writes a redacted `last-crash.json` file in the diagnostics root and prints the same safe-to-paste metadata to stderr. No crash report is uploaded automatically.
 
 ## Bridge Diagnostics
 

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -28,6 +28,40 @@ Use `-C, --dir` with `doctor` to inspect project-local settings for a specific f
 claude-rs -C path/to/project doctor
 ```
 
+## Config Inspection
+
+Inspect resolved config paths without starting the TUI:
+
+```bash
+claude-rs config
+claude-rs config path
+```
+
+`claude-rs config` prints the same path summary as `config path`, including user settings, project-local settings, user preferences, and whether each file is present and valid. Use `-C, --dir` to inspect project-local config for a specific folder.
+
+For script-friendly path output:
+
+```bash
+claude-rs config path --which settings
+claude-rs config path --which local-settings
+claude-rs config path --which preferences
+```
+
+Show a concise redacted config summary:
+
+```bash
+claude-rs config show
+claude-rs config show --json
+```
+
+Export a support-safe config snapshot:
+
+```bash
+claude-rs config export --output claude-rs-config.json
+```
+
+Config output redacts obvious credentials by default. Export refuses to overwrite existing files, and inspection does not repair, back up, normalize, or rewrite config files. Malformed existing config files are reported as invalid and cause `show` or `export` to return a non-zero exit code.
+
 ## Logging
 
 Enable runtime diagnostics with a named preset:

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -2,6 +2,32 @@
 
 Diagnostics are off by default. Enable them only when debugging or preparing a useful issue report because verbose logs can grow quickly.
 
+## Doctor
+
+Run deterministic environment diagnostics:
+
+```bash
+claude-rs doctor
+```
+
+For machine-readable output:
+
+```bash
+claude-rs doctor --json
+```
+
+For CI or support scripts that should fail on hard runtime prerequisites:
+
+```bash
+claude-rs doctor --strict
+```
+
+Use `-C, --dir` with `doctor` to inspect project-local settings for a specific folder:
+
+```bash
+claude-rs -C path/to/project doctor
+```
+
 ## Logging
 
 Enable runtime diagnostics with a named preset:
@@ -50,6 +76,47 @@ claude-rs-20260614T075924Z-p12345-r8f3a2c1.log
 Logs rotate at 10 MB and keep up to five rotated files per run. Default runtime logs are retained up to 256 MB or 30 days, while always preserving at least 10 newest files. Retention only applies to app-managed timestamped files in the default runtime log directory; explicit `--log-file` paths are never cleaned up by the app.
 
 `--log-append` appends to an explicit `--log-file`. When used without `--log-file`, it appends to the legacy shared default file `claude-rs.log` for compatibility; prefer the normal timestamped defaults for new diagnostics.
+
+## Finding Logs
+
+Use the logs command to find diagnostics paths without starting the TUI:
+
+```bash
+claude-rs logs
+claude-rs logs --path
+claude-rs logs --latest
+```
+
+`claude-rs logs` prints the runtime log directory, legacy log path, perf log directory, latest discovered log, and common follow-up commands. `--path` prints only the default runtime log directory for scripts. `--latest` prints only the latest runtime log path, falling back to the legacy shared log when no timestamped runtime log exists.
+
+To inspect recent log output safely:
+
+```bash
+claude-rs logs --tail 200
+```
+
+Tail output is redacted for obvious credentials such as API keys, bearer tokens, OAuth tokens, passwords, and authorization headers before it is printed.
+
+## Debug Bundles
+
+Create a redacted support bundle with:
+
+```bash
+claude-rs logs --bundle --yes
+```
+
+Without `--yes`, an interactive terminal is prompted before the bundle is written. Use `--output <PATH>` to choose the ZIP path.
+
+The bundle includes:
+
+- `manifest.json`
+- `doctor.json`, equivalent to `claude-rs doctor --json`
+- selected recent runtime logs
+- the legacy log if present
+- bridge diagnostics extracted from structured log records
+- diagnostics paths
+
+The bundle excludes full config files, Claude credentials, environment dumps, and arbitrary project files. Redaction removes obvious credentials, but logs can still contain private conversation text, local file paths, command output, or project-specific context. Review a bundle before sharing it publicly.
 
 ## Bridge Diagnostics
 
@@ -105,4 +172,4 @@ Include:
 - The exact command used to launch the app.
 - Whether a custom bridge script or Node runtime was used.
 - A short reproduction.
-- Relevant log snippets, not full secrets or private conversation content.
+- A `claude-rs logs --bundle --yes` bundle or relevant redacted log snippets, not full secrets or private conversation content.

--- a/docs/src/settings.md
+++ b/docs/src/settings.md
@@ -53,6 +53,16 @@ Settings are loaded from Claude-compatible JSON files. The app can edit supporte
 
 Malformed JSON files are backed up with a timestamped `.bak` extension and replaced in memory with an empty object so the app can keep running.
 
+For read-only support workflows, use:
+
+```bash
+claude-rs config
+claude-rs config show
+claude-rs config export --output claude-rs-config.json
+```
+
+These commands inspect and export redacted config data without starting the TUI and without rewriting or backing up malformed files.
+
 ## Supported Settings
 
 | Setting | File | JSON path | Notes |

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -37,6 +37,9 @@ Use support commands when you need a repeatable snapshot of the local environmen
 | `claude-rs logs` | Show diagnostics log locations and useful follow-up commands. |
 | `claude-rs logs --tail <LINES>` | Print redacted lines from the latest discovered log. |
 | `claude-rs logs --bundle --yes` | Write a redacted ZIP debug bundle. |
+| `claude-rs config` | Show resolved config paths and file states. |
+| `claude-rs config show` | Show a concise redacted config summary. |
+| `claude-rs config export --output <PATH>` | Write a redacted config export without overwriting existing files. |
 
 See [Diagnostics](diagnostics.md) for full options, logging presets, bundle contents, and sharing guidance.
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -26,6 +26,20 @@ claude-rs resume <session_id>
 
 The app prints a resume hint on clean exit when the active session has an id.
 
+## Support And Diagnostics
+
+Use support commands when you need a repeatable snapshot of the local environment or diagnostic logs.
+
+| Command | Purpose |
+| --- | --- |
+| `claude-rs doctor` | Run installation, runtime, config path, log path, npm metadata, and credential checks. |
+| `claude-rs doctor --json` | Emit the diagnostics report as JSON. |
+| `claude-rs logs` | Show diagnostics log locations and useful follow-up commands. |
+| `claude-rs logs --tail <LINES>` | Print redacted lines from the latest discovered log. |
+| `claude-rs logs --bundle --yes` | Write a redacted ZIP debug bundle. |
+
+See [Diagnostics](diagnostics.md) for full options, logging presets, bundle contents, and sharing guidance.
+
 ## CLI Options
 
 The installed `claude-rs --help` command exposes these options:

--- a/src/agent/bridge.rs
+++ b/src/agent/bridge.rs
@@ -257,20 +257,24 @@ fn resolve_bridge_runtime_path_with(
 
 fn validate_script_path(path: &Path) -> anyhow::Result<PathBuf> {
     if !path.exists() {
-        return Err(anyhow::anyhow!("bridge script does not exist: {}", path.display()));
+        return Err(anyhow::Error::new(AppError::BridgeSpawnFailed)
+            .context(format!("bridge script does not exist: {}", path.display())));
     }
     if !path.is_file() {
-        return Err(anyhow::anyhow!("bridge script is not a file: {}", path.display()));
+        return Err(anyhow::Error::new(AppError::BridgeSpawnFailed)
+            .context(format!("bridge script is not a file: {}", path.display())));
     }
     Ok(path.to_path_buf())
 }
 
 fn validate_runtime_path(path: &Path) -> anyhow::Result<PathBuf> {
     if !path.exists() {
-        return Err(anyhow::anyhow!("bridge runtime does not exist: {}", path.display()));
+        return Err(anyhow::Error::new(AppError::NodeNotFound)
+            .context(format!("bridge runtime does not exist: {}", path.display())));
     }
     if !path.is_file() {
-        return Err(anyhow::anyhow!("bridge runtime is not a file: {}", path.display()));
+        return Err(anyhow::Error::new(AppError::NodeNotFound)
+            .context(format!("bridge runtime is not a file: {}", path.display())));
     }
     Ok(path.to_path_buf())
 }

--- a/src/agent/bridge.rs
+++ b/src/agent/bridge.rs
@@ -6,8 +6,9 @@ use anyhow::Context as _;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
-const BRIDGE_SCRIPT_RELATIVE_PATH: &str = "agent-sdk/dist/bridge.js";
-const BRIDGE_RUNTIME_ENV_VAR: &str = "CLAUDE_RS_AGENT_BRIDGE_NODE";
+pub const BRIDGE_SCRIPT_RELATIVE_PATH: &str = "agent-sdk/dist/bridge.js";
+pub const BRIDGE_SCRIPT_ENV_VAR: &str = "CLAUDE_RS_AGENT_BRIDGE";
+pub const BRIDGE_RUNTIME_ENV_VAR: &str = "CLAUDE_RS_AGENT_BRIDGE_NODE";
 const MAX_BRIDGE_EXE_ANCESTORS: usize = 8;
 #[cfg(windows)]
 const RENAMED_BRIDGE_RUNTIME_FILE_NAME: &str = "claude-rs-bridge-node.exe";
@@ -18,6 +19,31 @@ const RENAMED_BRIDGE_RUNTIME_FILE_NAME: &str = "claude-rs-bridge-node";
 pub struct BridgeLauncher {
     pub runtime_path: PathBuf,
     pub script_path: PathBuf,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BridgeCandidateInspection {
+    pub source: String,
+    pub path: PathBuf,
+    pub is_file: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BridgeScriptInspection {
+    pub explicit_path: Option<PathBuf>,
+    pub env_path: Option<PathBuf>,
+    pub candidates: Vec<BridgeCandidateInspection>,
+    pub resolved_path: Option<PathBuf>,
+    pub error: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BridgeRuntimeInspection {
+    pub env_path: Option<PathBuf>,
+    pub packaged_candidates: Vec<BridgeCandidateInspection>,
+    pub path_node: Option<PathBuf>,
+    pub resolved_path: Option<PathBuf>,
+    pub error: Option<String>,
 }
 
 impl BridgeLauncher {
@@ -46,6 +72,141 @@ pub fn resolve_bridge_launcher(explicit_script: Option<&Path>) -> anyhow::Result
     let script = resolve_bridge_script_path(explicit_script)?;
     let runtime = resolve_bridge_runtime_path()?;
     Ok(BridgeLauncher { runtime_path: runtime, script_path: script })
+}
+
+pub fn inspect_bridge_script(explicit_script: Option<&Path>) -> BridgeScriptInspection {
+    let resolver = BridgeScriptResolver::from_process(explicit_script);
+    let explicit_path = resolver.explicit_script.map(Path::to_path_buf);
+
+    if let Some(path) = resolver.explicit_script {
+        let is_file = path.is_file();
+        return BridgeScriptInspection {
+            explicit_path,
+            env_path: resolver.env_script.clone(),
+            candidates: Vec::new(),
+            resolved_path: is_file.then(|| path.to_path_buf()),
+            error: (!is_file).then(|| {
+                if path.exists() {
+                    format!("bridge script is not a file: {}", path.display())
+                } else {
+                    format!("bridge script does not exist: {}", path.display())
+                }
+            }),
+        };
+    }
+
+    if let Some(path) = resolver.env_script.as_deref() {
+        let is_file = path.is_file();
+        return BridgeScriptInspection {
+            explicit_path,
+            env_path: resolver.env_script.clone(),
+            candidates: Vec::new(),
+            resolved_path: is_file.then(|| path.to_path_buf()),
+            error: (!is_file).then(|| {
+                if path.exists() {
+                    format!(
+                        "bridge script from {BRIDGE_SCRIPT_ENV_VAR} is not a file: {}",
+                        path.display()
+                    )
+                } else {
+                    format!(
+                        "bridge script from {BRIDGE_SCRIPT_ENV_VAR} does not exist: {}",
+                        path.display()
+                    )
+                }
+            }),
+        };
+    }
+
+    let candidates = resolver
+        .automatic_candidates()
+        .into_iter()
+        .map(|candidate| BridgeCandidateInspection {
+            source: candidate.source.label().to_owned(),
+            is_file: candidate.path.is_file(),
+            path: candidate.path,
+        })
+        .collect::<Vec<_>>();
+    let resolved_path = candidates
+        .iter()
+        .find(|candidate| candidate.is_file)
+        .map(|candidate| candidate.path.clone());
+
+    BridgeScriptInspection {
+        explicit_path,
+        env_path: resolver.env_script.clone(),
+        error: resolved_path
+            .is_none()
+            .then(|| "bridge script not found near the installed executable".to_owned()),
+        candidates,
+        resolved_path,
+    }
+}
+
+pub fn inspect_bridge_runtime() -> BridgeRuntimeInspection {
+    let env_path = std::env::var_os(BRIDGE_RUNTIME_ENV_VAR).map(PathBuf::from);
+    let current_exe = std::env::current_exe().ok();
+    inspect_bridge_runtime_with(
+        env_path.as_deref(),
+        current_exe.as_deref(),
+        cfg!(debug_assertions),
+        || which::which("node"),
+    )
+}
+
+fn inspect_bridge_runtime_with(
+    env_path: Option<&Path>,
+    current_exe: Option<&Path>,
+    allow_dev_fallbacks: bool,
+    node_lookup: impl FnOnce() -> Result<PathBuf, which::Error>,
+) -> BridgeRuntimeInspection {
+    let path_node = node_lookup().ok();
+    if let Some(path) = env_path {
+        let is_file = path.is_file();
+        let resolved_path = is_file.then(|| path.to_path_buf());
+        let error = (!is_file).then(|| {
+            if path.exists() {
+                format!(
+                    "bridge runtime from {BRIDGE_RUNTIME_ENV_VAR} is not a file: {}",
+                    path.display()
+                )
+            } else {
+                format!(
+                    "bridge runtime from {BRIDGE_RUNTIME_ENV_VAR} does not exist: {}",
+                    path.display()
+                )
+            }
+        });
+        return BridgeRuntimeInspection {
+            env_path: env_path.map(Path::to_path_buf),
+            packaged_candidates: Vec::new(),
+            path_node,
+            resolved_path,
+            error,
+        };
+    }
+
+    let packaged_candidates = renamed_bridge_runtime_candidates(current_exe, allow_dev_fallbacks)
+        .into_iter()
+        .map(|path| BridgeCandidateInspection {
+            source: "packaged-runtime".to_owned(),
+            is_file: path.is_file(),
+            path,
+        })
+        .collect::<Vec<_>>();
+    let packaged_runtime = packaged_candidates
+        .iter()
+        .find(|candidate| candidate.is_file)
+        .map(|candidate| candidate.path.clone());
+    let resolved_path = packaged_runtime.clone().or_else(|| path_node.clone());
+
+    BridgeRuntimeInspection {
+        env_path: None,
+        packaged_candidates,
+        path_node,
+        error: resolved_path.is_none().then(|| "Node.js runtime not found".to_owned()),
+        resolved_path,
+    }
 }
 
 #[cfg(test)]
@@ -164,7 +325,7 @@ impl<'a> BridgeScriptResolver<'a> {
     fn from_process(explicit_script: Option<&'a Path>) -> Self {
         Self {
             explicit_script,
-            env_script: std::env::var_os("CLAUDE_RS_AGENT_BRIDGE").map(PathBuf::from),
+            env_script: std::env::var_os(BRIDGE_SCRIPT_ENV_VAR).map(PathBuf::from),
             current_exe: std::env::current_exe().ok(),
             allow_dev_fallbacks: cfg!(debug_assertions),
             cwd_script: PathBuf::from(BRIDGE_SCRIPT_RELATIVE_PATH),
@@ -349,7 +510,7 @@ mod tests {
     use super::{
         AutomaticCandidateSource, BRIDGE_SCRIPT_RELATIVE_PATH, BridgeLauncher,
         BridgeScriptResolver, RENAMED_BRIDGE_RUNTIME_FILE_NAME, exe_relative_bridge_candidates,
-        resolve_bridge_launcher, resolve_bridge_launcher_with_runtime,
+        inspect_bridge_runtime_with, resolve_bridge_launcher, resolve_bridge_launcher_with_runtime,
         resolve_bridge_runtime_path_with,
     };
     use std::fs;
@@ -679,6 +840,22 @@ mod tests {
         .expect("env bridge runtime should resolve");
 
         assert_eq!(resolved, fixture.env_runtime);
+    }
+
+    #[test]
+    fn bridge_runtime_inspection_reports_path_node_when_env_override_is_set() {
+        let fixture = resolver_fixture();
+
+        let inspection = inspect_bridge_runtime_with(
+            Some(&fixture.env_runtime),
+            Some(&fixture.installed_exe),
+            false,
+            || Ok(fixture.node_runtime.clone()),
+        );
+
+        assert_eq!(inspection.resolved_path, Some(fixture.env_runtime));
+        assert_eq!(inspection.path_node, Some(fixture.node_runtime));
+        assert!(inspection.error.is_none());
     }
 
     #[test]

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -37,7 +37,7 @@ impl BridgeClient {
         let mut child = launcher
             .command(bridge_diagnostics_enabled)
             .spawn()
-            .map_err(|_| anyhow::Error::new(AppError::AdapterCrashed))
+            .map_err(|_| anyhow::Error::new(AppError::BridgeSpawnFailed))
             .with_context(|| format!("failed to spawn bridge process: {}", launcher.describe()))?;
 
         tracing::info!(

--- a/src/app/config/store.rs
+++ b/src/app/config/store.rs
@@ -370,7 +370,7 @@ pub fn set_preferred_notification_channel(document: &mut Value, channel: Preferr
     );
 }
 
-fn resolve_paths(
+pub fn resolve_paths(
     home_override: Option<&Path>,
     project_root_override: Option<&Path>,
 ) -> Result<SettingsPaths, String> {

--- a/src/app/config/store.rs
+++ b/src/app/config/store.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Simon Peter Rothgang
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::Serialize;
 use serde_json::{Map, Value};
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -27,7 +28,7 @@ pub enum PersistedSettingValue {
     String(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct SettingsPaths {
     pub settings: PathBuf,
     pub local_settings: PathBuf,
@@ -40,6 +41,43 @@ pub struct LoadedSettingsDocuments {
     pub local_settings_document: Value,
     pub preferences_document: Value,
     pub notice: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InspectedConfigFileKind {
+    Settings,
+    LocalSettings,
+    Preferences,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InspectedConfigFileStatus {
+    Missing,
+    Valid,
+    Invalid,
+    Unreadable,
+    NotFile,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct InspectedConfigFile {
+    pub kind: InspectedConfigFileKind,
+    pub label: &'static str,
+    pub scope: &'static str,
+    pub path: PathBuf,
+    pub status: InspectedConfigFileStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub document: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct InspectedConfigDocuments {
+    pub paths: SettingsPaths,
+    pub files: Vec<InspectedConfigFile>,
 }
 
 pub fn load(
@@ -66,6 +104,35 @@ pub fn load(
     })
 }
 
+pub fn inspect_read_only(
+    home_override: Option<&Path>,
+    project_root_override: Option<&Path>,
+) -> Result<InspectedConfigDocuments, String> {
+    let paths = resolve_paths(home_override, project_root_override)?;
+    let files = vec![
+        inspect_config_file(
+            InspectedConfigFileKind::Settings,
+            "Global settings",
+            "user",
+            paths.settings.clone(),
+        ),
+        inspect_config_file(
+            InspectedConfigFileKind::LocalSettings,
+            "Local settings",
+            "project",
+            paths.local_settings.clone(),
+        ),
+        inspect_config_file(
+            InspectedConfigFileKind::Preferences,
+            "Preferences",
+            "user",
+            paths.preferences.clone(),
+        ),
+    ];
+
+    Ok(InspectedConfigDocuments { paths, files })
+}
+
 pub fn save(path: &Path, document: &Value) -> Result<(), String> {
     let parent = path.parent().ok_or_else(|| "Settings path has no parent directory".to_owned())?;
     std::fs::create_dir_all(parent)
@@ -87,6 +154,96 @@ pub fn save(path: &Path, document: &Value) -> Result<(), String> {
     std::fs::rename(&temp_path, path)
         .map_err(|err| format!("Failed to move settings file into place: {err}"))?;
     Ok(())
+}
+
+fn inspect_config_file(
+    kind: InspectedConfigFileKind,
+    label: &'static str,
+    scope: &'static str,
+    path: PathBuf,
+) -> InspectedConfigFile {
+    match std::fs::metadata(&path) {
+        Ok(metadata) if !metadata.is_file() => InspectedConfigFile {
+            kind,
+            label,
+            scope,
+            path,
+            status: InspectedConfigFileStatus::NotFile,
+            document: None,
+            error: Some("path exists but is not a file".to_owned()),
+        },
+        Ok(_) => inspect_config_file_contents(kind, label, scope, path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => InspectedConfigFile {
+            kind,
+            label,
+            scope,
+            path,
+            status: InspectedConfigFileStatus::Missing,
+            document: None,
+            error: None,
+        },
+        Err(error) => InspectedConfigFile {
+            kind,
+            label,
+            scope,
+            path,
+            status: InspectedConfigFileStatus::Unreadable,
+            document: None,
+            error: Some(format!("failed to inspect file metadata: {error}")),
+        },
+    }
+}
+
+fn inspect_config_file_contents(
+    kind: InspectedConfigFileKind,
+    label: &'static str,
+    scope: &'static str,
+    path: PathBuf,
+) -> InspectedConfigFile {
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(error) => {
+            return InspectedConfigFile {
+                kind,
+                label,
+                scope,
+                path,
+                status: InspectedConfigFileStatus::Unreadable,
+                document: None,
+                error: Some(format!("failed to read file: {error}")),
+            };
+        }
+    };
+
+    match serde_json::from_str::<Value>(&raw) {
+        Ok(Value::Object(object)) => InspectedConfigFile {
+            kind,
+            label,
+            scope,
+            path,
+            status: InspectedConfigFileStatus::Valid,
+            document: Some(Value::Object(object)),
+            error: None,
+        },
+        Ok(_) => InspectedConfigFile {
+            kind,
+            label,
+            scope,
+            path,
+            status: InspectedConfigFileStatus::Invalid,
+            document: None,
+            error: Some("expected top-level JSON object".to_owned()),
+        },
+        Err(error) => InspectedConfigFile {
+            kind,
+            label,
+            scope,
+            path,
+            status: InspectedConfigFileStatus::Invalid,
+            document: None,
+            error: Some(format!("failed to parse JSON: {error}")),
+        },
+    }
 }
 
 pub fn read_persisted_setting(

--- a/src/app/connect/bridge_lifecycle.rs
+++ b/src/app/connect/bridge_lifecycle.rs
@@ -94,10 +94,14 @@ fn resolve_launcher(params: &StartConnectionParams) -> Option<BridgeLauncher> {
                 outcome = "failure",
                 error = %err,
             );
-            let app_error = extract_app_error(&err).unwrap_or(AppError::ConnectionFailed);
+            let app_error = extract_app_error(&err).unwrap_or(AppError::BridgeSpawnFailed);
             emit_connection_failed(
                 &params.event_tx,
-                format!("Failed to resolve bridge launcher: {err}"),
+                format!(
+                    "{} Detail: {}",
+                    app_error.user_message(),
+                    crate::cli::redaction::redact_line(&err.to_string())
+                ),
                 app_error,
             );
             None
@@ -119,8 +123,16 @@ fn spawn_bridge_client(
                 outcome = "failure",
                 error = %err,
             );
-            let app_error = extract_app_error(&err).unwrap_or(AppError::AdapterCrashed);
-            emit_connection_failed(event_tx, format!("Failed to spawn bridge: {err}"), app_error);
+            let app_error = extract_app_error(&err).unwrap_or(AppError::BridgeSpawnFailed);
+            emit_connection_failed(
+                event_tx,
+                format!(
+                    "{} Detail: {}",
+                    app_error.user_message(),
+                    crate::cli::redaction::redact_line(&err.to_string())
+                ),
+                app_error,
+            );
             None
         }
     }
@@ -148,8 +160,12 @@ async fn send_initialize_command(
     if let Err(err) = bridge.send(init_cmd).await {
         emit_connection_failed(
             &params.event_tx,
-            format!("Failed to initialize bridge: {err}"),
-            AppError::ConnectionFailed,
+            format!(
+                "{} Detail: {}",
+                AppError::BridgeInitializationFailed.user_message(),
+                crate::cli::redaction::redact_line(&err.to_string())
+            ),
+            AppError::BridgeInitializationFailed,
         );
         return false;
     }
@@ -218,8 +234,12 @@ async fn send_session_command(params: &StartConnectionParams, bridge: &mut Bridg
     if let Err(err) = bridge.send(command.clone()).await {
         emit_connection_failed(
             &params.event_tx,
-            format!("Failed to create bridge session: {err}"),
-            AppError::ConnectionFailed,
+            format!(
+                "{} Detail: {}",
+                AppError::BridgeSdkFailure.user_message(),
+                crate::cli::redaction::redact_line(&err.to_string())
+            ),
+            AppError::BridgeSdkFailure,
         );
         return false;
     }
@@ -240,8 +260,12 @@ async fn bridge_event_loop(
                 if let Err(err) = bridge.send(cmd).await {
                     emit_connection_failed(
                         &params.event_tx,
-                        format!("Failed to send bridge command: {err}"),
-                        AppError::ConnectionFailed,
+                        format!(
+                            "{} Detail: {}",
+                            AppError::BridgeSdkFailure.user_message(),
+                            crate::cli::redaction::redact_line(&err.to_string())
+                        ),
+                        AppError::BridgeSdkFailure,
                     );
                     break;
                 }
@@ -266,16 +290,20 @@ async fn bridge_event_loop(
                         );
                         emit_connection_failed(
                             &params.event_tx,
-                            "Bridge process exited unexpectedly".to_owned(),
-                            AppError::ConnectionFailed,
+                            AppError::BridgeStdoutClosed.user_message().to_owned(),
+                            AppError::BridgeStdoutClosed,
                         );
                         break;
                     }
                     Err(err) => {
                         emit_connection_failed(
                             &params.event_tx,
-                            format!("Bridge communication failure: {err}"),
-                            AppError::ConnectionFailed,
+                            format!(
+                                "{} Detail: {}",
+                                AppError::BridgeSdkFailure.user_message(),
+                                crate::cli::redaction::redact_line(&err.to_string())
+                            ),
+                            AppError::BridgeSdkFailure,
                         );
                         break;
                     }
@@ -290,6 +318,15 @@ pub(super) fn emit_connection_failed(
     message: String,
     app_error: AppError,
 ) {
+    tracing::error!(
+        target: crate::logging::targets::BRIDGE_LIFECYCLE,
+        event_name = "bridge_failure_reported",
+        message = "bridge failure reported to app",
+        outcome = "failure",
+        error_category = app_error.category_tag(),
+        exit_code = app_error.exit_code(),
+        user_message = %message,
+    );
     let _ = event_tx.send(ClientEvent::ConnectionFailed(message));
     let _ = event_tx.send(ClientEvent::FatalError(app_error));
 }
@@ -341,7 +378,7 @@ async fn wait_for_bridge_initialized_with_timeout(
                     outcome = "timeout",
                     timeout_ms,
                 );
-                return Err(AppError::ConnectionFailed);
+                return Err(AppError::BridgeTimeout);
             }
 
             let event = tokio::time::timeout(remaining, bridge.recv()).await;
@@ -358,7 +395,7 @@ async fn wait_for_bridge_initialized_with_timeout(
                             resume_requested,
                             envelope,
                         );
-                        return Err(AppError::ConnectionFailed);
+                        return Err(AppError::BridgeInitializationFailed);
                     }
                     handle_bridge_event(
                         event_tx,
@@ -368,7 +405,9 @@ async fn wait_for_bridge_initialized_with_timeout(
                         envelope,
                     );
                 }
-                Ok(Ok(None) | Err(_)) | Err(_) => return Err(AppError::ConnectionFailed),
+                Ok(Ok(None)) => return Err(AppError::BridgeStdoutClosed),
+                Ok(Err(_)) => return Err(AppError::BridgeSdkFailure),
+                Err(_) => return Err(AppError::BridgeTimeout),
             }
         }
     }
@@ -450,7 +489,7 @@ mod tests {
         .await
         .expect_err("closed stdout should fail initialization");
 
-        assert_eq!(err, AppError::ConnectionFailed);
+        assert_eq!(err, AppError::BridgeStdoutClosed);
         let status = bridge.wait().await.expect("wait for bridge");
         assert!(!status.success());
     }
@@ -474,7 +513,7 @@ mod tests {
         .await
         .expect_err("missing initialized event should time out");
 
-        assert_eq!(err, AppError::ConnectionFailed);
+        assert_eq!(err, AppError::BridgeTimeout);
         let _ = bridge.wait().await;
     }
 

--- a/src/app/connect/event_dispatch.rs
+++ b/src/app/connect/event_dispatch.rs
@@ -62,7 +62,7 @@ pub(super) fn handle_bridge_event(
             let _ = event_tx.send(ClientEvent::AuthRequired { method_name, method_description });
         }
         crate::agent::wire::BridgeEvent::ConnectionFailed { message } => {
-            emit_connection_failed(event_tx, message, AppError::ConnectionFailed);
+            emit_connection_failed(event_tx, message, AppError::BridgeSdkFailure);
         }
         crate::agent::wire::BridgeEvent::SessionUpdate { update, .. } => {
             if let Some(update) = map_session_update(update) {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,0 +1,864 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use super::redaction;
+use crate::app::config::store::{
+    InspectedConfigDocuments, InspectedConfigFile, InspectedConfigFileKind,
+    InspectedConfigFileStatus, inspect_read_only,
+};
+use crate::{
+    Cli, ConfigArgs, ConfigCommand, ConfigExportArgs, ConfigFileSelector, ConfigPathArgs,
+    ConfigShowArgs,
+};
+use anyhow::Context as _;
+use serde::Serialize;
+use serde_json::Value;
+use std::fs::{self, OpenOptions, create_dir_all};
+use std::io::{IsTerminal as _, Write};
+use std::path::{Path, PathBuf};
+use time::{OffsetDateTime, macros::format_description};
+
+const EXPORT_SCHEMA: &str = "claude-rs-config-export/v1";
+const HUMAN_DOCUMENT_PREVIEW_LINES: usize = 24;
+
+pub fn run(
+    cli: &Cli,
+    args: &ConfigArgs,
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+) -> anyhow::Result<i32> {
+    match &args.command {
+        Some(ConfigCommand::Path(args)) => write_path(cli, args, stdout),
+        Some(ConfigCommand::Show(args)) => write_show(cli, args, stdout),
+        Some(ConfigCommand::Export(args)) => write_export(cli, args, stdout, stderr),
+        None => write_path(cli, &ConfigPathArgs { json: false, which: None }, stdout),
+    }
+}
+
+fn write_path(cli: &Cli, args: &ConfigPathArgs, stdout: &mut impl Write) -> anyhow::Result<i32> {
+    write_path_with_home_override(cli, args, None, stdout)
+}
+
+fn write_path_with_home_override(
+    cli: &Cli,
+    args: &ConfigPathArgs,
+    home_override: Option<&Path>,
+    stdout: &mut impl Write,
+) -> anyhow::Result<i32> {
+    let project_root = project_root(cli)?;
+    let inspection = inspect_config(cli, &project_root, home_override)?;
+
+    if let Some(which) = args.which {
+        let Some(file) = selected_file(&inspection, which) else {
+            anyhow::bail!("selected config file was not found in inspection report");
+        };
+        writeln!(stdout, "{}", file.path.display())?;
+        return Ok(0);
+    }
+
+    if args.json {
+        write_json(stdout, &PathReport::from_inspection(&inspection, &project_root))?;
+    } else {
+        write_path_human(stdout, &inspection)?;
+    }
+
+    Ok(0)
+}
+
+fn write_show(cli: &Cli, args: &ConfigShowArgs, stdout: &mut impl Write) -> anyhow::Result<i32> {
+    write_show_with_home_override(cli, args, None, stdout)
+}
+
+fn write_show_with_home_override(
+    cli: &Cli,
+    args: &ConfigShowArgs,
+    home_override: Option<&Path>,
+    stdout: &mut impl Write,
+) -> anyhow::Result<i32> {
+    let project_root = project_root(cli)?;
+    let inspection = inspect_config(cli, &project_root, home_override)?;
+    let report = ShowReport::from_inspection(&inspection, &project_root);
+
+    if args.json {
+        write_json(stdout, &report)?;
+    } else {
+        write_show_human(stdout, &report)?;
+    }
+
+    Ok(i32::from(report.has_failures()))
+}
+
+fn write_export(
+    cli: &Cli,
+    args: &ConfigExportArgs,
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+) -> anyhow::Result<i32> {
+    write_export_with_home_override(cli, args, None, stdout, stderr)
+}
+
+fn write_export_with_home_override(
+    cli: &Cli,
+    args: &ConfigExportArgs,
+    home_override: Option<&Path>,
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+) -> anyhow::Result<i32> {
+    let project_root = project_root(cli)?;
+    let inspection = inspect_config(cli, &project_root, home_override)?;
+    let report = ExportReport::from_inspection(&inspection, &project_root);
+    if report.has_failures() {
+        writeln!(
+            stderr,
+            "Cannot export config because one or more existing config files are invalid or unreadable."
+        )?;
+        return Ok(1);
+    }
+
+    let text = json_text(&report)?;
+    if let Some(output) = &args.output {
+        if output.exists() {
+            writeln!(stderr, "Refusing to overwrite existing file: {}", output.display())?;
+            return Ok(1);
+        }
+        write_new_file_atomically(output, &text)?;
+        writeln!(stdout, "Exported redacted config: {}", output.display())?;
+    } else {
+        writeln!(stdout, "{text}")?;
+    }
+
+    Ok(0)
+}
+
+fn inspect_config(
+    cli: &Cli,
+    project_root: &Path,
+    home_override: Option<&Path>,
+) -> anyhow::Result<InspectedConfigDocuments> {
+    inspect_read_only(home_override, Some(cli.dir.as_deref().unwrap_or(project_root)))
+        .map_err(anyhow::Error::msg)
+}
+
+fn project_root(cli: &Cli) -> anyhow::Result<PathBuf> {
+    if let Some(path) = &cli.dir {
+        Ok(path.clone())
+    } else {
+        std::env::current_dir().context("failed to resolve current directory")
+    }
+}
+
+fn write_path_human(
+    stdout: &mut impl Write,
+    inspection: &InspectedConfigDocuments,
+) -> anyhow::Result<()> {
+    let style = HumanStyle::detect();
+    writeln!(stdout, "{}", style.title("claude-rs config"))?;
+    writeln!(stdout, "{} {}", style.detail_label("Summary:"), summary_counts(inspection))?;
+    writeln!(stdout)?;
+    writeln!(stdout, "{}", style.heading("Locations"))?;
+    for file in &inspection.files {
+        write_location(stdout, style, file)?;
+    }
+    writeln!(stdout)?;
+    writeln!(stdout, "{}", style.heading("Commands"))?;
+    writeln!(
+        stdout,
+        "{}",
+        style.command_block(
+            "show",
+            "claude-rs config show",
+            "Show a concise redacted config summary"
+        )
+    )?;
+    writeln!(
+        stdout,
+        "{}",
+        style.command_block(
+            "export",
+            "claude-rs config export --output config.json",
+            "Write a redacted support export"
+        )
+    )?;
+    Ok(())
+}
+
+fn write_show_human(stdout: &mut impl Write, report: &ShowReport) -> anyhow::Result<()> {
+    let style = HumanStyle::detect();
+    writeln!(stdout, "{}", style.title("claude-rs config"))?;
+    writeln!(stdout, "{} {}", style.detail_label("Summary:"), report.summary.as_human())?;
+    writeln!(stdout)?;
+    writeln!(stdout, "{}", style.heading("Documents"))?;
+
+    for (index, file) in report.files.iter().enumerate() {
+        write_show_file(stdout, style, file)?;
+        if index + 1 < report.files.len() {
+            writeln!(stdout)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn write_show_file(
+    stdout: &mut impl Write,
+    style: HumanStyle,
+    file: &ConfigFileReport,
+) -> anyhow::Result<()> {
+    writeln!(stdout, "  {} {}", style.status(file.status), file.label)?;
+    writeln!(stdout, "      - {} {}", style.detail_label("Scope:"), file.scope)?;
+    writeln!(stdout, "      - {} {}", style.detail_label("Path:"), file.path)?;
+    writeln!(stdout, "      - {} {}", style.detail_label("State:"), file.status.as_human())?;
+    if let Some(error) = &file.error {
+        writeln!(stdout, "      - {} {}", style.detail_label("Error:"), error)?;
+    }
+
+    if let Some(document) = &file.document {
+        write_document_summary(stdout, style, document)?;
+    }
+
+    Ok(())
+}
+
+fn write_document_summary(
+    stdout: &mut impl Write,
+    style: HumanStyle,
+    document: &Value,
+) -> anyhow::Result<()> {
+    let text = json_text(document)?;
+    let lines = text.lines().collect::<Vec<_>>();
+    if lines.len() <= HUMAN_DOCUMENT_PREVIEW_LINES {
+        writeln!(stdout, "      - {}", style.detail_label("Redacted document:"))?;
+        for line in lines {
+            writeln!(stdout, "        {line}")?;
+        }
+        return Ok(());
+    }
+
+    let Some(object) = document.as_object() else {
+        writeln!(
+            stdout,
+            "      - {} {} lines, hidden from human output",
+            style.detail_label("Redacted document:"),
+            lines.len()
+        )?;
+        return Ok(());
+    };
+
+    writeln!(stdout, "      - {} {}", style.detail_label("Top-level keys:"), object.len())?;
+    if object.is_empty() {
+        return Ok(());
+    }
+
+    let mut keys = object.keys().cloned().collect::<Vec<_>>();
+    keys.sort();
+    let visible = keys.iter().take(8).map(String::as_str).collect::<Vec<_>>();
+    writeln!(stdout, "      - {} {}", style.detail_label("Keys:"), visible.join(", "))?;
+    if keys.len() > visible.len() {
+        writeln!(
+            stdout,
+            "      - {} {} more",
+            style.detail_label("Hidden keys:"),
+            keys.len() - visible.len()
+        )?;
+    }
+    writeln!(
+        stdout,
+        "      - {} {} lines, hidden from human output",
+        style.detail_label("Redacted document:"),
+        lines.len()
+    )?;
+    writeln!(
+        stdout,
+        "      - {} claude-rs config show --json",
+        style.detail_label("Full redacted JSON:")
+    )?;
+    Ok(())
+}
+
+fn write_location(
+    stdout: &mut impl Write,
+    style: HumanStyle,
+    file: &InspectedConfigFile,
+) -> std::io::Result<()> {
+    writeln!(stdout, "  {} {}", style.status(file.status), file.label)?;
+    writeln!(stdout, "      - {} {}", style.detail_label("Scope:"), file.scope)?;
+    writeln!(stdout, "      - {} {}", style.detail_label("Path:"), file.path.display())?;
+    writeln!(stdout, "      - {} {}", style.detail_label("State:"), file.status.as_human())
+}
+
+fn selected_file(
+    inspection: &InspectedConfigDocuments,
+    selector: ConfigFileSelector,
+) -> Option<&InspectedConfigFile> {
+    let kind = match selector {
+        ConfigFileSelector::Settings => InspectedConfigFileKind::Settings,
+        ConfigFileSelector::LocalSettings => InspectedConfigFileKind::LocalSettings,
+        ConfigFileSelector::Preferences => InspectedConfigFileKind::Preferences,
+    };
+    inspection.files.iter().find(|file| file.kind == kind)
+}
+
+#[derive(Debug, Serialize)]
+struct PathReport {
+    version: &'static str,
+    project_root: String,
+    files: Vec<ConfigFileMetadata>,
+}
+
+impl PathReport {
+    fn from_inspection(inspection: &InspectedConfigDocuments, project_root: &Path) -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION"),
+            project_root: project_root.display().to_string(),
+            files: inspection.files.iter().map(ConfigFileMetadata::from).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ShowReport {
+    version: &'static str,
+    project_root: String,
+    summary: ConfigSummary,
+    files: Vec<ConfigFileReport>,
+}
+
+impl ShowReport {
+    fn from_inspection(inspection: &InspectedConfigDocuments, project_root: &Path) -> Self {
+        let files = inspection.files.iter().map(ConfigFileReport::from).collect::<Vec<_>>();
+        Self {
+            version: env!("CARGO_PKG_VERSION"),
+            project_root: project_root.display().to_string(),
+            summary: ConfigSummary::from_files(&files),
+            files,
+        }
+    }
+
+    fn has_failures(&self) -> bool {
+        self.files.iter().any(ConfigFileReport::is_failure)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ExportReport {
+    schema: &'static str,
+    created_at: String,
+    version: &'static str,
+    platform: PlatformReport,
+    project_root: String,
+    summary: ConfigSummary,
+    files: Vec<ConfigFileReport>,
+    skipped: Vec<&'static str>,
+    redaction: &'static str,
+}
+
+impl ExportReport {
+    fn from_inspection(inspection: &InspectedConfigDocuments, project_root: &Path) -> Self {
+        let files = inspection.files.iter().map(ConfigFileReport::from).collect::<Vec<_>>();
+        Self {
+            schema: EXPORT_SCHEMA,
+            created_at: timestamp_now(),
+            version: env!("CARGO_PKG_VERSION"),
+            platform: PlatformReport { os: std::env::consts::OS, arch: std::env::consts::ARCH },
+            project_root: project_root.display().to_string(),
+            summary: ConfigSummary::from_files(&files),
+            files,
+            skipped: vec![
+                "Claude credentials",
+                "environment variable dumps",
+                "runtime MCP state",
+                "plugin inventory",
+                "logs",
+                "arbitrary project files",
+            ],
+            redaction: "credential-like keys and bearer/API token values are replaced with [redacted]",
+        }
+    }
+
+    fn has_failures(&self) -> bool {
+        self.files.iter().any(ConfigFileReport::is_failure)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct PlatformReport {
+    os: &'static str,
+    arch: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigFileMetadata {
+    kind: InspectedConfigFileKind,
+    label: &'static str,
+    scope: &'static str,
+    path: String,
+    status: InspectedConfigFileStatus,
+    state: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+impl From<&InspectedConfigFile> for ConfigFileMetadata {
+    fn from(file: &InspectedConfigFile) -> Self {
+        Self {
+            kind: file.kind,
+            label: file.label,
+            scope: file.scope,
+            path: file.path.display().to_string(),
+            status: file.status,
+            state: file.status.as_human(),
+            error: file.error.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigFileReport {
+    #[serde(flatten)]
+    metadata: ConfigFileMetadata,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    document: Option<Value>,
+}
+
+impl From<&InspectedConfigFile> for ConfigFileReport {
+    fn from(file: &InspectedConfigFile) -> Self {
+        Self {
+            metadata: ConfigFileMetadata::from(file),
+            document: file.document.as_ref().map(redacted_document),
+        }
+    }
+}
+
+impl ConfigFileReport {
+    fn is_failure(&self) -> bool {
+        matches!(
+            self.status,
+            InspectedConfigFileStatus::Invalid
+                | InspectedConfigFileStatus::Unreadable
+                | InspectedConfigFileStatus::NotFile
+        )
+    }
+
+    fn has_document(&self) -> bool {
+        self.document.is_some()
+    }
+}
+
+impl std::ops::Deref for ConfigFileReport {
+    type Target = ConfigFileMetadata;
+
+    fn deref(&self) -> &Self::Target {
+        &self.metadata
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigSummary {
+    found: usize,
+    missing: usize,
+    invalid: usize,
+    documents: usize,
+}
+
+impl ConfigSummary {
+    fn from_files(files: &[ConfigFileReport]) -> Self {
+        Self {
+            found: files
+                .iter()
+                .filter(|file| file.status != InspectedConfigFileStatus::Missing)
+                .count(),
+            missing: files
+                .iter()
+                .filter(|file| file.status == InspectedConfigFileStatus::Missing)
+                .count(),
+            invalid: files.iter().filter(|file| file.is_failure()).count(),
+            documents: files.iter().filter(|file| file.has_document()).count(),
+        }
+    }
+
+    fn as_human(&self) -> String {
+        format!("{} files found, {} missing, {} invalid", self.found, self.missing, self.invalid)
+    }
+}
+
+fn summary_counts(inspection: &InspectedConfigDocuments) -> String {
+    let files = inspection.files.iter().map(ConfigFileReport::from).collect::<Vec<_>>();
+    ConfigSummary::from_files(&files).as_human()
+}
+
+fn redacted_document(document: &Value) -> Value {
+    let mut redacted = document.clone();
+    redaction::redact_json_value(&mut redacted);
+    redacted
+}
+
+fn write_json<T: Serialize>(stdout: &mut impl Write, value: &T) -> anyhow::Result<()> {
+    writeln!(stdout, "{}", json_text(value)?)?;
+    Ok(())
+}
+
+fn json_text<T: Serialize>(value: &T) -> anyhow::Result<String> {
+    let text = serde_json::to_string_pretty(value)?;
+    Ok(redaction::redact_text(&text))
+}
+
+fn write_new_file_atomically(path: &Path, text: &str) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        create_dir_all(parent).with_context(|| {
+            format!("failed to create config export directory {}", parent.display())
+        })?;
+    }
+
+    write_new_file(path, text)
+}
+
+fn write_new_file(path: &Path, text: &str) -> anyhow::Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .with_context(|| format!("failed to create config export {}", path.display()))?;
+
+    let write_result = (|| {
+        file.write_all(text.as_bytes())
+            .with_context(|| format!("failed to write config export {}", path.display()))?;
+        file.write_all(b"\n")
+            .with_context(|| format!("failed to finalize config export {}", path.display()))?;
+        file.flush()
+            .with_context(|| format!("failed to flush config export {}", path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("failed to sync config export {}", path.display()))?;
+        Ok(())
+    })();
+
+    drop(file);
+
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(path);
+        return Err(error);
+    }
+
+    Ok(())
+}
+
+fn timestamp_now() -> String {
+    OffsetDateTime::now_utc()
+        .format(format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]Z"))
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+#[derive(Clone, Copy, Debug)]
+struct HumanStyle {
+    color: bool,
+}
+
+impl HumanStyle {
+    fn detect() -> Self {
+        Self { color: std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none() }
+    }
+
+    fn title(self, text: &str) -> String {
+        if self.color { format!("\x1b[1;36m{text}\x1b[0m") } else { text.to_owned() }
+    }
+
+    fn heading(self, text: &str) -> String {
+        if self.color { format!("\x1b[1;36m{text}\x1b[0m") } else { text.to_owned() }
+    }
+
+    fn detail_label(self, text: &str) -> String {
+        if self.color { format!("\x1b[2m{text}\x1b[0m") } else { text.to_owned() }
+    }
+
+    fn status(self, status: InspectedConfigFileStatus) -> String {
+        let label = format!("[{}]", status.as_tag());
+        if !self.color {
+            return label;
+        }
+
+        match status {
+            InspectedConfigFileStatus::Valid => format!("\x1b[32m{label}\x1b[0m"),
+            InspectedConfigFileStatus::Missing => format!("\x1b[2m{label}\x1b[0m"),
+            InspectedConfigFileStatus::Invalid
+            | InspectedConfigFileStatus::Unreadable
+            | InspectedConfigFileStatus::NotFile => format!("\x1b[31m{label}\x1b[0m"),
+        }
+    }
+
+    fn command_block(self, mode: &str, command: &str, purpose: &str) -> String {
+        format!("  {} {}\n      {}", self.mode(mode), command, purpose)
+    }
+
+    fn mode(self, mode: &str) -> String {
+        if self.color { format!("\x1b[2m{mode}\x1b[0m") } else { mode.to_owned() }
+    }
+}
+
+impl InspectedConfigFileStatus {
+    const fn as_tag(self) -> &'static str {
+        match self {
+            Self::Missing => "MISS",
+            Self::Valid => "FILE",
+            Self::Invalid => "INVALID",
+            Self::Unreadable => "UNREADABLE",
+            Self::NotFile => "NOTFILE",
+        }
+    }
+
+    const fn as_human(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::Valid => "valid JSON file",
+            Self::Invalid => "invalid JSON",
+            Self::Unreadable => "unreadable",
+            Self::NotFile => "not a file",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        write_export_with_home_override, write_new_file_atomically, write_path_with_home_override,
+        write_show_with_home_override,
+    };
+    use crate::{Cli, ConfigExportArgs, ConfigFileSelector, ConfigPathArgs, ConfigShowArgs};
+    use serde_json::Value;
+    use std::fs;
+    use std::io::Write;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    #[test]
+    fn path_output_uses_sections_and_status_rows() {
+        let dir = tempdir().expect("tempdir");
+        let mut stdout = Vec::new();
+
+        let code =
+            write_test_path(dir.path(), &ConfigPathArgs { json: false, which: None }, &mut stdout)
+                .expect("path");
+
+        assert_eq!(code, 0);
+        let output = String::from_utf8(stdout).expect("utf8");
+        assert!(output.contains("claude-rs config"));
+        assert!(output.contains("Summary: 0 files found, 3 missing, 0 invalid"));
+        assert!(output.contains("Locations"));
+        assert!(output.contains("[MISS] Global settings"));
+        assert!(output.contains("Commands"));
+    }
+
+    #[test]
+    fn which_path_output_is_script_friendly() {
+        let dir = tempdir().expect("tempdir");
+        let mut stdout = Vec::new();
+
+        let code = write_test_path(
+            dir.path(),
+            &ConfigPathArgs { json: true, which: Some(ConfigFileSelector::LocalSettings) },
+            &mut stdout,
+        )
+        .expect("path");
+
+        assert_eq!(code, 0);
+        assert_eq!(
+            String::from_utf8(stdout).expect("utf8"),
+            format!("{}\n", dir.path().join(".claude").join("settings.local.json").display())
+        );
+    }
+
+    #[test]
+    fn show_json_redacts_nested_secrets() {
+        let dir = tempdir().expect("tempdir");
+        let settings = dir.path().join(".claude").join("settings.local.json");
+        fs::create_dir_all(settings.parent().expect("settings parent")).expect("settings dir");
+        fs::write(&settings, r#"{"model":"sonnet","env":{"ANTHROPIC_API_KEY":"sk-ant-secret"}}"#)
+            .expect("write settings");
+        let mut stdout = Vec::new();
+
+        let code =
+            write_test_show(dir.path(), &ConfigShowArgs { json: true }, &mut stdout).expect("show");
+
+        assert_eq!(code, 0);
+        let output = String::from_utf8(stdout).expect("utf8");
+        assert!(!output.contains("sk-ant-secret"));
+        assert!(output.contains("[redacted]"));
+        serde_json::from_str::<Value>(&output).expect("json");
+    }
+
+    #[test]
+    fn show_human_prints_small_redacted_documents() {
+        let dir = tempdir().expect("tempdir");
+        let settings = dir.path().join(".claude").join("settings.local.json");
+        fs::create_dir_all(settings.parent().expect("settings parent")).expect("settings dir");
+        fs::write(
+            &settings,
+            r#"{"permissions":{"allow":["mcp__fff__grep"]},"env":{"ANTHROPIC_API_KEY":"sk-ant-secret"}}"#,
+        )
+        .expect("write settings");
+        let mut stdout = Vec::new();
+
+        let code = write_test_show(dir.path(), &ConfigShowArgs { json: false }, &mut stdout)
+            .expect("show");
+
+        assert_eq!(code, 0);
+        let output = String::from_utf8(stdout).expect("utf8");
+        assert!(output.contains("Redacted document:"));
+        assert!(output.contains("mcp__fff__grep"));
+        assert!(!output.contains("sk-ant-secret"));
+    }
+
+    #[test]
+    fn show_human_summarizes_large_documents_without_dumping_contents() {
+        let dir = tempdir().expect("tempdir");
+        let settings = dir.path().join(".claude").join("settings.local.json");
+        fs::create_dir_all(settings.parent().expect("settings parent")).expect("settings dir");
+        let values = (0..40).map(|index| format!(r#""value-{index}""#)).collect::<Vec<_>>();
+        fs::write(
+            &settings,
+            format!(
+                r#"{{"additionalModelOptionsCache":[{}],"anonymousId":"claudecode.v1.example"}}"#,
+                values.join(",")
+            ),
+        )
+        .expect("write settings");
+        let mut stdout = Vec::new();
+
+        let code = write_test_show(dir.path(), &ConfigShowArgs { json: false }, &mut stdout)
+            .expect("show");
+
+        assert_eq!(code, 0);
+        let output = String::from_utf8(stdout).expect("utf8");
+        assert!(output.contains("Top-level keys: 2"));
+        assert!(output.contains("Redacted document:"));
+        assert!(output.contains("hidden from human output"));
+        assert!(output.contains("Full redacted JSON: claude-rs config show --json"));
+        assert!(!output.contains("value-39"));
+        assert!(!output.contains("claudecode.v1.example"));
+    }
+
+    #[test]
+    fn show_malformed_json_returns_failure_without_backup() {
+        let dir = tempdir().expect("tempdir");
+        let local_settings = dir.path().join(".claude").join("settings.local.json");
+        fs::create_dir_all(local_settings.parent().expect("local settings parent"))
+            .expect("local settings dir");
+        fs::write(&local_settings, "{ not-json").expect("write malformed");
+        let mut stdout = Vec::new();
+
+        let code = write_test_show(dir.path(), &ConfigShowArgs { json: false }, &mut stdout)
+            .expect("show");
+
+        assert_eq!(code, 1);
+        let output = String::from_utf8(stdout).expect("utf8");
+        assert!(output.contains("[INVALID] Local settings"));
+        let backups = fs::read_dir(local_settings.parent().expect("local settings parent"))
+            .expect("read dir")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| path != &local_settings)
+            .collect::<Vec<_>>();
+        assert!(backups.is_empty());
+    }
+
+    #[test]
+    fn export_refuses_existing_output_without_overwrite() {
+        let dir = tempdir().expect("tempdir");
+        let output_path = dir.path().join("config.json");
+        fs::write(&output_path, "keep").expect("write output");
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let code = write_test_export(
+            dir.path(),
+            &ConfigExportArgs { output: Some(output_path.clone()) },
+            &mut stdout,
+            &mut stderr,
+        )
+        .expect("export");
+
+        assert_eq!(code, 1);
+        assert!(stdout.is_empty());
+        assert!(String::from_utf8(stderr).expect("utf8").contains("Refusing to overwrite"));
+        assert_eq!(fs::read_to_string(output_path).expect("read output"), "keep");
+    }
+
+    #[test]
+    fn export_fails_invalid_config_without_partial_file() {
+        let dir = tempdir().expect("tempdir");
+        let local_settings = dir.path().join(".claude").join("settings.local.json");
+        fs::create_dir_all(local_settings.parent().expect("local settings parent"))
+            .expect("local settings dir");
+        fs::write(local_settings, "{ not-json").expect("write malformed");
+        let output_path = dir.path().join("out").join("config.json");
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let code = write_test_export(
+            dir.path(),
+            &ConfigExportArgs { output: Some(output_path.clone()) },
+            &mut stdout,
+            &mut stderr,
+        )
+        .expect("export");
+
+        assert_eq!(code, 1);
+        assert!(!output_path.exists());
+        assert!(String::from_utf8(stderr).expect("utf8").contains("Cannot export config"));
+    }
+
+    #[test]
+    fn atomic_export_preserves_existing_file_when_create_new_fails() {
+        let dir = tempdir().expect("tempdir");
+        let output_path = dir.path().join("config.json");
+        fs::write(&output_path, "keep").expect("write output");
+
+        let error = write_new_file_atomically(&output_path, "{}").expect_err("existing output");
+
+        assert!(error.to_string().contains("failed to create config export"));
+        assert_eq!(fs::read_to_string(output_path).expect("read output"), "keep");
+    }
+
+    fn write_test_path(
+        project_root: &Path,
+        args: &ConfigPathArgs,
+        stdout: &mut impl Write,
+    ) -> anyhow::Result<i32> {
+        let cli = test_cli(project_root);
+        write_path_with_home_override(&cli, args, Some(project_root), stdout)
+    }
+
+    fn write_test_show(
+        project_root: &Path,
+        args: &ConfigShowArgs,
+        stdout: &mut impl Write,
+    ) -> anyhow::Result<i32> {
+        let cli = test_cli(project_root);
+        write_show_with_home_override(&cli, args, Some(project_root), stdout)
+    }
+
+    fn write_test_export(
+        project_root: &Path,
+        args: &ConfigExportArgs,
+        stdout: &mut impl Write,
+        stderr: &mut impl Write,
+    ) -> anyhow::Result<i32> {
+        let cli = test_cli(project_root);
+        write_export_with_home_override(&cli, args, Some(project_root), stdout, stderr)
+    }
+
+    fn test_cli(project_root: &Path) -> Cli {
+        Cli {
+            command: None,
+            no_update_check: false,
+            dir: Some(project_root.to_path_buf()),
+            bridge_script: None,
+            enable_logs: false,
+            diagnostics_preset: None,
+            log_file: None,
+            log_filter: None,
+            log_append: false,
+            enable_perf: false,
+            perf_log: None,
+            perf_append: false,
+        }
+    }
+}

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -62,7 +62,7 @@ pub fn run(cli: &Cli, args: &DoctorArgs, writer: &mut impl Write) -> anyhow::Res
     Ok(i32::from(args.strict && report.has_hard_failures()))
 }
 
-fn build_report(cli: &Cli) -> DoctorReport {
+pub(crate) fn build_report(cli: &Cli) -> DoctorReport {
     let runtime = inspect_bridge_runtime();
     let script = inspect_bridge_script(cli.bridge_script.as_deref());
     let mut checks = vec![

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1,0 +1,981 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::agent::bridge::{
+    BRIDGE_RUNTIME_ENV_VAR, BRIDGE_SCRIPT_ENV_VAR, BridgeRuntimeInspection, BridgeScriptInspection,
+    inspect_bridge_runtime, inspect_bridge_script,
+};
+use crate::app::{auth, config};
+use crate::{Cli, DoctorArgs};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::io::IsTerminal as _;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const MIN_NODE_MAJOR: u64 = 18;
+const ROOT_NPM_PACKAGE_NAME: &str = "claude-code-rust";
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct DoctorReport {
+    version: String,
+    platform: PlatformReport,
+    checks: Vec<DoctorCheck>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+struct PlatformReport {
+    os: String,
+    arch: String,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+struct DoctorCheck {
+    id: &'static str,
+    label: &'static str,
+    status: DoctorStatus,
+    message: String,
+    hard_failure: bool,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    details: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum DoctorStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+pub fn run(cli: &Cli, args: &DoctorArgs, writer: &mut impl Write) -> anyhow::Result<i32> {
+    let report = build_report(cli);
+
+    if args.json {
+        serde_json::to_writer_pretty(&mut *writer, &report)?;
+        writeln!(writer)?;
+    } else {
+        write_human_report(writer, &report)?;
+    }
+
+    Ok(i32::from(args.strict && report.has_hard_failures()))
+}
+
+fn build_report(cli: &Cli) -> DoctorReport {
+    let runtime = inspect_bridge_runtime();
+    let script = inspect_bridge_script(cli.bridge_script.as_deref());
+    let mut checks = vec![
+        binary_version_check(),
+        platform_check(),
+        current_exe_check(),
+        node_runtime_check(&runtime),
+        node_version_check(runtime.resolved_path.as_deref()),
+        bridge_script_check(&script),
+    ];
+    checks.extend(config_path_checks(cli.dir.as_deref()));
+    checks.extend(log_path_checks());
+    checks.extend(npm_metadata_checks(&script));
+    checks.push(credentials_check());
+
+    DoctorReport {
+        version: env!("CARGO_PKG_VERSION").to_owned(),
+        platform: PlatformReport {
+            os: std::env::consts::OS.to_owned(),
+            arch: std::env::consts::ARCH.to_owned(),
+        },
+        checks,
+    }
+}
+
+impl DoctorReport {
+    fn has_hard_failures(&self) -> bool {
+        self.checks
+            .iter()
+            .any(|check| check.hard_failure && matches!(check.status, DoctorStatus::Fail))
+    }
+
+    fn status_count(&self, status: DoctorStatus) -> usize {
+        self.checks.iter().filter(|check| check.status == status).count()
+    }
+}
+
+fn write_human_report(writer: &mut impl Write, report: &DoctorReport) -> std::io::Result<()> {
+    let style = HumanStyle::detect();
+    writeln!(writer, "{}", style.title("claude-rs doctor"))?;
+    writeln!(writer, "{} {}", style.detail_label("Version:"), report.version)?;
+    writeln!(
+        writer,
+        "{} {}/{}",
+        style.detail_label("Platform:"),
+        report.platform.os,
+        report.platform.arch
+    )?;
+    writeln!(
+        writer,
+        "{} {}, {}, {}",
+        style.detail_label("Summary:"),
+        style.summary_count(report.status_count(DoctorStatus::Pass), "passed", DoctorStatus::Pass),
+        style.summary_count(
+            report.status_count(DoctorStatus::Warn),
+            "warnings",
+            DoctorStatus::Warn
+        ),
+        style.summary_count(
+            report.status_count(DoctorStatus::Fail),
+            "failures",
+            DoctorStatus::Fail
+        )
+    )?;
+    writeln!(writer)?;
+
+    for section in DoctorSection::ALL {
+        let section_checks = report
+            .checks
+            .iter()
+            .filter(|check| DoctorSection::for_check(check.id) == section)
+            .collect::<Vec<_>>();
+        if section_checks.is_empty() {
+            continue;
+        }
+
+        writeln!(writer, "{}", style.heading(section.title()))?;
+        writeln!(writer, "  {}  {:<22} Result", style.table_header("Status"), "Check")?;
+        writeln!(writer, "  {}  {:<22} ------", style.table_header("------"), "-----")?;
+        for (index, check) in section_checks.iter().enumerate() {
+            write_human_check(writer, check, style)?;
+            if index + 1 < section_checks.len() {
+                writeln!(writer)?;
+            }
+        }
+        writeln!(writer)?;
+    }
+
+    Ok(())
+}
+
+fn write_human_check(
+    writer: &mut impl Write,
+    check: &DoctorCheck,
+    style: HumanStyle,
+) -> std::io::Result<()> {
+    writeln!(writer, "  {}  {:<22} {}", style.status(check.status), check.label, check.message)?;
+
+    let mut candidate_details = Vec::new();
+    for (key, value) in &check.details {
+        if is_candidate_detail_key(key) {
+            candidate_details.push(parse_candidate_detail(value));
+        } else {
+            writeln!(writer, "      - {} {}", style.detail_label(&format!("{key}:")), value)?;
+        }
+    }
+
+    if !candidate_details.is_empty() {
+        write_candidate_table(writer, &candidate_details, style)?;
+    }
+
+    Ok(())
+}
+
+fn write_candidate_table(
+    writer: &mut impl Write,
+    candidates: &[CandidateDetail<'_>],
+    style: HumanStyle,
+) -> std::io::Result<()> {
+    let show_source = candidates.iter().any(|candidate| candidate.source.is_some());
+    writeln!(writer, "      {}", style.detail_label("Candidates:"))?;
+
+    if show_source {
+        writeln!(
+            writer,
+            "        {:>2}  {:<21} {:<8} Path",
+            style.table_header("#"),
+            "Source",
+            "State"
+        )?;
+        writeln!(
+            writer,
+            "        {:>2}  {:<21} {:<8} ----",
+            style.table_header("--"),
+            "------",
+            "-----"
+        )?;
+        for (index, candidate) in candidates.iter().enumerate() {
+            writeln!(
+                writer,
+                "        {:>2}. {:<21} {:<8} {}",
+                index + 1,
+                candidate.source.unwrap_or("-"),
+                style.state(candidate.state),
+                candidate.path
+            )?;
+        }
+    } else {
+        writeln!(writer, "        {:>2}  {:<8} Path", style.table_header("#"), "State")?;
+        writeln!(writer, "        {:>2}  {:<8} ----", style.table_header("--"), "-----")?;
+        for (index, candidate) in candidates.iter().enumerate() {
+            writeln!(
+                writer,
+                "        {:>2}. {:<8} {}",
+                index + 1,
+                style.state(candidate.state),
+                candidate.path
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CandidateDetail<'a> {
+    source: Option<&'a str>,
+    path: &'a str,
+    state: &'a str,
+}
+
+fn parse_candidate_detail(value: &str) -> CandidateDetail<'_> {
+    let (value, state) = value
+        .strip_suffix(')')
+        .and_then(|without_suffix| without_suffix.rsplit_once(" ("))
+        .unwrap_or((value, ""));
+    let (source, path) = value
+        .split_once(": ")
+        .filter(|(source, _)| !source.contains('\\') && !source.contains('/'))
+        .map_or((None, value), |(source, path)| (Some(source), path));
+
+    CandidateDetail { source, path, state }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DoctorSection {
+    Overview,
+    Runtime,
+    Configuration,
+    Logs,
+    Npm,
+    Credentials,
+}
+
+impl DoctorSection {
+    const ALL: [Self; 6] = [
+        Self::Overview,
+        Self::Runtime,
+        Self::Configuration,
+        Self::Logs,
+        Self::Npm,
+        Self::Credentials,
+    ];
+
+    fn title(self) -> &'static str {
+        match self {
+            Self::Overview => "Overview",
+            Self::Runtime => "Runtime prerequisites",
+            Self::Configuration => "Configuration",
+            Self::Logs => "Logs",
+            Self::Npm => "npm installation",
+            Self::Credentials => "Claude credentials",
+        }
+    }
+
+    fn for_check(id: &str) -> Self {
+        match id {
+            "node_runtime" | "node_version" | "bridge_script" => Self::Runtime,
+            "config_settings" | "config_local_settings" | "config_preferences" | "config_paths" => {
+                Self::Configuration
+            }
+            "runtime_log_dir" | "legacy_log_path" | "perf_log_dir" => Self::Logs,
+            "npm_root_package" | "npm_platform_package" => Self::Npm,
+            "claude_credentials" => Self::Credentials,
+            _ => Self::Overview,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct HumanStyle {
+    color: bool,
+}
+
+impl HumanStyle {
+    fn detect() -> Self {
+        Self { color: std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none() }
+    }
+
+    fn title(self, text: &str) -> String {
+        if self.color { format!("\x1b[1;36m{text}\x1b[0m") } else { text.to_owned() }
+    }
+
+    fn heading(self, text: &str) -> String {
+        if self.color { format!("\x1b[1;36m{text}\x1b[0m") } else { text.to_owned() }
+    }
+
+    fn table_header(self, text: &str) -> String {
+        if self.color { format!("\x1b[2m{text}\x1b[0m") } else { text.to_owned() }
+    }
+
+    fn detail_label(self, text: &str) -> String {
+        if self.color { format!("\x1b[2m{text}\x1b[0m") } else { text.to_owned() }
+    }
+
+    fn status(self, status: DoctorStatus) -> String {
+        let label = format!("[{}]", status.as_label());
+        if !self.color {
+            return label;
+        }
+
+        match status {
+            DoctorStatus::Pass => format!("\x1b[32m{label}\x1b[0m"),
+            DoctorStatus::Warn => format!("\x1b[33m{label}\x1b[0m"),
+            DoctorStatus::Fail => format!("\x1b[31m{label}\x1b[0m"),
+        }
+    }
+
+    fn state(self, state: &str) -> String {
+        if !self.color {
+            return state.to_owned();
+        }
+
+        match state {
+            "file" | "directory" | "exists" => format!("\x1b[32m{state}\x1b[0m"),
+            "missing" => format!("\x1b[2m{state}\x1b[0m"),
+            _ => state.to_owned(),
+        }
+    }
+
+    fn summary_count(self, count: usize, label: &str, status: DoctorStatus) -> String {
+        let text = format!("{count} {label}");
+        if !self.color {
+            return text;
+        }
+
+        match status {
+            DoctorStatus::Pass => format!("\x1b[32m{text}\x1b[0m"),
+            DoctorStatus::Warn => format!("\x1b[33m{text}\x1b[0m"),
+            DoctorStatus::Fail => format!("\x1b[31m{text}\x1b[0m"),
+        }
+    }
+}
+
+fn is_candidate_detail_key(key: &str) -> bool {
+    key.starts_with("candidate_") || key.starts_with("packaged_candidate_")
+}
+
+impl DoctorStatus {
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::Pass => "PASS",
+            Self::Warn => "WARN",
+            Self::Fail => "FAIL",
+        }
+    }
+}
+
+fn binary_version_check() -> DoctorCheck {
+    DoctorCheck::pass("binary_version", "Binary version", env!("CARGO_PKG_VERSION"))
+}
+
+fn platform_check() -> DoctorCheck {
+    let mut details = BTreeMap::new();
+    details.insert("os".to_owned(), std::env::consts::OS.to_owned());
+    details.insert("arch".to_owned(), std::env::consts::ARCH.to_owned());
+    DoctorCheck::pass_with_details("platform", "Platform", "platform detected", details)
+}
+
+fn current_exe_check() -> DoctorCheck {
+    match std::env::current_exe() {
+        Ok(path) => DoctorCheck::pass_with_detail(
+            "current_exe",
+            "Current executable",
+            "current executable resolved",
+            "path",
+            path.display().to_string(),
+        ),
+        Err(error) => DoctorCheck::warn(
+            "current_exe",
+            "Current executable",
+            format!("failed to resolve current executable: {error}"),
+        ),
+    }
+}
+
+fn node_runtime_check(inspection: &BridgeRuntimeInspection) -> DoctorCheck {
+    let mut details = BTreeMap::new();
+    details.insert(
+        BRIDGE_RUNTIME_ENV_VAR.to_owned(),
+        inspection
+            .env_path
+            .as_ref()
+            .map_or_else(|| "unset".to_owned(), |path| path.display().to_string()),
+    );
+    if let Some(path) = &inspection.path_node {
+        details.insert("path_node".to_owned(), path.display().to_string());
+    }
+    for (index, candidate) in inspection.packaged_candidates.iter().enumerate() {
+        details.insert(
+            format!("packaged_candidate_{index}"),
+            format!("{} ({})", candidate.path.display(), file_state(candidate.path.as_path())),
+        );
+    }
+
+    match (&inspection.resolved_path, &inspection.error) {
+        (Some(path), _) => DoctorCheck::pass_with_details(
+            "node_runtime",
+            "Node runtime",
+            format!("resolved {}", path.display()),
+            details,
+        ),
+        (None, Some(error)) => DoctorCheck::fail_hard_with_details(
+            "node_runtime",
+            "Node runtime",
+            error.clone(),
+            details,
+        ),
+        (None, None) => DoctorCheck::fail_hard_with_details(
+            "node_runtime",
+            "Node runtime",
+            "Node.js runtime not found".to_owned(),
+            details,
+        ),
+    }
+}
+
+fn node_version_check(runtime: Option<&Path>) -> DoctorCheck {
+    let Some(runtime) = runtime else {
+        return DoctorCheck::fail_hard(
+            "node_version",
+            "Node version",
+            "cannot check Node version because no runtime was resolved",
+        );
+    };
+
+    match Command::new(runtime).arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let raw = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+            classify_node_version(&raw, runtime)
+        }
+        Ok(output) => DoctorCheck::fail_hard(
+            "node_version",
+            "Node version",
+            format!("failed to run `{}` --version: {}", runtime.display(), output.status),
+        ),
+        Err(error) => DoctorCheck::fail_hard(
+            "node_version",
+            "Node version",
+            format!("failed to run `{}` --version: {error}", runtime.display()),
+        ),
+    }
+}
+
+fn classify_node_version(raw: &str, runtime: &Path) -> DoctorCheck {
+    let Some(major) = parse_node_major(raw) else {
+        return DoctorCheck::fail_hard_with_detail(
+            "node_version",
+            "Node version",
+            format!("could not parse Node version output `{raw}`"),
+            "runtime",
+            runtime.display().to_string(),
+        );
+    };
+
+    let mut details = BTreeMap::new();
+    details.insert("runtime".to_owned(), runtime.display().to_string());
+    details.insert("version".to_owned(), raw.to_owned());
+    details.insert("minimum_major".to_owned(), MIN_NODE_MAJOR.to_string());
+
+    if major >= MIN_NODE_MAJOR {
+        DoctorCheck::pass_with_details("node_version", "Node version", raw, details)
+    } else {
+        DoctorCheck::fail_hard_with_details(
+            "node_version",
+            "Node version",
+            format!("Node.js {raw} is older than required major version {MIN_NODE_MAJOR}"),
+            details,
+        )
+    }
+}
+
+fn parse_node_major(raw: &str) -> Option<u64> {
+    raw.trim().strip_prefix('v').unwrap_or(raw.trim()).split('.').next()?.parse().ok()
+}
+
+fn bridge_script_check(inspection: &BridgeScriptInspection) -> DoctorCheck {
+    let mut details = BTreeMap::new();
+    details.insert(
+        BRIDGE_SCRIPT_ENV_VAR.to_owned(),
+        inspection
+            .env_path
+            .as_ref()
+            .map_or_else(|| "unset".to_owned(), |path| path.display().to_string()),
+    );
+    if let Some(path) = &inspection.explicit_path {
+        details.insert("explicit_bridge_script".to_owned(), path.display().to_string());
+    }
+    for (index, candidate) in inspection.candidates.iter().enumerate() {
+        details.insert(
+            format!("candidate_{index}"),
+            format!(
+                "{}: {} ({})",
+                candidate.source,
+                candidate.path.display(),
+                file_state(candidate.path.as_path())
+            ),
+        );
+    }
+
+    match (&inspection.resolved_path, &inspection.error) {
+        (Some(path), _) => DoctorCheck::pass_with_details(
+            "bridge_script",
+            "Bridge script",
+            format!("resolved {}", path.display()),
+            details,
+        ),
+        (None, Some(error)) => DoctorCheck::fail_hard_with_details(
+            "bridge_script",
+            "Bridge script",
+            error.clone(),
+            details,
+        ),
+        (None, None) => DoctorCheck::fail_hard_with_details(
+            "bridge_script",
+            "Bridge script",
+            "bridge script not found".to_owned(),
+            details,
+        ),
+    }
+}
+
+fn config_path_checks(project_root: Option<&Path>) -> Vec<DoctorCheck> {
+    match config::store::resolve_paths(None, project_root) {
+        Ok(paths) => vec![
+            path_check("config_settings", "Global settings", &paths.settings, false),
+            path_check("config_local_settings", "Local settings", &paths.local_settings, false),
+            path_check("config_preferences", "Preferences", &paths.preferences, false),
+        ],
+        Err(error) => vec![DoctorCheck::warn(
+            "config_paths",
+            "Config paths",
+            format!("failed to resolve config paths: {error}"),
+        )],
+    }
+}
+
+fn log_path_checks() -> Vec<DoctorCheck> {
+    vec![
+        result_path_check(
+            "runtime_log_dir",
+            "Runtime log directory",
+            crate::logging::default_runtime_log_dir(),
+            false,
+        ),
+        result_path_check(
+            "legacy_log_path",
+            "Legacy log path",
+            crate::logging::default_legacy_log_path(),
+            false,
+        ),
+        result_path_check(
+            "perf_log_dir",
+            "Perf log directory",
+            crate::logging::default_perf_log_dir(),
+            false,
+        ),
+    ]
+}
+
+fn result_path_check(
+    id: &'static str,
+    label: &'static str,
+    result: anyhow::Result<PathBuf>,
+    require_exists: bool,
+) -> DoctorCheck {
+    match result {
+        Ok(path) => path_check(id, label, &path, require_exists),
+        Err(error) => DoctorCheck::warn(id, label, format!("failed to resolve path: {error}")),
+    }
+}
+
+fn path_check(
+    id: &'static str,
+    label: &'static str,
+    path: &Path,
+    require_exists: bool,
+) -> DoctorCheck {
+    let mut details = BTreeMap::new();
+    details.insert("path".to_owned(), path.display().to_string());
+    details.insert("state".to_owned(), file_state(path).to_owned());
+
+    if require_exists && !path.exists() {
+        DoctorCheck::fail_hard_with_details(id, label, "path is missing".to_owned(), details)
+    } else {
+        DoctorCheck::pass_with_details(id, label, "path resolved", details)
+    }
+}
+
+fn npm_metadata_checks(script: &BridgeScriptInspection) -> Vec<DoctorCheck> {
+    vec![root_package_check(script), platform_package_check(script)]
+}
+
+fn root_package_check(script: &BridgeScriptInspection) -> DoctorCheck {
+    let candidates = root_package_json_candidates(script);
+    package_json_check(
+        "npm_root_package",
+        "npm root package",
+        candidates,
+        Some(ROOT_NPM_PACKAGE_NAME),
+        false,
+    )
+}
+
+fn platform_package_check(script: &BridgeScriptInspection) -> DoctorCheck {
+    let mut candidates = Vec::new();
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(bin_dir) = current_exe.parent()
+        && let Some(package_root) = bin_dir.parent()
+    {
+        candidates.push(package_root.join("package.json"));
+    }
+
+    if let (Some(root), Some(package_name)) = (root_package_dir(script), platform_package_name()) {
+        candidates.push(root.join("node_modules").join(package_name).join("package.json"));
+    }
+
+    package_json_check(
+        "npm_platform_package",
+        "npm platform package",
+        candidates,
+        platform_package_name(),
+        true,
+    )
+}
+
+fn package_json_check(
+    id: &'static str,
+    label: &'static str,
+    candidates: Vec<PathBuf>,
+    expected_name: Option<&str>,
+    optional: bool,
+) -> DoctorCheck {
+    let mut details = BTreeMap::new();
+    for (index, path) in candidates.iter().enumerate() {
+        details.insert(
+            format!("candidate_{index}"),
+            format!("{} ({})", path.display(), file_state(path)),
+        );
+    }
+
+    let mut rejected_packages = Vec::new();
+    for (index, path) in candidates.into_iter().enumerate() {
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            return DoctorCheck::warn_with_details(
+                id,
+                label,
+                format!("package metadata is not valid JSON: {}", path.display()),
+                details,
+            );
+        };
+        let name = json.get("name").and_then(serde_json::Value::as_str).unwrap_or("<unknown>");
+        let version =
+            json.get("version").and_then(serde_json::Value::as_str).unwrap_or("<unknown>");
+        if let Some(expected_name) = expected_name
+            && name != expected_name
+        {
+            details.insert(format!("candidate_{index}_name"), name.to_owned());
+            rejected_packages.push(format!("{} ({name})", path.display()));
+            continue;
+        }
+
+        details.insert("path".to_owned(), path.display().to_string());
+        details.insert("name".to_owned(), name.to_owned());
+        details.insert("version".to_owned(), version.to_owned());
+        return DoctorCheck::pass_with_details(id, label, format!("{name} {version}"), details);
+    }
+
+    let message = if let (Some(expected_name), false) =
+        (expected_name, rejected_packages.is_empty())
+    {
+        format!(
+            "expected {expected_name} package metadata but found unrelated package metadata: {}",
+            rejected_packages.join(", ")
+        )
+    } else if let Some(expected_name) = expected_name {
+        format!("{expected_name} package metadata was not discoverable")
+    } else if optional {
+        "optional platform package metadata was not discoverable".to_owned()
+    } else {
+        "npm root package metadata was not discoverable".to_owned()
+    };
+    DoctorCheck::warn_with_details(id, label, message, details)
+}
+
+fn root_package_json_candidates(script: &BridgeScriptInspection) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(root) = root_package_dir(script) {
+        candidates.push(root.join("package.json"));
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        candidates.push(cwd.join("package.json"));
+    }
+    unique_paths(candidates)
+}
+
+fn root_package_dir(script: &BridgeScriptInspection) -> Option<PathBuf> {
+    let script = script.resolved_path.as_ref()?;
+    let dist_dir = script.parent()?;
+    let agent_sdk_dir = dist_dir.parent()?;
+    agent_sdk_dir.parent().map(Path::to_path_buf)
+}
+
+fn unique_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut unique = Vec::new();
+    for path in paths {
+        if !unique.iter().any(|candidate| candidate == &path) {
+            unique.push(path);
+        }
+    }
+    unique
+}
+
+fn platform_package_name() -> Option<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Some("@srothgan/claude-code-rust-darwin-arm64"),
+        ("macos", "x86_64") => Some("@srothgan/claude-code-rust-darwin-x64"),
+        ("linux", "x86_64") => Some("@srothgan/claude-code-rust-linux-x64-gnu"),
+        ("windows", "x86_64") => Some("@srothgan/claude-code-rust-win32-x64-msvc"),
+        _ => None,
+    }
+}
+
+fn credentials_check() -> DoctorCheck {
+    let mut details = BTreeMap::new();
+    if let Some(path) = auth::credentials_path() {
+        details.insert("path".to_owned(), path.display().to_string());
+        details.insert("state".to_owned(), file_state(&path).to_owned());
+    }
+
+    if auth::has_credentials() {
+        DoctorCheck::pass_with_details(
+            "claude_credentials",
+            "Claude credentials",
+            "Claude OAuth credentials appear configured",
+            details,
+        )
+    } else {
+        DoctorCheck::warn_with_details(
+            "claude_credentials",
+            "Claude credentials",
+            "Claude credentials were not found or are not readable",
+            details,
+        )
+    }
+}
+
+fn file_state(path: &Path) -> &'static str {
+    if path.is_file() {
+        "file"
+    } else if path.is_dir() {
+        "directory"
+    } else if path.exists() {
+        "exists"
+    } else {
+        "missing"
+    }
+}
+
+impl DoctorCheck {
+    fn pass(id: &'static str, label: &'static str, message: impl Into<String>) -> Self {
+        Self::new(id, label, DoctorStatus::Pass, message, false, BTreeMap::new())
+    }
+
+    fn pass_with_detail(
+        id: &'static str,
+        label: &'static str,
+        message: impl Into<String>,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        let mut details = BTreeMap::new();
+        details.insert(key.into(), value.into());
+        Self::pass_with_details(id, label, message, details)
+    }
+
+    fn pass_with_details(
+        id: &'static str,
+        label: &'static str,
+        message: impl Into<String>,
+        details: BTreeMap<String, String>,
+    ) -> Self {
+        Self::new(id, label, DoctorStatus::Pass, message, false, details)
+    }
+
+    fn warn(id: &'static str, label: &'static str, message: impl Into<String>) -> Self {
+        Self::new(id, label, DoctorStatus::Warn, message, false, BTreeMap::new())
+    }
+
+    fn warn_with_details(
+        id: &'static str,
+        label: &'static str,
+        message: impl Into<String>,
+        details: BTreeMap<String, String>,
+    ) -> Self {
+        Self::new(id, label, DoctorStatus::Warn, message, false, details)
+    }
+
+    fn fail_hard(id: &'static str, label: &'static str, message: impl Into<String>) -> Self {
+        Self::new(id, label, DoctorStatus::Fail, message, true, BTreeMap::new())
+    }
+
+    fn fail_hard_with_detail(
+        id: &'static str,
+        label: &'static str,
+        message: impl Into<String>,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        let mut details = BTreeMap::new();
+        details.insert(key.into(), value.into());
+        Self::fail_hard_with_details(id, label, message, details)
+    }
+
+    fn fail_hard_with_details(
+        id: &'static str,
+        label: &'static str,
+        message: impl Into<String>,
+        details: BTreeMap<String, String>,
+    ) -> Self {
+        Self::new(id, label, DoctorStatus::Fail, message, true, details)
+    }
+
+    fn new(
+        id: &'static str,
+        label: &'static str,
+        status: DoctorStatus,
+        message: impl Into<String>,
+        hard_failure: bool,
+        details: BTreeMap<String, String>,
+    ) -> Self {
+        Self { id, label, status, message: message.into(), hard_failure, details }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DoctorReport, DoctorStatus, MIN_NODE_MAJOR, PlatformReport, ROOT_NPM_PACKAGE_NAME,
+        classify_node_version, config_path_checks, package_json_check, parse_node_major,
+        write_human_report,
+    };
+    use std::path::Path;
+
+    #[test]
+    fn parses_node_major_versions() {
+        assert_eq!(parse_node_major("v20.11.1"), Some(20));
+        assert_eq!(parse_node_major("18.19.0"), Some(18));
+        assert_eq!(parse_node_major("not-node"), None);
+    }
+
+    #[test]
+    fn node_version_below_minimum_is_hard_failure() {
+        let raw = format!("v{}.0.0", MIN_NODE_MAJOR - 1);
+        let check = classify_node_version(&raw, Path::new("node"));
+
+        assert_eq!(check.status, DoctorStatus::Fail);
+        assert!(check.hard_failure);
+    }
+
+    #[test]
+    fn human_report_does_not_print_json() {
+        let report = DoctorReport {
+            version: "1.2.3".to_owned(),
+            platform: PlatformReport { os: "test-os".to_owned(), arch: "test-arch".to_owned() },
+            checks: vec![super::DoctorCheck::pass("binary_version", "Binary version", "1.2.3")],
+        };
+        let mut output = Vec::new();
+
+        write_human_report(&mut output, &report).expect("write report");
+
+        let output = String::from_utf8(output).expect("utf8");
+        assert!(output.contains("claude-rs doctor"));
+        assert!(output.contains("[PASS]  Binary version"));
+        assert!(output.contains("Status  Check"));
+        assert!(!output.trim_start().starts_with('{'));
+    }
+
+    #[test]
+    fn config_path_checks_use_project_root_override_for_local_settings() {
+        let project = tempfile::tempdir().expect("tempdir");
+
+        let checks = config_path_checks(Some(project.path()));
+
+        let local = checks
+            .iter()
+            .find(|check| check.id == "config_local_settings")
+            .expect("local settings check");
+        assert_eq!(
+            local.details.get("path").map(String::as_str),
+            Some(
+                project
+                    .path()
+                    .join(".claude")
+                    .join("settings.local.json")
+                    .to_string_lossy()
+                    .as_ref()
+            )
+        );
+    }
+
+    #[test]
+    fn package_json_check_skips_unrelated_packages_until_expected_package() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let unrelated = dir.path().join("unrelated").join("package.json");
+        let expected = dir.path().join("expected").join("package.json");
+        std::fs::create_dir_all(unrelated.parent().expect("unrelated parent"))
+            .expect("create unrelated parent");
+        std::fs::create_dir_all(expected.parent().expect("expected parent"))
+            .expect("create expected parent");
+        std::fs::write(&unrelated, r#"{"name":"other-project","version":"9.9.9"}"#)
+            .expect("write unrelated package");
+        std::fs::write(
+            &expected,
+            format!(r#"{{"name":"{ROOT_NPM_PACKAGE_NAME}","version":"1.2.3"}}"#),
+        )
+        .expect("write expected package");
+
+        let check = package_json_check(
+            "npm_root_package",
+            "npm root package",
+            vec![unrelated, expected.clone()],
+            Some(ROOT_NPM_PACKAGE_NAME),
+            false,
+        );
+
+        assert_eq!(check.status, DoctorStatus::Pass);
+        assert_eq!(
+            check.details.get("path").map(String::as_str),
+            Some(expected.to_string_lossy().as_ref())
+        );
+        assert_eq!(check.details.get("name").map(String::as_str), Some(ROOT_NPM_PACKAGE_NAME));
+    }
+
+    #[test]
+    fn package_json_check_warns_on_unrelated_package_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let unrelated = dir.path().join("package.json");
+        std::fs::write(&unrelated, r#"{"name":"other-project","version":"9.9.9"}"#)
+            .expect("write unrelated package");
+
+        let check = package_json_check(
+            "npm_root_package",
+            "npm root package",
+            vec![unrelated],
+            Some(ROOT_NPM_PACKAGE_NAME),
+            false,
+        );
+
+        assert_eq!(check.status, DoctorStatus::Warn);
+        assert!(check.message.contains("expected claude-code-rust package metadata"));
+    }
+}

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -1,0 +1,788 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{doctor, redaction};
+use crate::{Cli, LogsArgs};
+use anyhow::Context as _;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs::{self, File, OpenOptions, create_dir_all, rename};
+use std::io::{IsTerminal as _, Write};
+use std::path::{Path, PathBuf};
+use time::{OffsetDateTime, macros::format_description};
+use zip::CompressionMethod;
+use zip::ZipWriter;
+use zip::write::SimpleFileOptions;
+
+const BUNDLE_SCHEMA: &str = "claude-rs-debug-bundle/v1";
+const BUNDLE_RUNTIME_LOG_LIMIT: usize = 5;
+
+pub fn run(
+    cli: &Cli,
+    args: &LogsArgs,
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+) -> anyhow::Result<i32> {
+    let paths = crate::logging::default_diagnostics_paths()?;
+
+    if args.path {
+        writeln!(stdout, "{}", paths.runtime_dir.display())?;
+        return Ok(0);
+    }
+
+    if args.latest {
+        return write_latest_path(stdout, stderr, &paths.runtime_dir, &paths.legacy_log_path);
+    }
+
+    if let Some(lines) = args.tail {
+        return write_tail(stdout, stderr, &paths.runtime_dir, &paths.legacy_log_path, lines);
+    }
+
+    if args.bundle {
+        return write_bundle(cli, args, stdout, stderr, &paths);
+    }
+
+    write_summary(stdout, &paths)
+}
+
+fn write_summary(
+    stdout: &mut impl Write,
+    paths: &crate::logging::DiagnosticsPaths,
+) -> anyhow::Result<i32> {
+    let runtime_logs = crate::logging::list_managed_runtime_logs_in(&paths.runtime_dir)?;
+    let latest = crate::logging::latest_log_path_in(&paths.runtime_dir, &paths.legacy_log_path)?;
+    let style = HumanStyle::detect();
+
+    writeln!(stdout, "{}", style.title("claude-rs logs"))?;
+    writeln!(
+        stdout,
+        "{} {}, {}",
+        style.detail_label("Summary:"),
+        style.count(runtime_logs.len(), "managed runtime logs"),
+        if latest.is_some() { "latest log found" } else { "no logs found" }
+    )?;
+    writeln!(stdout)?;
+
+    writeln!(stdout, "{}", style.heading("Locations"))?;
+    write_path_row(stdout, style, "Runtime logs", &paths.runtime_dir)?;
+    write_path_row(stdout, style, "Legacy log", &paths.legacy_log_path)?;
+    write_path_row(stdout, style, "Perf telemetry", &paths.perf_dir)?;
+    writeln!(stdout)?;
+
+    writeln!(stdout, "{}", style.heading("Latest"))?;
+    if let Some(path) = latest {
+        write_status_block(stdout, style, "FOUND", "Latest log", &path.display().to_string())?;
+    } else {
+        write_status_block(stdout, style, "MISS", "Latest log", "none found")?;
+    }
+    writeln!(stdout)?;
+
+    writeln!(stdout, "{}", style.heading("Commands"))?;
+    write_command_block(
+        stdout,
+        style,
+        "path",
+        "claude-rs logs --path",
+        "Print runtime log directory",
+    )?;
+    write_command_block(
+        stdout,
+        style,
+        "latest",
+        "claude-rs logs --latest",
+        "Print latest log path",
+    )?;
+    write_command_block(
+        stdout,
+        style,
+        "tail",
+        "claude-rs logs --tail 200",
+        "Print redacted latest log tail",
+    )?;
+    write_command_block(
+        stdout,
+        style,
+        "bundle",
+        "claude-rs logs --bundle --yes",
+        "Create redacted support ZIP",
+    )?;
+    Ok(0)
+}
+
+fn write_command_block(
+    stdout: &mut impl Write,
+    style: HumanStyle,
+    mode: &str,
+    command: &str,
+    purpose: &str,
+) -> std::io::Result<()> {
+    writeln!(stdout, "{}", style.command_block(mode, command, purpose))
+}
+
+fn write_status_block(
+    stdout: &mut impl Write,
+    style: HumanStyle,
+    status: &str,
+    label: &str,
+    value: &str,
+) -> std::io::Result<()> {
+    writeln!(stdout, "  {} {}", style.status(status), label)?;
+    writeln!(stdout, "      {value}")
+}
+
+fn write_path_row(
+    stdout: &mut impl Write,
+    style: HumanStyle,
+    label: &str,
+    path: &Path,
+) -> std::io::Result<()> {
+    write_status_block(stdout, style, path_status(path), label, &path.display().to_string())
+}
+
+fn path_status(path: &Path) -> &'static str {
+    if path.is_dir() {
+        "DIR"
+    } else if path.is_file() {
+        "FILE"
+    } else if path.exists() {
+        "EXISTS"
+    } else {
+        "MISS"
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct HumanStyle {
+    color: bool,
+}
+
+impl HumanStyle {
+    fn detect() -> Self {
+        Self { color: std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none() }
+    }
+
+    fn title(self, text: &str) -> String {
+        if self.color { format!("\x1b[1;36m{text}\x1b[0m") } else { text.to_owned() }
+    }
+
+    fn heading(self, text: &str) -> String {
+        if self.color { format!("\x1b[1;36m{text}\x1b[0m") } else { text.to_owned() }
+    }
+
+    fn detail_label(self, text: &str) -> String {
+        if self.color { format!("\x1b[2m{text}\x1b[0m") } else { text.to_owned() }
+    }
+
+    fn status(self, status: &str) -> String {
+        let label = format!("[{status}]");
+        if !self.color {
+            return label;
+        }
+
+        match status {
+            "DIR" | "FILE" | "FOUND" | "EXISTS" => format!("\x1b[32m{label}\x1b[0m"),
+            "MISS" => format!("\x1b[2m{label}\x1b[0m"),
+            _ => label,
+        }
+    }
+
+    fn count(self, count: usize, label: &str) -> String {
+        let text = format!("{count} {label}");
+        if self.color { format!("\x1b[32m{text}\x1b[0m") } else { text }
+    }
+
+    fn mode(self, mode: &str) -> String {
+        if self.color { format!("\x1b[2m{mode}\x1b[0m") } else { mode.to_owned() }
+    }
+
+    fn command_block(self, mode: &str, command: &str, purpose: &str) -> String {
+        format!("  {} {}\n      {}", self.mode(mode), command, purpose)
+    }
+}
+
+fn write_latest_path(
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+    runtime_dir: &Path,
+    legacy_log_path: &Path,
+) -> anyhow::Result<i32> {
+    let Some(path) = crate::logging::latest_log_path_in(runtime_dir, legacy_log_path)? else {
+        writeln!(stderr, "No claude-rs log file was found.")?;
+        return Ok(1);
+    };
+
+    writeln!(stdout, "{}", path.display())?;
+    Ok(0)
+}
+fn write_tail(
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+    runtime_dir: &Path,
+    legacy_log_path: &Path,
+    line_count: usize,
+) -> anyhow::Result<i32> {
+    let Some(path) = crate::logging::latest_log_path_in(runtime_dir, legacy_log_path)? else {
+        writeln!(stderr, "No claude-rs log file was found.")?;
+        return Ok(1);
+    };
+
+    let text =
+        read_text_lossy(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let lines = text.lines().collect::<Vec<_>>();
+    let start = lines.len().saturating_sub(line_count);
+    for line in &lines[start..] {
+        writeln!(stdout, "{}", redaction::redact_line(line))?;
+    }
+    Ok(0)
+}
+
+fn write_bundle(
+    cli: &Cli,
+    args: &LogsArgs,
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+    paths: &crate::logging::DiagnosticsPaths,
+) -> anyhow::Result<i32> {
+    let plan = BundlePlan::build(paths, args.output.clone())?;
+    if !args.yes && !confirm_bundle(stderr, &plan)? {
+        writeln!(stderr, "Bundle creation cancelled.")?;
+        return Ok(1);
+    }
+
+    let report = create_bundle(cli, paths, &plan)?;
+    writeln!(stdout, "Created debug bundle: {}", report.output_path.display())?;
+    Ok(0)
+}
+
+fn confirm_bundle(stderr: &mut impl Write, plan: &BundlePlan) -> anyhow::Result<bool> {
+    if !std::io::stdin().is_terminal() {
+        writeln!(stderr, "Refusing to create a debug bundle non-interactively without --yes.")?;
+        return Ok(false);
+    }
+
+    writeln!(stderr, "claude-rs will create a redacted debug bundle at:")?;
+    writeln!(stderr, "  {}", plan.output_path.display())?;
+    writeln!(stderr)?;
+    writeln!(stderr, "Included files:")?;
+    writeln!(stderr, "  manifest.json")?;
+    writeln!(stderr, "  doctor.json")?;
+    writeln!(stderr, "  paths.json")?;
+    for path in &plan.runtime_logs {
+        writeln!(stderr, "  {}", path.display())?;
+    }
+    if let Some(path) = &plan.legacy_log {
+        writeln!(stderr, "  {}", path.display())?;
+    }
+    writeln!(stderr)?;
+    write!(stderr, "Continue? [y/N] ")?;
+    stderr.flush()?;
+
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    Ok(matches!(input.trim(), "y" | "Y" | "yes" | "YES"))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BundlePlan {
+    output_path: PathBuf,
+    runtime_logs: Vec<PathBuf>,
+    legacy_log: Option<PathBuf>,
+}
+
+impl BundlePlan {
+    fn build(
+        paths: &crate::logging::DiagnosticsPaths,
+        output_path: Option<PathBuf>,
+    ) -> anyhow::Result<Self> {
+        let runtime_logs = select_bundle_runtime_logs(&paths.runtime_dir)?;
+        let legacy_log = paths.legacy_log_path.is_file().then(|| paths.legacy_log_path.clone());
+        Ok(Self {
+            output_path: output_path.unwrap_or_else(|| default_bundle_path(&paths.root_dir)),
+            runtime_logs,
+            legacy_log,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct BundleManifest {
+    schema: &'static str,
+    created_at: String,
+    version: &'static str,
+    platform: PlatformManifest,
+    output_path: String,
+    diagnostics_root: String,
+    runtime_log_dir: String,
+    legacy_log_path: String,
+    perf_log_dir: String,
+    included_files: Vec<String>,
+    skipped: Vec<&'static str>,
+    redaction: &'static str,
+    last_crash_metadata: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct PlatformManifest {
+    os: &'static str,
+    arch: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BundleReport {
+    output_path: PathBuf,
+}
+
+fn create_bundle(
+    cli: &Cli,
+    paths: &crate::logging::DiagnosticsPaths,
+    plan: &BundlePlan,
+) -> anyhow::Result<BundleReport> {
+    if plan.output_path.exists() {
+        anyhow::bail!("bundle output already exists: {}", plan.output_path.display());
+    }
+    if let Some(parent) = plan.output_path.parent() {
+        create_dir_all(parent).with_context(|| {
+            format!("failed to create bundle output directory {}", parent.display())
+        })?;
+    }
+
+    let temp_path = temporary_bundle_path(&plan.output_path);
+    let temp_file =
+        OpenOptions::new().write(true).create_new(true).open(&temp_path).with_context(|| {
+            format!("failed to create temporary bundle {}", temp_path.display())
+        })?;
+
+    let result = write_bundle_zip(cli, paths, plan, temp_file);
+    if let Err(error) = result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(error);
+    }
+
+    rename(&temp_path, &plan.output_path).with_context(|| {
+        format!(
+            "failed to move bundle from {} to {}",
+            temp_path.display(),
+            plan.output_path.display()
+        )
+    })?;
+    Ok(BundleReport { output_path: plan.output_path.clone() })
+}
+
+fn write_bundle_zip(
+    cli: &Cli,
+    paths: &crate::logging::DiagnosticsPaths,
+    plan: &BundlePlan,
+    file: File,
+) -> anyhow::Result<()> {
+    let mut zip = ZipWriter::new(file);
+    let mut included_files =
+        vec!["manifest.json".to_owned(), "doctor.json".to_owned(), "paths.json".to_owned()];
+
+    let mut runtime_log_entries = Vec::new();
+    for path in &plan.runtime_logs {
+        let entry_name = format!("logs/runtime/{}", safe_file_name(path));
+        let text =
+            read_text_lossy(path).with_context(|| format!("failed to read {}", path.display()))?;
+        runtime_log_entries.push((entry_name, redaction::redact_text(&text)));
+    }
+
+    let legacy_log_entry = if let Some(path) = &plan.legacy_log {
+        let text =
+            read_text_lossy(path).with_context(|| format!("failed to read {}", path.display()))?;
+        Some((format!("logs/legacy/{}", safe_file_name(path)), redaction::redact_text(&text)))
+    } else {
+        None
+    };
+
+    included_files.extend(runtime_log_entries.iter().map(|(name, _)| name.clone()));
+    if let Some((name, _)) = &legacy_log_entry {
+        included_files.push(name.clone());
+    }
+    included_files.push("logs/bridge-diagnostics.jsonl".to_owned());
+
+    let manifest = BundleManifest {
+        schema: BUNDLE_SCHEMA,
+        created_at: timestamp_now(),
+        version: env!("CARGO_PKG_VERSION"),
+        platform: PlatformManifest { os: std::env::consts::OS, arch: std::env::consts::ARCH },
+        output_path: plan.output_path.display().to_string(),
+        diagnostics_root: paths.root_dir.display().to_string(),
+        runtime_log_dir: paths.runtime_dir.display().to_string(),
+        legacy_log_path: paths.legacy_log_path.display().to_string(),
+        perf_log_dir: paths.perf_dir.display().to_string(),
+        included_files,
+        skipped: vec![
+            "full config files",
+            "Claude credentials",
+            "environment variable dumps",
+            "arbitrary project files",
+        ],
+        redaction: "credential-like keys and bearer/API token values are replaced with [redacted]",
+        last_crash_metadata: "not_available",
+    };
+
+    add_json_file(&mut zip, "manifest.json", &manifest)?;
+
+    let mut doctor_json = serde_json::to_value(doctor::build_report(cli))?;
+    redaction::redact_json_value(&mut doctor_json);
+    add_json_value_file(&mut zip, "doctor.json", &doctor_json)?;
+
+    add_json_file(
+        &mut zip,
+        "paths.json",
+        &serde_json::json!({
+            "diagnostics_root": paths.root_dir.display().to_string(),
+            "runtime_log_dir": paths.runtime_dir.display().to_string(),
+            "legacy_log_path": paths.legacy_log_path.display().to_string(),
+            "perf_log_dir": paths.perf_dir.display().to_string(),
+            "config_files": "excluded",
+        }),
+    )?;
+
+    for (entry_name, text) in &runtime_log_entries {
+        add_text_file(&mut zip, entry_name, text)?;
+    }
+    if let Some((entry_name, text)) = &legacy_log_entry {
+        add_text_file(&mut zip, entry_name, text)?;
+    }
+
+    let bridge_diagnostics = extract_bridge_diagnostics(
+        runtime_log_entries
+            .iter()
+            .map(|(_, text)| text.as_str())
+            .chain(legacy_log_entry.iter().map(|(_, text)| text.as_str())),
+    );
+    add_text_file(&mut zip, "logs/bridge-diagnostics.jsonl", &bridge_diagnostics)?;
+
+    zip.finish()?;
+    Ok(())
+}
+
+fn add_json_file<T: Serialize>(
+    zip: &mut ZipWriter<File>,
+    name: &str,
+    value: &T,
+) -> anyhow::Result<()> {
+    let text = serde_json::to_string_pretty(value)?;
+    add_text_file(zip, name, &format!("{text}\n"))
+}
+
+fn add_json_value_file(zip: &mut ZipWriter<File>, name: &str, value: &Value) -> anyhow::Result<()> {
+    let text = serde_json::to_string_pretty(value)?;
+    add_text_file(zip, name, &format!("{text}\n"))
+}
+
+fn add_text_file(zip: &mut ZipWriter<File>, name: &str, text: &str) -> anyhow::Result<()> {
+    let options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        .unix_permissions(0o644);
+    zip.start_file(name, options)?;
+    zip.write_all(text.as_bytes())?;
+    Ok(())
+}
+
+fn select_bundle_runtime_logs(runtime_dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let logs = crate::logging::list_managed_runtime_logs_in(runtime_dir)?;
+    let selected_bases = logs
+        .iter()
+        .filter(|log| !is_rotated_log(&log.path))
+        .take(BUNDLE_RUNTIME_LOG_LIMIT)
+        .map(|log| log.path.clone())
+        .collect::<Vec<_>>();
+
+    if selected_bases.is_empty() {
+        return Ok(logs.into_iter().take(BUNDLE_RUNTIME_LOG_LIMIT).map(|log| log.path).collect());
+    }
+
+    let selected_base_set = selected_bases.iter().collect::<BTreeSet<_>>();
+    let selected = logs
+        .into_iter()
+        .filter(|log| {
+            base_log_path(&log.path).as_ref().is_some_and(|base| selected_base_set.contains(base))
+        })
+        .map(|log| log.path)
+        .collect();
+    Ok(selected)
+}
+
+fn extract_bridge_diagnostics<'a>(logs: impl Iterator<Item = &'a str>) -> String {
+    let mut output = String::new();
+    for log in logs {
+        for line in log.lines() {
+            let Ok(value) = serde_json::from_str::<Value>(line) else {
+                continue;
+            };
+            let target = value.get("target").and_then(Value::as_str).unwrap_or_default();
+            let event_name = value.get("event_name").and_then(Value::as_str).unwrap_or_default();
+            if target.starts_with("bridge.") || event_name.contains("bridge_stderr") {
+                output.push_str(&redaction::redact_line(line));
+                output.push('\n');
+            }
+        }
+    }
+    output
+}
+
+fn read_text_lossy(path: &Path) -> std::io::Result<String> {
+    let bytes = fs::read(path)?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn default_bundle_path(root_dir: &Path) -> PathBuf {
+    root_dir.join(format!("claude-rs-debug-bundle-{}.zip", timestamp_for_file()))
+}
+
+fn temporary_bundle_path(output_path: &Path) -> PathBuf {
+    let file_name = output_path.file_name().and_then(|name| name.to_str()).unwrap_or("bundle.zip");
+    output_path.with_file_name(format!("{file_name}.{}.tmp", uuid::Uuid::new_v4().simple()))
+}
+
+fn timestamp_now() -> String {
+    OffsetDateTime::now_utc()
+        .format(format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]Z"))
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+fn timestamp_for_file() -> String {
+    OffsetDateTime::now_utc()
+        .format(format_description!("[year][month][day]T[hour][minute][second]Z"))
+        .unwrap_or_else(|_| "19700101T000000Z".to_owned())
+}
+
+fn safe_file_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map_or_else(|| "log-file".to_owned(), ToOwned::to_owned)
+}
+
+fn is_rotated_log(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.rsplit_once('.'))
+        .is_some_and(|(_, suffix)| suffix.chars().all(|ch| ch.is_ascii_digit()))
+}
+
+fn base_log_path(path: &Path) -> Option<PathBuf> {
+    let name = path.file_name()?.to_str()?;
+    let base_name = name
+        .rsplit_once('.')
+        .filter(|(_, suffix)| suffix.chars().all(|ch| ch.is_ascii_digit()))
+        .map_or(name, |(base, _)| base);
+    Some(path.with_file_name(base_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BundlePlan, create_bundle, extract_bridge_diagnostics, select_bundle_runtime_logs,
+        write_latest_path, write_summary, write_tail,
+    };
+    use crate::{Cli, LogsArgs};
+    use std::fs;
+    use std::io::Read as _;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+    use zip::ZipArchive;
+
+    #[test]
+    fn latest_path_falls_back_to_legacy_log() {
+        let dir = tempdir().expect("tempdir");
+        let runtime_dir = dir.path().join("runtime");
+        let legacy = dir.path().join("claude-rs.log");
+        fs::write(&legacy, "legacy").expect("write legacy");
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let code =
+            write_latest_path(&mut stdout, &mut stderr, &runtime_dir, &legacy).expect("latest");
+
+        assert_eq!(code, 0);
+        assert_eq!(stderr, b"");
+        assert!(String::from_utf8(stdout).expect("utf8").contains("claude-rs.log"));
+    }
+
+    #[test]
+    fn summary_output_uses_sections_and_status_rows() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().join("logs");
+        let runtime_dir = root.join("runtime");
+        let perf_dir = root.join("perf");
+        fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        fs::create_dir_all(&perf_dir).expect("perf dir");
+        fs::write(runtime_dir.join("claude-rs-20260614T075924Z-p1-rabc.log"), "runtime")
+            .expect("runtime log");
+        let paths = crate::logging::DiagnosticsPaths {
+            root_dir: root.clone(),
+            runtime_dir,
+            legacy_log_path: root.join("claude-rs.log"),
+            perf_dir,
+        };
+        let mut stdout = Vec::new();
+
+        let code = write_summary(&mut stdout, &paths).expect("summary");
+
+        assert_eq!(code, 0);
+        let output = String::from_utf8(stdout).expect("utf8");
+        assert!(output.contains("claude-rs logs"));
+        assert!(output.contains("Summary: 1 managed runtime logs, latest log found"));
+        assert!(output.contains("Locations"));
+        assert!(output.contains("[DIR]"));
+        assert!(output.contains("[MISS] Legacy log"));
+        assert!(output.contains("Latest"));
+        assert!(output.contains("[FOUND] Latest log"));
+        assert!(output.contains("Commands"));
+        assert!(output.contains("Print redacted latest log tail"));
+    }
+
+    #[test]
+    fn latest_path_reports_missing_logs() {
+        let dir = tempdir().expect("tempdir");
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let code = write_latest_path(
+            &mut stdout,
+            &mut stderr,
+            &dir.path().join("runtime"),
+            &dir.path().join("claude-rs.log"),
+        )
+        .expect("latest");
+
+        assert_eq!(code, 1);
+        assert!(stdout.is_empty());
+        assert!(String::from_utf8(stderr).expect("utf8").contains("No claude-rs log"));
+    }
+
+    #[test]
+    fn tail_redacts_latest_log_lines() {
+        let dir = tempdir().expect("tempdir");
+        let runtime_dir = dir.path().join("runtime");
+        fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let log = runtime_dir.join("claude-rs-20260614T075924Z-p1-rabc.log");
+        fs::write(&log, "first\nANTHROPIC_API_KEY=sk-ant-secret\nlast\n").expect("write log");
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let code = write_tail(
+            &mut stdout,
+            &mut stderr,
+            &runtime_dir,
+            &dir.path().join("claude-rs.log"),
+            2,
+        )
+        .expect("tail");
+
+        assert_eq!(code, 0);
+        assert!(stderr.is_empty());
+        let output = String::from_utf8(stdout).expect("utf8");
+        assert!(!output.contains("sk-ant-secret"));
+        assert!(output.contains("ANTHROPIC_API_KEY=[redacted]"));
+        assert!(output.contains("last"));
+    }
+
+    #[test]
+    fn bundle_runtime_selection_includes_rotated_siblings() {
+        let dir = tempdir().expect("tempdir");
+        let runtime_dir = dir.path();
+        let base = runtime_dir.join("claude-rs-20260614T075924Z-p1-rabc.log");
+        let rotated = runtime_dir.join("claude-rs-20260614T075924Z-p1-rabc.log.1");
+        fs::write(&base, "base").expect("write base");
+        fs::write(&rotated, "rotated").expect("write rotated");
+        fs::write(runtime_dir.join("other.log"), "ignored").expect("write ignored");
+
+        let selected = select_bundle_runtime_logs(runtime_dir).expect("select");
+
+        assert!(selected.contains(&base));
+        assert!(selected.contains(&rotated));
+        assert_eq!(selected.len(), 2);
+    }
+
+    #[test]
+    fn bridge_diagnostics_extracts_bridge_targets_only() {
+        let logs = r#"{"target":"app.session","event_name":"x","message":"skip"}"#.to_owned()
+            + "\n"
+            + r#"{"target":"bridge.sdk","event_name":"sdk_stderr_line","fields":{"Authorization":"Bearer secret"}}"#;
+
+        let extracted = extract_bridge_diagnostics([logs.as_str()].into_iter());
+
+        assert!(extracted.contains("bridge.sdk"));
+        assert!(!extracted.contains("app.session"));
+        assert!(!extracted.contains("secret"));
+        assert!(extracted.contains("[redacted]"));
+    }
+
+    #[test]
+    fn bundle_contains_manifest_doctor_paths_and_redacted_logs() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().join("logs");
+        let runtime_dir = root.join("runtime");
+        let perf_dir = root.join("perf");
+        fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let runtime_log = runtime_dir.join("claude-rs-20260614T075924Z-p1-rabc.log");
+        fs::write(
+            &runtime_log,
+            r#"{"target":"bridge.sdk","event_name":"sdk_stderr_line","fields":{"Authorization":"Bearer secret"}}"#,
+        )
+        .expect("write runtime log");
+        let legacy_log_path = root.join("claude-rs.log");
+        fs::write(&legacy_log_path, "accessToken=secret-token").expect("write legacy log");
+        let output_path = dir.path().join("bundle.zip");
+        let paths = crate::logging::DiagnosticsPaths {
+            root_dir: root,
+            runtime_dir,
+            legacy_log_path,
+            perf_dir,
+        };
+        let plan = BundlePlan {
+            output_path: output_path.clone(),
+            runtime_logs: vec![runtime_log],
+            legacy_log: Some(paths.legacy_log_path.clone()),
+        };
+
+        create_bundle(&test_cli(), &paths, &plan).expect("bundle");
+
+        let file = fs::File::open(output_path).expect("open bundle");
+        let mut archive = ZipArchive::new(file).expect("zip archive");
+        let names = (0..archive.len())
+            .map(|index| archive.by_index(index).expect("entry").name().to_owned())
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"manifest.json".to_owned()));
+        assert!(names.contains(&"doctor.json".to_owned()));
+        assert!(names.contains(&"paths.json".to_owned()));
+        assert!(names.contains(&"logs/bridge-diagnostics.jsonl".to_owned()));
+
+        let mut bridge = String::new();
+        archive
+            .by_name("logs/bridge-diagnostics.jsonl")
+            .expect("bridge entry")
+            .read_to_string(&mut bridge)
+            .expect("read bridge");
+        assert!(!bridge.contains("secret"));
+        assert!(bridge.contains("[redacted]"));
+    }
+
+    fn test_cli() -> Cli {
+        Cli {
+            command: Some(crate::Command::Logs(LogsArgs {
+                path: false,
+                latest: false,
+                tail: None,
+                bundle: true,
+                output: Some(PathBuf::from("bundle.zip")),
+                yes: true,
+            })),
+            no_update_check: false,
+            dir: None,
+            bridge_script: None,
+            enable_logs: false,
+            diagnostics_preset: None,
+            log_file: None,
+            log_filter: None,
+            log_append: false,
+            enable_perf: false,
+            perf_log: None,
+            perf_append: false,
+        }
+    }
+}

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -268,6 +268,9 @@ fn confirm_bundle(stderr: &mut impl Write, plan: &BundlePlan) -> anyhow::Result<
     writeln!(stderr, "  manifest.json")?;
     writeln!(stderr, "  doctor.json")?;
     writeln!(stderr, "  paths.json")?;
+    if crate::failure::read_last_crash_metadata_from_path(&plan.last_crash_metadata).is_some() {
+        writeln!(stderr, "  {}", crate::failure::LAST_CRASH_FILE_NAME)?;
+    }
     for path in &plan.runtime_logs {
         writeln!(stderr, "  {}", path.display())?;
     }
@@ -288,6 +291,7 @@ struct BundlePlan {
     output_path: PathBuf,
     runtime_logs: Vec<PathBuf>,
     legacy_log: Option<PathBuf>,
+    last_crash_metadata: PathBuf,
 }
 
 impl BundlePlan {
@@ -301,6 +305,7 @@ impl BundlePlan {
             output_path: output_path.unwrap_or_else(|| default_bundle_path(&paths.root_dir)),
             runtime_logs,
             legacy_log,
+            last_crash_metadata: crate::failure::last_crash_metadata_path(paths),
         })
     }
 }
@@ -399,6 +404,12 @@ fn write_bundle_zip(
     if let Some((name, _)) = &legacy_log_entry {
         included_files.push(name.clone());
     }
+    let last_crash_entry =
+        crate::failure::read_last_crash_metadata_from_path(&plan.last_crash_metadata)
+            .map(|text| (crate::failure::LAST_CRASH_FILE_NAME.to_owned(), text));
+    if let Some((name, _)) = &last_crash_entry {
+        included_files.push(name.clone());
+    }
     included_files.push("logs/bridge-diagnostics.jsonl".to_owned());
 
     let manifest = BundleManifest {
@@ -419,7 +430,7 @@ fn write_bundle_zip(
             "arbitrary project files",
         ],
         redaction: "credential-like keys and bearer/API token values are replaced with [redacted]",
-        last_crash_metadata: "not_available",
+        last_crash_metadata: if last_crash_entry.is_some() { "included" } else { "not_available" },
     };
 
     add_json_file(&mut zip, "manifest.json", &manifest)?;
@@ -444,6 +455,9 @@ fn write_bundle_zip(
         add_text_file(&mut zip, entry_name, text)?;
     }
     if let Some((entry_name, text)) = &legacy_log_entry {
+        add_text_file(&mut zip, entry_name, text)?;
+    }
+    if let Some((entry_name, text)) = &last_crash_entry {
         add_text_file(&mut zip, entry_name, text)?;
     }
 
@@ -738,6 +752,7 @@ mod tests {
             output_path: output_path.clone(),
             runtime_logs: vec![runtime_log],
             legacy_log: Some(paths.legacy_log_path.clone()),
+            last_crash_metadata: paths.root_dir.join(crate::failure::LAST_CRASH_FILE_NAME),
         };
 
         create_bundle(&test_cli(), &paths, &plan).expect("bundle");
@@ -760,6 +775,48 @@ mod tests {
             .expect("read bridge");
         assert!(!bridge.contains("secret"));
         assert!(bridge.contains("[redacted]"));
+    }
+
+    #[test]
+    fn bundle_includes_redacted_last_crash_metadata_when_available() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().join("logs");
+        let runtime_dir = root.join("runtime");
+        let perf_dir = root.join("perf");
+        fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        fs::create_dir_all(&root).expect("root dir");
+        let crash_path = root.join(crate::failure::LAST_CRASH_FILE_NAME);
+        fs::write(
+            &crash_path,
+            r#"{"schema":"claude-rs-crash/v1","message":"ANTHROPIC_API_KEY=sk-ant-secret"}"#,
+        )
+        .expect("write crash metadata");
+        let output_path = dir.path().join("bundle.zip");
+        let paths = crate::logging::DiagnosticsPaths {
+            root_dir: root,
+            runtime_dir,
+            legacy_log_path: dir.path().join("claude-rs.log"),
+            perf_dir,
+        };
+        let plan = BundlePlan {
+            output_path: output_path.clone(),
+            runtime_logs: Vec::new(),
+            legacy_log: None,
+            last_crash_metadata: crash_path,
+        };
+
+        create_bundle(&test_cli(), &paths, &plan).expect("bundle");
+
+        let file = fs::File::open(output_path).expect("open bundle");
+        let mut archive = ZipArchive::new(file).expect("zip archive");
+        let mut crash = String::new();
+        archive
+            .by_name(crate::failure::LAST_CRASH_FILE_NAME)
+            .expect("crash metadata entry")
+            .read_to_string(&mut crash)
+            .expect("read crash metadata");
+        assert!(crash.contains("[redacted]"));
+        assert!(!crash.contains("sk-ant-secret"));
     }
 
     fn test_cli() -> Cli {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,87 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+mod doctor;
+pub mod redaction;
+
+use crate::{Cli, Command};
+use std::io::Write;
+
+pub fn run_support_command(
+    cli: &Cli,
+    stdout: &mut impl Write,
+    _stderr: &mut impl Write,
+) -> anyhow::Result<Option<i32>> {
+    match &cli.command {
+        Some(Command::Doctor(args)) => doctor::run(cli, args, stdout).map(Some),
+        Some(Command::Resume { .. }) | None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_support_command;
+    use crate::{Cli, Command, DoctorArgs};
+    use std::path::PathBuf;
+
+    #[test]
+    fn no_subcommand_uses_interactive_path() {
+        let cli = test_cli(None);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let result = run_support_command(&cli, &mut stdout, &mut stderr).expect("dispatch");
+
+        assert_eq!(result, None);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn resume_uses_interactive_path() {
+        let cli = test_cli(Some(Command::Resume { session_id: Some("abc-123".to_owned()) }));
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let result = run_support_command(&cli, &mut stdout, &mut stderr).expect("dispatch");
+
+        assert_eq!(result, None);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn doctor_is_a_support_command() {
+        let cli = test_cli(Some(Command::Doctor(DoctorArgs { json: true, strict: false })));
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let result = run_support_command(&cli, &mut stdout, &mut stderr).expect("dispatch");
+
+        assert_eq!(result, Some(0));
+        assert!(!stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
+
+    fn test_cli(command: Option<Command>) -> Cli {
+        Cli {
+            command,
+            no_update_check: false,
+            dir: None,
+            bridge_script: None,
+            enable_logs: false,
+            diagnostics_preset: None,
+            log_file: None,
+            log_filter: None,
+            log_append: false,
+            enable_perf: false,
+            perf_log: None,
+            perf_append: false,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn path(path: &str) -> PathBuf {
+        PathBuf::from(path)
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod doctor;
+mod logs;
 pub mod redaction;
 
 use crate::{Cli, Command};
@@ -10,10 +11,11 @@ use std::io::Write;
 pub fn run_support_command(
     cli: &Cli,
     stdout: &mut impl Write,
-    _stderr: &mut impl Write,
+    stderr: &mut impl Write,
 ) -> anyhow::Result<Option<i32>> {
     match &cli.command {
         Some(Command::Doctor(args)) => doctor::run(cli, args, stdout).map(Some),
+        Some(Command::Logs(args)) => logs::run(cli, args, stdout, stderr).map(Some),
         Some(Command::Resume { .. }) | None => Ok(None),
     }
 }
@@ -21,7 +23,7 @@ pub fn run_support_command(
 #[cfg(test)]
 mod tests {
     use super::run_support_command;
-    use crate::{Cli, Command, DoctorArgs};
+    use crate::{Cli, Command, DoctorArgs, LogsArgs};
     use std::path::PathBuf;
 
     #[test]
@@ -53,6 +55,26 @@ mod tests {
     #[test]
     fn doctor_is_a_support_command() {
         let cli = test_cli(Some(Command::Doctor(DoctorArgs { json: true, strict: false })));
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let result = run_support_command(&cli, &mut stdout, &mut stderr).expect("dispatch");
+
+        assert_eq!(result, Some(0));
+        assert!(!stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn logs_is_a_support_command() {
+        let cli = test_cli(Some(Command::Logs(LogsArgs {
+            path: true,
+            latest: false,
+            tail: None,
+            bundle: false,
+            output: None,
+            yes: false,
+        })));
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Simon Peter Rothgang
 // SPDX-License-Identifier: Apache-2.0
 
+mod config;
 mod doctor;
 mod logs;
 pub mod redaction;
@@ -16,6 +17,7 @@ pub fn run_support_command(
     match &cli.command {
         Some(Command::Doctor(args)) => doctor::run(cli, args, stdout).map(Some),
         Some(Command::Logs(args)) => logs::run(cli, args, stdout, stderr).map(Some),
+        Some(Command::Config(args)) => config::run(cli, args, stdout, stderr).map(Some),
         Some(Command::Resume { .. }) | None => Ok(None),
     }
 }
@@ -23,8 +25,7 @@ pub fn run_support_command(
 #[cfg(test)]
 mod tests {
     use super::run_support_command;
-    use crate::{Cli, Command, DoctorArgs, LogsArgs};
-    use std::path::PathBuf;
+    use crate::{Cli, Command, ConfigArgs, ConfigCommand, ConfigPathArgs, DoctorArgs, LogsArgs};
 
     #[test]
     fn no_subcommand_uses_interactive_path() {
@@ -85,6 +86,21 @@ mod tests {
         assert!(stderr.is_empty());
     }
 
+    #[test]
+    fn config_is_a_support_command() {
+        let cli = test_cli(Some(Command::Config(ConfigArgs {
+            command: Some(ConfigCommand::Path(ConfigPathArgs { json: false, which: None })),
+        })));
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let result = run_support_command(&cli, &mut stdout, &mut stderr).expect("dispatch");
+
+        assert_eq!(result, Some(0));
+        assert!(!stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
+
     fn test_cli(command: Option<Command>) -> Cli {
         Cli {
             command,
@@ -100,10 +116,5 @@ mod tests {
             perf_log: None,
             perf_append: false,
         }
-    }
-
-    #[allow(dead_code)]
-    fn path(path: &str) -> PathBuf {
-        PathBuf::from(path)
     }
 }

--- a/src/cli/redaction.rs
+++ b/src/cli/redaction.rs
@@ -1,0 +1,81 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::Value;
+
+const REDACTED: &str = "[redacted]";
+
+pub fn redact_json_value(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object {
+                if is_secret_key(key) {
+                    *value = Value::String(REDACTED.to_owned());
+                } else {
+                    redact_json_value(value);
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                redact_json_value(value);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+pub fn redact_env_value(name: &str, value: Option<&str>) -> Option<String> {
+    value.map(|value| if is_secret_key(name) { REDACTED.to_owned() } else { value.to_owned() })
+}
+
+fn is_secret_key(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase().replace('-', "_");
+    normalized.contains("token")
+        || normalized.contains("secret")
+        || normalized.contains("api_key")
+        || normalized.contains("apikey")
+        || normalized.contains("authorization")
+        || normalized.contains("password")
+        || normalized.contains("credential")
+        || normalized == "accesskey"
+        || normalized == "refreshkey"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{redact_env_value, redact_json_value};
+
+    #[test]
+    fn redacts_secret_json_keys_recursively() {
+        let mut value = serde_json::json!({
+            "model": "sonnet",
+            "env": {
+                "ANTHROPIC_API_KEY": "sk-ant-secret",
+                "KEEP": "visible"
+            },
+            "claudeAiOauth": {
+                "accessToken": "access",
+                "refreshToken": "refresh"
+            }
+        });
+
+        redact_json_value(&mut value);
+
+        assert_eq!(value["model"], "sonnet");
+        assert_eq!(value["env"]["KEEP"], "visible");
+        assert_eq!(value["env"]["ANTHROPIC_API_KEY"], "[redacted]");
+        assert_eq!(value["claudeAiOauth"]["accessToken"], "[redacted]");
+        assert_eq!(value["claudeAiOauth"]["refreshToken"], "[redacted]");
+    }
+
+    #[test]
+    fn redacts_secret_env_values_only() {
+        assert_eq!(
+            redact_env_value("ANTHROPIC_API_KEY", Some("sk-ant-secret")).as_deref(),
+            Some("[redacted]")
+        );
+        assert_eq!(redact_env_value("PATH", Some("bin")).as_deref(), Some("bin"));
+        assert_eq!(redact_env_value("PATH", None), None);
+    }
+}

--- a/src/cli/redaction.rs
+++ b/src/cli/redaction.rs
@@ -4,6 +4,17 @@
 use serde_json::Value;
 
 const REDACTED: &str = "[redacted]";
+const SECRET_ASSIGNMENT_KEYS: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "api_key",
+    "apikey",
+    "accessToken",
+    "refreshToken",
+    "authorization",
+    "password",
+    "secret",
+    "credential",
+];
 
 pub fn redact_json_value(value: &mut Value) {
     match value {
@@ -29,7 +40,26 @@ pub fn redact_env_value(name: &str, value: Option<&str>) -> Option<String> {
     value.map(|value| if is_secret_key(name) { REDACTED.to_owned() } else { value.to_owned() })
 }
 
-fn is_secret_key(key: &str) -> bool {
+pub fn redact_text(input: &str) -> String {
+    input.lines().map(redact_line).collect::<Vec<_>>().join("\n")
+}
+
+pub fn redact_line(line: &str) -> String {
+    let mut redacted = if let Ok(mut value) = serde_json::from_str::<Value>(line) {
+        redact_json_value(&mut value);
+        serde_json::to_string(&value).unwrap_or_else(|_| line.to_owned())
+    } else {
+        line.to_owned()
+    };
+
+    redacted = redact_bearer_tokens(&redacted);
+    for key in SECRET_ASSIGNMENT_KEYS {
+        redacted = redact_assignment_values(&redacted, key);
+    }
+    redacted
+}
+
+pub fn is_secret_key(key: &str) -> bool {
     let normalized = key.to_ascii_lowercase().replace('-', "_");
     normalized.contains("token")
         || normalized.contains("secret")
@@ -42,9 +72,96 @@ fn is_secret_key(key: &str) -> bool {
         || normalized == "refreshkey"
 }
 
+fn redact_bearer_tokens(input: &str) -> String {
+    let mut output = input.to_owned();
+    let mut search_start = 0;
+    while let Some(relative_start) = find_ascii_case_insensitive(&output[search_start..], "Bearer ")
+    {
+        let start = search_start + relative_start;
+        let value_start = start + "Bearer ".len();
+        let value_end = output[value_start..]
+            .find(is_value_delimiter)
+            .map_or(output.len(), |offset| value_start + offset);
+        if value_end <= value_start {
+            break;
+        }
+        output.replace_range(value_start..value_end, REDACTED);
+        search_start = value_start + REDACTED.len();
+    }
+    output
+}
+
+fn redact_assignment_values(input: &str, key: &str) -> String {
+    let mut output = input.to_owned();
+    let mut search_start = 0;
+
+    while let Some(relative_key_start) = find_ascii_case_insensitive(&output[search_start..], key) {
+        let key_start = search_start + relative_key_start;
+        let Some((value_start, quote)) = assignment_value_start(&output, key_start + key.len())
+        else {
+            search_start = key_start + key.len();
+            continue;
+        };
+        let value_end = assignment_value_end(&output, value_start, quote);
+        if value_end <= value_start {
+            search_start = value_start;
+            continue;
+        }
+        output.replace_range(value_start..value_end, REDACTED);
+        search_start = value_start + REDACTED.len();
+    }
+
+    output
+}
+
+fn assignment_value_start(input: &str, offset: usize) -> Option<(usize, Option<u8>)> {
+    let bytes = input.as_bytes();
+    let mut index = offset;
+    if bytes.get(index).is_some_and(|byte| *byte == b'"' || *byte == b'\'') {
+        index += 1;
+    }
+    while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+        index += 1;
+    }
+    if !bytes.get(index).is_some_and(|byte| *byte == b':' || *byte == b'=') {
+        return None;
+    }
+    index += 1;
+    while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+        index += 1;
+    }
+    let quote = bytes.get(index).copied().filter(|byte| *byte == b'"' || *byte == b'\'');
+    if quote.is_some() {
+        index += 1;
+    }
+    Some((index, quote))
+}
+
+fn assignment_value_end(input: &str, start: usize, quote: Option<u8>) -> usize {
+    let bytes = input.as_bytes();
+    let mut index = start;
+    while let Some(byte) = bytes.get(index) {
+        if quote.is_some_and(|quote| *byte == quote)
+            || quote.is_none() && is_value_delimiter(char::from(*byte))
+        {
+            break;
+        }
+        index += 1;
+    }
+    index
+}
+
+fn find_ascii_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
+    haystack.to_ascii_lowercase().find(&needle.to_ascii_lowercase())
+}
+
+fn is_value_delimiter(ch: char) -> bool {
+    ch.is_ascii_whitespace() || matches!(ch, '"' | '\'' | ',' | ';' | '&' | '}')
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{redact_env_value, redact_json_value};
+    use super::{redact_env_value, redact_json_value, redact_line, redact_text};
 
     #[test]
     fn redacts_secret_json_keys_recursively() {
@@ -77,5 +194,31 @@ mod tests {
         );
         assert_eq!(redact_env_value("PATH", Some("bin")).as_deref(), Some("bin"));
         assert_eq!(redact_env_value("PATH", None), None);
+    }
+
+    #[test]
+    fn redacts_json_log_lines() {
+        let line =
+            r#"{"message":"x","fields":{"Authorization":"Bearer secret-token","keep":"ok"}}"#;
+
+        let redacted = redact_line(line);
+
+        assert!(redacted.contains(r#""keep":"ok""#));
+        assert!(!redacted.contains("secret-token"));
+        assert!(redacted.contains("[redacted]"));
+    }
+
+    #[test]
+    fn redacts_common_text_credentials() {
+        let text = "ANTHROPIC_API_KEY=sk-ant-secret\nAuthorization: Bearer oauth-secret\nraw Bearer raw-secret";
+
+        let redacted = redact_text(text);
+
+        assert!(!redacted.contains("sk-ant-secret"));
+        assert!(!redacted.contains("oauth-secret"));
+        assert!(!redacted.contains("raw-secret"));
+        assert!(redacted.contains("ANTHROPIC_API_KEY=[redacted]"));
+        assert!(redacted.contains("Authorization: [redacted]"));
+        assert!(redacted.contains("Bearer [redacted]"));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,16 @@
 pub enum AppError {
     #[error("Node.js runtime not found")]
     NodeNotFound,
+    #[error("Agent bridge process failed to start")]
+    BridgeSpawnFailed,
+    #[error("Agent bridge initialization failed")]
+    BridgeInitializationFailed,
+    #[error("Agent bridge stdout closed")]
+    BridgeStdoutClosed,
+    #[error("Agent SDK bridge failed")]
+    BridgeSdkFailure,
+    #[error("Agent bridge initialization timed out")]
+    BridgeTimeout,
     #[error("Agent bridge process failed")]
     AdapterCrashed,
     #[error("Agent bridge connection failed")]
@@ -26,8 +36,12 @@ impl AppError {
     pub fn exit_code(&self) -> i32 {
         match self {
             Self::NodeNotFound => Self::NODE_NOT_FOUND_EXIT_CODE,
-            Self::AdapterCrashed => Self::ADAPTER_CRASHED_EXIT_CODE,
-            Self::ConnectionFailed => Self::CONNECTION_FAILED_EXIT_CODE,
+            Self::BridgeSpawnFailed | Self::AdapterCrashed => Self::ADAPTER_CRASHED_EXIT_CODE,
+            Self::BridgeInitializationFailed
+            | Self::BridgeStdoutClosed
+            | Self::BridgeSdkFailure
+            | Self::BridgeTimeout
+            | Self::ConnectionFailed => Self::CONNECTION_FAILED_EXIT_CODE,
             Self::SessionNotFound => Self::SESSION_NOT_FOUND_EXIT_CODE,
             Self::AuthRequired => Self::AUTH_REQUIRED_EXIT_CODE,
         }
@@ -39,6 +53,21 @@ impl AppError {
             Self::NodeNotFound => {
                 "Node.js runtime not found. Install Node.js and ensure `node` is on PATH."
             }
+            Self::BridgeSpawnFailed => {
+                "Agent bridge process failed to start. Run `claude-rs doctor --strict` to inspect the runtime and bridge script."
+            }
+            Self::BridgeInitializationFailed => {
+                "Agent bridge failed during initialization. Run `claude-rs logs --bundle --yes` to collect diagnostics."
+            }
+            Self::BridgeStdoutClosed => {
+                "Agent bridge exited before completing the protocol. Run `claude-rs logs --latest` for details."
+            }
+            Self::BridgeSdkFailure => {
+                "Agent SDK bridge reported a failure. Run `claude-rs logs --bundle --yes` to collect diagnostics."
+            }
+            Self::BridgeTimeout => {
+                "Agent bridge did not initialize before the timeout. Run `claude-rs doctor --strict` and retry with bridge diagnostics enabled."
+            }
             Self::AdapterCrashed => "Agent bridge process crashed or failed to start.",
             Self::ConnectionFailed => {
                 "Failed to establish or maintain the Agent SDK bridge connection."
@@ -47,6 +76,50 @@ impl AppError {
             Self::AuthRequired => {
                 "Authentication required. Type /login to authenticate, or run `claude auth login` in a terminal."
             }
+        }
+    }
+
+    #[must_use]
+    pub fn report_title(&self) -> &'static str {
+        match self {
+            Self::NodeNotFound => "Environment problem",
+            Self::BridgeSpawnFailed | Self::AdapterCrashed => "Bridge spawn failure",
+            Self::BridgeInitializationFailed => "Bridge initialization failure",
+            Self::BridgeStdoutClosed => "Bridge process exited",
+            Self::BridgeSdkFailure | Self::ConnectionFailed => "Bridge communication failure",
+            Self::BridgeTimeout => "Bridge initialization timeout",
+            Self::SessionNotFound => "Session not found",
+            Self::AuthRequired => "Authentication required",
+        }
+    }
+
+    #[must_use]
+    pub fn category_tag(&self) -> &'static str {
+        match self {
+            Self::NodeNotFound => "environment",
+            Self::BridgeSpawnFailed | Self::AdapterCrashed => "bridge_spawn",
+            Self::BridgeInitializationFailed => "bridge_initialization",
+            Self::BridgeStdoutClosed => "bridge_stdout_closed",
+            Self::BridgeSdkFailure | Self::ConnectionFailed => "bridge_sdk_failure",
+            Self::BridgeTimeout => "bridge_timeout",
+            Self::SessionNotFound => "session",
+            Self::AuthRequired => "auth",
+        }
+    }
+
+    #[must_use]
+    pub fn recommended_command(&self) -> &'static str {
+        match self {
+            Self::NodeNotFound
+            | Self::BridgeSpawnFailed
+            | Self::AdapterCrashed
+            | Self::BridgeTimeout => "claude-rs doctor --strict",
+            Self::BridgeInitializationFailed
+            | Self::BridgeStdoutClosed
+            | Self::BridgeSdkFailure
+            | Self::ConnectionFailed => "claude-rs logs --bundle --yes",
+            Self::SessionNotFound => "claude-rs resume",
+            Self::AuthRequired => "claude auth login",
         }
     }
 }

--- a/src/failure.rs
+++ b/src/failure.rs
@@ -1,0 +1,295 @@
+// Copyright 2025 Simon Peter Rothgang
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli::redaction;
+use crate::error::AppError;
+use serde::Serialize;
+use std::cell::Cell;
+use std::panic::{self, AssertUnwindSafe, PanicHookInfo};
+use std::path::{Path, PathBuf};
+use std::thread;
+use time::{OffsetDateTime, macros::format_description};
+
+pub const LAST_CRASH_FILE_NAME: &str = "last-crash.json";
+
+thread_local! {
+    static EXPECTED_PANIC_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CrashMetadata {
+    schema: &'static str,
+    kind: &'static str,
+    created_at: String,
+    version: &'static str,
+    platform: PlatformMetadata,
+    message: String,
+    location: Option<String>,
+    latest_log_path: Option<String>,
+    diagnostics_bundle_command: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct PlatformMetadata {
+    os: &'static str,
+    arch: &'static str,
+}
+
+pub fn install_panic_hook() {
+    std::panic::set_hook(Box::new(|panic_info| {
+        if !should_report_panic() {
+            return;
+        }
+
+        let metadata = CrashMetadata::from_panic_info(panic_info);
+        if let Err(error) = write_last_crash_metadata(&metadata) {
+            tracing::warn!(
+                target: crate::logging::targets::APP_LIFECYCLE,
+                event_name = "last_crash_metadata_write_failed",
+                message = "failed to write last crash metadata",
+                outcome = "failure",
+                error_message = %error,
+            );
+        }
+
+        let mut stderr = std::io::stderr().lock();
+        let _ = write_panic_report(&mut stderr, &metadata);
+    }));
+}
+
+pub(crate) fn catch_expected_panic<F, R>(operation: F) -> thread::Result<R>
+where
+    F: FnOnce() -> R,
+{
+    let _guard = ExpectedPanicGuard::enter();
+    panic::catch_unwind(AssertUnwindSafe(operation))
+}
+
+pub fn write_app_error_report(
+    writer: &mut impl std::io::Write,
+    error: &AppError,
+) -> std::io::Result<()> {
+    write_app_error_report_with_detail(writer, error, None)
+}
+
+pub fn write_app_error_report_with_detail(
+    writer: &mut impl std::io::Write,
+    error: &AppError,
+    detail: Option<&str>,
+) -> std::io::Result<()> {
+    let latest_log = latest_log_path_display();
+    writeln!(writer, "{}", error.report_title())?;
+    writeln!(writer, "  category: {}", error.category_tag())?;
+    writeln!(writer, "  message: {}", error.user_message())?;
+    if let Some(detail) = detail {
+        writeln!(writer, "  detail: {}", redaction::redact_line(detail))?;
+    }
+    writeln!(writer, "  exit_code: {}", error.exit_code())?;
+    writeln!(writer, "  version: {}", env!("CARGO_PKG_VERSION"))?;
+    writeln!(writer, "  platform: {}/{}", std::env::consts::OS, std::env::consts::ARCH)?;
+    match latest_log {
+        Some(path) => writeln!(writer, "  latest_log: {path}")?,
+        None => writeln!(writer, "  latest_log: not found")?,
+    }
+    writeln!(writer, "  next_step: {}", error.recommended_command())?;
+    writeln!(
+        writer,
+        "  issue_guidance: paste this report with `claude-rs logs --bundle --yes` output if the problem persists"
+    )
+}
+
+pub fn last_crash_metadata_path(paths: &crate::logging::DiagnosticsPaths) -> PathBuf {
+    paths.root_dir.join(LAST_CRASH_FILE_NAME)
+}
+
+pub fn read_last_crash_metadata(paths: &crate::logging::DiagnosticsPaths) -> Option<String> {
+    read_last_crash_metadata_from_path(&last_crash_metadata_path(paths))
+}
+
+pub fn read_last_crash_metadata_from_path(path: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(path).ok()?;
+    Some(redaction::redact_text(&text))
+}
+
+fn write_panic_report(
+    writer: &mut impl std::io::Write,
+    metadata: &CrashMetadata,
+) -> std::io::Result<()> {
+    writeln!(writer)?;
+    writeln!(writer, "claude-rs crashed unexpectedly")?;
+    writeln!(writer, "  category: crash")?;
+    writeln!(writer, "  message: {}", metadata.message)?;
+    if let Some(location) = &metadata.location {
+        writeln!(writer, "  location: {location}")?;
+    }
+    writeln!(writer, "  version: {}", metadata.version)?;
+    writeln!(writer, "  platform: {}/{}", metadata.platform.os, metadata.platform.arch)?;
+    match &metadata.latest_log_path {
+        Some(path) => writeln!(writer, "  latest_log: {path}")?,
+        None => writeln!(writer, "  latest_log: not found")?,
+    }
+    writeln!(writer, "  next_step: {}", metadata.diagnostics_bundle_command)?;
+    writeln!(writer, "  issue_guidance: paste this report and the redacted debug bundle")
+}
+
+fn write_last_crash_metadata(metadata: &CrashMetadata) -> anyhow::Result<()> {
+    let paths = crate::logging::default_diagnostics_paths()?;
+    std::fs::create_dir_all(&paths.root_dir)?;
+    let path = last_crash_metadata_path(&paths);
+    write_last_crash_metadata_to(metadata, &path)
+}
+
+fn write_last_crash_metadata_to(metadata: &CrashMetadata, path: &Path) -> anyhow::Result<()> {
+    let text = serde_json::to_string_pretty(metadata)?;
+    std::fs::write(path, format!("{text}\n"))?;
+    Ok(())
+}
+
+fn should_report_panic() -> bool {
+    EXPECTED_PANIC_DEPTH.with(|depth| depth.get() == 0)
+}
+
+struct ExpectedPanicGuard;
+
+impl ExpectedPanicGuard {
+    fn enter() -> Self {
+        EXPECTED_PANIC_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        Self
+    }
+}
+
+impl Drop for ExpectedPanicGuard {
+    fn drop(&mut self) {
+        EXPECTED_PANIC_DEPTH.with(|depth| {
+            let current = depth.get();
+            if current > 0 {
+                depth.set(current - 1);
+            }
+        });
+    }
+}
+
+fn latest_log_path_display() -> Option<String> {
+    crate::logging::latest_default_log_path().ok().flatten().map(|path| path.display().to_string())
+}
+
+impl CrashMetadata {
+    fn from_panic_info(panic_info: &PanicHookInfo<'_>) -> Self {
+        Self {
+            schema: "claude-rs-crash/v1",
+            kind: "panic",
+            created_at: timestamp_now(),
+            version: env!("CARGO_PKG_VERSION"),
+            platform: PlatformMetadata { os: std::env::consts::OS, arch: std::env::consts::ARCH },
+            message: redaction::redact_line(&panic_message(panic_info)),
+            location: panic_info.location().map(|location| {
+                format!("{}:{}:{}", location.file(), location.line(), location.column())
+            }),
+            latest_log_path: latest_log_path_display(),
+            diagnostics_bundle_command: "claude-rs logs --bundle --yes",
+        }
+    }
+}
+
+fn panic_message(panic_info: &PanicHookInfo<'_>) -> String {
+    if let Some(message) = panic_info.payload().downcast_ref::<&str>() {
+        return (*message).to_owned();
+    }
+    if let Some(message) = panic_info.payload().downcast_ref::<String>() {
+        return message.clone();
+    }
+    "panic payload is not a string".to_owned()
+}
+
+fn timestamp_now() -> String {
+    OffsetDateTime::now_utc()
+        .format(format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]Z"))
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CrashMetadata, PlatformMetadata, catch_expected_panic, should_report_panic,
+        write_app_error_report_with_detail, write_last_crash_metadata_to,
+    };
+    use crate::error::AppError;
+    use std::panic;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static PANIC_HOOK_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn app_error_report_is_issue_friendly() {
+        let mut output = Vec::new();
+
+        write_app_error_report_with_detail(
+            &mut output,
+            &AppError::BridgeTimeout,
+            Some("ANTHROPIC_API_KEY=sk-ant-secret"),
+        )
+        .expect("write report");
+
+        let text = String::from_utf8(output).expect("utf8");
+        assert!(text.contains("Bridge initialization timeout"));
+        assert!(text.contains("category: bridge_timeout"));
+        assert!(text.contains("claude-rs doctor --strict"));
+        assert!(text.contains("version:"));
+        assert!(text.contains("platform:"));
+        assert!(text.contains("[redacted]"));
+        assert!(!text.contains("sk-ant-secret"));
+    }
+
+    #[test]
+    fn crash_metadata_file_redacts_secret_payloads() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("last-crash.json");
+        let metadata = CrashMetadata {
+            schema: "claude-rs-crash/v1",
+            kind: "panic",
+            created_at: "2026-07-03T00:00:00Z".to_owned(),
+            version: "0",
+            platform: PlatformMetadata { os: "test", arch: "test" },
+            message: crate::cli::redaction::redact_line("ANTHROPIC_API_KEY=sk-ant-secret"),
+            location: Some("src/main.rs:1:1".to_owned()),
+            latest_log_path: None,
+            diagnostics_bundle_command: "claude-rs logs --bundle --yes",
+        };
+
+        write_last_crash_metadata_to(&metadata, &path).expect("write metadata");
+
+        let text = std::fs::read_to_string(path).expect("read metadata");
+        assert!(!text.contains("sk-ant-secret"));
+        assert!(text.contains("[redacted]"));
+    }
+
+    #[test]
+    fn expected_caught_panics_do_not_count_as_reportable_crashes() {
+        let _guard = PANIC_HOOK_TEST_LOCK.lock().expect("lock panic hook test");
+        let original = panic::take_hook();
+        let reportable_panic_calls = Arc::new(AtomicUsize::new(0));
+        let reportable_panic_calls_for_hook = Arc::clone(&reportable_panic_calls);
+        panic::set_hook(Box::new(move |_panic_info| {
+            if should_report_panic() {
+                reportable_panic_calls_for_hook.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+
+        let expected = catch_expected_panic(|| {
+            panic!("expected renderer panic");
+        });
+        assert!(expected.is_err());
+        assert_eq!(reportable_panic_calls.load(Ordering::SeqCst), 0);
+
+        let unexpected = panic::catch_unwind(|| {
+            panic!("unexpected panic");
+        });
+        assert!(unexpected.is_err());
+        assert_eq!(reportable_panic_calls.load(Ordering::SeqCst), 1);
+
+        let _installed = panic::take_hook();
+        panic::set_hook(original);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod agent;
 pub mod app;
 pub mod cli;
 pub mod error;
+pub mod failure;
 pub mod logging;
 pub mod perf;
 pub mod ui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,8 @@ pub enum Command {
     },
     /// Run deterministic installation and runtime diagnostics
     Doctor(DoctorArgs),
+    /// Find runtime logs or create a redacted debug bundle
+    Logs(LogsArgs),
 }
 
 #[derive(Args, Clone, Debug, PartialEq, Eq)]
@@ -133,9 +135,37 @@ pub struct DoctorArgs {
     pub strict: bool,
 }
 
+#[derive(Args, Clone, Debug, PartialEq, Eq)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct LogsArgs {
+    /// Print only the runtime log directory path.
+    #[arg(long, conflicts_with_all = ["latest", "tail", "bundle"])]
+    pub path: bool,
+
+    /// Print only the latest discovered log path.
+    #[arg(long, conflicts_with_all = ["path", "tail", "bundle"])]
+    pub latest: bool,
+
+    /// Print the last N redacted lines from the latest discovered log.
+    #[arg(long, value_name = "LINES", conflicts_with_all = ["path", "latest", "bundle"])]
+    pub tail: Option<usize>,
+
+    /// Create a redacted ZIP bundle for support.
+    #[arg(long, conflicts_with_all = ["path", "latest", "tail"])]
+    pub bundle: bool,
+
+    /// Write the bundle ZIP to this path.
+    #[arg(long, value_name = "PATH", requires = "bundle")]
+    pub output: Option<std::path::PathBuf>,
+
+    /// Skip interactive confirmation for bundle creation.
+    #[arg(long)]
+    pub yes: bool,
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Command, DoctorArgs};
+    use super::{Cli, Command, DoctorArgs, LogsArgs};
     use clap::{CommandFactory, Parser};
 
     #[test]
@@ -172,6 +202,59 @@ mod tests {
         let cli =
             Cli::try_parse_from(["claude-rs", "doctor", "--json", "--strict"]).expect("parse");
         assert_eq!(cli.command, Some(Command::Doctor(DoctorArgs { json: true, strict: true })));
+    }
+
+    #[test]
+    fn cli_logs_defaults_to_summary() {
+        let cli = Cli::try_parse_from(["claude-rs", "logs"]).expect("parse");
+        assert_eq!(
+            cli.command,
+            Some(Command::Logs(LogsArgs {
+                path: false,
+                latest: false,
+                tail: None,
+                bundle: false,
+                output: None,
+                yes: false,
+            }))
+        );
+    }
+
+    #[test]
+    fn cli_logs_accepts_modes() {
+        let cli = Cli::try_parse_from(["claude-rs", "logs", "--tail", "200"]).expect("parse");
+        assert_eq!(
+            cli.command,
+            Some(Command::Logs(LogsArgs {
+                path: false,
+                latest: false,
+                tail: Some(200),
+                bundle: false,
+                output: None,
+                yes: false,
+            }))
+        );
+
+        let cli =
+            Cli::try_parse_from(["claude-rs", "logs", "--bundle", "--yes", "--output", "out.zip"])
+                .expect("parse");
+        assert_eq!(
+            cli.command,
+            Some(Command::Logs(LogsArgs {
+                path: false,
+                latest: false,
+                tail: None,
+                bundle: true,
+                output: Some(std::path::PathBuf::from("out.zip")),
+                yes: true,
+            }))
+        );
+    }
+
+    #[test]
+    fn cli_logs_rejects_conflicting_modes() {
+        assert!(Cli::try_parse_from(["claude-rs", "logs", "--path", "--latest"]).is_err());
+        assert!(Cli::try_parse_from(["claude-rs", "logs", "--output", "out.zip"]).is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,13 @@
 
 pub mod agent;
 pub mod app;
+pub mod cli;
 pub mod error;
 pub mod logging;
 pub mod perf;
 pub mod ui;
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Clone, Debug, ValueEnum, PartialEq, Eq)]
 pub enum DiagnosticsPreset {
@@ -117,11 +118,24 @@ pub enum Command {
         /// Session ID to resume directly. Omit to show a session picker.
         session_id: Option<String>,
     },
+    /// Run deterministic installation and runtime diagnostics
+    Doctor(DoctorArgs),
+}
+
+#[derive(Args, Clone, Debug, PartialEq, Eq)]
+pub struct DoctorArgs {
+    /// Emit a machine-readable JSON report.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Exit non-zero when hard runtime prerequisites fail.
+    #[arg(long)]
+    pub strict: bool,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Command};
+    use super::{Cli, Command, DoctorArgs};
     use clap::{CommandFactory, Parser};
 
     #[test]
@@ -145,6 +159,19 @@ mod tests {
     #[test]
     fn cli_rejects_legacy_resume_flag() {
         assert!(Cli::try_parse_from(["claude-rs", "--resume", "abc-123"]).is_err());
+    }
+
+    #[test]
+    fn cli_doctor_defaults_to_human_output() {
+        let cli = Cli::try_parse_from(["claude-rs", "doctor"]).expect("parse");
+        assert_eq!(cli.command, Some(Command::Doctor(DoctorArgs { json: false, strict: false })));
+    }
+
+    #[test]
+    fn cli_doctor_accepts_json_and_strict() {
+        let cli =
+            Cli::try_parse_from(["claude-rs", "doctor", "--json", "--strict"]).expect("parse");
+        assert_eq!(cli.command, Some(Command::Doctor(DoctorArgs { json: true, strict: true })));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,8 @@ pub enum Command {
     Doctor(DoctorArgs),
     /// Find runtime logs or create a redacted debug bundle
     Logs(LogsArgs),
+    /// Inspect and export redacted configuration
+    Config(ConfigArgs),
 }
 
 #[derive(Args, Clone, Debug, PartialEq, Eq)]
@@ -164,9 +166,60 @@ pub struct LogsArgs {
     pub yes: bool,
 }
 
+#[derive(Args, Clone, Debug, PartialEq, Eq)]
+pub struct ConfigArgs {
+    #[command(subcommand)]
+    pub command: Option<ConfigCommand>,
+}
+
+#[derive(Subcommand, Clone, Debug, PartialEq, Eq)]
+pub enum ConfigCommand {
+    /// Print resolved config file paths
+    Path(ConfigPathArgs),
+    /// Show a concise redacted config summary
+    Show(ConfigShowArgs),
+    /// Export a redacted support-safe config snapshot
+    Export(ConfigExportArgs),
+}
+
+#[derive(Args, Clone, Debug, PartialEq, Eq)]
+pub struct ConfigPathArgs {
+    /// Emit machine-readable JSON path metadata.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Print only one config file path for scripting.
+    #[arg(long, value_enum)]
+    pub which: Option<ConfigFileSelector>,
+}
+
+#[derive(Args, Clone, Debug, PartialEq, Eq)]
+pub struct ConfigShowArgs {
+    /// Emit machine-readable redacted JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Clone, Debug, PartialEq, Eq)]
+pub struct ConfigExportArgs {
+    /// Write the redacted export JSON to this new file.
+    #[arg(long, value_name = "PATH")]
+    pub output: Option<std::path::PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
+pub enum ConfigFileSelector {
+    Settings,
+    LocalSettings,
+    Preferences,
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Command, DoctorArgs, LogsArgs};
+    use super::{
+        Cli, Command, ConfigArgs, ConfigCommand, ConfigExportArgs, ConfigFileSelector,
+        ConfigPathArgs, ConfigShowArgs, DoctorArgs, LogsArgs,
+    };
     use clap::{CommandFactory, Parser};
 
     #[test]
@@ -256,6 +309,64 @@ mod tests {
     fn cli_logs_rejects_conflicting_modes() {
         assert!(Cli::try_parse_from(["claude-rs", "logs", "--path", "--latest"]).is_err());
         assert!(Cli::try_parse_from(["claude-rs", "logs", "--output", "out.zip"]).is_err());
+    }
+
+    #[test]
+    fn cli_config_accepts_path_modes() {
+        let cli = Cli::try_parse_from(["claude-rs", "config", "path"]).expect("parse");
+        assert_eq!(
+            cli.command,
+            Some(Command::Config(ConfigArgs {
+                command: Some(ConfigCommand::Path(ConfigPathArgs { json: false, which: None })),
+            }))
+        );
+
+        let cli = Cli::try_parse_from([
+            "claude-rs",
+            "config",
+            "path",
+            "--json",
+            "--which",
+            "local-settings",
+        ])
+        .expect("parse");
+        assert_eq!(
+            cli.command,
+            Some(Command::Config(ConfigArgs {
+                command: Some(ConfigCommand::Path(ConfigPathArgs {
+                    json: true,
+                    which: Some(ConfigFileSelector::LocalSettings),
+                })),
+            }))
+        );
+    }
+
+    #[test]
+    fn cli_config_defaults_to_summary() {
+        let cli = Cli::try_parse_from(["claude-rs", "config"]).expect("parse");
+        assert_eq!(cli.command, Some(Command::Config(ConfigArgs { command: None })));
+    }
+
+    #[test]
+    fn cli_config_accepts_show_and_export() {
+        let cli = Cli::try_parse_from(["claude-rs", "config", "show", "--json"]).expect("parse");
+        assert_eq!(
+            cli.command,
+            Some(Command::Config(ConfigArgs {
+                command: Some(ConfigCommand::Show(ConfigShowArgs { json: true })),
+            }))
+        );
+
+        let cli = Cli::try_parse_from(["claude-rs", "config", "export", "--output", "config.json"])
+            .expect("parse");
+        assert_eq!(
+            cli.command,
+            Some(Command::Config(ConfigArgs {
+                command: Some(ConfigCommand::Export(ConfigExportArgs {
+                    output: Some(std::path::PathBuf::from("config.json")),
+                })),
+            }))
+        );
     }
 
     #[test]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -275,7 +275,7 @@ fn logging_enabled_without_explicit_path(cli: &Cli) -> bool {
         || std::env::var_os("RUST_LOG").is_some()
 }
 
-fn default_legacy_log_path() -> anyhow::Result<PathBuf> {
+pub fn default_legacy_log_path() -> anyhow::Result<PathBuf> {
     let base_dir = default_diagnostics_dir()?;
     Ok(base_dir.join(DEFAULT_LOG_FILE_NAME))
 }
@@ -294,11 +294,11 @@ pub fn resolve_perf_path(cli: &Cli) -> anyhow::Result<Option<PathBuf>> {
     )))
 }
 
-fn default_runtime_log_dir() -> anyhow::Result<PathBuf> {
+pub fn default_runtime_log_dir() -> anyhow::Result<PathBuf> {
     Ok(default_diagnostics_dir()?.join(DEFAULT_RUNTIME_LOG_SUBDIR))
 }
 
-fn default_perf_log_dir() -> anyhow::Result<PathBuf> {
+pub fn default_perf_log_dir() -> anyhow::Result<PathBuf> {
     Ok(default_diagnostics_dir()?.join(DEFAULT_PERF_LOG_SUBDIR))
 }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -53,6 +53,21 @@ const LOG_RETENTION_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 const LOG_RETENTION_MIN_FILES: usize = 10;
 static BRIDGE_DIAGNOSTICS_ENABLED: AtomicBool = AtomicBool::new(false);
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticsPaths {
+    pub root_dir: PathBuf,
+    pub runtime_dir: PathBuf,
+    pub legacy_log_path: PathBuf,
+    pub perf_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedLogFile {
+    pub path: PathBuf,
+    pub modified: SystemTime,
+    pub size: u64,
+}
+
 pub struct LoggingRuntime {
     _guard: Option<WorkerGuard>,
 }
@@ -302,6 +317,70 @@ pub fn default_perf_log_dir() -> anyhow::Result<PathBuf> {
     Ok(default_diagnostics_dir()?.join(DEFAULT_PERF_LOG_SUBDIR))
 }
 
+pub fn default_diagnostics_paths() -> anyhow::Result<DiagnosticsPaths> {
+    let root_dir = default_diagnostics_dir()?;
+    Ok(DiagnosticsPaths {
+        runtime_dir: root_dir.join(DEFAULT_RUNTIME_LOG_SUBDIR),
+        legacy_log_path: root_dir.join(DEFAULT_LOG_FILE_NAME),
+        perf_dir: root_dir.join(DEFAULT_PERF_LOG_SUBDIR),
+        root_dir,
+    })
+}
+
+pub fn list_managed_runtime_logs() -> anyhow::Result<Vec<ManagedLogFile>> {
+    list_managed_runtime_logs_in(&default_runtime_log_dir()?)
+}
+
+pub fn list_managed_runtime_logs_in(directory: &Path) -> anyhow::Result<Vec<ManagedLogFile>> {
+    let mut logs = Vec::new();
+    let Ok(entries) = read_dir(directory) else {
+        return Ok(logs);
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !is_managed_runtime_log_file(name) {
+            continue;
+        }
+        let metadata = metadata(&path)?;
+        if !metadata.is_file() {
+            continue;
+        }
+        logs.push(ManagedLogFile {
+            path,
+            modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+            size: metadata.len(),
+        });
+    }
+
+    logs.sort_by(|left, right| {
+        right.modified.cmp(&left.modified).then_with(|| right.path.cmp(&left.path))
+    });
+    Ok(logs)
+}
+
+pub fn latest_default_log_path() -> anyhow::Result<Option<PathBuf>> {
+    let paths = default_diagnostics_paths()?;
+    latest_log_path_in(&paths.runtime_dir, &paths.legacy_log_path)
+}
+
+pub fn latest_log_path_in(
+    runtime_dir: &Path,
+    legacy_log_path: &Path,
+) -> anyhow::Result<Option<PathBuf>> {
+    if let Some(log) = list_managed_runtime_logs_in(runtime_dir)?.into_iter().next() {
+        return Ok(Some(log.path));
+    }
+    if legacy_log_path.is_file() {
+        return Ok(Some(legacy_log_path.to_path_buf()));
+    }
+    Ok(None)
+}
+
 fn generated_log_path(directory: &Path, prefix: &str, extension: &str) -> PathBuf {
     directory.join(generated_log_file_name(
         prefix,
@@ -333,7 +412,7 @@ fn perf_enabled_without_explicit_path(cli: &Cli) -> bool {
     cli.enable_perf || cli.perf_append
 }
 
-fn default_diagnostics_dir() -> anyhow::Result<PathBuf> {
+pub fn default_diagnostics_dir() -> anyhow::Result<PathBuf> {
     if let Some(dir) = dirs::data_local_dir() {
         return Ok(dir.join(DEFAULT_LOG_DIR).join("logs"));
     }
@@ -617,6 +696,10 @@ fn is_managed_log_file(name: &str, prefix: &str, extension: &str) -> bool {
     rest.rsplit_once('.').is_some_and(|(base, suffix)| {
         base.ends_with(&extension_suffix) && suffix.chars().all(|ch| ch.is_ascii_digit())
     })
+}
+
+pub fn is_managed_runtime_log_file(name: &str) -> bool {
+    is_managed_log_file(name, DEFAULT_RUNTIME_LOG_PREFIX, RUNTIME_LOG_EXTENSION)
 }
 
 pub fn emit_bridge_stderr_line(line: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,18 +9,30 @@ use tracing::info_span;
 
 #[allow(clippy::exit)]
 fn main() {
-    if let Err(err) = run() {
-        if let Some(app_error) = extract_app_error(&err) {
-            eprintln!("{}", app_error.user_message());
-            std::process::exit(app_error.exit_code());
+    match run() {
+        Ok(0) => {}
+        Ok(code) => std::process::exit(code),
+        Err(err) => {
+            if let Some(app_error) = extract_app_error(&err) {
+                eprintln!("{}", app_error.user_message());
+                std::process::exit(app_error.exit_code());
+            }
+            eprintln!("{err:#}");
+            std::process::exit(1);
         }
-        eprintln!("{err:#}");
-        std::process::exit(1);
     }
 }
 
-fn run() -> anyhow::Result<()> {
+fn run() -> anyhow::Result<i32> {
     let cli = Cli::parse();
+    if let Some(exit_code) = claude_code_rust::cli::run_support_command(
+        &cli,
+        &mut std::io::stdout().lock(),
+        &mut std::io::stderr().lock(),
+    )? {
+        return Ok(exit_code);
+    }
+
     let _logging = claude_code_rust::logging::LoggingRuntime::init(&cli)?;
     let perf_path = claude_code_rust::logging::resolve_perf_path(&cli)?;
 
@@ -77,7 +89,9 @@ fn run() -> anyhow::Result<()> {
         }
 
         result
-    }))
+    }))?;
+
+    Ok(0)
 }
 
 fn extract_app_error(err: &anyhow::Error) -> Option<AppError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,24 @@ use tracing::info_span;
 
 #[allow(clippy::exit)]
 fn main() {
+    claude_code_rust::failure::install_panic_hook();
     match run() {
         Ok(0) => {}
         Ok(code) => std::process::exit(code),
         Err(err) => {
             if let Some(app_error) = extract_app_error(&err) {
-                eprintln!("{}", app_error.user_message());
+                let mut stderr = std::io::stderr().lock();
+                let detail = format!("{err:#}");
+                if let Err(report_error) =
+                    claude_code_rust::failure::write_app_error_report_with_detail(
+                        &mut stderr,
+                        &app_error,
+                        Some(&detail),
+                    )
+                {
+                    eprintln!("{}", app_error.user_message());
+                    eprintln!("failed to write failure report: {report_error}");
+                }
                 std::process::exit(app_error.exit_code());
             }
             eprintln!("{err:#}");

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -1,9 +1,9 @@
 // Copyright 2025 Simon Peter Rothgang
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::failure;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
-use std::panic::{self, AssertUnwindSafe};
 
 pub(super) fn render_markdown_safe(text: &str, bg: Option<Color>) -> Vec<Line<'static>> {
     render_markdown_safe_with(text, bg, render_with_tui_markdown)
@@ -13,7 +13,7 @@ fn render_markdown_safe_with<F>(text: &str, bg: Option<Color>, renderer: F) -> V
 where
     F: FnOnce(&str, Option<Color>) -> Vec<Line<'static>>,
 {
-    if let Ok(lines) = panic::catch_unwind(AssertUnwindSafe(|| renderer(text, bg))) {
+    if let Ok(lines) = failure::catch_expected_panic(|| renderer(text, bg)) {
         lines
     } else {
         tracing::warn!(


### PR DESCRIPTION
## Summary

Adds the supportability command set for installation, runtime, log, failure, and config diagnostics:

- Add `claude-rs doctor` with human and JSON diagnostics for runtime, bridge, config paths, logs, npm metadata, and credentials presence.
- Add `claude-rs logs` with path/latest/tail helpers and redacted debug bundle creation.
- Add crash and bridge failure reporting with categorized, issue-friendly stderr output and local redacted crash metadata.
- Add `claude-rs config`, `config path`, `config show`, and `config export` for read-only, redacted config inspection/export.
- Document the new diagnostics, logs, bundle, failure-reporting, and config-inspection workflows.

## Why

This makes installation, runtime, bridge, log, crash, and config problems diagnosable before the `0.13.2` release train reaches users. The commands avoid starting the TUI where possible, redact obvious credentials, and provide support-safe outputs that users can paste or attach when reporting issues.

Closes # N/A

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `cargo check --offline`
- Manual:
  - `cargo run -- --diagnostics-preset full config`
  - `cargo run -- config show`
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: Yes, diagnostics/settings/usage docs now cover supportability commands and config inspection.
- Config inspection is read-only: it does not repair, normalize, back up, or overwrite config files.
- `config show` bounds human output for large config files; full redacted content remains available through `config show --json` and `config export`.
- `config export --output` refuses to overwrite existing files.
- No GitHub PR operations were performed from this workspace.
