### PR TITLE
fix(release): verify reusable workflow attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,7 @@ jobs:
         run: node scripts/smoke-npm-package-install.mjs --platform "${{ matrix.package_dir }}" --use-existing-tarballs --real-binary
 
   create-draft-github-release:
-    needs: [verify, smoke-test-packages]
+    needs: [verify, verify-release-attestations]
     name: Create draft GitHub Release
     runs-on: ubuntu-latest
     environment: npm-release
@@ -295,7 +295,7 @@ jobs:
             --notes-file release-notes.md
 
   verify-release-attestations:
-    needs: [verify, create-draft-github-release]
+    needs: [verify, smoke-test-packages]
     name: Verify binary attestations
     runs-on: ubuntu-latest
     permissions:
@@ -312,7 +312,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          signer_workflow="srothgan/claude-code-rust/.github/workflows/release.yml@refs/heads/main"
+          signer_workflow="srothgan/claude-code-rust/.github/workflows/_release-build.yml@refs/heads/main"
           gh attestation verify dist-assets/claude-code-rust-x86_64-unknown-linux-gnu \
             --repo srothgan/claude-code-rust \
             --signer-workflow "$signer_workflow" \
@@ -335,7 +335,7 @@ jobs:
             --deny-self-hosted-runners
 
   publish-platform-packages:
-    needs: [verify, verify-release-attestations]
+    needs: [verify, create-draft-github-release]
     name: Publish platform npm packages
     runs-on: ubuntu-latest
     environment: npm-release


### PR DESCRIPTION
## Summary

- Verify release binary attestations against the reusable `_release-build.yml` signer workflow.
- Run attestation verification before creating the draft GitHub Release and tag.
- Keep npm publishing gated on successful draft release creation.

## Why

The `0.13.2` release run failed because the verifier expected attestations from `release.yml`, but the binary attestations are signed by the reusable release build workflow. Verifying before draft release creation also avoids leaving a tag and draft release behind when this gate fails.

Closes #

## Validation

- Automated:
  - `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`
  - `git diff --check`
- Manual: Verified downloaded `0.13.2` run artifacts pass `gh attestation verify` with `_release-build.yml@refs/heads/main`.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
