### PR TITLE
fix(mention): improve file autocomplete completion and boundaries

### DIFF
--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -165,6 +165,7 @@ pub fn create_app(cli: &Cli) -> App {
         session_picker: SessionPickerState::default(),
         chat_render: super::ChatRenderState::default(),
         mention: None,
+        committed_mentions: Vec::new(),
         file_index: super::file_index::FileIndexState::default(),
         slash: None,
         subagent: None,

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -1121,9 +1121,9 @@ mod tests {
 
         assert_eq!(outcome, KeyOutcome::Handled(true));
         assert!(app.mention.is_none());
-        assert_eq!(app.input.text(), "@docs/manual path ");
+        assert_eq!(app.input.text(), "@'docs/manual path' ");
         assert_eq!(app.committed_mentions.len(), 1);
-        assert_eq!(app.committed_mentions[0].text, "@docs/manual path");
+        assert_eq!(app.committed_mentions[0].text, "@'docs/manual path'");
     }
 
     #[test]
@@ -1152,7 +1152,7 @@ mod tests {
 
         assert_eq!(outcome, KeyOutcome::Handled(true));
         assert!(app.mention.is_none());
-        assert_eq!(app.input.text(), "@src/lib.rs ");
+        assert_eq!(app.input.text(), "@'src/lib.rs' ");
         assert!(app.committed_mentions.is_empty());
     }
 

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -258,9 +258,10 @@ fn execute_app_action(app: &mut App, action: AppAction) -> KeyOutcome {
         }
         AppAction::CancelTurn => handle_turn_control(app).into(),
         AppAction::SubmitInput => handle_submit(app).into(),
-        AppAction::FocusPromptOrAcceptSuggestion => {
-            (handle_focus_toggle(app) || handle_prompt_suggestion(app)).into()
-        }
+        AppAction::FocusPromptOrAcceptSuggestion => (mention::commit_literal_if_active(app)
+            || handle_focus_toggle(app)
+            || handle_prompt_suggestion(app))
+        .into(),
         AppAction::CycleMode => handle_mode_cycle(app).into(),
     }
 }
@@ -884,7 +885,7 @@ mod tests {
     use crate::app::FocusTarget;
     use crate::app::keymap::{KeyBinding, KeyBindingSource, KeyCodeSpec, KeySpec, ResolvedKeymap};
     use crossterm::event::{KeyCode, KeyModifiers};
-    use std::time::{Duration, Instant};
+    use std::time::{Duration, Instant, SystemTime};
 
     #[test]
     fn ctrl_shortcut_accepts_standard_ctrl_v_encoding() {
@@ -1103,6 +1104,56 @@ mod tests {
         assert!(outcome.changed());
         let mention = app.mention.as_ref().expect("mention should stay active");
         assert_eq!(mention.query, " ");
+    }
+
+    #[test]
+    fn chat_input_tab_commits_literal_mention_without_candidates() {
+        let mut app = App::test_default();
+        app.input.set_text("@");
+        let _ = app.input.set_cursor(0, 1);
+        mention::activate(&mut app);
+        app.input.set_text("@docs/manual path");
+        let _ = app.input.set_cursor(0, "@docs/manual path".chars().count());
+        mention::update_query(&mut app);
+
+        let outcome =
+            handle_chat_input_key(&mut app, KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+        assert!(app.mention.is_none());
+        assert_eq!(app.input.text(), "@docs/manual path ");
+        assert_eq!(app.committed_mentions.len(), 1);
+        assert_eq!(app.committed_mentions[0].text, "@docs/manual path");
+    }
+
+    #[test]
+    fn autocomplete_tab_still_confirms_mention_candidate() {
+        let mut app = App::test_default();
+        app.input.set_text("@src");
+        let mut mention = mention::MentionState::new(
+            0,
+            0,
+            "src".to_owned(),
+            vec![crate::app::file_index::FileCandidate {
+                rel_path: "src/lib.rs".to_owned(),
+                rel_path_lower: "src/lib.rs".to_owned(),
+                basename_lower: "lib.rs".to_owned(),
+                depth: 1,
+                modified: SystemTime::UNIX_EPOCH,
+                is_dir: false,
+            }],
+        );
+        mention.replace_end_col = "@src".chars().count();
+        app.mention = Some(mention);
+        app.claim_focus_target(FocusTarget::Mention);
+
+        let outcome =
+            handle_autocomplete_key(&mut app, KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+        assert!(app.mention.is_none());
+        assert_eq!(app.input.text(), "@src/lib.rs ");
+        assert!(app.committed_mentions.is_empty());
     }
 
     #[test]

--- a/src/app/mention.rs
+++ b/src/app/mention.rs
@@ -29,6 +29,14 @@ pub struct MentionState {
     line_char_count: usize,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommittedMentionSpan {
+    pub row: usize,
+    pub start_col: usize,
+    pub end_col: usize,
+    pub text: String,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MentionSearchStatus {
     Hint,
@@ -513,6 +521,68 @@ pub fn confirm_selection(app: &mut App) {
     app.input.replace_lines_and_cursor(lines, trigger_row, new_cursor_col);
 }
 
+pub fn commit_literal_if_active(app: &mut App) -> bool {
+    let Some(mention) = app.mention.take() else {
+        return false;
+    };
+    if mention.has_selectable_candidates() {
+        app.mention = Some(mention);
+        return false;
+    }
+
+    if app.slash.is_none() && app.subagent.is_none() {
+        app.release_focus_target(FocusTarget::Mention);
+    }
+
+    if query_is_hint(&mention.query) {
+        app.input.highlight_version = u64::MAX;
+        return true;
+    }
+
+    let mut lines = app.input.lines().to_vec();
+    let Some(line) = lines.get(mention.trigger_row) else {
+        app.input.highlight_version = u64::MAX;
+        return true;
+    };
+    let chars: Vec<char> = line.chars().collect();
+    if chars.get(mention.trigger_col) != Some(&'@') {
+        app.input.highlight_version = u64::MAX;
+        return true;
+    }
+
+    let start_col = mention.trigger_col;
+    let raw_end_col = mention.replace_end_col.min(chars.len());
+    let end_col = trim_trailing_whitespace(chars.as_slice(), start_col + 1, raw_end_col);
+    if end_col <= start_col + 1 {
+        app.input.highlight_version = u64::MAX;
+        return true;
+    }
+
+    let committed_text: String = chars[start_col..end_col].iter().collect();
+    if raw_end_col == chars.len() && end_col == raw_end_col {
+        let before: String = chars[..end_col].iter().collect();
+        lines[mention.trigger_row] = format!("{before} ");
+        app.input.replace_lines_and_cursor(lines, mention.trigger_row, end_col + 1);
+    } else {
+        app.input.highlight_version = u64::MAX;
+    }
+
+    app.committed_mentions.push(CommittedMentionSpan {
+        row: mention.trigger_row,
+        start_col,
+        end_col,
+        text: committed_text,
+    });
+    true
+}
+
+fn trim_trailing_whitespace(chars: &[char], min_col: usize, mut end_col: usize) -> usize {
+    while end_col > min_col && chars[end_col - 1].is_whitespace() {
+        end_col -= 1;
+    }
+    end_col
+}
+
 fn resolve_confirm_end_col(
     mention: &MentionState,
     chars: &[char],
@@ -591,6 +661,25 @@ pub fn find_mention_spans(
     }
 
     spans
+}
+
+pub fn retain_valid_committed_mentions(
+    lines: &[String],
+    committed_mentions: &mut Vec<CommittedMentionSpan>,
+) {
+    committed_mentions.retain(|span| committed_mention_matches(lines, span));
+}
+
+pub fn committed_mention_matches(lines: &[String], span: &CommittedMentionSpan) -> bool {
+    let Some(line) = lines.get(span.row) else {
+        return false;
+    };
+    let chars: Vec<char> = line.chars().collect();
+    if span.start_col >= span.end_col || span.end_col > chars.len() {
+        return false;
+    }
+    let text: String = chars[span.start_col..span.end_col].iter().collect();
+    text == span.text
 }
 
 fn resolve_mention_span(
@@ -939,6 +1028,100 @@ mod tests {
         assert_eq!(mention.query, " ");
         assert!(mention.candidates.is_empty());
         assert!(matches!(mention.search_status, MentionSearchStatus::Hint));
+    }
+
+    #[test]
+    fn commit_literal_adds_trailing_space_at_line_end() {
+        let mut app = App::test_default();
+        app.input.set_text("@");
+        let _ = app.input.set_cursor(0, 1);
+        activate(&mut app);
+        app.input.set_text("@docs/manual path");
+        let _ = app.input.set_cursor(0, "@docs/manual path".chars().count());
+        update_query(&mut app);
+
+        assert!(commit_literal_if_active(&mut app));
+
+        assert!(app.mention.is_none());
+        assert_eq!(app.input.lines()[0], "@docs/manual path ");
+        assert_eq!(app.input.cursor_col(), "@docs/manual path ".chars().count());
+        assert_eq!(
+            app.committed_mentions,
+            vec![CommittedMentionSpan {
+                row: 0,
+                start_col: 0,
+                end_col: "@docs/manual path".chars().count(),
+                text: "@docs/manual path".to_owned(),
+            }]
+        );
+    }
+
+    #[test]
+    fn commit_literal_before_existing_space_does_not_add_double_space() {
+        let mut app = App::test_default();
+        app.input.set_text("@manual path now");
+        let end_col = "@manual path".chars().count();
+        let _ = app.input.set_cursor(0, end_col);
+        let mut mention = MentionState::new(0, 0, "manual path".to_owned(), Vec::new());
+        mention.replace_end_col = end_col;
+        app.mention = Some(mention);
+
+        assert!(commit_literal_if_active(&mut app));
+
+        assert_eq!(app.input.lines()[0], "@manual path now");
+        assert_eq!(app.committed_mentions.len(), 1);
+        assert_eq!(app.committed_mentions[0].text, "@manual path");
+        assert_eq!(app.committed_mentions[0].end_col, end_col);
+    }
+
+    #[test]
+    fn commit_literal_with_trailing_separator_space_does_not_add_another_space() {
+        let mut app = App::test_default();
+        app.input.set_text("@manual path ");
+        let end_col = "@manual path".chars().count();
+        let line_end_col = "@manual path ".chars().count();
+        let _ = app.input.set_cursor(0, line_end_col);
+        let mut mention = MentionState::new(0, 0, "manual path ".to_owned(), Vec::new());
+        mention.replace_end_col = line_end_col;
+        app.mention = Some(mention);
+
+        assert!(commit_literal_if_active(&mut app));
+
+        assert_eq!(app.input.lines()[0], "@manual path ");
+        assert_eq!(app.committed_mentions.len(), 1);
+        assert_eq!(app.committed_mentions[0].text, "@manual path");
+        assert_eq!(app.committed_mentions[0].end_col, end_col);
+    }
+
+    #[test]
+    fn commit_literal_empty_query_only_deactivates() {
+        let mut app = App::test_default();
+        app.input.set_text("@ ");
+        let _ = app.input.set_cursor(0, 2);
+        app.mention = Some(MentionState::new(0, 0, " ".to_owned(), Vec::new()));
+
+        assert!(commit_literal_if_active(&mut app));
+
+        assert!(app.mention.is_none());
+        assert!(app.committed_mentions.is_empty());
+        assert_eq!(app.input.lines()[0], "@ ");
+    }
+
+    #[test]
+    fn committed_mentions_are_exact_text_validated() {
+        let mut spans = vec![CommittedMentionSpan {
+            row: 0,
+            start_col: 0,
+            end_col: "@docs/manual path".chars().count(),
+            text: "@docs/manual path".to_owned(),
+        }];
+        let lines = vec!["@docs/manual path ".to_owned()];
+        retain_valid_committed_mentions(&lines, &mut spans);
+        assert_eq!(spans.len(), 1);
+
+        let lines = vec!["@docs/changed path ".to_owned()];
+        retain_valid_committed_mentions(&lines, &mut spans);
+        assert!(spans.is_empty());
     }
 
     #[test]

--- a/src/app/mention.rs
+++ b/src/app/mention.rs
@@ -48,6 +48,8 @@ enum MentionSearchStatus {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MentionSpanSource {
     Active,
+    QuotedPathClosed,
+    QuotedPathOpen,
     IndexedPath,
     BareToken,
 }
@@ -156,7 +158,18 @@ fn detect_mention_span_at_cursor(
         .filter_map(|trigger_col| {
             resolve_mention_span(cursor_row, &chars, trigger_col, cursor_col, file_index, active)
         })
-        .find(|span| cursor_col > span.trigger_col && cursor_col <= span.end_col)
+        .find(|span| span_contains_activation_cursor(span, cursor_col))
+}
+
+fn span_contains_activation_cursor(span: &MentionSpan, cursor_col: usize) -> bool {
+    cursor_col > span.trigger_col
+        && match span.source {
+            MentionSpanSource::QuotedPathClosed => cursor_col < span.end_col,
+            MentionSpanSource::Active
+            | MentionSpanSource::QuotedPathOpen
+            | MentionSpanSource::IndexedPath
+            | MentionSpanSource::BareToken => cursor_col <= span.end_col,
+        }
 }
 
 fn valid_trigger_cols_before_cursor(chars: &[char], cursor_col: usize) -> Vec<usize> {
@@ -480,7 +493,7 @@ pub fn sync_with_cursor(app: &mut App) {
     }
 }
 
-/// Confirm the selected candidate: replace `@query` in input with `@rel_path`.
+/// Confirm the selected candidate: replace `@query` in input with a quoted `@'rel_path'`.
 pub fn confirm_selection(app: &mut App) {
     let Some(mention) = app.mention.take() else {
         return;
@@ -511,8 +524,8 @@ pub fn confirm_selection(app: &mut App) {
 
     let before: String = chars[..trigger_col].iter().collect();
     let after: String = chars[mention_end..].iter().collect();
-    let replacement =
-        if after.is_empty() { format!("@{rel_path} ") } else { format!("@{rel_path}") };
+    let quoted_path = quote_mention_path(&rel_path);
+    let replacement = if after.is_empty() { format!("{quoted_path} ") } else { quoted_path };
 
     let new_line = format!("{before}{replacement}{after}");
     let new_cursor_col = trigger_col + replacement.chars().count();
@@ -558,22 +571,49 @@ pub fn commit_literal_if_active(app: &mut App) -> bool {
         return true;
     }
 
-    let committed_text: String = chars[start_col..end_col].iter().collect();
-    if raw_end_col == chars.len() && end_col == raw_end_col {
-        let before: String = chars[..end_col].iter().collect();
-        lines[mention.trigger_row] = format!("{before} ");
-        app.input.replace_lines_and_cursor(lines, mention.trigger_row, end_col + 1);
-    } else {
-        app.input.highlight_version = u64::MAX;
-    }
+    let literal_path = literal_path_from_mention_text(&chars[start_col..end_col]);
+    let committed_text = quote_mention_path(&literal_path);
+    let before: String = chars[..start_col].iter().collect();
+    let after: String = chars[end_col..].iter().collect();
+    let replacement =
+        if after.is_empty() { format!("{committed_text} ") } else { committed_text.clone() };
+    let new_cursor_col = start_col + replacement.chars().count();
+    lines[mention.trigger_row] = format!("{before}{replacement}{after}");
+    app.input.replace_lines_and_cursor(lines, mention.trigger_row, new_cursor_col);
 
     app.committed_mentions.push(CommittedMentionSpan {
         row: mention.trigger_row,
         start_col,
-        end_col,
+        end_col: start_col + committed_text.chars().count(),
         text: committed_text,
     });
     true
+}
+
+fn quote_mention_path(path: &str) -> String {
+    format!("@'{}'", escape_quoted_path(path))
+}
+
+fn escape_quoted_path(path: &str) -> String {
+    let mut escaped = String::with_capacity(path.len());
+    for ch in path.chars() {
+        if matches!(ch, '\\' | '\'') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
+fn literal_path_from_mention_text(chars: &[char]) -> String {
+    if chars.first() != Some(&'@') {
+        return chars.iter().collect();
+    }
+    if chars.get(1) == Some(&'\'') {
+        let parsed = parse_quoted_path(chars, 2);
+        return parse_quoted_path_content(chars, 2, parsed.content_end);
+    }
+    chars[1..].iter().collect()
 }
 
 fn trim_trailing_whitespace(chars: &[char], min_col: usize, mut end_col: usize) -> usize {
@@ -696,6 +736,10 @@ fn resolve_mention_span(
         return None;
     }
 
+    if chars.get(trigger_col + 1) == Some(&'\'') {
+        return Some(resolve_quoted_mention_span(row, chars, trigger_col, cursor_col, active));
+    }
+
     if let Some(active) = active
         && active.row == row
         && active.trigger_col == trigger_col
@@ -747,6 +791,98 @@ fn resolve_mention_span(
     Some(MentionSpan { row, trigger_col, end_col, query, source: MentionSpanSource::BareToken })
 }
 
+fn resolve_quoted_mention_span(
+    row: usize,
+    chars: &[char],
+    trigger_col: usize,
+    cursor_col: usize,
+    active: Option<ActiveMentionBounds>,
+) -> MentionSpan {
+    let content_start = trigger_col + 2;
+    let parsed = parse_quoted_path(chars, content_start);
+    let mut end_col = parsed.span_end;
+    if parsed.close.is_none()
+        && let Some(active) = active
+        && active.row == row
+        && active.trigger_col == trigger_col
+        && cursor_col > trigger_col
+        && (cursor_col <= active.replace_end_col || chars.len() > active.line_char_count)
+    {
+        end_col = active.replace_end_col.max(cursor_col).min(chars.len());
+    }
+
+    let query = quoted_span_query(chars, content_start, cursor_col, parsed.content_end);
+    MentionSpan {
+        row,
+        trigger_col,
+        end_col,
+        query,
+        source: if parsed.close.is_some() {
+            MentionSpanSource::QuotedPathClosed
+        } else {
+            MentionSpanSource::QuotedPathOpen
+        },
+    }
+}
+
+struct ParsedQuotedPath {
+    content_end: usize,
+    close: Option<usize>,
+    span_end: usize,
+}
+
+fn parse_quoted_path(chars: &[char], content_start: usize) -> ParsedQuotedPath {
+    let mut escaped = false;
+    for (col, ch) in chars.iter().enumerate().skip(content_start) {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' => escaped = true,
+            '\'' => {
+                return ParsedQuotedPath { content_end: col, close: Some(col), span_end: col + 1 };
+            }
+            _ => {}
+        }
+    }
+
+    ParsedQuotedPath { content_end: chars.len(), close: None, span_end: chars.len() }
+}
+
+fn quoted_span_query(
+    chars: &[char],
+    content_start: usize,
+    cursor_col: usize,
+    content_end: usize,
+) -> String {
+    let query_end = if cursor_col > content_start && cursor_col <= content_end {
+        cursor_col
+    } else {
+        content_end
+    };
+    parse_quoted_path_content(chars, content_start, query_end)
+}
+
+fn parse_quoted_path_content(chars: &[char], start_col: usize, end_col: usize) -> String {
+    let mut content = String::new();
+    let mut escaped = false;
+    for ch in chars[start_col.min(chars.len())..end_col.min(chars.len())].iter().copied() {
+        if escaped {
+            content.push(ch);
+            escaped = false;
+        } else if ch == '\\' {
+            escaped = true;
+        } else {
+            content.push(ch);
+        }
+    }
+    if escaped {
+        content.push('\\');
+    }
+    content
+}
+
 fn span_query(
     chars: &[char],
     trigger_col: usize,
@@ -780,10 +916,14 @@ fn longest_indexed_path_span(
 
 fn bare_token_end_col(chars: &[char], trigger_col: usize) -> usize {
     let mut end_col = trigger_col + 1;
-    while end_col < chars.len() && !chars[end_col].is_whitespace() {
+    while end_col < chars.len() && !is_bare_mention_delimiter(chars[end_col]) {
         end_col += 1;
     }
     end_col
+}
+
+fn is_bare_mention_delimiter(ch: char) -> bool {
+    ch.is_whitespace() || matches!(ch, '\'' | ',' | ';' | ')' | ']' | '}')
 }
 
 #[cfg(test)]
@@ -904,6 +1044,84 @@ mod tests {
     }
 
     #[test]
+    fn detects_and_highlights_quoted_indexed_path() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["docs/my file.md"]);
+
+        let spans = find_mention_spans(0, "open @'docs/my file.md' now", &app.file_index, None);
+
+        assert_eq!(spans, vec![(5, 23, "docs/my file.md".to_owned())]);
+    }
+
+    #[test]
+    fn comma_after_quoted_path_does_not_reenter_autocomplete() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["src/app/mention.rs"]);
+        app.input.set_text("@'src/app/mention.rs'");
+        let _ = app.input.set_cursor(0, app.input.lines()[0].chars().count());
+
+        sync_with_cursor(&mut app);
+        assert!(app.mention.is_none());
+
+        let _ = app.input.textarea_insert_char(',');
+        sync_with_cursor(&mut app);
+
+        assert_eq!(app.input.lines()[0], "@'src/app/mention.rs',");
+        assert!(app.mention.is_none());
+    }
+
+    #[test]
+    fn cursor_inside_quoted_path_reenters_autocomplete() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["src/app/mention.rs"]);
+        app.input.set_text("@'src/app/mention.rs'");
+        let _ = app.input.set_cursor(0, "@'src/app/mention".chars().count());
+
+        sync_with_cursor(&mut app);
+        run_search(&mut app);
+
+        let mention = app.mention.as_ref().expect("mention should re-enter inside quotes");
+        assert_eq!(mention.query, "src/app/mention");
+        assert_eq!(mention.replace_end_col, "@'src/app/mention.rs'".chars().count());
+        assert!(!mention.candidates.is_empty());
+    }
+
+    #[test]
+    fn missing_right_quote_stays_active_and_confirm_repairs_delimiter() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["src/app/mention.rs"]);
+        app.input.set_text("@'src/app/ment");
+        let _ = app.input.set_cursor(0, app.input.lines()[0].chars().count());
+
+        sync_with_cursor(&mut app);
+        run_search(&mut app);
+        confirm_selection(&mut app);
+
+        assert_eq!(app.input.lines()[0], "@'src/app/mention.rs' ");
+        assert!(app.mention.is_none());
+    }
+
+    #[test]
+    fn deleting_left_quote_falls_back_to_bare_path_highlighting() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["src/app/mention.rs"]);
+
+        let spans = find_mention_spans(0, "@src/app/mention.rs'", &app.file_index, None);
+
+        assert_eq!(spans, vec![(0, 19, "src/app/mention.rs".to_owned())]);
+    }
+
+    #[test]
+    fn deleting_right_quote_keeps_literal_highlighting_to_line_end() {
+        let mut app = App::test_default();
+        index_paths(&mut app, &["src/app/mention.rs"]);
+
+        let spans = find_mention_spans(0, "@'src/app/mention.rs", &app.file_index, None);
+
+        assert_eq!(spans, vec![(0, 20, "src/app/mention.rs".to_owned())]);
+    }
+
+    #[test]
     fn reentering_autocomplete_inside_spaced_path_uses_cursor_query_and_full_span() {
         let mut app = App::test_default();
         index_paths(&mut app, &["docs/my folder/read me.md"]);
@@ -934,7 +1152,7 @@ mod tests {
         }
         confirm_selection(&mut app);
 
-        assert_eq!(app.input.lines()[0], "open @docs/my folder/read me.md now");
+        assert_eq!(app.input.lines()[0], "open @'docs/my folder/read me.md' now");
     }
 
     #[test]
@@ -947,7 +1165,7 @@ mod tests {
         run_search(&mut app);
         confirm_selection(&mut app);
 
-        assert_eq!(app.input.lines()[0], "open @src/lib.rs now");
+        assert_eq!(app.input.lines()[0], "open @'src/lib.rs' now");
         assert!(app.mention.is_none());
     }
 
@@ -961,7 +1179,7 @@ mod tests {
         run_search(&mut app);
         confirm_selection(&mut app);
 
-        assert_eq!(app.input.lines()[0], "@src/main.rs ");
+        assert_eq!(app.input.lines()[0], "@'src/main.rs' ");
     }
 
     #[test]
@@ -974,7 +1192,7 @@ mod tests {
         run_search(&mut app);
         confirm_selection(&mut app);
 
-        assert_eq!(app.input.lines()[0], "@path with spaces.md ");
+        assert_eq!(app.input.lines()[0], "@'path with spaces.md' ");
     }
 
     #[test]
@@ -994,7 +1212,7 @@ mod tests {
 
         confirm_selection(&mut app);
 
-        assert_eq!(app.input.lines()[0], "open @path with spaces.md later");
+        assert_eq!(app.input.lines()[0], "open @'path with spaces.md' later");
     }
 
     #[test]
@@ -1043,15 +1261,15 @@ mod tests {
         assert!(commit_literal_if_active(&mut app));
 
         assert!(app.mention.is_none());
-        assert_eq!(app.input.lines()[0], "@docs/manual path ");
-        assert_eq!(app.input.cursor_col(), "@docs/manual path ".chars().count());
+        assert_eq!(app.input.lines()[0], "@'docs/manual path' ");
+        assert_eq!(app.input.cursor_col(), "@'docs/manual path' ".chars().count());
         assert_eq!(
             app.committed_mentions,
             vec![CommittedMentionSpan {
                 row: 0,
                 start_col: 0,
-                end_col: "@docs/manual path".chars().count(),
-                text: "@docs/manual path".to_owned(),
+                end_col: "@'docs/manual path'".chars().count(),
+                text: "@'docs/manual path'".to_owned(),
             }]
         );
     }
@@ -1068,17 +1286,16 @@ mod tests {
 
         assert!(commit_literal_if_active(&mut app));
 
-        assert_eq!(app.input.lines()[0], "@manual path now");
+        assert_eq!(app.input.lines()[0], "@'manual path' now");
         assert_eq!(app.committed_mentions.len(), 1);
-        assert_eq!(app.committed_mentions[0].text, "@manual path");
-        assert_eq!(app.committed_mentions[0].end_col, end_col);
+        assert_eq!(app.committed_mentions[0].text, "@'manual path'");
+        assert_eq!(app.committed_mentions[0].end_col, "@'manual path'".chars().count());
     }
 
     #[test]
     fn commit_literal_with_trailing_separator_space_does_not_add_another_space() {
         let mut app = App::test_default();
         app.input.set_text("@manual path ");
-        let end_col = "@manual path".chars().count();
         let line_end_col = "@manual path ".chars().count();
         let _ = app.input.set_cursor(0, line_end_col);
         let mut mention = MentionState::new(0, 0, "manual path ".to_owned(), Vec::new());
@@ -1087,10 +1304,10 @@ mod tests {
 
         assert!(commit_literal_if_active(&mut app));
 
-        assert_eq!(app.input.lines()[0], "@manual path ");
+        assert_eq!(app.input.lines()[0], "@'manual path' ");
         assert_eq!(app.committed_mentions.len(), 1);
-        assert_eq!(app.committed_mentions[0].text, "@manual path");
-        assert_eq!(app.committed_mentions[0].end_col, end_col);
+        assert_eq!(app.committed_mentions[0].text, "@'manual path'");
+        assert_eq!(app.committed_mentions[0].end_col, "@'manual path'".chars().count());
     }
 
     #[test]
@@ -1112,14 +1329,14 @@ mod tests {
         let mut spans = vec![CommittedMentionSpan {
             row: 0,
             start_col: 0,
-            end_col: "@docs/manual path".chars().count(),
-            text: "@docs/manual path".to_owned(),
+            end_col: "@'docs/manual path'".chars().count(),
+            text: "@'docs/manual path'".to_owned(),
         }];
-        let lines = vec!["@docs/manual path ".to_owned()];
+        let lines = vec!["@'docs/manual path' ".to_owned()];
         retain_valid_committed_mentions(&lines, &mut spans);
         assert_eq!(spans.len(), 1);
 
-        let lines = vec!["@docs/changed path ".to_owned()];
+        let lines = vec!["@'docs/changed path' ".to_owned()];
         retain_valid_committed_mentions(&lines, &mut spans);
         assert!(spans.is_empty());
     }

--- a/src/app/state/app.rs
+++ b/src/app/state/app.rs
@@ -54,6 +54,8 @@ pub struct App {
     pub chat_render: ChatRenderState,
     /// Active `@` file mention autocomplete state.
     pub mention: Option<mention::MentionState>,
+    /// Visual-only literal `@` mentions committed by the user.
+    pub committed_mentions: Vec<mention::CommittedMentionSpan>,
     /// App-owned file index backing `@` file mention autocomplete.
     pub file_index: file_index::FileIndexState,
     /// Active slash-command autocomplete state.
@@ -184,6 +186,7 @@ impl App {
             session_picker: SessionPickerState::default(),
             chat_render: ChatRenderState::default(),
             mention: None,
+            committed_mentions: Vec::new(),
             file_index: file_index::FileIndexState::default(),
             slash: None,
             subagent: None,

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -108,11 +108,19 @@ pub(crate) fn configure_input_textarea(app: &mut App) {
 
     if needs_highlight_update || app.mention.is_some() {
         let lines = app.input.lines().to_vec();
+        mention::retain_valid_committed_mentions(&lines, &mut app.committed_mentions);
+        let committed_mentions = app.committed_mentions.clone();
         let active_mention = app.mention.as_ref();
         let file_index = &app.file_index;
         let textarea = app.input.editor_mut();
         textarea.clear_custom_highlight();
-        apply_textarea_highlights(textarea, &lines, file_index, active_mention);
+        apply_textarea_highlights(
+            textarea,
+            &lines,
+            file_index,
+            active_mention,
+            &committed_mentions,
+        );
         app.input.highlight_version = app.input.content_version;
     }
 }
@@ -122,6 +130,7 @@ fn apply_textarea_highlights(
     lines: &[String],
     file_index: &crate::app::file_index::FileIndexState,
     active_mention: Option<&mention::MentionState>,
+    committed_mentions: &[mention::CommittedMentionSpan],
 ) {
     let slash_style = Style::default().fg(theme::SLASH_COMMAND);
     let mention_style = Style::default().fg(Color::Cyan);
@@ -141,6 +150,14 @@ fn apply_textarea_highlights(
         for (start, end, _) in mention::find_mention_spans(row, line, file_index, active_mention) {
             textarea.custom_highlight(
                 ((row, start), (row, end)),
+                mention_style,
+                HIGHLIGHT_MENTION_PRIORITY,
+            );
+        }
+
+        for span in committed_mentions.iter().filter(|span| span.row == row) {
+            textarea.custom_highlight(
+                ((row, span.start_col), (row, span.end_col)),
                 mention_style,
                 HIGHLIGHT_MENTION_PRIORITY,
             );
@@ -201,11 +218,12 @@ mod tests {
         CANCEL_HINT_LINES, LOGIN_HINT_LINES, MAX_INPUT_HEIGHT, PROMPT_SUGGESTION_HINT_LINES,
         configure_input_textarea, slash_command_range, visual_line_count,
     };
+    use crate::app::mention::CommittedMentionSpan;
     use crate::app::subagent::find_subagent_spans;
     use crate::app::{App, CancelOrigin, FocusTarget, LoginHint};
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
-    use ratatui::style::Modifier;
+    use ratatui::style::{Color, Modifier};
     use ratatui::widgets::Widget;
 
     #[test]
@@ -307,5 +325,43 @@ mod tests {
         let cursor_cell = buffer.cell((5, 0)).expect("cursor cell");
         assert_eq!(cursor_cell.symbol(), " ");
         assert!(cursor_cell.style().add_modifier.contains(Modifier::REVERSED));
+    }
+
+    #[test]
+    fn committed_literal_mention_renders_with_mention_style() {
+        let mut app = App::test_default();
+        app.input.set_text("@docs/manual path ");
+        let _ = app.input.set_cursor(0, app.input.lines()[0].chars().count());
+        app.committed_mentions.push(CommittedMentionSpan {
+            row: 0,
+            start_col: 0,
+            end_col: "@docs/manual path".chars().count(),
+            text: "@docs/manual path".to_owned(),
+        });
+
+        configure_input_textarea(&mut app);
+        let area = Rect::new(0, 0, 24, 1);
+        let mut buffer = Buffer::empty(area);
+        app.input.editor().render(area, &mut buffer);
+
+        let cell = buffer.cell((1, 0)).expect("mention cell");
+        assert_eq!(cell.symbol(), "d");
+        assert_eq!(cell.style().fg, Some(Color::Cyan));
+    }
+
+    #[test]
+    fn stale_committed_literal_mention_is_pruned_before_highlighting() {
+        let mut app = App::test_default();
+        app.input.set_text("@docs/changed path ");
+        app.committed_mentions.push(CommittedMentionSpan {
+            row: 0,
+            start_col: 0,
+            end_col: "@docs/manual path".chars().count(),
+            text: "@docs/manual path".to_owned(),
+        });
+
+        configure_input_textarea(&mut app);
+
+        assert!(app.committed_mentions.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Add Tab support for committing active file mentions even when autocomplete has no selectable match.
- Render committed literal file mentions as highlighted spans and prune stale spans when the input changes.
- Complete selected and literal file mentions as quoted `@'path'` tokens, with a trailing space at line end.
- Keep punctuation after quoted file mentions outside autocomplete while still allowing re-entry from inside the quoted path.

## Why

File mention autocomplete previously trapped users in the active mention state when they typed unknown paths, because whitespace no longer worked as an exit once paths with spaces were supported. After completion, punctuation next to file mentions could also reopen autocomplete and show a failed match state.

This gives users an explicit, keymap-backed exit with Tab for known and unknown paths, and adds visible quote boundaries so completed file mentions can sit next to commas or other prose without losing the ability to re-enter autocomplete by moving the cursor back into the path.

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
- Manual:
  - Confirmed Tab commits an unmatched `@` file path into a highlighted mention with a trailing space at line end.
  - Confirmed selected autocomplete candidates complete as quoted `@'path'` mentions.
  - Confirmed typing punctuation after a completed quoted mention does not reopen autocomplete.
  - Confirmed moving the cursor inside a quoted mention re-enters file autocomplete.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
