### PR TITLE
fix(release): scope release publish to target repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,4 +429,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh release edit "${{ needs.verify.outputs.tag }}" --draft=false
+          gh release edit "${{ needs.verify.outputs.tag }}" --draft=false --repo srothgan/claude-code-rust


### PR DESCRIPTION
## Summary

Add an explicit `--repo srothgan/claude-code-rust` flag to the final `gh release edit` call in the `publish-github-release` job, which flips the draft release to published.

## Why

Without an explicit `--repo`, `gh` relies on ambient repository resolution, which can be ambiguous depending on the runner's checkout/remote state. Pinning the repository ensures the draft-to-published transition always targets the intended repository, consistent with the other `gh` invocations in this workflow.

Closes #

## Validation

- Automated: N/A (workflow-only change; exercised on next release run)
- Manual: Reviewed the `publish-github-release` job diff
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
