### PR TITLE
chore(release): publish 0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.3] - 2026-07-04 [Changes][v0.13.3]
+
+### Features
+
+- **ARM64 npm binaries** (#243, @srothgan): Add Linux arm64 glibc and Windows arm64 MSVC platform packages to the npm release flow.
+
+### Fixes
+
+- **File mention completion** (#242, @srothgan): Let `Tab` commit selected or literal `@` file mentions with quoted paths and cleaner autocomplete boundaries.
+- **Release publication targeting** (#238, #239, @srothgan): Verify reusable-workflow attestations and pin GitHub Release publishing to the target repository.
+
+### Release and Packaging
+
+- **Platform package READMEs** (@srothgan): Generate concise platform-specific npm READMEs with version, install, target, and platform details.
+- **Dependency declarations** (#240, @srothgan): Remove redundant direct npm dependencies while keeping runtime installs unchanged.
+
 ## [0.13.2] - 2026-07-03 [Changes][v0.13.2]
 
 ### Features
@@ -698,6 +714,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.13.3]: https://github.com/srothgan/claude-code-rust/compare/v0.13.2...v0.13.3
 [v0.13.2]: https://github.com/srothgan/claude-code-rust/compare/v0.13.0...v0.13.2
 [v0.13.0]: https://github.com/srothgan/claude-code-rust/compare/v0.12.4...v0.13.0
 [v0.12.4]: https://github.com/srothgan/claude-code-rust/compare/v0.12.3...v0.12.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,8 @@ By participating, you agree to uphold this code.
 ### Prerequisites
 
 - Rust 1.88.0+ (install via https://rustup.rs)
-- Node.js 18+ (for the in-repo agent bridge)
+- Node.js 18+ for the in-repo agent bridge runtime. This follows `@anthropic-ai/claude-agent-sdk`, which currently declares Node `>=18.0.0`.
+- Node.js 24 is recommended for contributor JavaScript tooling and matches CI. Some `agent-sdk` dev dependencies require Node `20.19.x` or `>=22.12.0`, so Node 18 is not sufficient for every local `npm ci` or tooling run.
 - npx (included with Node.js)
 
 ### Clone and Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rust",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rust",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.198"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-rust",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Claude Code Rust - native Rust terminal interface for Claude Code",
   "keywords": [
     "cli",

--- a/scripts/generate-npm-packages.mjs
+++ b/scripts/generate-npm-packages.mjs
@@ -64,7 +64,7 @@ function generatePlatformPackage(platformPackage) {
     path.join(packageDir, "package.json"),
     buildPlatformPackageJson({ platformPackage, version, rootPackageJson })
   );
-  copyFileFromRepo("README.md", path.join(packageDir, "README.md"));
+  writePlatformReadme(platformPackage, path.join(packageDir, "README.md"));
   copyFileFromRepo("LICENSE", path.join(packageDir, "LICENSE"));
 
   const destination = path.join(packageDir, "bin", platformPackage.binaryName);
@@ -132,6 +132,40 @@ function copyFileFromRepo(relativeSource, destination) {
   const source = path.join(repoRoot, relativeSource);
   fs.mkdirSync(path.dirname(destination), { recursive: true });
   fs.copyFileSync(source, destination);
+}
+
+function writePlatformReadme(platformPackage, destination) {
+  const projectName = "claude-code-rust";
+  const projectUrl = typeof rootPackageJson.homepage === "string" ? rootPackageJson.homepage : undefined;
+  const projectReference = projectUrl ? `[${projectName}](${projectUrl})` : `\`${projectName}\``;
+  const npmPackageUrl = `https://www.npmjs.com/package/${platformPackage.packageName}`;
+  const targetDetails = [
+    `- Rust target: \`${platformPackage.rustTarget}\``,
+    `- npm package: [\`${platformPackage.packageName}\`](${npmPackageUrl})`,
+    `- npm platform directory: \`${platformPackage.dir}\``,
+    `- OS: \`${platformPackage.os.join(", ")}\``,
+    `- CPU: \`${platformPackage.cpu.join(", ")}\``
+  ];
+
+  if (platformPackage.libc) {
+    targetDetails.push(`- libc: \`${platformPackage.libc.join(", ")}\``);
+  }
+
+  const content = `# \`${platformPackage.packageName}\`
+
+This is the **${platformPackage.rustTarget}** native binary package for ${projectReference} version \`${version}\`.
+
+Install \`${projectName}\` instead; this package is selected automatically as an optional dependency on matching platforms.
+
+\`\`\`bash
+npm install -g ${projectName}
+\`\`\`
+
+${targetDetails.join("\n")}
+`;
+
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(destination, content, "utf8");
 }
 
 function writeMockBinary(platformPackage, destination) {

--- a/scripts/verify-npm-packages.mjs
+++ b/scripts/verify-npm-packages.mjs
@@ -132,6 +132,7 @@ function verifyPlatformPackage(platformPackage) {
     `${context} local file list`
   );
   expectNoForbiddenFiles(files, context);
+  expectPlatformReadme(packageDir, platformPackage, context);
   expectUnixBinaryExecutable(packageDir, platformPackage, expectedBinaryPath, context);
 
   const packManifest = packAndVerify(packageDir, context, (filePath) =>
@@ -325,6 +326,25 @@ function expectNoForbiddenFiles(files, context) {
   }
 }
 
+function expectPlatformReadme(packageDir, platformPackage, context) {
+  const readme = fs.readFileSync(path.join(packageDir, "README.md"), "utf8");
+  expectIncludes(readme, `# \`${platformPackage.packageName}\``, `${context} README title`);
+  expectIncludes(readme, platformPackage.rustTarget, `${context} README Rust target`);
+  expectIncludes(readme, `version \`${expectedVersion}\``, `${context} README version`);
+  expectIncludes(readme, "npm install -g claude-code-rust", `${context} README install command`);
+  expectIncludes(
+    readme,
+    `https://www.npmjs.com/package/${platformPackage.packageName}`,
+    `${context} README npm package link`
+  );
+
+  if (platformPackage.libc) {
+    expectIncludes(readme, `- libc: \`${platformPackage.libc.join(", ")}\``, `${context} README libc`);
+  } else if (readme.includes("- libc:")) {
+    fail(`${context} README must not include libc details`);
+  }
+}
+
 function expectLauncherUsesPlatformPackages(packageDir, context) {
   const launcher = fs.readFileSync(path.join(packageDir, "bin", "claude-rs.js"), "utf8");
   if (launcher.includes('"vendor"') || launcher.includes("'vendor'")) {
@@ -383,6 +403,12 @@ function expectEqual(actual, expected, label) {
 function expectDeepEqual(actual, expected, label) {
   if (JSON.stringify(actual) !== JSON.stringify(expected)) {
     fail(`${label}: expected ${formatValue(expected)}, got ${formatValue(actual)}`);
+  }
+}
+
+function expectIncludes(haystack, needle, label) {
+  if (!haystack.includes(needle)) {
+    fail(`${label}: expected to include ${formatValue(needle)}`);
   }
 }
 


### PR DESCRIPTION
## Summary

- Prepare the `0.13.3` release with Cargo/npm version bumps and a concise changelog entry.
- Add Linux arm64 glibc and Windows arm64 MSVC npm platform packages to the release pipeline.
- Improve file mention completion so `Tab` commits selected or literal `@` paths with cleaner quoted boundaries.
- Generate scoped platform-package READMEs instead of reusing the root project README.
- Tighten release publishing checks and trim redundant direct npm dependency declarations.

## Why

This release carries the post-`0.13.2` packaging and release hardening work, expands npm binary coverage to ARM64 Linux and Windows hosts, and includes the file mention completion fix needed for paths that do not map cleanly to an autocomplete selection.

The platform package README change makes scoped npm package pages clearer by identifying the native target, release version, install command, package link, and platform selectors without duplicating the full root README.

Closes #

## Validation

- Automated:
  - `git diff --check`
  - `node --check scripts\generate-npm-packages.mjs`
  - `node --check scripts\verify-npm-packages.mjs`
  - `node scripts\generate-npm-packages.mjs --mock-binaries`
  - `node scripts\verify-npm-packages.mjs`
  - `cargo fmt --all -- --check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
- Manual:
  - Reviewed merged PRs `#238`, `#239`, `#240`, `#242`, and `#243` for the `0.13.3` changelog.
  - Confirmed generated platform READMEs include the root install command and target-specific metadata.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: Yes, changelog, platform package READMEs, and contributor Node version guidance.
