### PR TITLE
feat(release): add arm64 npm binaries

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -155,11 +155,21 @@ jobs:
             package_dir: linux-x64-gnu
             exe: claude-rs
             asset: claude-code-rust-x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            package_dir: linux-arm64-gnu
+            exe: claude-rs
+            asset: claude-code-rust-aarch64-unknown-linux-gnu
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             package_dir: win32-x64-msvc
             exe: claude-rs.exe
             asset: claude-code-rust-x86_64-pc-windows-msvc.exe
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            package_dir: win32-arm64-msvc
+            exe: claude-rs.exe
+            asset: claude-code-rust-aarch64-pc-windows-msvc.exe
           - runner: macos-15-intel
             target: x86_64-apple-darwin
             package_dir: darwin-x64
@@ -182,7 +192,7 @@ jobs:
 
   assemble-release-candidate:
     needs: [verify-release-candidate, agent-sdk-preflight, build-release-candidate]
-    name: Assemble, verify, and smoke-test npm packages
+    name: Assemble and verify npm packages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -217,8 +227,17 @@ jobs:
       - name: Verify npm package layout
         run: node scripts/verify-npm-packages.mjs --version "${{ needs.verify-release-candidate.outputs.version }}"
 
-      - name: Pack and smoke-test npm install
-        run: node scripts/smoke-npm-package-install.mjs --real-binary
+      - name: Pack npm tarballs
+        run: |
+          set -euo pipefail
+          mkdir -p dist-pack
+          npm pack ./dist-npm/darwin-arm64 --pack-destination ./dist-pack --json
+          npm pack ./dist-npm/darwin-x64 --pack-destination ./dist-pack --json
+          npm pack ./dist-npm/linux-arm64-gnu --pack-destination ./dist-pack --json
+          npm pack ./dist-npm/linux-x64-gnu --pack-destination ./dist-pack --json
+          npm pack ./dist-npm/win32-arm64-msvc --pack-destination ./dist-pack --json
+          npm pack ./dist-npm/win32-x64-msvc --pack-destination ./dist-pack --json
+          npm pack ./dist-npm/root --pack-destination ./dist-pack --json
 
       - name: Generate SHA256SUMS
         shell: bash
@@ -239,3 +258,39 @@ jobs:
             dist-pack/*.tgz
             SHA256SUMS
           if-no-files-found: error
+
+  smoke-release-candidate-packages:
+    needs: [verify-release-candidate, assemble-release-candidate]
+    name: Smoke ${{ matrix.package_dir }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            package_dir: linux-x64-gnu
+          - runner: ubuntu-24.04-arm
+            package_dir: linux-arm64-gnu
+          - runner: windows-latest
+            package_dir: win32-x64-msvc
+          - runner: windows-11-arm
+            package_dir: win32-arm64-msvc
+          - runner: macos-15-intel
+            package_dir: darwin-x64
+          - runner: macos-15
+            package_dir: darwin-arm64
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+
+      - name: Download release candidate artifact set
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-candidate-${{ needs.verify-release-candidate.outputs.version }}
+          path: .
+
+      - name: Smoke-test installed npm tarballs
+        run: node scripts/smoke-npm-package-install.mjs --platform "${{ matrix.package_dir }}" --use-existing-tarballs --real-binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,9 @@ jobs:
           check_absent "claude-code-rust"
           check_absent "@srothgan/claude-code-rust-darwin-arm64"
           check_absent "@srothgan/claude-code-rust-darwin-x64"
+          check_absent "@srothgan/claude-code-rust-linux-arm64-gnu"
           check_absent "@srothgan/claude-code-rust-linux-x64-gnu"
+          check_absent "@srothgan/claude-code-rust-win32-arm64-msvc"
           check_absent "@srothgan/claude-code-rust-win32-x64-msvc"
 
   agent-sdk-preflight:
@@ -116,11 +118,21 @@ jobs:
             package_dir: linux-x64-gnu
             exe: claude-rs
             asset: claude-code-rust-x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            package_dir: linux-arm64-gnu
+            exe: claude-rs
+            asset: claude-code-rust-aarch64-unknown-linux-gnu
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             package_dir: win32-x64-msvc
             exe: claude-rs.exe
             asset: claude-code-rust-x86_64-pc-windows-msvc.exe
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            package_dir: win32-arm64-msvc
+            exe: claude-rs.exe
+            asset: claude-code-rust-aarch64-pc-windows-msvc.exe
           - runner: macos-15-intel
             target: x86_64-apple-darwin
             package_dir: darwin-x64
@@ -185,7 +197,9 @@ jobs:
           mkdir -p dist-pack
           npm pack ./dist-npm/darwin-arm64 --pack-destination ./dist-pack --json
           npm pack ./dist-npm/darwin-x64 --pack-destination ./dist-pack --json
+          npm pack ./dist-npm/linux-arm64-gnu --pack-destination ./dist-pack --json
           npm pack ./dist-npm/linux-x64-gnu --pack-destination ./dist-pack --json
+          npm pack ./dist-npm/win32-arm64-msvc --pack-destination ./dist-pack --json
           npm pack ./dist-npm/win32-x64-msvc --pack-destination ./dist-pack --json
           npm pack ./dist-npm/root --pack-destination ./dist-pack --json
 
@@ -218,8 +232,12 @@ jobs:
         include:
           - runner: ubuntu-latest
             package_dir: linux-x64-gnu
+          - runner: ubuntu-24.04-arm
+            package_dir: linux-arm64-gnu
           - runner: windows-latest
             package_dir: win32-x64-msvc
+          - runner: windows-11-arm
+            package_dir: win32-arm64-msvc
           - runner: macos-15-intel
             package_dir: darwin-x64
           - runner: macos-15
@@ -318,7 +336,17 @@ jobs:
             --signer-workflow "$signer_workflow" \
             --source-ref refs/heads/main \
             --deny-self-hosted-runners
+          gh attestation verify dist-assets/claude-code-rust-aarch64-unknown-linux-gnu \
+            --repo srothgan/claude-code-rust \
+            --signer-workflow "$signer_workflow" \
+            --source-ref refs/heads/main \
+            --deny-self-hosted-runners
           gh attestation verify dist-assets/claude-code-rust-x86_64-pc-windows-msvc.exe \
+            --repo srothgan/claude-code-rust \
+            --signer-workflow "$signer_workflow" \
+            --source-ref refs/heads/main \
+            --deny-self-hosted-runners
+          gh attestation verify dist-assets/claude-code-rust-aarch64-pc-windows-msvc.exe \
             --repo srothgan/claude-code-rust \
             --signer-workflow "$signer_workflow" \
             --source-ref refs/heads/main \
@@ -360,6 +388,28 @@ jobs:
           npm install -g npm@11
           npm --version
 
+      - name: Dry-run platform tarball publish
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.verify.outputs.version }}"
+          publish_package() {
+            local package_name="$1"
+            local filename="${package_name#@}"
+            filename="${filename/\//-}-${VERSION}.tgz"
+            local tarball="./dist-pack/$filename"
+            if [ ! -f "$tarball" ]; then
+              echo "::error::Missing npm package tarball: $tarball"
+              exit 1
+            fi
+            npm publish "$tarball" --access public --dry-run
+          }
+          publish_package "@srothgan/claude-code-rust-darwin-arm64"
+          publish_package "@srothgan/claude-code-rust-darwin-x64"
+          publish_package "@srothgan/claude-code-rust-linux-arm64-gnu"
+          publish_package "@srothgan/claude-code-rust-linux-x64-gnu"
+          publish_package "@srothgan/claude-code-rust-win32-arm64-msvc"
+          publish_package "@srothgan/claude-code-rust-win32-x64-msvc"
+
       - name: Publish platform tarballs
         run: |
           set -euo pipefail
@@ -377,7 +427,9 @@ jobs:
           }
           publish_package "@srothgan/claude-code-rust-darwin-arm64"
           publish_package "@srothgan/claude-code-rust-darwin-x64"
+          publish_package "@srothgan/claude-code-rust-linux-arm64-gnu"
           publish_package "@srothgan/claude-code-rust-linux-x64-gnu"
+          publish_package "@srothgan/claude-code-rust-win32-arm64-msvc"
           publish_package "@srothgan/claude-code-rust-win32-x64-msvc"
 
   publish-root-package:
@@ -405,6 +457,16 @@ jobs:
         run: |
           npm install -g npm@11
           npm --version
+
+      - name: Dry-run root tarball publish
+        run: |
+          set -euo pipefail
+          tarball="./dist-pack/claude-code-rust-${{ needs.verify.outputs.version }}.tgz"
+          if [ ! -f "$tarball" ]; then
+            echo "::error::Missing npm package tarball: $tarball"
+            exit 1
+          fi
+          npm publish "$tarball" --access public --dry-run
 
       - name: Publish root tarball
         run: |

--- a/bin/claude-rs.js
+++ b/bin/claude-rs.js
@@ -18,8 +18,16 @@ const TARGETS = {
     packageName: "@srothgan/claude-code-rust-linux-x64-gnu",
     exe: "claude-rs"
   },
+  "linux:arm64": {
+    packageName: "@srothgan/claude-code-rust-linux-arm64-gnu",
+    exe: "claude-rs"
+  },
   "win32:x64": {
     packageName: "@srothgan/claude-code-rust-win32-x64-msvc",
+    exe: "claude-rs.exe"
+  },
+  "win32:arm64": {
+    packageName: "@srothgan/claude-code-rust-win32-arm64-msvc",
     exe: "claude-rs.exe"
   }
 };

--- a/scripts/npm-package-config.mjs
+++ b/scripts/npm-package-config.mjs
@@ -31,12 +31,29 @@ export const PLATFORM_PACKAGES = [
     rustTarget: "x86_64-unknown-linux-gnu"
   },
   {
+    dir: "linux-arm64-gnu",
+    packageName: "@srothgan/claude-code-rust-linux-arm64-gnu",
+    os: ["linux"],
+    cpu: ["arm64"],
+    libc: ["glibc"],
+    binaryName: "claude-rs",
+    rustTarget: "aarch64-unknown-linux-gnu"
+  },
+  {
     dir: "win32-x64-msvc",
     packageName: "@srothgan/claude-code-rust-win32-x64-msvc",
     os: ["win32"],
     cpu: ["x64"],
     binaryName: "claude-rs.exe",
     rustTarget: "x86_64-pc-windows-msvc"
+  },
+  {
+    dir: "win32-arm64-msvc",
+    packageName: "@srothgan/claude-code-rust-win32-arm64-msvc",
+    os: ["win32"],
+    cpu: ["arm64"],
+    binaryName: "claude-rs.exe",
+    rustTarget: "aarch64-pc-windows-msvc"
   }
 ];
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -744,7 +744,9 @@ fn platform_package_name() -> Option<&'static str> {
         ("macos", "aarch64") => Some("@srothgan/claude-code-rust-darwin-arm64"),
         ("macos", "x86_64") => Some("@srothgan/claude-code-rust-darwin-x64"),
         ("linux", "x86_64") => Some("@srothgan/claude-code-rust-linux-x64-gnu"),
+        ("linux", "aarch64") => Some("@srothgan/claude-code-rust-linux-arm64-gnu"),
         ("windows", "x86_64") => Some("@srothgan/claude-code-rust-win32-x64-msvc"),
+        ("windows", "aarch64") => Some("@srothgan/claude-code-rust-win32-arm64-msvc"),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

Add Linux arm64 glibc and Windows arm64 MSVC npm platform package support for `claude-code-rust`.

## Why

The release pipeline currently builds and publishes only x64 Linux/Windows plus macOS platform packages. This change extends the existing platform-package contract so ARM64 Linux and Windows hosts can resolve, install, smoke-test, attest, and publish native binaries through the same npm release flow.

Refs #241

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `git diff --check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `npm --prefix agent-sdk test`
  - `npm --prefix agent-sdk run lint`
  - `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml .github/workflows/nightly.yml`
  - `node scripts/generate-npm-packages.mjs --mock-binaries --version 0.13.3 --out-dir <temp>`
  - `node scripts/verify-npm-packages.mjs --version 0.13.3 --dist-dir <temp>`
- Manual:
  - Verified release and nightly workflow package names/directories match `scripts/npm-package-config.mjs`.
  - Verified npm bootstrap packages exist for `@srothgan/claude-code-rust-linux-arm64-gnu` and `@srothgan/claude-code-rust-win32-arm64-msvc`.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Real ARM64 binary smoke coverage depends on the GitHub-hosted `ubuntu-24.04-arm` and `windows-11-arm` workflow jobs.
