### PR TITLE
feat(runtime): bundle Bun for Agent SDK bridge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,20 @@
 * text=auto
 
+.gitattributes text eol=lf
+.gitignore text eol=lf
 *.rs text eol=lf
 *.toml text eol=lf
 *.md text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
 *.json text eol=lf
+*.js text eol=lf
+*.cjs text eol=lf
+*.mjs text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.mts text eol=lf
+*.cts text eol=lf
 Cargo.lock text eol=lf
 
 *.bat text eol=crlf

--- a/.github/workflows/_release-build.yml
+++ b/.github/workflows/_release-build.yml
@@ -78,6 +78,6 @@ jobs:
         with:
           name: ${{ inputs.artifact_prefix }}-${{ inputs.package_dir }}
           path: |
-            dist-assets/*
-            dist-platform/${{ inputs.package_dir }}/bin/*
+            dist-assets/
+            dist-platform/${{ inputs.package_dir }}/
           if-no-files-found: error

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -127,12 +127,20 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
       - name: Get crate version
         id: get_version
         run: |
           VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Release candidate version: $VERSION"
+
+      - name: Validate Bun runtime manifest
+        run: node scripts/stage-bun-runtime.mjs --check --verify-upstream
 
   agent-sdk-preflight:
     needs: [verify-release-candidate]
@@ -190,8 +198,30 @@ jobs:
       artifact_prefix: release-candidate
       attest: false
 
+  stage-release-candidate-runtimes:
+    needs: [verify-release-candidate]
+    name: Stage bundled Bun runtimes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Download, verify, and stage Bun runtimes
+        run: node scripts/stage-bun-runtime.mjs --download
+
+      - name: Upload staged Bun runtimes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: bundled-bun-runtimes-candidate
+          path: dist-platform/*/bin/claude-rs-bridge-bun*
+          if-no-files-found: error
+
   assemble-release-candidate:
-    needs: [verify-release-candidate, agent-sdk-preflight, build-release-candidate]
+    needs: [verify-release-candidate, agent-sdk-preflight, build-release-candidate, stage-release-candidate-runtimes]
     name: Assemble and verify npm packages
     runs-on: ubuntu-latest
     steps:
@@ -212,6 +242,17 @@ jobs:
           merge-multiple: true
           path: .
 
+      - name: Download staged Bun runtimes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: bundled-bun-runtimes-candidate
+          path: dist-platform
+
+      - name: Restore executable bits for downloaded Unix artifacts
+        run: |
+          set -euo pipefail
+          find dist-platform -type f \( -name 'claude-rs' -o -name 'claude-rs-bridge-bun' \) -exec chmod 755 {} +
+
       - name: Install root dependencies
         run: npm ci
 
@@ -220,6 +261,11 @@ jobs:
 
       - name: Build agent-sdk bridge
         run: npm --prefix agent-sdk run build
+
+      - name: Verify staged Bun runtimes
+        run: |
+          node scripts/stage-bun-runtime.mjs --check
+          node scripts/verify-staged-bun-runtimes.mjs
 
       - name: Assemble npm packages
         run: node scripts/generate-npm-packages.mjs --version "${{ needs.verify-release-candidate.outputs.version }}"
@@ -239,11 +285,14 @@ jobs:
           npm pack ./dist-npm/win32-x64-msvc --pack-destination ./dist-pack --json
           npm pack ./dist-npm/root --pack-destination ./dist-pack --json
 
+      - name: Dry-run npm tarball publish
+        run: node scripts/dry-run-npm-publish.mjs --pack-dir dist-pack --version "${{ needs.verify-release-candidate.outputs.version }}"
+
       - name: Generate SHA256SUMS
         shell: bash
         run: |
           set -euo pipefail
-          find dist-assets dist-pack -type f -print0 \
+          find dist-assets dist-pack dist-npm/manifests -type f -print0 \
             | sort -z \
             | xargs -0 sha256sum > SHA256SUMS
           cat SHA256SUMS
@@ -253,9 +302,9 @@ jobs:
         with:
           name: release-candidate-${{ needs.verify-release-candidate.outputs.version }}
           path: |
-            dist-assets/*
-            dist-npm/manifests/*.json
-            dist-pack/*.tgz
+            dist-assets/
+            dist-npm/manifests/
+            dist-pack/
             SHA256SUMS
           if-no-files-found: error
 
@@ -286,6 +335,9 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Install root runtime dependencies for registry smoke
+        run: npm ci --omit=dev --ignore-scripts
+
       - name: Download release candidate artifact set
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -293,4 +345,7 @@ jobs:
           path: .
 
       - name: Smoke-test installed npm tarballs
-        run: node scripts/smoke-npm-package-install.mjs --platform "${{ matrix.package_dir }}" --use-existing-tarballs --real-binary
+        run: node scripts/smoke-npm-package-install.mjs --platform "${{ matrix.package_dir }}" --use-existing-tarballs --real-binary --no-system-runtime
+
+      - name: Smoke-test global npm install from temp registry
+        run: node scripts/smoke-npm-package-install.mjs --platform "${{ matrix.package_dir }}" --use-existing-tarballs --registry-smoke --real-binary --no-system-runtime

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -156,8 +156,11 @@ jobs:
           node scripts/verify-third-party-notices.mjs
           node --test scripts/npm-resolver.test.cjs scripts/smoke-npm-package-install.test.mjs scripts/verify-staged-bun-runtimes.test.mjs scripts/dry-run-npm-publish.test.mjs scripts/publish-npm-platform-packages.test.mjs
 
-      - name: Generate mock npm packages
-        run: node scripts/generate-npm-packages.mjs --mock-binaries
+      - name: Stage bundled Bun runtimes
+        run: node scripts/stage-bun-runtime.mjs --download
+
+      - name: Generate npm packages with mock native binaries
+        run: node scripts/generate-npm-packages.mjs --mock-native-binary
 
       - name: Verify npm package layout
         run: node scripts/verify-npm-packages.mjs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,7 +50,7 @@ jobs:
           agent_sdk=false
           while IFS= read -r path; do
             case "$path" in
-              Cargo.toml|Cargo.lock|deny.toml|package.json|package-lock.json|bin/*|agent-sdk/*|scripts/generate-npm-packages.mjs|scripts/npm-package-config.mjs|scripts/smoke-npm-package-install.mjs|scripts/verify-npm-packages.mjs|.github/workflows/pr.yml|.github/workflows/_agent-sdk.yml|.github/workflows/_release-build.yml|.github/workflows/release.yml|.github/workflows/nightly.yml)
+              Cargo.toml|Cargo.lock|deny.toml|package.json|package-lock.json|bin/*|agent-sdk/*|scripts/dry-run-npm-publish.mjs|scripts/dry-run-npm-publish.test.mjs|scripts/generate-npm-packages.mjs|scripts/npm-package-config.mjs|scripts/npm-resolver.test.cjs|scripts/publish-npm-platform-packages.mjs|scripts/publish-npm-platform-packages.test.mjs|scripts/smoke-npm-package-install.mjs|scripts/smoke-npm-package-install.test.mjs|scripts/stage-bun-runtime.mjs|scripts/third-party-notices.mjs|scripts/verify-npm-packages.mjs|scripts/verify-staged-bun-runtimes.mjs|scripts/verify-staged-bun-runtimes.test.mjs|scripts/verify-third-party-notices.mjs|.github/workflows/pr.yml|.github/workflows/_agent-sdk.yml|.github/workflows/_release-build.yml|.github/workflows/release.yml|.github/workflows/nightly.yml)
                 package=true
                 ;;
             esac
@@ -149,6 +149,12 @@ jobs:
 
       - name: Build agent-sdk bridge
         run: npm --prefix agent-sdk run build
+
+      - name: Run npm packaging script tests
+        run: |
+          node scripts/stage-bun-runtime.mjs --check
+          node scripts/verify-third-party-notices.mjs
+          node --test scripts/npm-resolver.test.cjs scripts/smoke-npm-package-install.test.mjs scripts/verify-staged-bun-runtimes.test.mjs scripts/dry-run-npm-publish.test.mjs scripts/publish-npm-platform-packages.test.mjs
 
       - name: Generate mock npm packages
         run: node scripts/generate-npm-packages.mjs --mock-binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
-          check_absent() {
+          check_recoverable() {
             local package_name="$1"
             local output
             local status
@@ -75,25 +75,27 @@ jobs:
             status=$?
             set -e
             if [ "$status" -eq 0 ]; then
-              echo "::error::npm package version already exists: ${package_name}@${VERSION}"
-              echo "$output"
-              exit 1
+              echo "NOTICE: ${package_name}@${VERSION} already exists; its publish job will verify tarball integrity before reusing it"
+              return
             fi
             if ! printf '%s\n' "$output" | grep -q 'E404'; then
-              echo "::error::Could not verify npm package absence for ${package_name}@${VERSION}"
+              echo "::error::Could not verify npm package state for ${package_name}@${VERSION}"
               echo "$output"
               exit 1
             fi
             echo "OK: ${package_name}@${VERSION} is not published"
           }
 
-          check_absent "claude-code-rust"
-          check_absent "@srothgan/claude-code-rust-darwin-arm64"
-          check_absent "@srothgan/claude-code-rust-darwin-x64"
-          check_absent "@srothgan/claude-code-rust-linux-arm64-gnu"
-          check_absent "@srothgan/claude-code-rust-linux-x64-gnu"
-          check_absent "@srothgan/claude-code-rust-win32-arm64-msvc"
-          check_absent "@srothgan/claude-code-rust-win32-x64-msvc"
+          check_recoverable "claude-code-rust"
+          check_recoverable "@srothgan/claude-code-rust-darwin-arm64"
+          check_recoverable "@srothgan/claude-code-rust-darwin-x64"
+          check_recoverable "@srothgan/claude-code-rust-linux-arm64-gnu"
+          check_recoverable "@srothgan/claude-code-rust-linux-x64-gnu"
+          check_recoverable "@srothgan/claude-code-rust-win32-arm64-msvc"
+          check_recoverable "@srothgan/claude-code-rust-win32-x64-msvc"
+
+      - name: Validate Bun runtime manifest
+        run: node scripts/stage-bun-runtime.mjs --check --verify-upstream
 
   agent-sdk-preflight:
     needs: [verify]
@@ -109,6 +111,7 @@ jobs:
       contents: read
       id-token: write
       attestations: write
+      artifact-metadata: write
     strategy:
       fail-fast: false
       matrix:
@@ -153,8 +156,30 @@ jobs:
       artifact_prefix: release-binary
       attest: true
 
+  stage-bun-runtimes:
+    needs: [verify]
+    name: Stage bundled Bun runtimes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Download, verify, and stage Bun runtimes
+        run: node scripts/stage-bun-runtime.mjs --download
+
+      - name: Upload staged Bun runtimes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: bundled-bun-runtimes
+          path: dist-platform/*/bin/claude-rs-bridge-bun*
+          if-no-files-found: error
+
   assemble-npm-packages:
-    needs: [verify, agent-sdk-preflight, build-binaries]
+    needs: [verify, agent-sdk-preflight, build-binaries, stage-bun-runtimes]
     name: Assemble npm packages
     runs-on: ubuntu-latest
     steps:
@@ -176,6 +201,17 @@ jobs:
           merge-multiple: true
           path: .
 
+      - name: Download staged Bun runtimes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: bundled-bun-runtimes
+          path: dist-platform
+
+      - name: Restore executable bits for downloaded Unix artifacts
+        run: |
+          set -euo pipefail
+          find dist-platform -type f \( -name 'claude-rs' -o -name 'claude-rs-bridge-bun' \) -exec chmod 755 {} +
+
       - name: Install root dependencies
         run: npm ci
 
@@ -184,6 +220,11 @@ jobs:
 
       - name: Build agent-sdk bridge
         run: npm --prefix agent-sdk run build
+
+      - name: Verify staged Bun runtimes
+        run: |
+          node scripts/stage-bun-runtime.mjs --check
+          node scripts/verify-staged-bun-runtimes.mjs
 
       - name: Assemble npm package directories
         run: node scripts/generate-npm-packages.mjs --version "${{ needs.verify.outputs.version }}"
@@ -216,9 +257,9 @@ jobs:
         with:
           name: release-package-set-${{ needs.verify.outputs.version }}
           path: |
-            dist-assets/*
-            dist-npm/manifests/*.json
-            dist-pack/*.tgz
+            dist-assets/
+            dist-npm/manifests/
+            dist-pack/
             SHA256SUMS
           if-no-files-found: error
 
@@ -249,6 +290,9 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Install root runtime dependencies for registry smoke
+        run: npm ci --omit=dev --ignore-scripts
+
       - name: Download release package set
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -256,61 +300,10 @@ jobs:
           path: .
 
       - name: Smoke-test installed npm tarballs
-        run: node scripts/smoke-npm-package-install.mjs --platform "${{ matrix.package_dir }}" --use-existing-tarballs --real-binary
+        run: node scripts/smoke-npm-package-install.mjs --platform "${{ matrix.package_dir }}" --use-existing-tarballs --real-binary --no-system-runtime
 
-  create-draft-github-release:
-    needs: [verify, verify-release-attestations]
-    name: Create draft GitHub Release
-    runs-on: ubuntu-latest
-    environment: npm-release
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          fetch-depth: 0
-
-      - name: Download release package set
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: release-package-set-${{ needs.verify.outputs.version }}
-          path: .
-
-      - name: Create release notes
-        run: |
-          set -euo pipefail
-          VERSION="${{ needs.verify.outputs.version }}"
-          awk '/^## \['"$VERSION"'\]/{found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md > release-notes.md
-          if [ ! -s release-notes.md ]; then
-            {
-              echo "Release ${{ needs.verify.outputs.tag }}"
-              echo
-              echo "Automated npm platform-package release for claude-code-rust $VERSION."
-            } > release-notes.md
-          fi
-
-      - name: Create annotated tag
-        run: |
-          set -euo pipefail
-          TAG="${{ needs.verify.outputs.tag }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-
-      - name: Create draft GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          TAG="${{ needs.verify.outputs.tag }}"
-          mapfile -t release_assets < <(find dist-assets dist-pack dist-npm/manifests -type f | sort)
-          release_assets+=(SHA256SUMS)
-          gh release create "$TAG" "${release_assets[@]}" \
-            --draft \
-            --verify-tag \
-            --title "$TAG" \
-            --notes-file release-notes.md
+      - name: Smoke-test global npm install from temp registry
+        run: node scripts/smoke-npm-package-install.mjs --platform "${{ matrix.package_dir }}" --use-existing-tarballs --registry-smoke --real-binary --no-system-runtime
 
   verify-release-attestations:
     needs: [verify, smoke-test-packages]
@@ -363,7 +356,7 @@ jobs:
             --deny-self-hosted-runners
 
   publish-platform-packages:
-    needs: [verify, create-draft-github-release]
+    needs: [verify, verify-release-attestations]
     name: Publish platform npm packages
     runs-on: ubuntu-latest
     environment: npm-release
@@ -371,6 +364,8 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
@@ -388,49 +383,18 @@ jobs:
           npm install -g npm@11
           npm --version
 
-      - name: Dry-run platform tarball publish
-        run: |
-          set -euo pipefail
-          VERSION="${{ needs.verify.outputs.version }}"
-          publish_package() {
-            local package_name="$1"
-            local filename="${package_name#@}"
-            filename="${filename/\//-}-${VERSION}.tgz"
-            local tarball="./dist-pack/$filename"
-            if [ ! -f "$tarball" ]; then
-              echo "::error::Missing npm package tarball: $tarball"
-              exit 1
-            fi
-            npm publish "$tarball" --access public --dry-run
-          }
-          publish_package "@srothgan/claude-code-rust-darwin-arm64"
-          publish_package "@srothgan/claude-code-rust-darwin-x64"
-          publish_package "@srothgan/claude-code-rust-linux-arm64-gnu"
-          publish_package "@srothgan/claude-code-rust-linux-x64-gnu"
-          publish_package "@srothgan/claude-code-rust-win32-arm64-msvc"
-          publish_package "@srothgan/claude-code-rust-win32-x64-msvc"
+      - name: Dry-run npm tarball publish
+        run: node scripts/dry-run-npm-publish.mjs --pack-dir dist-pack --version "${{ needs.verify.outputs.version }}"
 
       - name: Publish platform tarballs
-        run: |
-          set -euo pipefail
-          VERSION="${{ needs.verify.outputs.version }}"
-          publish_package() {
-            local package_name="$1"
-            local filename="${package_name#@}"
-            filename="${filename/\//-}-${VERSION}.tgz"
-            local tarball="./dist-pack/$filename"
-            if [ ! -f "$tarball" ]; then
-              echo "::error::Missing npm package tarball: $tarball"
-              exit 1
-            fi
-            npm publish "$tarball" --access public
-          }
-          publish_package "@srothgan/claude-code-rust-darwin-arm64"
-          publish_package "@srothgan/claude-code-rust-darwin-x64"
-          publish_package "@srothgan/claude-code-rust-linux-arm64-gnu"
-          publish_package "@srothgan/claude-code-rust-linux-x64-gnu"
-          publish_package "@srothgan/claude-code-rust-win32-arm64-msvc"
-          publish_package "@srothgan/claude-code-rust-win32-x64-msvc"
+        run: node scripts/publish-npm-platform-packages.mjs --pack-dir dist-pack --ledger-dir dist-publish-ledger --version "${{ needs.verify.outputs.version }}"
+
+      - name: Upload platform publish ledger
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: npm-platform-publish-ledger-${{ needs.verify.outputs.version }}
+          path: dist-publish-ledger/
+          if-no-files-found: error
 
   publish-root-package:
     needs: [verify, publish-platform-packages]
@@ -458,28 +422,106 @@ jobs:
           npm install -g npm@11
           npm --version
 
-      - name: Dry-run root tarball publish
-        run: |
-          set -euo pipefail
-          tarball="./dist-pack/claude-code-rust-${{ needs.verify.outputs.version }}.tgz"
-          if [ ! -f "$tarball" ]; then
-            echo "::error::Missing npm package tarball: $tarball"
-            exit 1
-          fi
-          npm publish "$tarball" --access public --dry-run
-
       - name: Publish root tarball
         run: |
           set -euo pipefail
+          VERSION="${{ needs.verify.outputs.version }}"
           tarball="./dist-pack/claude-code-rust-${{ needs.verify.outputs.version }}.tgz"
           if [ ! -f "$tarball" ]; then
             echo "::error::Missing npm package tarball: $tarball"
             exit 1
           fi
+          local_integrity="$(
+            node -e "const fs = require('node:fs'); const crypto = require('node:crypto'); console.log('sha512-' + crypto.createHash('sha512').update(fs.readFileSync(process.argv[1])).digest('base64'))" "$tarball"
+          )"
+          set +e
+          existing_integrity="$(npm view "claude-code-rust@${VERSION}" dist.integrity --json 2>&1)"
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            existing_integrity="$(printf '%s' "$existing_integrity" | node -e "let input=''; process.stdin.on('data', c => input += c); process.stdin.on('end', () => console.log(JSON.parse(input)))")"
+            if [ "$existing_integrity" != "$local_integrity" ]; then
+              echo "::error::claude-code-rust@${VERSION} already exists with different integrity: registry ${existing_integrity}, local ${local_integrity}"
+              exit 1
+            fi
+            echo "OK: claude-code-rust@${VERSION} already published with matching integrity"
+            exit 0
+          fi
+          if ! printf '%s\n' "$existing_integrity" | grep -q 'E404'; then
+            echo "::error::Could not inspect npm registry integrity for claude-code-rust@${VERSION}"
+            echo "$existing_integrity"
+            exit 1
+          fi
           npm publish "$tarball" --access public
+          registry_integrity="$(npm view "claude-code-rust@${VERSION}" dist.integrity --json | node -e "let input=''; process.stdin.on('data', c => input += c); process.stdin.on('end', () => console.log(JSON.parse(input)))")"
+          if [ "$registry_integrity" != "$local_integrity" ]; then
+            echo "::error::claude-code-rust@${VERSION} registry integrity mismatch after publish: registry ${registry_integrity}, local ${local_integrity}"
+            exit 1
+          fi
+
+  create-github-release:
+    needs: [verify, publish-root-package]
+    name: Create draft GitHub Release
+    runs-on: ubuntu-latest
+    environment: npm-release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Download release package set
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-package-set-${{ needs.verify.outputs.version }}
+          path: .
+
+      - name: Create release notes
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.verify.outputs.version }}"
+          awk '/^## \['"$VERSION"'\]/{found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            {
+              echo "Release ${{ needs.verify.outputs.tag }}"
+              echo
+              echo "Automated npm platform-package release for claude-code-rust $VERSION."
+            } > release-notes.md
+          fi
+          {
+            echo
+            echo "Bundled runtime provenance:"
+            echo
+            echo "- npm platform packages include private Bun runtime files."
+            echo "- Bun source asset names, source archive SHA256 checksums, runtime SHA256 checksums, and source URLs are recorded in dist-npm/manifests/*.json."
+          } >> release-notes.md
+
+      - name: Create annotated tag
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.verify.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+      - name: Create draft GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.verify.outputs.tag }}"
+          mapfile -t release_assets < <(find dist-assets dist-pack dist-npm/manifests -type f | sort)
+          release_assets+=(SHA256SUMS)
+          gh release create "$TAG" "${release_assets[@]}" \
+            --draft \
+            --verify-tag \
+            --title "$TAG" \
+            --notes-file release-notes.md
 
   publish-github-release:
-    needs: [verify, publish-root-package]
+    needs: [verify, create-github-release]
     name: Publish GitHub Release
     runs-on: ubuntu-latest
     environment: npm-release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
-# Contributing to claude_rust
+# Contributing to claude-code-rust
 
-Thank you for considering contributing to claude_rust! This document provides
-guidelines and information for contributors.
+Thank you for considering contributing to claude-code-rust! This document provides guidelines and information for contributors.
 
 ## Code of Conduct
 
@@ -52,15 +51,14 @@ By participating, you agree to uphold this code.
 ### Prerequisites
 
 - Rust 1.88.0+ (install via https://rustup.rs)
-- Node.js 18+ for the in-repo agent bridge runtime. This follows `@anthropic-ai/claude-agent-sdk`, which currently declares Node `>=18.0.0`.
-- Node.js 24 is recommended for contributor JavaScript tooling and matches CI. Some `agent-sdk` dev dependencies require Node `20.19.x` or `>=22.12.0`, so Node 18 is not sufficient for every local `npm ci` or tooling run.
-- npx (included with Node.js)
+- npm for contributor JavaScript tooling and package scripts.
+- Bun for source runs, bridge runtime checks, and release packaging validation.
 
 ### Clone and Build
 
 ```bash
 git clone https://github.com/srothgan/claude-code-rust.git
-cd claude_rust
+cd claude-code-rust
 cargo build
 ```
 
@@ -108,10 +106,24 @@ Release workflow changes are maintainer-owned and should preserve the package ar
 Important invariants:
 
 - The root npm package must not use `postinstall` or install-time binary downloads.
-- Native binaries live in platform-specific optional npm packages.
+- The root npm package owns the `claude-rs` bin through `bin/claude-rs.js`.
+- Native binaries and private Bun runtimes live in platform-specific optional npm packages.
+- Platform packages must not expose their own npm `claude-rs` bin; otherwise npm can link the payload package over the root resolver.
 - Platform packages must publish before the root package for a given version.
 - npm publication must use Trusted Publishing, not a checked-in token or `NPM_TOKEN`.
 - Release artifacts should be generated, verified, packed, and smoke-tested before publication.
+
+For local package-layout validation, use the platform mapping in `scripts/npm-package-config.mjs` rather than duplicating package names in docs:
+
+```bash
+npm ci
+npm ci --prefix agent-sdk
+npm run build --prefix agent-sdk
+node scripts/generate-npm-packages.mjs
+node scripts/verify-npm-packages.mjs
+node scripts/smoke-npm-package-install.mjs --platform <platform> --real-binary --no-system-runtime
+node scripts/smoke-npm-package-install.mjs --platform <platform> --registry-smoke --real-binary --no-system-runtime
+```
 
 Do not trigger releases, create tags, or publish npm packages from contributor PRs.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ A native Rust terminal interface for Claude Code. Drop-in replacement for Anthro
 [![CI](https://github.com/srothgan/claude-code-rust/actions/workflows/pr.yml/badge.svg)](https://github.com/srothgan/claude-code-rust/actions/workflows/pr.yml)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://srothgan.github.io/claude-code-rust/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Node.js](https://img.shields.io/badge/Node.js-%3E%3D18-green.svg)](https://nodejs.org/)
 
 <p align="center">
   <img src="assets/banner.png" alt="Claude Code Rust running a Read tool call with syntax-highlighted output" width="900">
@@ -19,7 +18,6 @@ Claude Code Rust replaces the stock Claude Code terminal interface with a native
 
 ## Requisites
 
-- Node.js 18+ (for the Agent SDK bridge)
 - Existing Claude Code authentication (`~/.claude/config.json`)
 
 ## Install
@@ -64,7 +62,7 @@ The stock Claude Code TUI runs on Node.js with React Ink, which renders by redra
 - **Scrollback**: Hijacks the terminal's native scrollback, erasing history you can no longer scroll back to
 - **Paste**: Large pastes can flood stdout and freeze the terminal
 
-Claude Code Rust addresses these by compiling to a single native binary with diffed, direct terminal control via Crossterm and Ratatui — no full-frame redraws, no Node runtime overhead.
+Claude Code Rust addresses these with a native terminal UI that uses diffed, direct terminal control via Crossterm and Ratatui -- no full-frame redraws and no React Ink rendering loop.
 
 ## Documentation
 

--- a/agent-sdk/README.md
+++ b/agent-sdk/README.md
@@ -2,6 +2,8 @@
 
 NDJSON stdio bridge that connects the Rust TUI (`claude-code-rust`) with `@anthropic-ai/claude-agent-sdk`. Spawned as a child process by the Rust binary and communicates via line-delimited JSON envelopes over stdin/stdout.
 
+Published npm platform packages run this bridge with the private `claude-rs-bridge-bun` runtime bundled beside the native binary. Local contributor builds still use npm/TypeScript tooling to build `dist/bridge.js`.
+
 ## Local build
 
 ```bash

--- a/agent-sdk/scripts/bridge-runtime-contract.mjs
+++ b/agent-sdk/scripts/bridge-runtime-contract.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+
+const options = parseArgs(process.argv.slice(2));
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+if (!options.runtime || !options.bridge) {
+  printHelp();
+  process.exit(1);
+}
+
+try {
+  await runContract(options);
+  console.log(`Bridge runtime contract passed for ${options.runtime} ${options.bridge}`);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+async function runContract({ runtime, bridge }) {
+  const child = spawn(runtime, [bridge], {
+    env: {
+      ...process.env,
+      CLAUDE_RS_BRIDGE_DIAGNOSTICS: "1",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+
+  const stdoutEvents = [];
+  const stderrLines = [];
+  const pending = [];
+  let stdoutRemainder = "";
+  let stderrRemainder = "";
+
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdoutRemainder += chunk;
+    const lines = stdoutRemainder.split(/\r?\n/);
+    stdoutRemainder = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim()) {
+        const event = JSON.parse(line);
+        stdoutEvents.push(event);
+        resolvePending(stdoutEvents, pending);
+      }
+    }
+  });
+
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderrRemainder += chunk;
+    const lines = stderrRemainder.split(/\r?\n/);
+    stderrRemainder = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim()) {
+        stderrLines.push(line);
+      }
+    }
+  });
+
+  child.stdin.write("{not json\n");
+  const malformed = await readEvent(
+    stdoutEvents,
+    pending,
+    (event) => event.event === "connection_failed",
+    "connection_failed after malformed JSON",
+  );
+  assert.match(malformed.message, /invalid command envelope/);
+
+  child.stdin.write(`${JSON.stringify({ request_id: "init-1", command: "initialize", cwd: process.cwd() })}\n`);
+  const initialized = await readEvent(
+    stdoutEvents,
+    pending,
+    (event) => event.event === "initialized" && event.request_id === "init-1",
+    "initialized event",
+  );
+  assert.deepEqual(initialized.result.capabilities, {
+    prompt_image: true,
+    prompt_embedded_context: true,
+    supports_session_listing: true,
+    supports_resume_session: true,
+  });
+  assert.equal(initialized.result.agent_name, "claude-rs-agent-bridge");
+
+  await readEvent(
+    stdoutEvents,
+    pending,
+    (event) => event.event === "sessions_listed" && event.request_id === "init-1",
+    "sessions_listed event",
+  );
+
+  child.stdin.write(`${JSON.stringify({ request_id: "shutdown-1", command: "shutdown" })}\n`);
+  child.stdin.end();
+  const exit = await waitForExit(child);
+  assert.equal(exit.code, 0, `bridge exited with code ${exit.code} signal ${exit.signal ?? ""}`);
+
+  if (stderrRemainder.trim()) {
+    stderrLines.push(stderrRemainder.trim());
+  }
+  assert(stderrLines.length > 0, "bridge diagnostics should emit JSON lines to stderr");
+  for (const line of stderrLines) {
+    const diagnostic = JSON.parse(line);
+    assert.equal(diagnostic.schema, "claude-rs-log/v1");
+    assert.equal(typeof diagnostic.timestamp, "string");
+    assert.equal(typeof diagnostic.level, "string");
+    assert.equal(typeof diagnostic.target, "string");
+    assert.equal(typeof diagnostic.event_name, "string");
+  }
+}
+
+function readEvent(events, pending, predicate, label) {
+  const found = events.find(predicate);
+  if (found) {
+    return Promise.resolve(found);
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${label}`));
+    }, 10_000);
+    pending.push({ predicate, resolve, timeout });
+  });
+}
+
+function resolvePending(events, pending) {
+  for (let index = 0; index < pending.length; index += 1) {
+    const waiter = pending[index];
+    const found = events.find(waiter.predicate);
+    if (!found) {
+      continue;
+    }
+    clearTimeout(waiter.timeout);
+    pending.splice(index, 1);
+    waiter.resolve(found);
+    index -= 1;
+  }
+}
+
+function waitForExit(child) {
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+function parseArgs(args) {
+  const parsed = {
+    runtime: undefined,
+    bridge: undefined,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--runtime":
+        parsed.runtime = readArgValue(args, ++index, arg);
+        break;
+      case "--bridge":
+        parsed.bridge = readArgValue(args, ++index, arg);
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function readArgValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: node agent-sdk/scripts/bridge-runtime-contract.mjs --runtime <path> --bridge <path>
+
+Options:
+  --runtime <path>    Runtime executable, such as bundled Bun.
+  --bridge <path>     Built agent-sdk/dist/bridge.js path.
+  -h, --help          Show this help.
+`);
+}

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -7,6 +7,7 @@ import {
   buildRateLimitUpdate,
   buildRewindConversationPlan,
   buildQueryOptions,
+  resolveClaudeCodeSpawnCommand,
   canGenerateSessionTitle,
   generatePersistedSessionTitle,
   buildSessionMutationOptions,
@@ -72,9 +73,10 @@ import { emitToolCall, emitToolProgressUpdate, emitToolResultUpdate } from "./br
 import { linkTaskToolUse } from "./bridge/task_links.js";
 import { requestAskUserQuestionAnswers } from "./bridge/user_interaction.js";
 import { flushPendingWorkerShutdown, handleResultMessage } from "./bridge/message_handlers.js";
+import { dispatchCancelTurnCommand } from "./bridge/command_dispatch.js";
 
 const BRIDGE_RUNTIME_PROCESS_NAME =
-  process.platform === "win32" ? "claude-rs-bridge-node.exe" : "claude-rs-bridge-node";
+  process.platform === "win32" ? "claude-rs-bridge-bun.exe" : "claude-rs-bridge-bun";
 const BRIDGE_RUNTIME_GUARD_PROMPT =
   `Do not terminate the Claude Rust bridge runtime process \`${BRIDGE_RUNTIME_PROCESS_NAME}\`; ` +
   "when cleaning up development servers, only stop processes by explicit PIDs you started in this session.";
@@ -1298,6 +1300,7 @@ test("buildQueryOptions maps launch settings into sdk query options", () => {
   assert.equal(options.agentProgressSummaries, true);
   assert.equal(options.promptSuggestions, true);
   assert.equal(options.enableFileCheckpointing, true);
+  assert.equal(options.executable, "bun");
   assert.equal(options.sessionId, "session-1");
   assert.deepEqual(options.settingSources, ["user", "project", "local"]);
   assert.deepEqual(options.toolConfig, {
@@ -1451,6 +1454,104 @@ test("buildQueryOptions omits optional startup overrides but keeps bridge guard 
     append: BRIDGE_RUNTIME_GUARD_PROMPT,
   });
   assert.equal("agentProgressSummaries" in options, false);
+});
+
+test("dispatchCancelTurnCommand interrupts the matching session query", async () => {
+  let interruptCount = 0;
+  const slashErrors: Array<{ sessionId: string; message: string; requestId?: string }> = [];
+
+  await dispatchCancelTurnCommand(
+    { command: "cancel_turn", session_id: "session-1" },
+    {
+      requestId: "request-1",
+      sessionById: (sessionId) =>
+        sessionId === "session-1"
+          ? {
+              query: {
+                interrupt: async () => {
+                  interruptCount += 1;
+                },
+              },
+            }
+          : undefined,
+      slashError: (sessionId, message, requestId) => {
+        slashErrors.push({ sessionId, message, requestId });
+      },
+    },
+  );
+
+  assert.equal(interruptCount, 1);
+  assert.deepEqual(slashErrors, []);
+});
+
+test("dispatchCancelTurnCommand emits slash error for unknown session", async () => {
+  const interruptCount = 0;
+  const slashErrors: Array<{ sessionId: string; message: string; requestId?: string }> = [];
+
+  await dispatchCancelTurnCommand(
+    { command: "cancel_turn", session_id: "missing-session" },
+    {
+      requestId: "request-2",
+      sessionById: () => undefined,
+      slashError: (sessionId, message, requestId) => {
+        slashErrors.push({ sessionId, message, requestId });
+      },
+    },
+  );
+
+  assert.equal(interruptCount, 0);
+  assert.deepEqual(slashErrors, [
+    {
+      sessionId: "missing-session",
+      message: "unknown session: missing-session",
+      requestId: "request-2",
+    },
+  ]);
+});
+
+test("resolveClaudeCodeSpawnCommand remaps bare bun to the bridge runtime executable", () => {
+  assert.equal(resolveClaudeCodeSpawnCommand("bun"), process.execPath);
+});
+
+test("resolveClaudeCodeSpawnCommand preserves commands with path separators", () => {
+  assert.equal(resolveClaudeCodeSpawnCommand("/opt/runtime/bun"), "/opt/runtime/bun");
+  assert.equal(resolveClaudeCodeSpawnCommand("C:\\runtime\\bun.exe"), "C:\\runtime\\bun.exe");
+});
+
+test("buildQueryOptions spawn hook remaps bare bun command", async () => {
+  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const options = buildQueryOptions({
+    cwd: "C:/work",
+    launchSettings: {},
+    provisionalSessionId: "session-spawn-bun",
+    input,
+    canUseTool: async () => ({ behavior: "deny", message: "not used" }),
+    enableSdkDebug: false,
+    enableSpawnDebug: false,
+    sessionIdForLogs: () => "session-spawn-bun",
+  });
+
+  const child = options.spawnClaudeCodeProcess({
+    command: "bun",
+    args: ["-e", "process.stdout.write(process.execPath)"],
+    cwd: process.cwd(),
+    env: {},
+    signal: new AbortController().signal,
+  });
+
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code) => resolve(code));
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(stdout, process.execPath);
 });
 
 test("buildQueryOptions forwards SDK-provided spawn env without passing top-level env", async () => {

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -72,6 +72,7 @@ import {
   staleMcpAuthCandidates,
 } from "./bridge/mcp.js";
 import { bridgeLogger, LOG_TARGETS, logBridgeCommandReceived } from "./bridge/logger.js";
+import { dispatchCancelTurnCommand } from "./bridge/command_dispatch.js";
 
 // Re-exports: all symbols that tests and external consumers import from bridge.js.
 export { AsyncQueue } from "./bridge/shared.js";
@@ -103,7 +104,10 @@ export {
 } from "./bridge/history.js";
 export { handleSdkMessage, handleTaskSystemMessage } from "./bridge/message_handlers.js";
 export { mapAvailableAgents } from "./bridge/agents.js";
-export { buildQueryOptions } from "./bridge/session_lifecycle.js";
+export {
+  buildQueryOptions,
+  resolveClaudeCodeSpawnCommand,
+} from "./bridge/session_lifecycle.js";
 export { mapAvailableModels } from "./bridge/model_metadata.js";
 export {
   bridgeMcpConfigToSdk,
@@ -913,12 +917,7 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
     }
 
     case "cancel_turn": {
-      const session = sessionById(command.session_id);
-      if (!session) {
-        slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
-        return;
-      }
-      await session.query.interrupt();
+      await dispatchCancelTurnCommand(command, { requestId, sessionById, slashError });
       return;
     }
 

--- a/agent-sdk/src/bridge/command_dispatch.ts
+++ b/agent-sdk/src/bridge/command_dispatch.ts
@@ -1,0 +1,27 @@
+import type { BridgeCommand } from "../types.js";
+
+type CancelTurnCommand = Extract<BridgeCommand, { command: "cancel_turn" }>;
+
+export type InterruptibleSession = {
+  query: {
+    interrupt: () => Promise<void>;
+  };
+};
+
+type CancelTurnDispatchDeps = {
+  requestId?: string;
+  sessionById: (sessionId: string) => InterruptibleSession | null | undefined;
+  slashError: (sessionId: string, message: string, requestId?: string) => void;
+};
+
+export async function dispatchCancelTurnCommand(
+  command: CancelTurnCommand,
+  deps: CancelTurnDispatchDeps,
+): Promise<void> {
+  const session = deps.sessionById(command.session_id);
+  if (!session) {
+    deps.slashError(command.session_id, `unknown session: ${command.session_id}`, deps.requestId);
+    return;
+  }
+  await session.query.interrupt();
+}

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -86,7 +86,7 @@ export type PendingRewindResult = Omit<
 >;
 
 const BRIDGE_RUNTIME_PROCESS_NAME =
-  process.platform === "win32" ? "claude-rs-bridge-node.exe" : "claude-rs-bridge-node";
+  process.platform === "win32" ? "claude-rs-bridge-bun.exe" : "claude-rs-bridge-bun";
 const BRIDGE_RUNTIME_GUARD_PROMPT =
   `Do not terminate the Claude Rust bridge runtime process \`${BRIDGE_RUNTIME_PROCESS_NAME}\`; ` +
   "when cleaning up development servers, only stop processes by explicit PIDs you started in this session.";
@@ -530,7 +530,7 @@ export async function createSession(params: {
       },
     });
     throw new Error(
-      `query() failed: node_executable=${process.execPath}; cwd=${params.cwd}; ` +
+      `query() failed: runtime_executable=${process.execPath}; cwd=${params.cwd}; ` +
         `resume=${params.resume ?? "<none>"}; ` +
         `CLAUDE_CODE_EXECUTABLE=${claudeCodeExecutable ?? "<unset>"}; error=${message}`,
     );
@@ -756,6 +756,10 @@ function logSdkProcessSpawnStarted(
   });
 }
 
+export function resolveClaudeCodeSpawnCommand(command: string): string {
+  return command === "bun" ? process.execPath : command;
+}
+
 function logSdkProcessSpawned(
   sessionId: string | undefined,
   child: ReturnType<typeof spawnChild>,
@@ -890,7 +894,7 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
     includePartialMessages: true,
     promptSuggestions: true,
     enableFileCheckpointing: true,
-    executable: "node" as const,
+    executable: "bun" as const,
     ...(params.resume ? {} : { sessionId: params.provisionalSessionId }),
     ...(settings ? { settings } : {}),
     ...modelOption,
@@ -917,8 +921,10 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
       env: Record<string, string | undefined>;
       signal: AbortSignal;
     }) => {
-      logSdkProcessSpawnStarted(options, params.enableSpawnDebug);
-      const child = spawnChild(options.command, options.args, {
+      const command = resolveClaudeCodeSpawnCommand(options.command);
+      const spawnOptions = { ...options, command };
+      logSdkProcessSpawnStarted(spawnOptions, params.enableSpawnDebug);
+      const child = spawnChild(command, options.args, {
         cwd: options.cwd,
         env: options.env,
         signal: options.signal,

--- a/bin/claude-rs.js
+++ b/bin/claude-rs.js
@@ -8,46 +8,109 @@ const path = require("node:path");
 const TARGETS = {
   "darwin:arm64": {
     packageName: "@srothgan/claude-code-rust-darwin-arm64",
-    exe: "claude-rs"
+    exe: "claude-rs",
+    display: "darwin:arm64"
   },
   "darwin:x64": {
     packageName: "@srothgan/claude-code-rust-darwin-x64",
-    exe: "claude-rs"
+    exe: "claude-rs",
+    display: "darwin:x64"
   },
   "linux:x64": {
     packageName: "@srothgan/claude-code-rust-linux-x64-gnu",
-    exe: "claude-rs"
+    exe: "claude-rs",
+    libc: "glibc",
+    display: "linux:x64 glibc"
   },
   "linux:arm64": {
     packageName: "@srothgan/claude-code-rust-linux-arm64-gnu",
-    exe: "claude-rs"
+    exe: "claude-rs",
+    libc: "glibc",
+    display: "linux:arm64 glibc"
   },
   "win32:x64": {
     packageName: "@srothgan/claude-code-rust-win32-x64-msvc",
-    exe: "claude-rs.exe"
+    exe: "claude-rs.exe",
+    display: "win32:x64"
   },
   "win32:arm64": {
     packageName: "@srothgan/claude-code-rust-win32-arm64-msvc",
-    exe: "claude-rs.exe"
+    exe: "claude-rs.exe",
+    display: "win32:arm64"
   }
 };
 
-function resolveInstall() {
-  const key = `${process.platform}:${process.arch}`;
-  const info = TARGETS[key];
-  if (!info) {
-    return { error: `Unsupported platform/arch for claude-rs: ${key}` };
+function detectLinuxLibc(processLike = process) {
+  if (processLike.platform !== "linux") {
+    return undefined;
   }
 
+  try {
+    const report = processLike.report?.getReport?.();
+    const glibcVersion = report?.header?.glibcVersionRuntime;
+    if (typeof glibcVersion === "string" && glibcVersion.length > 0) {
+      return "glibc";
+    }
+  } catch {
+    // A missing or disabled process report should not be mistaken for glibc.
+  }
+
+  return "musl";
+}
+
+function supportedPlatformsText() {
+  return Object.values(TARGETS)
+    .map((target) => target.display)
+    .join(", ");
+}
+
+function selectTarget(processLike = process) {
+  const key = `${processLike.platform}:${processLike.arch}`;
+  const info = TARGETS[key];
+  if (!info) {
+    return {
+      error:
+        `Unsupported platform/arch for claude-rs: ${key}\n` +
+        `Supported platforms: ${supportedPlatformsText()}\n` +
+        "Use one of the supported npm platforms, or build claude-code-rust from source for this host."
+    };
+  }
+
+  if (processLike.platform === "linux") {
+    const libc = detectLinuxLibc(processLike);
+    if (libc !== info.libc) {
+      return {
+        error:
+          `Unsupported Linux libc for claude-rs: linux/${processLike.arch} ${libc}\n` +
+          `linux/${processLike.arch} musl is not supported by the current npm packages.\n` +
+          "Linux npm packages currently require glibc. Build claude-code-rust from source for this host."
+      };
+    }
+  }
+
+  return { key, info };
+}
+
+function resolveInstall(options = {}) {
+  const processLike = options.processLike || process;
+  const requireResolve = options.requireResolve || require.resolve;
+  const existsSync = options.existsSync || fs.existsSync;
+  const dirname = options.dirname || __dirname;
+  const selected = selectTarget(processLike);
+  if (selected.error) {
+    return { error: selected.error };
+  }
+
+  const { key, info } = selected;
   let packageJsonPath;
   try {
-    packageJsonPath = require.resolve(`${info.packageName}/package.json`);
+    packageJsonPath = requireResolve(`${info.packageName}/package.json`);
   } catch (error) {
     if (error && error.code === "MODULE_NOT_FOUND") {
       return {
         error:
           `Missing platform package ${info.packageName} for ${key}.\n` +
-          "This usually means npm optional dependencies were omitted.\n" +
+          "This usually means npm optional dependencies were omitted, for example by `npm install --omit=optional`.\n" +
           "Check `npm config get omit`, then reinstall with:\n" +
           "  npm install -g claude-code-rust"
       };
@@ -56,7 +119,7 @@ function resolveInstall() {
   }
 
   const binaryPath = path.join(path.dirname(packageJsonPath), "bin", info.exe);
-  if (!fs.existsSync(binaryPath)) {
+  if (!existsSync(binaryPath)) {
     return {
       error:
         `Missing binary at ${binaryPath}\n` +
@@ -65,8 +128,8 @@ function resolveInstall() {
     };
   }
 
-  const bundledBridgeScript = path.join(__dirname, "..", "agent-sdk", "dist", "bridge.js");
-  if (!fs.existsSync(bundledBridgeScript)) {
+  const bundledBridgeScript = path.join(dirname, "..", "agent-sdk", "dist", "bridge.js");
+  if (!existsSync(bundledBridgeScript)) {
     return {
       error:
         `Missing bundled bridge at ${bundledBridgeScript}\n` +
@@ -78,30 +141,44 @@ function resolveInstall() {
   return { binaryPath, bundledBridgeScript };
 }
 
-const resolved = resolveInstall();
-if (resolved.error) {
-  console.error(resolved.error);
-  process.exit(1);
+function main() {
+  const resolved = resolveInstall();
+  if (resolved.error) {
+    console.error(resolved.error);
+    process.exit(1);
+  }
+
+  const child = spawn(resolved.binaryPath, process.argv.slice(2), {
+    env: {
+      ...process.env,
+      CLAUDE_RS_AGENT_BRIDGE: process.env.CLAUDE_RS_AGENT_BRIDGE || resolved.bundledBridgeScript
+    },
+    stdio: "inherit",
+    windowsHide: true
+  });
+
+  child.on("error", (error) => {
+    console.error(`Failed to launch claude-rs: ${error.message}`);
+    process.exit(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
 }
 
-const child = spawn(resolved.binaryPath, process.argv.slice(2), {
-  env: {
-    ...process.env,
-    CLAUDE_RS_AGENT_BRIDGE: process.env.CLAUDE_RS_AGENT_BRIDGE || resolved.bundledBridgeScript
-  },
-  stdio: "inherit",
-  windowsHide: true
-});
+if (require.main === module) {
+  main();
+}
 
-child.on("error", (error) => {
-  console.error(`Failed to launch claude-rs: ${error.message}`);
-  process.exit(1);
-});
-
-child.on("exit", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-    return;
-  }
-  process.exit(code ?? 1);
-});
+module.exports = {
+  TARGETS,
+  detectLinuxLibc,
+  resolveInstall,
+  selectTarget,
+  supportedPlatformsText
+};

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -24,7 +24,7 @@ The current runtime uses inline terminal-owned rendering rather than an older fu
 
 ## Agent SDK Bridge
 
-The Rust process spawns a local Node runtime that runs:
+In packaged npm installs, the Rust process resolves a private Bun runtime named `claude-rs-bridge-bun` or `claude-rs-bridge-bun.exe` from the installed package layout. That runtime runs:
 
 ```text
 agent-sdk/dist/bridge.js
@@ -36,38 +36,33 @@ Rust sends commands such as session creation, session resume, prompt submission,
 
 ## Packaging
 
-The npm install is split across a root launcher package and platform-specific optional packages.
+The npm install is split across a root command package and platform payload packages.
 
-The root package is `claude-code-rust`. It exposes the global `claude-rs` JavaScript launcher and includes the built Agent SDK bridge under:
+The root package is `claude-code-rust`. It exposes the `claude-rs` command through the npm launcher and includes the built Agent SDK bridge under:
 
 ```text
+bin/claude-rs.js
 agent-sdk/dist/bridge.js
 ```
 
-The native Rust binaries live in platform packages:
+The platform packages are selected through root package optional dependencies. They include the native Rust binary and private Bun runtime. The exact package mapping lives in `scripts/npm-package-config.mjs`; supported npm payloads currently cover Linux x64/arm64 glibc, Windows x64/arm64, and macOS x64/arm64.
 
-```text
-@srothgan/claude-code-rust-darwin-arm64
-@srothgan/claude-code-rust-darwin-x64
-@srothgan/claude-code-rust-linux-x64-gnu
-@srothgan/claude-code-rust-win32-x64-msvc
-```
-
-The root launcher resolves the package for the current OS and CPU, sets `CLAUDE_RS_AGENT_BRIDGE` to the bundled bridge path in the root package, and forwards CLI arguments to the native binary. There is no npm `postinstall` script and no install-time binary download.
+At runtime, npm's generated shim starts `bin/claude-rs.js`. The launcher selects the matching platform package, sets `CLAUDE_RS_AGENT_BRIDGE` to the root package bridge script, and spawns the native binary. The native binary resolves the bundled Bun runtime from the platform package `bin/` directory. No npm `postinstall` script, install-time binary download, or global Bun is required.
 
 ## Release Model
 
 Release packaging is designed around immutable artifacts:
 
-- Native binaries are built on GitHub-hosted runners for Linux x64 glibc, Windows x64, macOS x64, and macOS arm64.
+- Native binaries are built on GitHub-hosted runners for Linux x64 glibc, Linux arm64 glibc, Windows x64, Windows arm64, macOS x64, and macOS arm64.
+- Private Bun runtime files are staged into each platform package as third-party runtime artifacts.
 - Generated npm package directories are verified against allowlisted package contents before packing.
 - Packed npm tarballs are smoke-tested before publication.
 - GitHub Releases include native binaries, npm tarballs, package-content manifests, build metadata, and `SHA256SUMS`.
 - The release workflow generates and verifies build provenance attestations for native binaries before npm publication.
 - npm publication uses Trusted Publishing rather than a long-lived npm token.
-- Platform packages are published before the root package so users never receive a root package version whose optional native packages do not exist.
+- The root package remains the user-facing npm install package and depends optionally on platform payload packages.
 
-Source builds are different: `cargo build` or `cargo install --path .` produce only the Rust binary. They do not build or install the JavaScript bridge. Build the bridge with npm and provide it through the checkout fallback, `--bridge-script`, or `CLAUDE_RS_AGENT_BRIDGE`.
+Source builds are different: `cargo build` or `cargo install --path .` produce only the Rust binary. They do not build or install the JavaScript bridge or private Bun runtime. Build the bridge with npm and provide it through the checkout fallback, `--bridge-script`, or `CLAUDE_RS_AGENT_BRIDGE`. Debug builds can use `CLAUDE_RS_AGENT_BRIDGE_RUNTIME` to point at a local Bun runtime; release npm installs use only the bundled runtime.
 
 ## Boundaries
 

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -175,11 +175,13 @@ or:
 CLAUDE_RS_AGENT_BRIDGE=/path/to/agent-sdk/dist/bridge.js
 ```
 
-The bridge Node runtime can be overridden with:
+Debug builds can override the bridge runtime with:
 
 ```bash
-CLAUDE_RS_AGENT_BRIDGE_NODE=/path/to/node
+CLAUDE_RS_AGENT_BRIDGE_RUNTIME=/path/to/bun
 ```
+
+Release npm installs use the root package launcher to start the native platform binary and point it at the bundled bridge script. The native binary resolves the private `claude-rs-bridge-bun` executable from the installed platform package. In `doctor --json`, the runtime checks are reported as `bridge_runtime`, `bridge_runtime_version`, and `bridge_script`.
 
 ## Perf Telemetry
 
@@ -211,6 +213,6 @@ Include:
 - OS and terminal.
 - Install method: npm package, source build, fork build, or manual binary.
 - The exact command used to launch the app.
-- Whether a custom bridge script or Node runtime was used.
+- Whether a custom bridge script or debug bridge runtime override was used.
 - A short reproduction.
 - A `claude-rs logs --bundle --yes` bundle or relevant redacted log snippets, not full secrets or private conversation content.

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -4,13 +4,12 @@
 
 Claude Code Rust needs:
 
-- Node.js 18 or newer for the Agent SDK bridge runtime.
 - Existing Claude Code authentication, currently read from `~/.claude/config.json`.
-- Rust 1.88.0 or newer only when building from source.
+- Rust 1.88.0 or newer, npm, and Bun only when building or running from source.
 
 ## Install From npm
 
-The recommended install path is the published npm package:
+The recommended npm install path is the root package:
 
 ```bash
 npm install -g claude-code-rust
@@ -18,18 +17,9 @@ claude-rs --version
 claude-rs
 ```
 
-The npm package installs a small launcher plus a platform-specific optional dependency containing the prebuilt Rust binary for your OS and architecture. No install-time binary download or `postinstall` script is used.
+The npm package owns the `claude-rs` command, selects the matching platform payload with npm optional dependencies, and includes the private Bun runtime used by the Agent SDK bridge. A separate Bun install is not required for npm installs. No install-time binary download or `postinstall` script is used.
 
-Supported npm platform packages:
-
-| Platform | Package |
-| --- | --- |
-| Linux x64 glibc | `@srothgan/claude-code-rust-linux-x64-gnu` |
-| Windows x64 | `@srothgan/claude-code-rust-win32-x64-msvc` |
-| macOS x64 | `@srothgan/claude-code-rust-darwin-x64` |
-| macOS arm64 | `@srothgan/claude-code-rust-darwin-arm64` |
-
-The root package exposes the global `claude-rs` command. The launcher resolves the matching platform package, passes the bundled Agent SDK bridge path to the Rust binary, and forwards CLI arguments unchanged.
+Supported npm platforms are Linux x64/arm64 with glibc, Windows x64/arm64, and macOS x64/arm64.
 
 ## Troubleshooting npm Installs
 
@@ -40,7 +30,9 @@ npm config get omit
 npm install -g claude-code-rust
 ```
 
-Avoid installing with `--omit=optional`; that prevents npm from installing the native binary package.
+If the resolver reports a missing platform package, npm optional dependencies were likely omitted. Check `npm config get omit` and reinstall without `--omit=optional`.
+
+Linux npm packages currently require glibc. On musl-based distributions, build from source until a matching npm package is available.
 
 If `claude-rs` resolves to an older global shim, ensure your npm global bin directory comes first on `PATH` or remove the stale shim before retrying.
 
@@ -56,9 +48,11 @@ npm run build --prefix agent-sdk
 cargo run
 ```
 
-Debug builds resolve `agent-sdk/dist/bridge.js` from the checkout after the bridge is built.
+Debug builds resolve `agent-sdk/dist/bridge.js` from the checkout after the bridge is built. They use `bun` from `PATH` unless `CLAUDE_RS_AGENT_BRIDGE_RUNTIME` points at a specific Bun executable.
 
-For a release-mode source binary:
+For a release-mode source binary, build the bridge and binary, then run the binary with an explicit bridge script:
+
+Release-mode source binaries do not use the debug PATH fallback for Bun. To run a release binary outside the npm package layout, place a Bun executable named `claude-rs-bridge-bun` or `claude-rs-bridge-bun.exe` next to the `claude-rs` binary, or use the generated npm package layout.
 
 ```bash
 npm ci --prefix agent-sdk
@@ -69,34 +63,7 @@ cargo build --release --locked --bin claude-rs
 
 On Windows, run `.\target\release\claude-rs.exe --bridge-script .\agent-sdk\dist\bridge.js`.
 
-## Install A Source Or Fork Build Globally
-
-For a local global install that mirrors the published npm layout, generate local npm tarballs and install the root tarball together with the matching platform tarball.
-
-Build and stage the native binary under `dist-platform/<platform>/bin/`:
-
-| Platform directory | Rust target | Binary |
-| --- | --- | --- |
-| `linux-x64-gnu` | `x86_64-unknown-linux-gnu` | `claude-rs` |
-| `win32-x64-msvc` | `x86_64-pc-windows-msvc` | `claude-rs.exe` |
-| `darwin-x64` | `x86_64-apple-darwin` | `claude-rs` |
-| `darwin-arm64` | `aarch64-apple-darwin` | `claude-rs` |
-
-Then run:
-
-```bash
-npm ci
-npm ci --prefix agent-sdk
-npm run build --prefix agent-sdk
-node scripts/generate-npm-packages.mjs
-node scripts/verify-npm-packages.mjs
-node scripts/smoke-npm-package-install.mjs --platform <platform> --real-binary
-npm install -g ./dist-pack/claude-code-rust-<version>.tgz ./dist-pack/<platform-package-tarball>.tgz
-```
-
-The smoke command packs the generated packages into `dist-pack/` before installing them in a temporary project.
-
-Do not use `cargo install --path .` if you want to test the npm install shape. `cargo install` writes only the Rust binary to Cargo's bin directory and does not install the bundled Agent SDK bridge or platform package layout.
+Do not use `cargo install --path .` if you want to test the npm install shape. `cargo install` writes only the Rust binary to Cargo's bin directory and does not install the bundled Agent SDK bridge, private Bun runtime, or platform package layout.
 
 ## Manual Bridge Overrides
 
@@ -112,11 +79,13 @@ You can also set:
 CLAUDE_RS_AGENT_BRIDGE=/path/to/agent-sdk/dist/bridge.js
 ```
 
-If Node needs an explicit override, set:
+Debug builds can use a local runtime override while developing the bridge:
 
 ```bash
-CLAUDE_RS_AGENT_BRIDGE_NODE=/path/to/node
+CLAUDE_RS_AGENT_BRIDGE_RUNTIME=/path/to/bun
 ```
+
+Release npm installs ignore runtime overrides and use the bundled `claude-rs-bridge-bun` executable from the platform package.
 
 ## Reporting Install Problems
 
@@ -125,8 +94,9 @@ Include:
 - install method
 - OS and architecture
 - terminal
-- `node --version`
+- `npm --version`
 - `npm config get omit`
 - `claude-rs --version`
+- `claude-rs doctor --json`
 - the command you ran
 - the exact error output

--- a/scripts/bun-runtime-manifest.json
+++ b/scripts/bun-runtime-manifest.json
@@ -1,0 +1,43 @@
+{
+  "manifestVersion": 1,
+  "version": "1.3.14",
+  "checksumSourceUrl": "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/SHASUMS256.txt",
+  "assets": {
+    "darwin-arm64": {
+      "assetName": "bun-darwin-aarch64.zip",
+      "archiveBinaryPath": "bun-darwin-aarch64/bun",
+      "sha256": "d8b96221828ad6f97ac7ac0ab7e95872341af763001e8803e8267652c2652620",
+      "binarySha256": "e0c90ec15d33363e6b70713d56bc3b2c7585c17f40a0fe0f8fd9305901d4e233"
+    },
+    "darwin-x64": {
+      "assetName": "bun-darwin-x64-baseline.zip",
+      "archiveBinaryPath": "bun-darwin-x64-baseline/bun",
+      "sha256": "3e35ad6f53971a9834bf9e6786e2adf72b5f1921cc9a9c5fde073d2972944076",
+      "binarySha256": "ea2f223e94bb2f4bf3050895113c3cf346438f6fa0501c8532284e063f72f7a0"
+    },
+    "linux-x64-gnu": {
+      "assetName": "bun-linux-x64-baseline.zip",
+      "archiveBinaryPath": "bun-linux-x64-baseline/bun",
+      "sha256": "a063908ae08b7852ca10939bbdc6ceed3ddabce8fb9402dce83d65d73b36e6c7",
+      "binarySha256": "a8f9ebd1770ddc8e55dab7a68d4ec1ec1eebf374bb97cc65cf2c3cb373fc6791"
+    },
+    "linux-arm64-gnu": {
+      "assetName": "bun-linux-aarch64.zip",
+      "archiveBinaryPath": "bun-linux-aarch64/bun",
+      "sha256": "a27ffb63a8310375836e0d6f668ae17fa8d8d18b88c37c821c65331973a19a3b",
+      "binarySha256": "37141662ebed915a2ab89313156e455e2a1374395f5f6760d06407f49406f086"
+    },
+    "win32-x64-msvc": {
+      "assetName": "bun-windows-x64-baseline.zip",
+      "archiveBinaryPath": "bun-windows-x64-baseline/bun.exe",
+      "sha256": "538f9c846355d9e847b2671bc00c47da4229a0befb24df3282b739770f3b475f",
+      "binarySha256": "9005d0d585d80425e9b715690de3e614651124c94458ef3d3a302ca1a6d3d813"
+    },
+    "win32-arm64-msvc": {
+      "assetName": "bun-windows-aarch64.zip",
+      "archiveBinaryPath": "bun-windows-aarch64/bun.exe",
+      "sha256": "89841f5a57f2348b67ec0839b718f4bf4ea7d07c371c9ba4b77b6c790f918953",
+      "binarySha256": "c48ea01208766207606927a320d640371140dca51e9963367779b32d18460716"
+    }
+  }
+}

--- a/scripts/dry-run-npm-publish.mjs
+++ b/scripts/dry-run-npm-publish.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  PLATFORM_PACKAGES,
+  ROOT_PACKAGE_NAME,
+  readCargoPackageMetadata,
+} from "./npm-package-config.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+export function npmTarballName(packageName, version) {
+  const filenamePrefix = packageName.replace(/^@/, "").replace("/", "-");
+  return `${filenamePrefix}-${version}.tgz`;
+}
+
+export function expectedPublishTarballs(packDir, version) {
+  return [
+    ...PLATFORM_PACKAGES.map((platformPackage) => ({
+      packageName: platformPackage.packageName,
+      tarball: path.join(packDir, npmTarballName(platformPackage.packageName, version)),
+    })),
+    {
+      packageName: ROOT_PACKAGE_NAME,
+      tarball: path.join(packDir, npmTarballName(ROOT_PACKAGE_NAME, version)),
+    },
+  ];
+}
+
+export function resolveNpmInvocation(
+  args,
+  {
+    env = process.env,
+    execPath = process.execPath,
+    existsSync = fs.existsSync,
+    platform = process.platform,
+  } = {},
+) {
+  if (platform !== "win32") {
+    return { command: "npm", args };
+  }
+
+  const cliCandidates = [
+    env.npm_execpath,
+    env.npm_config_npm_execpath,
+    path.join(path.dirname(execPath), "node_modules", "npm", "bin", "npm-cli.js"),
+  ].filter((candidate) => typeof candidate === "string" && candidate.endsWith(".js"));
+
+  const npmCli = cliCandidates.find((candidate) => existsSync(candidate));
+  if (!npmCli) {
+    throw new Error("Could not resolve npm CLI script on Windows; set npm_execpath or install Node.js with npm");
+  }
+
+  return { command: execPath, args: [npmCli, ...args] };
+}
+
+export function execNpmSync(args, options) {
+  const invocation = resolveNpmInvocation(args);
+  return execFileSync(invocation.command, invocation.args, options);
+}
+
+function dryRunNpmPublish({ packDir, version }) {
+  for (const { packageName, tarball } of expectedPublishTarballs(packDir, version)) {
+    if (!fs.existsSync(tarball)) {
+      throw new Error(`Missing npm package tarball for ${packageName}: ${relativePath(tarball)}`);
+    }
+
+    runNpmPublishDryRun({ packageName, tarball });
+  }
+}
+
+function runNpmPublishDryRun({ packageName, tarball }) {
+  const invocation = resolveNpmInvocation(["publish", tarball, "--access", "public", "--dry-run"]);
+  const result = spawnSync(invocation.command, invocation.args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status === 0) {
+    return;
+  }
+
+  const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+  throw new Error(
+    `npm publish --dry-run failed for ${packageName} with exit code ${result.status}\n${output}`.trim()
+  );
+}
+
+function parseArgs(args) {
+  const parsed = {
+    packDir: "dist-pack",
+    version: undefined,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--pack-dir":
+        parsed.packDir = readArgValue(args, ++index, arg);
+        break;
+      case "--version":
+        parsed.version = readArgValue(args, ++index, arg);
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function readArgValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function relativePath(filePath) {
+  return path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/dry-run-npm-publish.mjs [options]
+
+Options:
+  --pack-dir <dir>           Directory containing npm tarballs. Defaults to dist-pack.
+  --version <version>        Expected package version. Defaults to Cargo.toml.
+  -h, --help                 Show this help.
+`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const cargoPackage = readCargoPackageMetadata(path.join(repoRoot, "Cargo.toml"));
+  const version = options.version ?? cargoPackage.version;
+  const packDir = path.resolve(repoRoot, options.packDir);
+
+  dryRunNpmPublish({
+    packDir,
+    version,
+  });
+  console.log(`Dry-run checked ${PLATFORM_PACKAGES.length + 1} npm tarballs from ${relativePath(packDir)}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/dry-run-npm-publish.test.mjs
+++ b/scripts/dry-run-npm-publish.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { PLATFORM_PACKAGES, ROOT_PACKAGE_NAME } from "./npm-package-config.mjs";
+import {
+  expectedPublishTarballs,
+  npmTarballName,
+  resolveNpmInvocation,
+} from "./dry-run-npm-publish.mjs";
+
+test("npmTarballName matches npm scoped package tarball filenames", () => {
+  assert.equal(
+    npmTarballName("@srothgan/claude-code-rust-linux-x64-gnu", "1.2.3"),
+    "srothgan-claude-code-rust-linux-x64-gnu-1.2.3.tgz",
+  );
+  assert.equal(npmTarballName(ROOT_PACKAGE_NAME, "1.2.3"), "claude-code-rust-1.2.3.tgz");
+});
+
+test("expectedPublishTarballs includes all platform packages before root", () => {
+  const tarballs = expectedPublishTarballs("dist-pack", "1.2.3");
+
+  assert.equal(tarballs.length, PLATFORM_PACKAGES.length + 1);
+  assert.deepEqual(
+    tarballs.slice(0, PLATFORM_PACKAGES.length).map((entry) => entry.packageName),
+    PLATFORM_PACKAGES.map((entry) => entry.packageName),
+  );
+  assert.equal(tarballs.at(-1).packageName, ROOT_PACKAGE_NAME);
+  assert.equal(tarballs.at(-1).tarball, path.join("dist-pack", "claude-code-rust-1.2.3.tgz"));
+});
+
+test("resolveNpmInvocation uses direct npm outside Windows", () => {
+  assert.deepEqual(resolveNpmInvocation(["publish"], { platform: "linux" }), {
+    command: "npm",
+    args: ["publish"],
+  });
+});
+
+test("resolveNpmInvocation uses npm CLI script on Windows", () => {
+  const execPath = path.join("node-home", "node.exe");
+  const npmCli = path.join("node-home", "node_modules", "npm", "bin", "npm-cli.js");
+
+  assert.deepEqual(
+    resolveNpmInvocation(["publish", "pkg.tgz"], {
+      env: {},
+      execPath,
+      existsSync: (candidate) => candidate === npmCli,
+      platform: "win32",
+    }),
+    {
+      command: execPath,
+      args: [npmCli, "publish", "pkg.tgz"],
+    },
+  );
+});
+
+test("resolveNpmInvocation prefers npm_execpath on Windows", () => {
+  const execPath = path.join("node-home", "node.exe");
+  const npmCli = path.join("custom-npm", "npm-cli.js");
+
+  assert.deepEqual(
+    resolveNpmInvocation(["view", "pkg"], {
+      env: { npm_execpath: npmCli },
+      execPath,
+      existsSync: (candidate) => candidate === npmCli,
+      platform: "win32",
+    }),
+    {
+      command: execPath,
+      args: [npmCli, "view", "pkg"],
+    },
+  );
+});

--- a/scripts/generate-npm-packages.mjs
+++ b/scripts/generate-npm-packages.mjs
@@ -81,12 +81,16 @@ function generatePlatformPackage(platformPackage) {
     return;
   }
 
-  copyStagedBinary(
-    platformPackage,
-    path.join(binaryRoot, platformPackage.dir, "bin", platformPackage.binaryName),
-    binaryDestination,
-    "native binary"
-  );
+  if (options.mockNativeBinary) {
+    writeMockBinary(platformPackage, binaryDestination, "claude-rs 0.0.0-mock");
+  } else {
+    copyStagedBinary(
+      platformPackage,
+      path.join(binaryRoot, platformPackage.dir, "bin", platformPackage.binaryName),
+      binaryDestination,
+      "native binary"
+    );
+  }
   copyStagedBinary(
     platformPackage,
     path.join(binaryRoot, platformPackage.dir, "bin", platformPackage.bundledRuntimeName),
@@ -224,6 +228,7 @@ function parseArgs(args) {
   const parsed = {
     help: false,
     mockBinaries: false,
+    mockNativeBinary: false,
     version: undefined,
     binaryRoot: undefined,
     outDir: undefined
@@ -238,6 +243,9 @@ function parseArgs(args) {
         break;
       case "--mock-binaries":
         parsed.mockBinaries = true;
+        break;
+      case "--mock-native-binary":
+        parsed.mockNativeBinary = true;
         break;
       case "--version":
         parsed.version = readArgValue(args, ++index, arg);
@@ -272,7 +280,8 @@ Options:
   --binary-root <dir>       Directory containing staged platform binaries.
                             Defaults to dist-platform.
   --out-dir <dir>           Output directory. Defaults to dist-npm.
-  --mock-binaries           Generate placeholder platform binaries for layout tests.
+  --mock-binaries           Generate placeholder native and runtime binaries for layout tests.
+  --mock-native-binary      Generate placeholder native binaries while copying staged runtimes.
   -h, --help                Show this help.
 `);
 }

--- a/scripts/generate-npm-packages.mjs
+++ b/scripts/generate-npm-packages.mjs
@@ -8,8 +8,10 @@ import {
   buildPlatformPackageJson,
   buildRootPackageJson,
   readCargoPackageMetadata,
+  readBunRuntimeManifest,
   readJson
 } from "./npm-package-config.mjs";
+import { buildThirdPartyNotices } from "./third-party-notices.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -27,6 +29,7 @@ const cargoPackage = readCargoPackageMetadata(path.join(repoRoot, "Cargo.toml"))
 const version = options.version ?? cargoPackage.version;
 const rootPackageJson = readJson(path.join(repoRoot, "package.json"));
 const agentSdkPackageJson = readJson(path.join(repoRoot, "agent-sdk", "package.json"));
+const bunRuntimeManifest = readBunRuntimeManifest(repoRoot);
 
 if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
   throw new Error(`Invalid package version: ${version}`);
@@ -66,19 +69,36 @@ function generatePlatformPackage(platformPackage) {
   );
   writePlatformReadme(platformPackage, path.join(packageDir, "README.md"));
   copyFileFromRepo("LICENSE", path.join(packageDir, "LICENSE"));
+  writeThirdPartyNotices(path.join(packageDir, "THIRD-PARTY-NOTICES.md"));
 
-  const destination = path.join(packageDir, "bin", platformPackage.binaryName);
-  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  const binaryDestination = path.join(packageDir, "bin", platformPackage.binaryName);
+  const runtimeDestination = path.join(packageDir, "bin", platformPackage.bundledRuntimeName);
+  fs.mkdirSync(path.dirname(binaryDestination), { recursive: true });
 
   if (options.mockBinaries) {
-    writeMockBinary(platformPackage, destination);
+    writeMockBinary(platformPackage, binaryDestination, "claude-rs 0.0.0-mock");
+    writeMockBinary(platformPackage, runtimeDestination, bunRuntimeManifest.version);
     return;
   }
 
-  const source = path.join(binaryRoot, platformPackage.dir, "bin", platformPackage.binaryName);
+  copyStagedBinary(
+    platformPackage,
+    path.join(binaryRoot, platformPackage.dir, "bin", platformPackage.binaryName),
+    binaryDestination,
+    "native binary"
+  );
+  copyStagedBinary(
+    platformPackage,
+    path.join(binaryRoot, platformPackage.dir, "bin", platformPackage.bundledRuntimeName),
+    runtimeDestination,
+    "bundled Bun runtime"
+  );
+}
+
+function copyStagedBinary(platformPackage, source, destination, label) {
   if (!fs.existsSync(source)) {
     throw new Error(
-      `Missing binary for ${platformPackage.packageName}: ${path.relative(repoRoot, source)}. ` +
+      `Missing ${label} for ${platformPackage.packageName}: ${path.relative(repoRoot, source)}. ` +
         "Build/stage binaries first or pass --mock-binaries."
     );
   }
@@ -143,6 +163,8 @@ function writePlatformReadme(platformPackage, destination) {
     `- Rust target: \`${platformPackage.rustTarget}\``,
     `- npm package: [\`${platformPackage.packageName}\`](${npmPackageUrl})`,
     `- npm platform directory: \`${platformPackage.dir}\``,
+    `- Bundled runtime: \`${platformPackage.bundledRuntimeName}\``,
+    `- Bun release asset: \`${platformPackage.bunAssetName}\``,
     `- OS: \`${platformPackage.os.join(", ")}\``,
     `- CPU: \`${platformPackage.cpu.join(", ")}\``
   ];
@@ -155,7 +177,7 @@ function writePlatformReadme(platformPackage, destination) {
 
 This is the **${platformPackage.rustTarget}** native binary package for ${projectReference} version \`${version}\`.
 
-Install \`${projectName}\` instead; this package is selected automatically as an optional dependency on matching platforms.
+This package is selected automatically by the root \`${projectName}\` npm package on matching platforms. It contains the native Rust binary and a private Bun runtime named \`${platformPackage.bundledRuntimeName}\` for the Agent SDK bridge. The bundled runtime is not a user-facing \`bun\` command.
 
 \`\`\`bash
 npm install -g ${projectName}
@@ -168,11 +190,20 @@ ${targetDetails.join("\n")}
   fs.writeFileSync(destination, content, "utf8");
 }
 
-function writeMockBinary(platformPackage, destination) {
+function writeThirdPartyNotices(destination) {
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(
+    destination,
+    buildThirdPartyNotices({ manifest: bunRuntimeManifest }),
+    "utf8"
+  );
+}
+
+function writeMockBinary(platformPackage, destination, output) {
   const isWindows = platformPackage.os.includes("win32");
   const content = isWindows
-    ? "@echo off\r\necho claude-rs 0.0.0-mock\r\n"
-    : "#!/usr/bin/env sh\necho \"claude-rs 0.0.0-mock\"\n";
+    ? `@echo off\r\necho ${output}\r\n`
+    : `#!/usr/bin/env sh\necho "${output}"\n`;
 
   fs.writeFileSync(destination, content, "utf8");
   ensureExecutableMode(platformPackage, destination);

--- a/scripts/npm-package-config.mjs
+++ b/scripts/npm-package-config.mjs
@@ -1,8 +1,13 @@
 import fs from "node:fs";
+import path from "node:path";
 
 export const ROOT_PACKAGE_NAME = "claude-code-rust";
 
 export const DIST_NPM_DIR = "dist-npm";
+
+export const BUNDLED_BUN_RUNTIME_VERSION = "1.3.14";
+
+export const BUN_RUNTIME_MANIFEST_RELATIVE_PATH = "scripts/bun-runtime-manifest.json";
 
 export const PLATFORM_PACKAGES = [
   {
@@ -11,6 +16,9 @@ export const PLATFORM_PACKAGES = [
     os: ["darwin"],
     cpu: ["arm64"],
     binaryName: "claude-rs",
+    bundledRuntimeName: "claude-rs-bridge-bun",
+    bunAssetName: "bun-darwin-aarch64.zip",
+    bunArchiveBinaryPath: "bun-darwin-aarch64/bun",
     rustTarget: "aarch64-apple-darwin"
   },
   {
@@ -19,6 +27,9 @@ export const PLATFORM_PACKAGES = [
     os: ["darwin"],
     cpu: ["x64"],
     binaryName: "claude-rs",
+    bundledRuntimeName: "claude-rs-bridge-bun",
+    bunAssetName: "bun-darwin-x64-baseline.zip",
+    bunArchiveBinaryPath: "bun-darwin-x64-baseline/bun",
     rustTarget: "x86_64-apple-darwin"
   },
   {
@@ -28,6 +39,9 @@ export const PLATFORM_PACKAGES = [
     cpu: ["x64"],
     libc: ["glibc"],
     binaryName: "claude-rs",
+    bundledRuntimeName: "claude-rs-bridge-bun",
+    bunAssetName: "bun-linux-x64-baseline.zip",
+    bunArchiveBinaryPath: "bun-linux-x64-baseline/bun",
     rustTarget: "x86_64-unknown-linux-gnu"
   },
   {
@@ -37,6 +51,9 @@ export const PLATFORM_PACKAGES = [
     cpu: ["arm64"],
     libc: ["glibc"],
     binaryName: "claude-rs",
+    bundledRuntimeName: "claude-rs-bridge-bun",
+    bunAssetName: "bun-linux-aarch64.zip",
+    bunArchiveBinaryPath: "bun-linux-aarch64/bun",
     rustTarget: "aarch64-unknown-linux-gnu"
   },
   {
@@ -45,6 +62,9 @@ export const PLATFORM_PACKAGES = [
     os: ["win32"],
     cpu: ["x64"],
     binaryName: "claude-rs.exe",
+    bundledRuntimeName: "claude-rs-bridge-bun.exe",
+    bunAssetName: "bun-windows-x64-baseline.zip",
+    bunArchiveBinaryPath: "bun-windows-x64-baseline/bun.exe",
     rustTarget: "x86_64-pc-windows-msvc"
   },
   {
@@ -53,9 +73,20 @@ export const PLATFORM_PACKAGES = [
     os: ["win32"],
     cpu: ["arm64"],
     binaryName: "claude-rs.exe",
+    bundledRuntimeName: "claude-rs-bridge-bun.exe",
+    bunAssetName: "bun-windows-aarch64.zip",
+    bunArchiveBinaryPath: "bun-windows-aarch64/bun.exe",
     rustTarget: "aarch64-pc-windows-msvc"
   }
 ];
+
+export function readBunRuntimeManifest(repoRoot) {
+  return readJson(path.join(repoRoot, BUN_RUNTIME_MANIFEST_RELATIVE_PATH));
+}
+
+export function bunRuntimeAssetUrl(version, assetName) {
+  return `https://github.com/oven-sh/bun/releases/download/bun-v${version}/${assetName}`;
+}
 
 export function readJson(path) {
   return JSON.parse(fs.readFileSync(path, "utf8"));
@@ -138,13 +169,13 @@ export function buildPlatformPackageJson({ platformPackage, version, rootPackage
   return removeUndefined({
     name: platformPackage.packageName,
     version,
-    description: `${rootPackageJson.description} native binary for ${platformPackage.dir}`,
+    description: `Claude Code Rust native binary and private Bun bridge runtime for ${platformPackage.dir}`,
     keywords: rootPackageJson.keywords,
     license: rootPackageJson.license,
     repository: rootPackageJson.repository,
     bugs: rootPackageJson.bugs,
     homepage: rootPackageJson.homepage,
-    files: ["bin", "README.md", "LICENSE"],
+    files: ["bin", "README.md", "LICENSE", "THIRD-PARTY-NOTICES.md"],
     os: platformPackage.os,
     cpu: platformPackage.cpu,
     libc: platformPackage.libc,

--- a/scripts/npm-resolver.test.cjs
+++ b/scripts/npm-resolver.test.cjs
@@ -1,0 +1,89 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  detectLinuxLibc,
+  resolveInstall,
+  selectTarget,
+  supportedPlatformsText
+} = require("../bin/claude-rs.js");
+
+function processLike(platform, arch, glibcVersionRuntime) {
+  return {
+    platform,
+    arch,
+    report: {
+      getReport() {
+        return {
+          header: glibcVersionRuntime ? { glibcVersionRuntime } : {}
+        };
+      }
+    }
+  };
+}
+
+test("selectTarget resolves glibc Linux platform package", () => {
+  const selected = selectTarget(processLike("linux", "x64", "2.39"));
+
+  assert.equal(selected.error, undefined);
+  assert.equal(selected.info.packageName, "@srothgan/claude-code-rust-linux-x64-gnu");
+});
+
+test("selectTarget rejects musl Linux without reinstall advice", () => {
+  const selected = selectTarget(processLike("linux", "x64", undefined));
+
+  assert.match(selected.error, /linux\/x64 musl is not supported/);
+  assert.match(selected.error, /require glibc/);
+  assert.doesNotMatch(selected.error, /reinstall/);
+});
+
+test("selectTarget lists supported platforms for unsupported host", () => {
+  const selected = selectTarget(processLike("freebsd", "x64", undefined));
+
+  assert.match(selected.error, /Unsupported platform\/arch/);
+  assert.match(selected.error, /Supported platforms:/);
+  assert.match(selected.error, /darwin:arm64/);
+  assert.equal(supportedPlatformsText().includes("linux:x64 glibc"), true);
+});
+
+test("resolveInstall reports omitted optional dependency for supported platform", () => {
+  const resolved = resolveInstall({
+    processLike: processLike("linux", "arm64", "2.39"),
+    requireResolve() {
+      const error = new Error("missing");
+      error.code = "MODULE_NOT_FOUND";
+      throw error;
+    }
+  });
+
+  assert.match(resolved.error, /@srothgan\/claude-code-rust-linux-arm64-gnu/);
+  assert.match(resolved.error, /npm install --omit=optional/);
+  assert.match(resolved.error, /npm config get omit/);
+});
+
+test("resolveInstall returns binary and bridge paths when package payload is complete", () => {
+  const packageJsonPath = path.join("node_modules", "@srothgan", "claude-code-rust-darwin-arm64", "package.json");
+  const resolved = resolveInstall({
+    processLike: processLike("darwin", "arm64", undefined),
+    dirname: path.join("node_modules", "claude-code-rust", "bin"),
+    requireResolve(request) {
+      assert.equal(request, "@srothgan/claude-code-rust-darwin-arm64/package.json");
+      return packageJsonPath;
+    },
+    existsSync() {
+      return true;
+    }
+  });
+
+  assert.equal(resolved.error, undefined);
+  assert.equal(resolved.binaryPath, path.join("node_modules", "@srothgan", "claude-code-rust-darwin-arm64", "bin", "claude-rs"));
+  assert.equal(
+    resolved.bundledBridgeScript,
+    path.join("node_modules", "claude-code-rust", "agent-sdk", "dist", "bridge.js")
+  );
+});
+
+test("detectLinuxLibc treats missing process report as musl-class unsupported libc", () => {
+  assert.equal(detectLinuxLibc({ platform: "linux", arch: "x64" }), "musl");
+});

--- a/scripts/publish-npm-platform-packages.mjs
+++ b/scripts/publish-npm-platform-packages.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  PLATFORM_PACKAGES,
+  readCargoPackageMetadata,
+} from "./npm-package-config.mjs";
+import { execNpmSync, npmTarballName } from "./dry-run-npm-publish.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+export function tarballIntegrity(tarballPath) {
+  return `sha512-${crypto.createHash("sha512").update(fs.readFileSync(tarballPath)).digest("base64")}`;
+}
+
+export function platformPublishPlan(packDir, version) {
+  return PLATFORM_PACKAGES.map((platformPackage) => ({
+    packageName: platformPackage.packageName,
+    version,
+    tarball: path.join(packDir, npmTarballName(platformPackage.packageName, version)),
+  }));
+}
+
+function publishPlatformPackages({ packDir, version, ledgerDir }) {
+  fs.mkdirSync(ledgerDir, { recursive: true });
+  const ledgerEntries = [];
+
+  for (const plan of platformPublishPlan(packDir, version)) {
+    if (!fs.existsSync(plan.tarball)) {
+      throw new Error(`Missing npm package tarball for ${plan.packageName}: ${relativePath(plan.tarball)}`);
+    }
+
+    const localIntegrity = tarballIntegrity(plan.tarball);
+    const existingIntegrity = npmViewIntegrity(plan.packageName, version);
+    if (existingIntegrity) {
+      if (existingIntegrity !== localIntegrity) {
+        throw new Error(
+          `${plan.packageName}@${version} already exists with different integrity: ` +
+            `registry ${existingIntegrity}, local ${localIntegrity}`
+        );
+      }
+      ledgerEntries.push(ledgerEntry(plan, localIntegrity, existingIntegrity, "already_published"));
+      console.log(`OK: ${plan.packageName}@${version} already published with matching integrity`);
+      continue;
+    }
+
+    execNpmSync(["publish", plan.tarball, "--access", "public"], {
+      cwd: repoRoot,
+      stdio: "inherit",
+      windowsHide: true,
+    });
+    const registryIntegrity = npmViewIntegrity(plan.packageName, version);
+    if (registryIntegrity !== localIntegrity) {
+      throw new Error(
+        `${plan.packageName}@${version} registry integrity mismatch after publish: ` +
+          `registry ${registryIntegrity ?? "<missing>"}, local ${localIntegrity}`
+      );
+    }
+    ledgerEntries.push(ledgerEntry(plan, localIntegrity, registryIntegrity, "published"));
+  }
+
+  const ledgerPath = path.join(ledgerDir, `platform-packages-${version}.json`);
+  fs.writeFileSync(
+    ledgerPath,
+    `${JSON.stringify({ manifestVersion: 1, version, entries: ledgerEntries }, null, 2)}\n`,
+    "utf8",
+  );
+  console.log(`Wrote npm publish ledger to ${relativePath(ledgerPath)}`);
+}
+
+function ledgerEntry(plan, localIntegrity, registryIntegrity, status) {
+  return {
+    package_name: plan.packageName,
+    version: plan.version,
+    tarball_filename: path.basename(plan.tarball),
+    local_npm_pack_integrity: localIntegrity,
+    registry_dist_integrity: registryIntegrity,
+    status,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function npmViewIntegrity(packageName, version) {
+  try {
+    const output = execNpmSync(["view", `${packageName}@${version}`, "dist.integrity", "--json"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    }).trim();
+    if (!output) {
+      return undefined;
+    }
+    const parsed = JSON.parse(output);
+    return typeof parsed === "string" && parsed.length > 0 ? parsed : undefined;
+  } catch (error) {
+    const stderr = bufferToString(error.stderr);
+    const stdout = bufferToString(error.stdout);
+    if (`${stdout}\n${stderr}`.includes("E404")) {
+      return undefined;
+    }
+    throw new Error(
+      `Could not inspect npm registry integrity for ${packageName}@${version}:\n${stdout}\n${stderr}`.trim()
+    );
+  }
+}
+
+function parseArgs(args) {
+  const parsed = {
+    packDir: "dist-pack",
+    ledgerDir: "dist-publish-ledger",
+    version: undefined,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--pack-dir":
+        parsed.packDir = readArgValue(args, ++index, arg);
+        break;
+      case "--ledger-dir":
+        parsed.ledgerDir = readArgValue(args, ++index, arg);
+        break;
+      case "--version":
+        parsed.version = readArgValue(args, ++index, arg);
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function readArgValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function bufferToString(value) {
+  if (!value) {
+    return "";
+  }
+  return Buffer.isBuffer(value) ? value.toString("utf8") : String(value);
+}
+
+function relativePath(filePath) {
+  return path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/publish-npm-platform-packages.mjs [options]
+
+Options:
+  --pack-dir <dir>      Directory containing platform npm tarballs. Defaults to dist-pack.
+  --ledger-dir <dir>    Directory for publish ledger JSON. Defaults to dist-publish-ledger.
+  --version <version>   Expected package version. Defaults to Cargo.toml.
+  -h, --help            Show this help.
+`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const cargoPackage = readCargoPackageMetadata(path.join(repoRoot, "Cargo.toml"));
+  const version = options.version ?? cargoPackage.version;
+  publishPlatformPackages({
+    packDir: path.resolve(repoRoot, options.packDir),
+    ledgerDir: path.resolve(repoRoot, options.ledgerDir),
+    version,
+  });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/publish-npm-platform-packages.test.mjs
+++ b/scripts/publish-npm-platform-packages.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { PLATFORM_PACKAGES } from "./npm-package-config.mjs";
+import {
+  platformPublishPlan,
+  tarballIntegrity,
+} from "./publish-npm-platform-packages.mjs";
+
+test("tarballIntegrity returns npm dist integrity format", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-integrity-"));
+  try {
+    const tarball = path.join(tempDir, "pkg.tgz");
+    fs.writeFileSync(tarball, "package bytes", "utf8");
+
+    assert.equal(
+      tarballIntegrity(tarball),
+      `sha512-${crypto.createHash("sha512").update("package bytes").digest("base64")}`,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("platformPublishPlan covers only platform packages", () => {
+  const plan = platformPublishPlan("dist-pack", "1.2.3");
+
+  assert.equal(plan.length, PLATFORM_PACKAGES.length);
+  assert.deepEqual(
+    plan.map((entry) => entry.packageName),
+    PLATFORM_PACKAGES.map((entry) => entry.packageName),
+  );
+  assert.equal(plan.some((entry) => entry.packageName === "claude-code-rust"), false);
+});

--- a/scripts/smoke-npm-package-install.mjs
+++ b/scripts/smoke-npm-package-install.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
+import crypto from "node:crypto";
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { execFileSync, spawn } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   DIST_NPM_DIR,
   PLATFORM_PACKAGES,
@@ -15,15 +17,15 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
-const npmCliPath = resolveNpmCliPath();
+let npmCliPath;
 
-const options = parseArgs(process.argv.slice(2));
-if (options.help) {
-  printHelp();
-  process.exit(0);
-}
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
 
-try {
   const distDir = path.resolve(repoRoot, options.distDir ?? DIST_NPM_DIR);
   const packDir = path.resolve(repoRoot, options.packDir ?? "dist-pack");
   const platformDir = options.platform ?? "linux-x64-gnu";
@@ -49,14 +51,26 @@ try {
 
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-npm-smoke-"));
   try {
-    smokeInstall({
-      projectDir: tempDir,
-      rootTarball,
-      platformTarball,
-      platformPackage,
-      cargoPackage,
-      realBinary: options.realBinary
-    });
+    if (options.registrySmoke) {
+      await smokeRegistryInstall({
+        tempDir,
+        packedPackages,
+        platformPackage,
+        cargoPackage,
+        realBinary: options.realBinary,
+        noSystemRuntime: options.noSystemRuntime,
+      });
+    } else {
+      smokeInstall({
+        projectDir: tempDir,
+        rootTarball,
+        platformTarball,
+        platformPackage,
+        cargoPackage,
+        realBinary: options.realBinary,
+        noSystemRuntime: options.noSystemRuntime
+      });
+    }
   } finally {
     if (!options.keepTemp) {
       fs.rmSync(tempDir, { recursive: true, force: true });
@@ -68,9 +82,6 @@ try {
   printManifestSummary(distDir);
   console.log(`Packed npm tarballs in ${path.relative(repoRoot, packDir)}`);
   console.log(`Smoke-tested ${ROOT_PACKAGE_NAME} with ${platformPackage.packageName}`);
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
 }
 
 function assertHostCanSmokePlatform(platform) {
@@ -81,7 +92,7 @@ function assertHostCanSmokePlatform(platform) {
   if (process.platform !== expectedOs || process.arch !== expectedCpu) {
     throw new Error(
       `Cannot smoke-test ${platform.dir} on ${hostKey}. ` +
-        "The launcher resolves the platform package from the current Node platform. " +
+        "npm platform package constraints must match the current host. " +
         "Run this smoke on a matching host or pass a matching --platform."
     );
   }
@@ -142,7 +153,15 @@ function npmTarballName(packageName, version) {
   return `${filenamePrefix}-${version}.tgz`;
 }
 
-function smokeInstall({ projectDir, rootTarball, platformTarball, platformPackage, cargoPackage, realBinary }) {
+function smokeInstall({
+  projectDir,
+  rootTarball,
+  platformTarball,
+  platformPackage,
+  cargoPackage,
+  realBinary,
+  noSystemRuntime
+}) {
   writeJson(path.join(projectDir, "package.json"), {
     private: true,
     name: "claude-rs-npm-smoke",
@@ -175,18 +194,259 @@ function smokeInstall({ projectDir, rootTarball, platformTarball, platformPackag
     throw new Error(`Installed platform version ${installedPlatform.version} does not match ${cargoPackage.version}`);
   }
 
-  const installedCommand = installedLauncherCommand(projectDir);
-  const versionOutput = runInstalledCommand(installedCommand, ["--version"], projectDir);
-  const helpOutput = runInstalledCommand(installedCommand, ["--help"], projectDir);
+  const nodeModulesDir = path.join(projectDir, "node_modules");
+  assertInstalledPlatformPackageLayout(nodeModulesDir, platformPackage);
+  assertInstalledRootPackageLayout(nodeModulesDir);
+  const installState = installedPackageState(nodeModulesDir, platformPackage);
+
+  const commandEnv = noSystemRuntime ? envWithoutSystemRuntimePath() : process.env;
+  const installedCommands = installedLauncherCommands(projectDir);
+  const versionOutputs = runInstalledCommands(installedCommands, ["--version"], projectDir, commandEnv);
+  const helpOutputs = runInstalledCommands(installedCommands, ["--help"], projectDir, commandEnv);
 
   if (realBinary) {
-    printCommandOutput("--version", versionOutput);
-    printCommandOutput("--help", helpOutput);
+    for (const output of versionOutputs) {
+      printCommandOutput(`${output.label} --version`, output);
+    }
+    for (const output of helpOutputs) {
+      printCommandOutput(`${output.label} --help`, output);
+    }
+    const doctorOutputs = runInstalledCommands(installedCommands, ["doctor", "--json", "--strict"], projectDir, commandEnv);
+    for (const output of doctorOutputs) {
+      assertDoctorReportsBridgeReadiness(output.stdout, platformPackage, output.label);
+      printCommandOutput(`${output.label} doctor --json --strict`, output);
+    }
+    runBridgeRuntimeContract(installState.runtimePath, installState.bridgeScriptPath, projectDir);
     return;
   }
 
-  assertMockOutput(versionOutput.stdout, "--version");
-  assertMockOutput(helpOutput.stdout, "--help");
+  for (const output of versionOutputs) {
+    assertMockOutput(output.stdout, `${output.label} --version`);
+  }
+  for (const output of helpOutputs) {
+    assertMockOutput(output.stdout, `${output.label} --help`);
+  }
+}
+
+async function smokeRegistryInstall({
+  tempDir,
+  packedPackages,
+  platformPackage,
+  cargoPackage,
+  realBinary,
+  noSystemRuntime,
+}) {
+  const prefix = path.join(tempDir, "global-prefix");
+  const cacheDir = path.join(tempDir, "npm-cache");
+  const dependencyPackDir = path.join(tempDir, "registry-dependencies");
+  const npmConfig = createIsolatedNpmConfig(tempDir);
+  const npmEnv = sanitizedNpmEnvironment(process.env);
+  const seededDependencies = packRegistryDependencyTarballs({
+    packDir: dependencyPackDir,
+    npmConfigArgs: npmConfig.args,
+    env: npmEnv,
+  });
+  const registryPackages = new Map([...packedPackages, ...seededDependencies]);
+  const registry = await startLocalRegistry(registryPackages);
+  const installConfigArgs = npmConfig.argsWithRegistry(registry.url);
+  const installArgs = [
+    "install",
+    "-g",
+    ROOT_PACKAGE_NAME,
+    "--prefix",
+    prefix,
+    "--cache",
+    cacheDir,
+    ...installConfigArgs,
+    "--ignore-scripts",
+    "--no-audit",
+    "--include=optional",
+    "--fund=false",
+  ];
+  const uninstallArgs = [
+    "uninstall",
+    "-g",
+    ROOT_PACKAGE_NAME,
+    "--prefix",
+    prefix,
+    "--cache",
+    cacheDir,
+    ...installConfigArgs,
+    "--no-audit",
+    "--fund=false",
+  ];
+
+  try {
+    await runNpmAsync(installArgs, tempDir, { env: npmEnv });
+    assertGlobalInstall(prefix, platformPackage, cargoPackage);
+    await runNpmAsync(uninstallArgs, tempDir, { env: npmEnv });
+    assertGlobalBinsRemoved(prefix);
+    await runNpmAsync(installArgs, tempDir, { env: npmEnv });
+    const installState = assertGlobalInstall(prefix, platformPackage, cargoPackage);
+    const commandEnv = noSystemRuntime ? envWithoutSystemRuntimePath() : process.env;
+    const installedCommands = globalLauncherCommands(prefix);
+    const versionOutputs = runInstalledCommands(installedCommands, ["--version"], tempDir, commandEnv);
+    const helpOutputs = runInstalledCommands(installedCommands, ["--help"], tempDir, commandEnv);
+    const manifest = {
+      root_package_version: installState.installedRoot.version,
+      selected_platform_package: platformPackage.packageName,
+      global_bin_path: installState.globalBinPath,
+      bundled_bridge_script_path: installState.bridgeScriptPath,
+      bundled_bun_runtime_path: installState.runtimePath,
+      doctor_bridge_runtime_kind: null,
+    };
+
+    if (realBinary) {
+      for (const output of versionOutputs) {
+        printCommandOutput(`${output.label} --version`, output);
+      }
+      for (const output of helpOutputs) {
+        printCommandOutput(`${output.label} --help`, output);
+      }
+      const doctorOutputs = runInstalledCommands(
+        installedCommands,
+        ["doctor", "--json", "--strict"],
+        tempDir,
+        commandEnv,
+      );
+      for (const output of doctorOutputs) {
+        const doctorDetails = assertDoctorReportsBridgeReadiness(output.stdout, platformPackage, output.label);
+        manifest.doctor_bridge_runtime_kind = doctorDetails.runtimeKind;
+        manifest.bundled_bridge_script_path = doctorDetails.bridgeScriptPath;
+        manifest.bundled_bun_runtime_path = doctorDetails.runtimePath;
+        printCommandOutput(`${output.label} doctor --json --strict`, output);
+      }
+      runBridgeRuntimeContract(installState.runtimePath, installState.bridgeScriptPath, tempDir);
+    } else {
+      for (const output of versionOutputs) {
+        assertMockOutput(output.stdout, `${output.label} --version`);
+      }
+      for (const output of helpOutputs) {
+        assertMockOutput(output.stdout, `${output.label} --help`);
+      }
+    }
+
+    console.log(`Registry smoke manifest:\n${JSON.stringify(manifest, null, 2)}`);
+  } finally {
+    await registry.close();
+  }
+}
+
+function packRegistryDependencyTarballs({ packDir, npmConfigArgs, env }) {
+  const packages = new Map();
+  const packageDirs = runtimeDependencyPackageDirs(readJson(path.join(repoRoot, "package-lock.json")));
+  fs.mkdirSync(packDir, { recursive: true });
+
+  for (const packageDir of packageDirs) {
+    const packageJson = readJson(path.join(packageDir, "package.json"));
+    const key = `${packageJson.name}@${packageJson.version}`;
+    if (packages.has(key)) {
+      continue;
+    }
+
+    const output = runNpm(
+      ["pack", packageDir, "--pack-destination", packDir, "--json", "--ignore-scripts", ...npmConfigArgs],
+      repoRoot,
+      { env },
+    );
+    const [packResult] = JSON.parse(output);
+    if (!packResult?.filename) {
+      throw new Error(`npm pack did not return a filename for registry seed package ${key}`);
+    }
+    packages.set(key, path.join(packDir, packResult.filename));
+  }
+
+  return packages;
+}
+
+export function runtimeDependencyPackageDirs(lockfile, {
+  nodeModulesRoot = path.join(repoRoot, "node_modules"),
+  platform = process.platform,
+  arch = process.arch,
+  linuxLibc = currentLinuxLibc(),
+} = {}) {
+  const packages = [];
+  const missing = [];
+
+  for (const [packagePath, packageEntry] of Object.entries(lockfile.packages ?? {})) {
+    if (!packagePath.startsWith("node_modules/") || packageEntry.dev || !packageEntry.version) {
+      continue;
+    }
+
+    const relativePackagePath = packagePath.slice("node_modules/".length);
+    const packageDir = path.join(nodeModulesRoot, ...relativePackagePath.split("/"));
+    if (!fs.existsSync(path.join(packageDir, "package.json"))) {
+      if (packageEntry.optional && !packageEntryMatchesHost(packageEntry, { platform, arch, linuxLibc })) {
+        continue;
+      }
+      missing.push(packagePath);
+      continue;
+    }
+
+    packages.push(packageDir);
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      "Cannot seed hermetic npm registry because package-lock runtime dependencies are missing from node_modules. " +
+        "Run `npm ci` before `--registry-smoke`.\n" +
+        missing.map((entry) => `- ${entry}`).join("\n"),
+    );
+  }
+
+  return packages;
+}
+
+function packageEntryMatchesHost(packageEntry, { platform, arch, linuxLibc }) {
+  return listAllows(packageEntry.os, platform) &&
+    listAllows(packageEntry.cpu, arch) &&
+    (!packageEntry.libc || (platform === "linux" && listAllows(packageEntry.libc, linuxLibc)));
+}
+
+function listAllows(values, actual) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return true;
+  }
+  if (values.includes(`!${actual}`)) {
+    return false;
+  }
+  const positiveValues = values.filter((value) => !String(value).startsWith("!"));
+  return positiveValues.length === 0 || positiveValues.includes(actual);
+}
+
+function currentLinuxLibc() {
+  if (process.platform !== "linux") {
+    return undefined;
+  }
+  try {
+    const glibcVersion = process.report?.getReport?.()?.header?.glibcVersionRuntime;
+    return typeof glibcVersion === "string" && glibcVersion.length > 0 ? "glibc" : "musl";
+  } catch {
+    return "musl";
+  }
+}
+
+function createIsolatedNpmConfig(tempDir) {
+  const userconfig = path.join(tempDir, "registry-smoke-user.npmrc");
+  const globalconfig = path.join(tempDir, "registry-smoke-global.npmrc");
+  fs.writeFileSync(userconfig, "audit=false\nfund=false\n", "utf8");
+  fs.writeFileSync(globalconfig, "", "utf8");
+  const args = ["--userconfig", userconfig, "--globalconfig", globalconfig];
+  return {
+    args,
+    argsWithRegistry: (registryUrl) => ["--registry", registryUrl, ...args],
+  };
+}
+
+export function sanitizedNpmEnvironment(baseEnv = process.env) {
+  const env = {};
+  for (const [key, value] of Object.entries(baseEnv)) {
+    if (/^npm_config_/i.test(key) || key === "NPM_TOKEN" || key === "NODE_AUTH_TOKEN") {
+      continue;
+    }
+    env[key] = value;
+  }
+  return env;
 }
 
 function assertMockOutput(output, commandName) {
@@ -195,38 +455,552 @@ function assertMockOutput(output, commandName) {
   }
 }
 
-function installedLauncherCommand(projectDir) {
-  if (process.platform === "win32") {
-    return {
-      command: process.execPath,
-      baseArgs: [path.join(projectDir, "node_modules", ROOT_PACKAGE_NAME, "bin", "claude-rs.js")]
-    };
+function assertInstalledPlatformPackageLayout(nodeModulesDir, platformPackage) {
+  const packageDir = path.join(nodeModulesDir, ...platformPackage.packageName.split("/"));
+  assertInstalledPlatformPackageDirLayout(packageDir, platformPackage);
+}
+
+function assertInstalledPlatformPackageDirLayout(packageDir, platformPackage) {
+  const packageJson = readJson(path.join(packageDir, "package.json"));
+  const binaryPath = path.join(packageDir, "bin", platformPackage.binaryName);
+  const runtimePath = path.join(packageDir, "bin", platformPackage.bundledRuntimeName);
+  if (packageJson.bin !== undefined) {
+    throw new Error(`Installed platform package must not expose npm bins: ${JSON.stringify(packageJson.bin)}`);
+  }
+  if (!fs.existsSync(binaryPath)) {
+    throw new Error(`Installed platform binary is missing: ${binaryPath}`);
+  }
+  if (!fs.existsSync(runtimePath)) {
+    throw new Error(`Installed bundled Bun runtime is missing: ${runtimePath}`);
+  }
+  for (const genericName of ["bun", "bun.exe"]) {
+    const genericPath = path.join(packageDir, "bin", genericName);
+    if (fs.existsSync(genericPath)) {
+      throw new Error(`Installed platform package exposes a generic Bun command: ${genericPath}`);
+    }
+  }
+}
+
+function assertInstalledRootPackageLayout(nodeModulesDir) {
+  const packageDir = path.join(nodeModulesDir, ROOT_PACKAGE_NAME);
+  const packageJson = readJson(path.join(packageDir, "package.json"));
+  const expectedBin = { "claude-rs": "bin/claude-rs.js" };
+  if (JSON.stringify(packageJson.bin) !== JSON.stringify(expectedBin)) {
+    throw new Error(`Installed root package did not expose the resolver bin: ${JSON.stringify(packageJson.bin)}`);
+  }
+  const launcherPath = path.join(packageDir, "bin", "claude-rs.js");
+  if (!fs.existsSync(launcherPath)) {
+    throw new Error(`Installed root resolver is missing: ${launcherPath}`);
+  }
+}
+
+function assertGlobalInstall(prefix, platformPackage, cargoPackage) {
+  const nodeModulesDir = globalNodeModulesDir(prefix);
+  const rootPackageDir = path.join(nodeModulesDir, ROOT_PACKAGE_NAME);
+  const platformPackageDir = findInstalledPackageDir(
+    [nodeModulesDir, path.join(rootPackageDir, "node_modules")],
+    platformPackage.packageName,
+  );
+  const installedRoot = readJson(path.join(rootPackageDir, "package.json"));
+  const installedPlatform = readJson(path.join(platformPackageDir, "package.json"));
+
+  if (installedRoot.version !== cargoPackage.version) {
+    throw new Error(`Installed global root version ${installedRoot.version} does not match ${cargoPackage.version}`);
+  }
+  if (installedPlatform.version !== cargoPackage.version) {
+    throw new Error(
+      `Installed global platform version ${installedPlatform.version} does not match ${cargoPackage.version}`
+    );
+  }
+
+  assertInstalledRootPackageLayout(nodeModulesDir);
+  assertInstalledPlatformPackageDirLayout(platformPackageDir, platformPackage);
+  const globalBinPath = assertSingleGlobalBin(prefix);
+  const bridgeScriptPath = path.join(rootPackageDir, "agent-sdk", "dist", "bridge.js");
+  const runtimePath = path.join(platformPackageDir, "bin", platformPackage.bundledRuntimeName);
+  if (!fs.existsSync(bridgeScriptPath)) {
+    throw new Error(`Installed global bridge script is missing: ${bridgeScriptPath}`);
+  }
+  if (!fs.existsSync(runtimePath)) {
+    throw new Error(`Installed global bundled Bun runtime is missing: ${runtimePath}`);
   }
 
   return {
-    command: path.join(projectDir, "node_modules", ".bin", "claude-rs"),
-    baseArgs: []
+    installedRoot,
+    installedPlatform,
+    globalBinPath,
+    bridgeScriptPath,
+    runtimePath,
   };
 }
 
-function runInstalledCommand(installedCommand, args, cwd) {
+function findInstalledPackageDir(nodeModulesDirs, packageName) {
+  for (const nodeModulesDir of nodeModulesDirs) {
+    const packageDir = path.join(nodeModulesDir, ...packageName.split("/"));
+    if (fs.existsSync(path.join(packageDir, "package.json"))) {
+      return packageDir;
+    }
+  }
+
+  throw new Error(
+    `Installed package ${packageName} was not found in: ` +
+      nodeModulesDirs.map((dir) => path.join(dir, ...packageName.split("/"))).join(", ")
+  );
+}
+
+function installedPackageState(nodeModulesDir, platformPackage) {
+  const rootPackageDir = path.join(nodeModulesDir, ROOT_PACKAGE_NAME);
+  const platformPackageDir = path.join(nodeModulesDir, ...platformPackage.packageName.split("/"));
+  return {
+    bridgeScriptPath: path.join(rootPackageDir, "agent-sdk", "dist", "bridge.js"),
+    runtimePath: path.join(platformPackageDir, "bin", platformPackage.bundledRuntimeName),
+  };
+}
+
+function globalNodeModulesDir(prefix) {
+  return process.platform === "win32"
+    ? path.join(prefix, "node_modules")
+    : path.join(prefix, "lib", "node_modules");
+}
+
+function globalBinDir(prefix) {
+  return process.platform === "win32" ? prefix : path.join(prefix, "bin");
+}
+
+function assertSingleGlobalBin(prefix) {
+  const binDir = globalBinDir(prefix);
+  const entries = fs.existsSync(binDir)
+    ? fs.readdirSync(binDir).filter((entry) => entry === "claude-rs" || entry.startsWith("claude-rs."))
+    : [];
+
+  const allowedEntries =
+    process.platform === "win32"
+      ? new Set(["claude-rs", "claude-rs.cmd", "claude-rs.ps1"])
+      : new Set(["claude-rs"]);
+  for (const entry of entries) {
+    if (!allowedEntries.has(entry)) {
+      throw new Error(`Unexpected global claude-rs bin entry after install: ${entry}`);
+    }
+  }
+  const requiredEntry = process.platform === "win32" ? "claude-rs.cmd" : "claude-rs";
+  if (!entries.includes(requiredEntry)) {
+    throw new Error(`Missing global claude-rs bin entry: ${path.join(binDir, requiredEntry)}`);
+  }
+  return path.join(binDir, requiredEntry);
+}
+
+function assertGlobalBinsRemoved(prefix) {
+  const binDir = globalBinDir(prefix);
+  if (!fs.existsSync(binDir)) {
+    return;
+  }
+  const entries = fs.readdirSync(binDir).filter((entry) => entry === "claude-rs" || entry.startsWith("claude-rs."));
+  if (entries.length > 0) {
+    throw new Error(`Global claude-rs bin entries remained after uninstall: ${entries.join(", ")}`);
+  }
+}
+
+function installedLauncherCommands(projectDir) {
+  const binDir = path.join(projectDir, "node_modules", ".bin");
+  if (process.platform === "win32") {
+    return [
+      {
+        label: "cmd shim",
+        command: process.env.ComSpec || "cmd.exe",
+        windowsVerbatimArguments: true,
+        args: (commandArgs) => [
+          "/d",
+          "/c",
+          ["call", path.join(binDir, "claude-rs.cmd"), ...commandArgs]
+            .map((arg, index) => (index === 0 ? arg : quoteCmdArg(arg)))
+            .join(" ")
+        ]
+      },
+      {
+        label: "PowerShell shim",
+        command: "powershell.exe",
+        args: (commandArgs) => [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          path.join(binDir, "claude-rs.ps1"),
+          ...commandArgs
+        ]
+      }
+    ];
+  }
+
+  return [
+    {
+      label: "npm symlink",
+      command: path.join(binDir, "claude-rs"),
+      args: (commandArgs) => commandArgs
+    }
+  ];
+}
+
+function globalLauncherCommands(prefix) {
+  const binDir = globalBinDir(prefix);
+  if (process.platform === "win32") {
+    return [
+      {
+        label: "global cmd shim",
+        command: process.env.ComSpec || "cmd.exe",
+        windowsVerbatimArguments: true,
+        args: (commandArgs) => [
+          "/d",
+          "/c",
+          ["call", path.join(binDir, "claude-rs.cmd"), ...commandArgs]
+            .map((arg, index) => (index === 0 ? arg : quoteCmdArg(arg)))
+            .join(" ")
+        ]
+      },
+      {
+        label: "global PowerShell shim",
+        command: "powershell.exe",
+        args: (commandArgs) => [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          path.join(binDir, "claude-rs.ps1"),
+          ...commandArgs
+        ]
+      }
+    ];
+  }
+
+  return [
+    {
+      label: "global npm bin",
+      command: path.join(binDir, "claude-rs"),
+      args: (commandArgs) => commandArgs
+    }
+  ];
+}
+
+function quoteCmdArg(value) {
+  return `"${String(value).replaceAll('"', '""')}"`;
+}
+
+function runInstalledCommands(installedCommands, args, cwd, env) {
+  return installedCommands.map((installedCommand) => ({
+    label: installedCommand.label,
+    ...runInstalledCommand(installedCommand, args, cwd, env)
+  }));
+}
+
+function runInstalledCommand(installedCommand, args, cwd, env) {
   try {
-    const stdout = execFileSync(installedCommand.command, [...installedCommand.baseArgs, ...args], {
+    const stdout = execFileSync(installedCommand.command, installedCommand.args(args), {
       cwd,
+      env,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-      windowsHide: true
+      windowsHide: true,
+      windowsVerbatimArguments: installedCommand.windowsVerbatimArguments === true
     });
     return { stdout, stderr: "" };
   } catch (error) {
     const stdout = bufferToString(error.stdout);
     const stderr = bufferToString(error.stderr);
     throw new Error(
-      `Installed claude-rs command failed: ${args.join(" ")}\n` +
+      `Installed claude-rs command failed via ${installedCommand.label}: ${args.join(" ")}\n` +
         `status: ${error.status ?? "unknown"}\n` +
         `stdout:\n${stdout}\n` +
         `stderr:\n${stderr}`
     );
+  }
+}
+
+function assertDoctorReportsBridgeReadiness(stdout, platformPackage, label) {
+  const report = JSON.parse(stdout);
+  const runtimeDetails = assertDoctorReportsBundledRuntime(report, platformPackage, label);
+  const bridgeDetails = assertDoctorReportsBridgeScript(report, label);
+  return {
+    runtimeKind: runtimeDetails.runtimeKind,
+    runtimePath: runtimeDetails.runtimePath,
+    bridgeScriptPath: bridgeDetails.bridgeScriptPath,
+  };
+}
+
+function assertDoctorReportsBundledRuntime(report, platformPackage, label) {
+  const runtimeCheck = report.checks?.find((check) => check.id === "bridge_runtime");
+  if (!runtimeCheck) {
+    throw new Error(`${label} doctor output did not include bridge_runtime check`);
+  }
+  if (runtimeCheck.status !== "pass") {
+    throw new Error(`${label} bridge_runtime check did not pass: ${runtimeCheck.message}`);
+  }
+  if (runtimeCheck.details?.runtime_kind !== "bundled_bun") {
+    throw new Error(`${label} bridge_runtime kind was not bundled_bun: ${runtimeCheck.details?.runtime_kind}`);
+  }
+  const expectedPackagePath = normalizePath(path.join(...platformPackage.packageName.split("/")));
+  const runtimePath = normalizePath(runtimeCheck.message);
+  if (!runtimePath.includes(expectedPackagePath) || runtimePath.includes("node.exe")) {
+    throw new Error(`${label} bridge_runtime path did not point at the installed platform package: ${runtimePath}`);
+  }
+  return {
+    runtimeKind: runtimeCheck.details.runtime_kind,
+    runtimePath: runtimeCheck.message,
+  };
+}
+
+function assertDoctorReportsBridgeScript(report, label) {
+  const scriptCheck = report.checks?.find((check) => check.id === "bridge_script");
+  if (!scriptCheck) {
+    throw new Error(`${label} doctor output did not include bridge_script check`);
+  }
+  if (scriptCheck.status !== "pass") {
+    throw new Error(`${label} bridge_script check did not pass: ${scriptCheck.message}`);
+  }
+
+  const expectedBridgePath = normalizePath(
+    path.join("node_modules", ROOT_PACKAGE_NAME, "agent-sdk", "dist", "bridge.js")
+  );
+  const resolvedPath = normalizePath(scriptCheck.message);
+  const envPath = normalizePath(scriptCheck.details?.CLAUDE_RS_AGENT_BRIDGE ?? "");
+  if (!resolvedPath.includes(expectedBridgePath) || !envPath.includes(expectedBridgePath)) {
+    throw new Error(
+      `${label} bridge_script path did not point at the installed root package: ` +
+        `message=${resolvedPath}; env=${envPath}`
+    );
+  }
+  return {
+    bridgeScriptPath: scriptCheck.message,
+  };
+}
+
+export async function startLocalRegistry(packedPackages) {
+  const packages = new Map();
+  const tarballs = new Map();
+
+  for (const tarballPath of packedPackages.values()) {
+    const packageJson = readPackageJsonFromTarball(tarballPath);
+    const tarballBuffer = fs.readFileSync(tarballPath);
+    const filename = path.basename(tarballPath);
+    const record = {
+      packageJson,
+      tarballPath,
+      filename,
+      shasum: crypto.createHash("sha1").update(tarballBuffer).digest("hex"),
+      integrity: `sha512-${crypto.createHash("sha512").update(tarballBuffer).digest("base64")}`,
+    };
+    const versions = packages.get(packageJson.name) ?? new Map();
+    versions.set(packageJson.version, record);
+    packages.set(packageJson.name, versions);
+    tarballs.set(filename, record);
+  }
+
+  const server = http.createServer((request, response) => {
+    void handleRegistryRequest({ request, response, packages, tarballs }).catch((error) => {
+      response.writeHead(500, { "content-type": "text/plain; charset=utf-8" });
+      response.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const url = `http://127.0.0.1:${address.port}`;
+  return {
+    url,
+    close: () => new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve()))),
+  };
+}
+
+async function handleRegistryRequest({ request, response, packages, tarballs }) {
+  if (!request.url) {
+    response.writeHead(400);
+    response.end("missing url");
+    return;
+  }
+
+  const url = new URL(request.url, "http://127.0.0.1");
+  if ((request.method === "GET" || request.method === "HEAD") && url.pathname.startsWith("/tarballs/")) {
+    const filename = decodeURIComponent(url.pathname.split("/").at(-1) ?? "");
+    const record = tarballs.get(filename);
+    if (!record) {
+      response.writeHead(404);
+      response.end("missing tarball");
+      return;
+    }
+    response.writeHead(200, {
+      "content-type": "application/octet-stream",
+      "content-length": fs.statSync(record.tarballPath).size,
+    });
+    if (request.method === "HEAD") {
+      response.end();
+      return;
+    }
+    fs.createReadStream(record.tarballPath).pipe(response);
+    return;
+  }
+
+  const packageName = decodeURIComponent(url.pathname.slice(1));
+  const versions = packages.get(packageName);
+  if ((request.method === "GET" || request.method === "HEAD") && versions) {
+    const baseUrl = `http://${request.headers.host}`;
+    const metadata = packageMetadata(packageName, versions, baseUrl);
+    const body = JSON.stringify(metadata);
+    response.writeHead(200, {
+      "content-type": "application/json",
+      "content-length": Buffer.byteLength(body),
+    });
+    response.end(request.method === "HEAD" ? undefined : body);
+    return;
+  }
+
+  response.writeHead(404, { "content-type": "application/json" });
+  response.end(JSON.stringify({ error: `local registry has no package metadata for ${packageName}` }));
+}
+
+function packageMetadata(packageName, versions, baseUrl) {
+  const sortedRecords = [...versions.values()].sort((left, right) =>
+    left.packageJson.version.localeCompare(right.packageJson.version, "en", { numeric: true })
+  );
+  const latest = sortedRecords.at(-1)?.packageJson.version;
+  return {
+    name: packageName,
+    "dist-tags": {
+      latest,
+    },
+    versions: Object.fromEntries(
+      sortedRecords.map(({ packageJson, filename, shasum, integrity }) => [
+        packageJson.version,
+        {
+          ...packageJson,
+          dist: {
+            shasum,
+            integrity,
+            tarball: `${baseUrl}/tarballs/${encodeURIComponent(filename)}`,
+          },
+        },
+      ])
+    ),
+  };
+}
+
+function readPackageJsonFromTarball(tarballPath) {
+  const output = execFileSync("tar", ["-xOf", tarballPath, "package/package.json"], {
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  return JSON.parse(output);
+}
+
+export function envWithoutSystemRuntimePath(baseEnv = process.env, platform = process.platform) {
+  const env = { ...baseEnv };
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+  const runtimeDirs = runtimeExecutableDirs(env, platform);
+  const entries = (env[pathKey] ?? "")
+    .split(path.delimiter)
+    .filter((entry) => entry.trim().length > 0)
+    .filter((entry) => !runtimeDirs.has(normalizePathForCompare(entry, platform)));
+  env[pathKey] = entries.join(path.delimiter);
+  return env;
+}
+
+function runtimeExecutableDirs(env, platform) {
+  const dirs = new Set();
+  for (const executable of resolveExecutablesOnPath("bun", env, platform)) {
+    dirs.add(normalizePathForCompare(path.dirname(executable.path), platform));
+    if (executable.realPath) {
+      dirs.add(normalizePathForCompare(path.dirname(executable.realPath), platform));
+    }
+  }
+  return dirs;
+}
+
+export function resolveExecutablesOnPath(command, env = process.env, platform = process.platform, options = {}) {
+  const includeWhere = options.includeWhere ?? true;
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+  const entries = (env[pathKey] ?? "").split(path.delimiter).filter((entry) => entry.trim().length > 0);
+  const executables = new Map();
+  const candidates =
+    platform === "win32"
+      ? windowsExecutableNames(command, env)
+      : [command];
+
+  for (const entry of entries) {
+    for (const candidate of candidates) {
+      const executablePath = path.join(entry, candidate);
+      const stat = statExecutable(executablePath, platform);
+      if (!stat) {
+        continue;
+      }
+      const realPath = realpathOrUndefined(executablePath);
+      executables.set(normalizePathForCompare(executablePath, platform), {
+        path: executablePath,
+        realPath
+      });
+    }
+  }
+
+  if (platform === "win32" && includeWhere) {
+    for (const wherePath of whereExecutablePaths(command)) {
+      executables.set(normalizePathForCompare(wherePath, platform), {
+        path: wherePath,
+        realPath: realpathOrUndefined(wherePath)
+      });
+    }
+  }
+
+  return [...executables.values()];
+}
+
+function windowsExecutableNames(command, env) {
+  const extension = path.extname(command);
+  if (extension) {
+    return [command];
+  }
+  const pathExt = env.PATHEXT ?? env.PathExt ?? ".COM;.EXE;.BAT;.CMD";
+  return [command, ...pathExt.split(";").filter(Boolean).map((ext) => `${command}${ext.toLowerCase()}`)];
+}
+
+function whereExecutablePaths(command) {
+  try {
+    return execFileSync("where.exe", [command], { encoding: "utf8", windowsHide: true })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function runBridgeRuntimeContract(runtimePath, bridgeScriptPath, cwd) {
+  const contractScript = path.join(repoRoot, "agent-sdk", "scripts", "bridge-runtime-contract.mjs");
+  execFileSync(process.execPath, [contractScript, "--runtime", runtimePath, "--bridge", bridgeScriptPath], {
+    cwd,
+    stdio: "inherit",
+    windowsHide: true,
+  });
+}
+
+function statExecutable(executablePath, platform) {
+  try {
+    const stat = fs.statSync(executablePath);
+    if (!stat.isFile()) {
+      return undefined;
+    }
+    if (platform !== "win32" && process.platform !== "win32" && (stat.mode & 0o111) === 0) {
+      return undefined;
+    }
+    return stat;
+  } catch {
+    return undefined;
+  }
+}
+
+function realpathOrUndefined(executablePath) {
+  try {
+    return fs.realpathSync(executablePath);
+  } catch {
+    return undefined;
   }
 }
 
@@ -248,6 +1022,15 @@ function printCommandOutput(commandName, output) {
   }
 }
 
+function normalizePath(filePath) {
+  return filePath.replaceAll(path.sep, "/");
+}
+
+function normalizePathForCompare(filePath, platform = process.platform) {
+  const resolved = path.resolve(filePath);
+  return platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
 function printManifestSummary(distDir) {
   const summaryPath = path.join(distDir, "manifests", "summary.json");
   if (!fs.existsSync(summaryPath)) {
@@ -258,13 +1041,44 @@ function printManifestSummary(distDir) {
   console.log(fs.readFileSync(summaryPath, "utf8").trim());
 }
 
-function runNpm(args, cwd) {
-  return execFileSync(process.execPath, [npmCliPath, ...args], {
+function runNpm(args, cwd, { env = process.env } = {}) {
+  return execFileSync(process.execPath, [resolvedNpmCliPath(), ...args], {
     cwd,
+    env,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "inherit"],
     windowsHide: true
   });
+}
+
+function runNpmAsync(args, cwd, { env = process.env } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [resolvedNpmCliPath(), ...args], {
+      cwd,
+      env,
+      stdio: ["ignore", "pipe", "inherit"],
+      windowsHide: true,
+    });
+    let stdout = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+      reject(new Error(`npm ${args.join(" ")} failed with exit code ${code ?? "unknown"}`));
+    });
+  });
+}
+
+function resolvedNpmCliPath() {
+  npmCliPath ??= resolveNpmCliPath();
+  return npmCliPath;
 }
 
 function resolveNpmCliPath() {
@@ -298,7 +1112,9 @@ function parseArgs(args) {
     platform: undefined,
     keepTemp: false,
     useExistingTarballs: false,
-    realBinary: false
+    realBinary: false,
+    noSystemRuntime: false,
+    registrySmoke: false
   };
 
   for (let index = 0; index < args.length; index += 1) {
@@ -326,6 +1142,12 @@ function parseArgs(args) {
       case "--real-binary":
         parsed.realBinary = true;
         break;
+      case "--no-system-runtime":
+        parsed.noSystemRuntime = true;
+        break;
+      case "--registry-smoke":
+        parsed.registrySmoke = true;
+        break;
       default:
         throw new Error(`Unknown argument: ${arg}`);
     }
@@ -351,8 +1173,17 @@ Options:
   --platform <dir>      Platform package directory to install. Defaults to linux-x64-gnu.
   --use-existing-tarballs
                         Install tarballs that already exist in --pack-dir instead of packing dist-npm.
+  --registry-smoke      Serve tarballs from a temp registry and npm install -g the root package.
   --real-binary         Require --version and --help to exit successfully without mock output checks.
+  --no-system-runtime   Strip directories containing bun from PATH when running claude-rs.
   --keep-temp           Keep the temporary smoke project for inspection.
   -h, --help            Show this help.
 `);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
 }

--- a/scripts/smoke-npm-package-install.test.mjs
+++ b/scripts/smoke-npm-package-install.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  envWithoutSystemRuntimePath,
+  runtimeDependencyPackageDirs,
+  resolveExecutablesOnPath,
+  sanitizedNpmEnvironment,
+  startLocalRegistry,
+} from "./smoke-npm-package-install.mjs";
+
+function makeExecutable(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, "#!/usr/bin/env sh\n", "utf8");
+  fs.chmodSync(filePath, 0o755);
+}
+
+test("envWithoutSystemRuntimePath removes every Unix Bun directory from PATH", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-path-test-"));
+  try {
+    const firstBunDir = path.join(tempDir, "first");
+    const secondBunDir = path.join(tempDir, "second");
+    const nonBunDir = path.join(tempDir, "plain");
+    makeExecutable(path.join(firstBunDir, "bun"));
+    makeExecutable(path.join(secondBunDir, "bun"));
+    fs.mkdirSync(nonBunDir, { recursive: true });
+
+    const env = {
+      PATH: [firstBunDir, nonBunDir, secondBunDir, ""].join(path.delimiter),
+    };
+    const filtered = envWithoutSystemRuntimePath(env, "linux");
+
+    assert.equal(filtered.PATH, nonBunDir);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveExecutablesOnPath ignores non-executable Unix files", { skip: process.platform === "win32" }, () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-path-test-"));
+  try {
+    const binDir = path.join(tempDir, "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, "bun"), "", "utf8");
+
+    assert.deepEqual(resolveExecutablesOnPath("bun", { PATH: binDir }, "linux"), []);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveExecutablesOnPath respects Windows PATHEXT path shapes", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-path-test-"));
+  try {
+    const bunDir = path.join(tempDir, "bin");
+    fs.mkdirSync(bunDir, { recursive: true });
+    fs.writeFileSync(path.join(bunDir, "bun.exe"), "", "utf8");
+
+    const matches = resolveExecutablesOnPath(
+      "bun",
+      { PATH: bunDir, PATHEXT: ".EXE;.CMD" },
+      "win32",
+      { includeWhere: false },
+    );
+
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].path, path.join(bunDir, "bun.exe"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("sanitizedNpmEnvironment removes npm registry and token overrides", () => {
+  const sanitized = sanitizedNpmEnvironment({
+    PATH: "bin",
+    npm_config_registry: "https://registry.example.test",
+    NPM_CONFIG_USERCONFIG: "custom.npmrc",
+    NPM_TOKEN: "secret",
+    NODE_AUTH_TOKEN: "secret",
+  });
+
+  assert.deepEqual(sanitized, { PATH: "bin" });
+});
+
+test("runtimeDependencyPackageDirs skips missing incompatible optional packages", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-lock-test-"));
+  try {
+    const installedPackage = path.join(tempDir, "node_modules", "present");
+    fs.mkdirSync(installedPackage, { recursive: true });
+    fs.writeFileSync(
+      path.join(installedPackage, "package.json"),
+      JSON.stringify({ name: "present", version: "1.0.0" }),
+      "utf8",
+    );
+
+    const dirs = runtimeDependencyPackageDirs(
+      {
+        packages: {
+          "node_modules/present": { version: "1.0.0" },
+          "node_modules/missing-dev": { version: "1.0.0", dev: true },
+          "node_modules/missing-darwin": {
+            version: "1.0.0",
+            optional: true,
+            os: ["darwin"],
+          },
+        },
+      },
+      { nodeModulesRoot: path.join(tempDir, "node_modules"), platform: "win32", arch: "x64" },
+    );
+
+    assert.deepEqual(dirs, [installedPackage]);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("startLocalRegistry returns 404 for unseeded packages instead of proxying", async () => {
+  const registry = await startLocalRegistry(new Map());
+  try {
+    const response = await fetch(`${registry.url}/left-pad`);
+    assert.equal(response.status, 404);
+    assert.match(await response.text(), /local registry has no package metadata/);
+  } finally {
+    await registry.close();
+  }
+});

--- a/scripts/stage-bun-runtime.mjs
+++ b/scripts/stage-bun-runtime.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+import crypto from "node:crypto";
+import fs from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  BUNDLED_BUN_RUNTIME_VERSION,
+  PLATFORM_PACKAGES,
+  bunRuntimeAssetUrl,
+  readBunRuntimeManifest
+} from "./npm-package-config.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const options = parseArgs(process.argv.slice(2));
+
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const manifest = readBunRuntimeManifest(repoRoot);
+validateManifest(manifest);
+
+if (options.verifyUpstream) {
+  await verifyUpstreamChecksums(manifest);
+}
+
+if ((options.check || options.verifyUpstream) && !options.download) {
+  console.log(`Validated Bun runtime manifest for Bun ${manifest.version}`);
+  process.exit(0);
+}
+
+if (!options.download) {
+  printHelp();
+  process.exit(1);
+}
+
+const selectedPackages = selectPackages(options.platform);
+const distPlatformDir = path.resolve(repoRoot, options.distPlatform ?? "dist-platform");
+await stageRuntimes(selectedPackages, distPlatformDir);
+
+async function stageRuntimes(platformPackages, distPlatformDir) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-bun-runtime-"));
+
+  try {
+    for (const platformPackage of platformPackages) {
+      const runtimeAsset = manifest.assets[platformPackage.dir];
+      const url = bunRuntimeAssetUrl(manifest.version, runtimeAsset.assetName);
+      const zipPath = path.join(tempDir, runtimeAsset.assetName);
+      const extractDir = path.join(tempDir, platformPackage.dir);
+      const destination = path.join(distPlatformDir, platformPackage.dir, "bin", platformPackage.bundledRuntimeName);
+
+      await downloadFile(url, zipPath);
+      verifySha256(zipPath, runtimeAsset.sha256, runtimeAsset.assetName);
+      extractSingleFile(zipPath, runtimeAsset.archiveBinaryPath, extractDir);
+
+      const extractedBinary = path.join(extractDir, ...runtimeAsset.archiveBinaryPath.split("/"));
+      if (!fs.existsSync(extractedBinary)) {
+        throw new Error(`Bun archive did not contain ${runtimeAsset.archiveBinaryPath}`);
+      }
+      verifySha256(extractedBinary, runtimeAsset.binarySha256, `${runtimeAsset.assetName} ${runtimeAsset.archiveBinaryPath}`);
+
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.copyFileSync(extractedBinary, destination);
+      fs.chmodSync(destination, 0o755);
+      console.log(
+        `Staged ${runtimeAsset.assetName} as ${path.relative(repoRoot, destination).replaceAll(path.sep, "/")}`
+      );
+    }
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function validateManifest(manifest) {
+  const failures = [];
+
+  if (manifest.manifestVersion !== 1) {
+    failures.push(`manifestVersion must be 1, got ${manifest.manifestVersion}`);
+  }
+
+  if (manifest.version !== BUNDLED_BUN_RUNTIME_VERSION) {
+    failures.push(
+      `manifest version ${manifest.version} must match BUNDLED_BUN_RUNTIME_VERSION ${BUNDLED_BUN_RUNTIME_VERSION}`
+    );
+  }
+
+  if (!/^\d+\.\d+\.\d+$/.test(manifest.version ?? "")) {
+    failures.push(`Bun runtime version must be pinned as x.y.z, got ${manifest.version}`);
+  }
+
+  const expectedChecksumSourceUrl = `https://github.com/oven-sh/bun/releases/download/bun-v${manifest.version}/SHASUMS256.txt`;
+  if (manifest.checksumSourceUrl !== expectedChecksumSourceUrl) {
+    failures.push(`checksumSourceUrl must be ${expectedChecksumSourceUrl}`);
+  }
+
+  const expectedDirs = PLATFORM_PACKAGES.map((platformPackage) => platformPackage.dir).sort();
+  const actualDirs = Object.keys(manifest.assets ?? {}).sort();
+  if (JSON.stringify(actualDirs) !== JSON.stringify(expectedDirs)) {
+    failures.push(`manifest assets must cover exactly: ${expectedDirs.join(", ")}`);
+  }
+
+  for (const platformPackage of PLATFORM_PACKAGES) {
+    const asset = manifest.assets?.[platformPackage.dir];
+    if (!asset) {
+      continue;
+    }
+
+    if (asset.assetName !== platformPackage.bunAssetName) {
+      failures.push(`${platformPackage.dir} assetName must be ${platformPackage.bunAssetName}`);
+    }
+
+    if (asset.archiveBinaryPath !== platformPackage.bunArchiveBinaryPath) {
+      failures.push(`${platformPackage.dir} archiveBinaryPath must be ${platformPackage.bunArchiveBinaryPath}`);
+    }
+
+    if (!/^[a-f0-9]{64}$/.test(asset.sha256 ?? "")) {
+      failures.push(`${platformPackage.dir} sha256 must be a 64-character lowercase hex digest`);
+    }
+    if (!/^[a-f0-9]{64}$/.test(asset.binarySha256 ?? "")) {
+      failures.push(`${platformPackage.dir} binarySha256 must be a 64-character lowercase hex digest`);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Invalid Bun runtime manifest:\n- ${failures.join("\n- ")}`);
+  }
+}
+
+function selectPackages(platform) {
+  if (!platform) {
+    return PLATFORM_PACKAGES;
+  }
+
+  const platformPackage = PLATFORM_PACKAGES.find((candidate) => candidate.dir === platform);
+  if (!platformPackage) {
+    throw new Error(`Unknown platform package directory: ${platform}`);
+  }
+  return [platformPackage];
+}
+
+function verifySha256(filePath, expectedSha256, label) {
+  const actualSha256 = crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+  if (actualSha256 !== expectedSha256) {
+    throw new Error(`${label} SHA256 mismatch: expected ${expectedSha256}, got ${actualSha256}`);
+  }
+}
+
+async function verifyUpstreamChecksums(manifest) {
+  const shasums = parseShasums256(await fetchText(manifest.checksumSourceUrl));
+  const failures = [];
+
+  for (const platformPackage of PLATFORM_PACKAGES) {
+    const runtimeAsset = manifest.assets[platformPackage.dir];
+    const upstreamSha256 = shasums.get(runtimeAsset.assetName);
+    if (!upstreamSha256) {
+      failures.push(`missing ${runtimeAsset.assetName} in ${manifest.checksumSourceUrl}`);
+      continue;
+    }
+    if (upstreamSha256 !== runtimeAsset.sha256) {
+      failures.push(
+        `${runtimeAsset.assetName} SHA256 mismatch: manifest ${runtimeAsset.sha256}, upstream ${upstreamSha256}`
+      );
+    }
+  }
+
+  await verifyGithubReleaseDigests(manifest, failures);
+
+  if (failures.length > 0) {
+    throw new Error(`Bun upstream checksum verification failed:\n- ${failures.join("\n- ")}`);
+  }
+
+  console.log(`Verified Bun ${manifest.version} runtime checksums against upstream release metadata`);
+}
+
+function parseShasums256(text) {
+  const entries = new Map();
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const match = trimmed.match(/^([a-f0-9]{64})\s+\*?(.+)$/);
+    if (match) {
+      entries.set(path.basename(match[2].trim()), match[1]);
+    }
+  }
+  return entries;
+}
+
+async function verifyGithubReleaseDigests(manifest, failures) {
+  const releaseApiUrl = `https://api.github.com/repos/oven-sh/bun/releases/tags/bun-v${manifest.version}`;
+  let release;
+  try {
+    release = JSON.parse(await fetchText(releaseApiUrl));
+  } catch (error) {
+    console.warn(
+      `Warning: could not cross-check GitHub release API asset digests for Bun ${manifest.version}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return;
+  }
+
+  const digestsByName = new Map(
+    (release.assets ?? [])
+      .filter((asset) => typeof asset.name === "string" && typeof asset.digest === "string")
+      .map((asset) => [asset.name, asset.digest])
+  );
+
+  for (const platformPackage of PLATFORM_PACKAGES) {
+    const runtimeAsset = manifest.assets[platformPackage.dir];
+    const digest = digestsByName.get(runtimeAsset.assetName);
+    if (!digest) {
+      continue;
+    }
+    const expectedDigest = `sha256:${runtimeAsset.sha256}`;
+    if (digest !== expectedDigest) {
+      failures.push(
+        `${runtimeAsset.assetName} GitHub release digest mismatch: manifest ${expectedDigest}, API ${digest}`
+      );
+    }
+  }
+}
+
+async function fetchText(url) {
+  const response = await requestWithRedirects(url);
+  if (response.statusCode !== 200) {
+    response.resume();
+    throw new Error(`Fetch failed for ${url}: HTTP ${response.statusCode}`);
+  }
+  return new Promise((resolve, reject) => {
+    let body = "";
+    response.setEncoding("utf8");
+    response.on("data", (chunk) => {
+      body += chunk;
+    });
+    response.on("end", () => resolve(body));
+    response.on("error", reject);
+  });
+}
+
+async function downloadFile(url, destination) {
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  const response = await requestWithRedirects(url);
+  await new Promise((resolve, reject) => {
+    const output = fs.createWriteStream(destination);
+
+    if (response.statusCode !== 200) {
+      output.destroy();
+      response.resume();
+      reject(new Error(`Download failed for ${url}: HTTP ${response.statusCode}`));
+      return;
+    }
+
+    response.pipe(output);
+    output.on("finish", () => {
+      output.close(resolve);
+    });
+    output.on("error", reject);
+    response.on("error", (error) => {
+      output.destroy();
+      reject(error);
+    });
+  });
+}
+
+function requestWithRedirects(url, redirectCount = 0) {
+  return new Promise((resolve, reject) => {
+    if (redirectCount > 5) {
+      reject(new Error(`Too many redirects while downloading ${url}`));
+      return;
+    }
+
+    const client = url.startsWith("https:") ? https : http;
+    const request = client.get(
+      url,
+      {
+        headers: {
+          "User-Agent": "claude-code-rust-release-check"
+        }
+      },
+      (response) => {
+      if ([301, 302, 303, 307, 308].includes(response.statusCode) && response.headers.location) {
+        response.resume();
+        const redirectedUrl = new URL(response.headers.location, url).toString();
+        requestWithRedirects(redirectedUrl, redirectCount + 1).then(resolve, reject);
+        return;
+      }
+
+      resolve(response);
+    });
+    request.on("error", reject);
+  });
+}
+
+function extractSingleFile(zipPath, archivePath, destinationDir) {
+  fs.mkdirSync(destinationDir, { recursive: true });
+  if (process.platform === "win32") {
+    const command =
+      `Expand-Archive -LiteralPath ${quotePowerShellString(zipPath)} ` +
+      `-DestinationPath ${quotePowerShellString(destinationDir)} -Force`;
+    execFileSync("powershell.exe", ["-NoProfile", "-Command", command], { stdio: "inherit" });
+    return;
+  }
+
+  execFileSync("unzip", ["-q", zipPath, archivePath, "-d", destinationDir], {
+    stdio: "inherit"
+  });
+}
+
+function quotePowerShellString(value) {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function parseArgs(args) {
+  const parsed = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--check":
+        parsed.check = true;
+        break;
+      case "--download":
+        parsed.download = true;
+        break;
+      case "--verify-upstream":
+        parsed.verifyUpstream = true;
+        break;
+      case "--dist-platform":
+        parsed.distPlatform = requireValue(args, ++index, arg);
+        break;
+      case "--platform":
+        parsed.platform = requireValue(args, ++index, arg);
+        break;
+      case "-h":
+      case "--help":
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function requireValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/stage-bun-runtime.mjs [options]
+
+Options:
+  --check                         Validate scripts/bun-runtime-manifest.json.
+  --verify-upstream               Fetch upstream Bun checksums and verify manifest SHA256 values.
+  --download                      Download, verify, extract, and stage Bun runtimes.
+  --platform <package-dir>        Stage one platform package directory only.
+  --dist-platform <dir>           Staging root. Defaults to dist-platform.
+  -h, --help                      Show this help.
+`);
+}

--- a/scripts/third-party-notices.mjs
+++ b/scripts/third-party-notices.mjs
@@ -1,0 +1,138 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { PLATFORM_PACKAGES, readBunRuntimeManifest } from "./npm-package-config.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+export const BUN_LINKED_LIBRARIES = [
+  ["BoringSSL", "several licenses"],
+  ["brotli", "MIT"],
+  ["libarchive", "several licenses"],
+  ["lol-html", "BSD 3-Clause"],
+  ["mimalloc", "MIT"],
+  ["picohttp", "Perl License or MIT"],
+  ["zstd", "BSD License or GPLv2"],
+  ["simdutf", "Apache 2.0"],
+  ["tinycc", "LGPL v2.1"],
+  ["uSockets", "Apache 2.0"],
+  ["zlib-ng", "zlib"],
+  ["c-ares", "MIT"],
+  ["libicu", "ICU license"],
+  ["libbase64", "BSD 2-Clause"],
+  ["libuv", "MIT on Windows"],
+  ["libdeflate", "MIT"],
+  ["uWebSockets fork", "Apache 2.0"],
+  ["TigerBeetle IO code", "Apache 2.0"]
+];
+
+export const BUN_EMBEDDED_POLYFILLS = [
+  "assert",
+  "browserify-zlib",
+  "buffer",
+  "constants-browserify",
+  "crypto-browserify",
+  "domain-browser",
+  "events",
+  "https-browserify",
+  "os-browserify",
+  "path-browserify",
+  "process",
+  "punycode",
+  "querystring-es3",
+  "stream-browserify",
+  "stream-http",
+  "string_decoder",
+  "timers-browserify",
+  "tty-browserify",
+  "url",
+  "util",
+  "vm-browserify"
+];
+
+export function buildThirdPartyNotices({
+  manifest = readBunRuntimeManifest(repoRoot),
+  platformPackages = PLATFORM_PACKAGES
+} = {}) {
+  const assetRows = platformPackages.map((platformPackage) => {
+    const asset = manifest.assets?.[platformPackage.dir];
+    if (!asset) {
+      throw new Error(`Bun runtime manifest is missing ${platformPackage.dir}`);
+    }
+
+    return [
+      `| \`${platformPackage.dir}\``,
+      `\`${asset.assetName}\``,
+      `\`${asset.archiveBinaryPath}\``,
+      `\`${asset.sha256}\` |`
+    ].join(" | ");
+  });
+
+  const linkedLibraryRows = BUN_LINKED_LIBRARIES.map(
+    ([library, license]) => `| ${library} | ${license} |`
+  );
+  const embeddedPolyfillRows = BUN_EMBEDDED_POLYFILLS.map((polyfill) => `| ${polyfill} | MIT |`);
+
+  return `# Third-Party Notices
+
+This npm platform package redistributes a private Bun executable used only to
+run the bundled Agent SDK bridge for \`claude-code-rust\`. The executable is
+renamed to \`claude-rs-bridge-bun\` or \`claude-rs-bridge-bun.exe\`; it is not
+exposed as a user-facing \`bun\` command.
+
+The \`claude-code-rust\` project is licensed under Apache-2.0.
+
+## Bundled Bun Runtime
+
+- Bun version: ${manifest.version}
+- Upstream project: https://github.com/oven-sh/bun
+- Bun license documentation: https://bun.com/docs/project/license
+- Bun license: MIT
+- Bun checksum source: ${manifest.checksumSourceUrl}
+
+Bundled Bun release assets:
+
+| Platform package | Bun release asset | Archive binary path | Source archive SHA256 |
+| --- | --- | --- | --- |
+${assetRows.join("\n")}
+
+Release package manifests record the upstream asset URL, archive path, source
+archive SHA256, and packaged runtime SHA256 for each platform package.
+
+## JavaScriptCore And WebKit
+
+Bun statically links JavaScriptCore and WebKit components. Bun's license page
+identifies JavaScriptCore, WebKit, and WebCore files as LGPL-2 licensed and
+describes the relinking obligation for static LGPL linkage.
+
+Bun's patched WebKit source is published at:
+
+https://github.com/oven-sh/WebKit
+
+Downstream redistribution of the platform packages should preserve this notice,
+the Bun license information, and the WebKit source/relinking reference.
+
+## Statically Linked Libraries
+
+Bun's license page lists these statically linked libraries and license notices:
+
+| Library | License notice |
+| --- | --- |
+${linkedLibraryRows.join("\n")}
+
+## Embedded Polyfills
+
+Bun embeds these compatibility polyfill packages into its binary and injects
+them if imported. Bun's license page lists each as MIT licensed:
+
+| Package | License |
+| --- | --- |
+${embeddedPolyfillRows.join("\n")}
+
+## Additional Credits
+
+Bun's license page also credits esbuild-derived source code in Bun's JS
+transpiler, CSS lexer, and Node.js module resolver.
+`;
+}

--- a/scripts/verify-npm-packages.mjs
+++ b/scripts/verify-npm-packages.mjs
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import {
+  BUNDLED_BUN_RUNTIME_VERSION,
   DIST_NPM_DIR,
   PLATFORM_PACKAGES,
   ROOT_PACKAGE_NAME,
+  bunRuntimeAssetUrl,
   readCargoPackageMetadata,
+  readBunRuntimeManifest,
   readJson
 } from "./npm-package-config.mjs";
+import { verifyThirdPartyNoticeCoverage } from "./verify-third-party-notices.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -29,7 +34,9 @@ const cargoPackage = readCargoPackageMetadata(path.join(repoRoot, "Cargo.toml"))
 const expectedVersion = options.version ?? cargoPackage.version;
 const failures = [];
 const packageManifests = [];
+const bunRuntimeManifest = readBunRuntimeManifest(repoRoot);
 
+expectEqual(bunRuntimeManifest.version, BUNDLED_BUN_RUNTIME_VERSION, "Bun runtime manifest version");
 verifyDistDir();
 exitIfFailures();
 fs.rmSync(manifestsDir, { recursive: true, force: true });
@@ -46,12 +53,15 @@ for (const platformPackage of PLATFORM_PACKAGES) {
 writeJson(path.join(manifestsDir, "summary.json"), {
   manifestVersion: 1,
   packageCount: packageManifests.length,
-  packages: packageManifests.map(({ name, version, directory, files }) => ({
-    name,
-    version,
-    directory,
-    fileCount: files.length
-  }))
+  packages: packageManifests.map(({ name, version, directory, files, bundledRuntime }) =>
+    removeUndefined({
+      name,
+      version,
+      directory,
+      fileCount: files.length,
+      bundledRuntime
+    })
+  )
 });
 
 if (failures.length > 0) {
@@ -75,29 +85,21 @@ function verifyRootPackage() {
   expectEqual(packageJson.name, ROOT_PACKAGE_NAME, `${context} name`);
   expectEqual(packageJson.version, expectedVersion, `${context} version`);
   expectDeepEqual(packageJson.bin, { "claude-rs": "bin/claude-rs.js" }, `${context} bin`);
+  expectDeepEqual(
+    packageJson.optionalDependencies,
+    expectedPlatformOptionalDependencies(),
+    `${context} optionalDependencies`
+  );
+  expectDeepEqual(packageJson.engines, { node: ">=18" }, `${context} engines`);
   expectNoLifecycleScripts(packageJson, context);
   expectNoForbiddenManifestFields(packageJson, context);
-
-  const optionalDependencies = packageJson.optionalDependencies ?? {};
-  for (const platformPackage of PLATFORM_PACKAGES) {
-    expectEqual(
-      optionalDependencies[platformPackage.packageName],
-      expectedVersion,
-      `${context} optional dependency ${platformPackage.packageName}`
-    );
-  }
-  expectEqual(
-    Object.keys(optionalDependencies).length,
-    PLATFORM_PACKAGES.length,
-    `${context} optional dependency count`
-  );
 
   const files = listPackageFiles(packageDir);
   expectFilesExist(files, ["package.json", "bin/claude-rs.js", "agent-sdk/package.json", "README.md", "LICENSE"], context);
   expectFilesExist(files, ["agent-sdk/dist/bridge.js", "agent-sdk/dist/types.js"], context);
   expectOnlyAllowedFiles(files, rootAllowedFile, context);
   expectNoForbiddenFiles(files, context);
-  expectLauncherUsesPlatformPackages(packageDir, context);
+  expectNoNodeShebangs(packageDir, files, context, ["bin/claude-rs.js"]);
 
   const packManifest = packAndVerify(packageDir, context, rootAllowedFile);
   writePackageManifest("root", packageJson, packManifest.files);
@@ -115,6 +117,7 @@ function verifyPlatformPackage(platformPackage) {
   const packageJson = readPackageJson(packageDir);
   const context = `${platformPackage.dir} package`;
   const expectedBinaryPath = `bin/${platformPackage.binaryName}`;
+  const expectedRuntimePath = `bin/${platformPackage.bundledRuntimeName}`;
 
   expectEqual(packageJson.name, platformPackage.packageName, `${context} name`);
   expectEqual(packageJson.version, expectedVersion, `${context} version`);
@@ -122,29 +125,35 @@ function verifyPlatformPackage(platformPackage) {
   expectDeepEqual(packageJson.cpu, platformPackage.cpu, `${context} cpu`);
   expectDeepEqual(packageJson.libc, platformPackage.libc, `${context} libc`);
   expectEqual(packageJson.bin, undefined, `${context} bin`);
+  expectEqual(packageJson.dependencies, undefined, `${context} dependencies`);
   expectNoLifecycleScripts(packageJson, context);
   expectNoForbiddenManifestFields(packageJson, context);
 
   const files = listPackageFiles(packageDir);
   expectDeepEqual(
     files,
-    ["LICENSE", "README.md", expectedBinaryPath, "package.json"].sort(),
+    ["LICENSE", "README.md", "THIRD-PARTY-NOTICES.md", expectedBinaryPath, expectedRuntimePath, "package.json"].sort(),
     `${context} local file list`
   );
   expectNoForbiddenFiles(files, context);
+  expectNoNodeShebangs(packageDir, files, context);
+  expectThirdPartyNoticeCoverage(packageDir, context);
   expectPlatformReadme(packageDir, platformPackage, context);
   expectUnixBinaryExecutable(packageDir, platformPackage, expectedBinaryPath, context);
+  expectUnixBinaryExecutable(packageDir, platformPackage, expectedRuntimePath, context);
+  const bundledRuntime = buildBunRuntimeProvenance(platformPackage, packageDir, expectedRuntimePath, context);
 
   const packManifest = packAndVerify(packageDir, context, (filePath) =>
-    ["LICENSE", "README.md", expectedBinaryPath, "package.json"].includes(filePath)
+    ["LICENSE", "README.md", "THIRD-PARTY-NOTICES.md", expectedBinaryPath, expectedRuntimePath, "package.json"].includes(filePath)
   );
-  writePackageManifest(platformPackage.dir, packageJson, packManifest.files);
+  writePackageManifest(platformPackage.dir, packageJson, packManifest.files, { bundledRuntime });
 
   return {
     directory: platformPackage.dir,
     name: packageJson.name,
     version: packageJson.version,
-    files: packManifest.files
+    files: packManifest.files,
+    bundledRuntime
   };
 }
 
@@ -254,12 +263,67 @@ function resolveNpmCliPath() {
   );
 }
 
-function writePackageManifest(directory, packageJson, files) {
+function writePackageManifest(directory, packageJson, files, extra = {}) {
   writeJson(path.join(manifestsDir, `${directory}.json`), {
     name: packageJson.name,
     version: packageJson.version,
+    ...extra,
     files
   });
+}
+
+function buildBunRuntimeProvenance(platformPackage, packageDir, runtimeFilePath, context) {
+  const runtimeAsset = bunRuntimeManifest.assets?.[platformPackage.dir];
+  if (!runtimeAsset) {
+    fail(`${context} missing Bun runtime manifest entry`);
+    return undefined;
+  }
+
+  expectEqual(runtimeAsset.assetName, platformPackage.bunAssetName, `${context} Bun asset name`);
+  expectEqual(
+    runtimeAsset.archiveBinaryPath,
+    platformPackage.bunArchiveBinaryPath,
+    `${context} Bun archive binary path`
+  );
+  const actualRuntimeSha256 = fileSha256(path.join(packageDir, runtimeFilePath));
+  expectEqual(actualRuntimeSha256, runtimeAsset.binarySha256, `${context} bundled Bun runtime SHA256`);
+
+  return {
+    name: platformPackage.bundledRuntimeName,
+    version: bunRuntimeManifest.version,
+    sourceAsset: runtimeAsset.assetName,
+    sourceUrl: bunRuntimeAssetUrl(bunRuntimeManifest.version, runtimeAsset.assetName),
+    checksumSourceUrl: bunRuntimeManifest.checksumSourceUrl,
+    archiveBinaryPath: runtimeAsset.archiveBinaryPath,
+    sourceArchiveSha256: runtimeAsset.sha256,
+    runtimeSha256: actualRuntimeSha256
+  };
+}
+
+function fileSha256(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function removeUndefined(value) {
+  if (Array.isArray(value)) {
+    return value.map(removeUndefined);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, entryValue]) => entryValue !== undefined)
+        .map(([entryKey, entryValue]) => [entryKey, removeUndefined(entryValue)])
+    );
+  }
+
+  return value;
+}
+
+function expectedPlatformOptionalDependencies() {
+  return Object.fromEntries(
+    PLATFORM_PACKAGES.map((platformPackage) => [platformPackage.packageName, expectedVersion])
+  );
 }
 
 function rootAllowedFile(filePath) {
@@ -326,12 +390,41 @@ function expectNoForbiddenFiles(files, context) {
   }
 }
 
+function expectNoNodeShebangs(packageDir, files, context, allowedFiles = []) {
+  const allowed = new Set(allowedFiles);
+  for (const file of files) {
+    const fullPath = path.join(packageDir, file);
+    if (!fs.statSync(fullPath).isFile()) {
+      continue;
+    }
+    const buffer = fs.readFileSync(fullPath);
+    const prefix = buffer.subarray(0, 64).toString("utf8");
+    if (prefix.startsWith("#!/usr/bin/env node") && !allowed.has(file)) {
+      fail(`${context} contains forbidden Node shebang: ${file}`);
+    }
+  }
+}
+
+function expectThirdPartyNoticeCoverage(packageDir, context) {
+  try {
+    verifyThirdPartyNoticeCoverage({
+      noticesPath: path.join(packageDir, "THIRD-PARTY-NOTICES.md"),
+      manifest: bunRuntimeManifest
+    });
+  } catch (error) {
+    fail(`${context} third-party notices: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
 function expectPlatformReadme(packageDir, platformPackage, context) {
   const readme = fs.readFileSync(path.join(packageDir, "README.md"), "utf8");
   expectIncludes(readme, `# \`${platformPackage.packageName}\``, `${context} README title`);
   expectIncludes(readme, platformPackage.rustTarget, `${context} README Rust target`);
   expectIncludes(readme, `version \`${expectedVersion}\``, `${context} README version`);
-  expectIncludes(readme, "npm install -g claude-code-rust", `${context} README install command`);
+  expectIncludes(readme, `npm install -g ${ROOT_PACKAGE_NAME}`, `${context} README install command`);
+  expectIncludes(readme, "selected automatically by the root", `${context} README root selection`);
+  expectIncludes(readme, platformPackage.bundledRuntimeName, `${context} README bundled runtime`);
+  expectIncludes(readme, "not a user-facing `bun` command", `${context} README private runtime`);
   expectIncludes(
     readme,
     `https://www.npmjs.com/package/${platformPackage.packageName}`,
@@ -345,25 +438,6 @@ function expectPlatformReadme(packageDir, platformPackage, context) {
   }
 }
 
-function expectLauncherUsesPlatformPackages(packageDir, context) {
-  const launcher = fs.readFileSync(path.join(packageDir, "bin", "claude-rs.js"), "utf8");
-  if (launcher.includes('"vendor"') || launcher.includes("'vendor'")) {
-    fail(`${context} launcher must not resolve vendor binaries`);
-  }
-  if (launcher.includes("refreshBridgeRuntime") || launcher.includes("claude-rs-bridge-node")) {
-    fail(`${context} launcher must not manage a copied Node bridge runtime`);
-  }
-  if (!launcher.includes("CLAUDE_RS_AGENT_BRIDGE") || !launcher.includes("agent-sdk")) {
-    fail(`${context} launcher must pass the bundled agent-sdk bridge path to the native binary`);
-  }
-
-  for (const platformPackage of PLATFORM_PACKAGES) {
-    if (!launcher.includes(platformPackage.packageName)) {
-      fail(`${context} launcher does not reference ${platformPackage.packageName}`);
-    }
-  }
-}
-
 function isForbiddenFile(filePath) {
   const normalized = normalizePath(filePath);
   const segments = normalized.split("/");
@@ -372,6 +446,8 @@ function isForbiddenFile(filePath) {
   return (
     basename === ".env" ||
     basename === ".npmrc" ||
+    basename === "bun" ||
+    basename === "bun.exe" ||
     basename.endsWith(".log") ||
     basename.endsWith(".map") ||
     basename.endsWith(".test.js") ||

--- a/scripts/verify-staged-bun-runtimes.mjs
+++ b/scripts/verify-staged-bun-runtimes.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  PLATFORM_PACKAGES,
+  readBunRuntimeManifest,
+} from "./npm-package-config.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+export function verifyStagedBunRuntimes({
+  distPlatformDir,
+  platformPackages = PLATFORM_PACKAGES,
+  manifest = readBunRuntimeManifest(repoRoot),
+  rootForMessages = repoRoot,
+}) {
+  const failures = [];
+
+  for (const platformPackage of platformPackages) {
+    const runtimeAsset = manifest.assets?.[platformPackage.dir];
+    const packageBinDir = path.join(distPlatformDir, platformPackage.dir, "bin");
+    const runtimePath = path.join(packageBinDir, platformPackage.bundledRuntimeName);
+
+    if (!runtimeAsset) {
+      failures.push(`${platformPackage.dir}: missing Bun runtime manifest entry`);
+      continue;
+    }
+    if (!fs.existsSync(runtimePath)) {
+      failures.push(`${platformPackage.dir}: missing staged runtime ${relativePath(rootForMessages, runtimePath)}`);
+      continue;
+    }
+    if (!fs.statSync(runtimePath).isFile()) {
+      failures.push(`${platformPackage.dir}: staged runtime is not a file ${relativePath(rootForMessages, runtimePath)}`);
+    }
+    if (["bun", "bun.exe"].includes(path.basename(runtimePath))) {
+      failures.push(`${platformPackage.dir}: staged runtime must be privately renamed, got ${path.basename(runtimePath)}`);
+    }
+    if (!platformPackage.os.includes("win32") && process.platform !== "win32") {
+      const mode = fs.statSync(runtimePath).mode;
+      if ((mode & 0o111) === 0) {
+        failures.push(`${platformPackage.dir}: staged runtime is not executable ${relativePath(rootForMessages, runtimePath)}`);
+      }
+    }
+    const actualSha256 = fileSha256(runtimePath);
+    if (actualSha256 !== runtimeAsset.binarySha256) {
+      failures.push(
+        `${platformPackage.dir}: staged runtime SHA256 mismatch for ${relativePath(
+          rootForMessages,
+          runtimePath,
+        )}: expected ${runtimeAsset.binarySha256}, got ${actualSha256}`
+      );
+    }
+
+    for (const genericName of ["bun", "bun.exe"]) {
+      const genericRuntimePath = path.join(packageBinDir, genericName);
+      if (fs.existsSync(genericRuntimePath)) {
+        failures.push(
+          `${platformPackage.dir}: staged runtime directory contains forbidden generic Bun name ${relativePath(
+            rootForMessages,
+            genericRuntimePath,
+          )}`
+        );
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Staged Bun runtime verification failed:\n- ${failures.join("\n- ")}`);
+  }
+}
+
+function fileSha256(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function relativePath(root, target) {
+  return path.relative(root, target).replaceAll(path.sep, "/");
+}
+
+function parseArgs(args) {
+  const parsed = {
+    distPlatform: "dist-platform",
+    platform: undefined,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--dist-platform":
+        parsed.distPlatform = readArgValue(args, ++index, arg);
+        break;
+      case "--platform":
+        parsed.platform = readArgValue(args, ++index, arg);
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function readArgValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/verify-staged-bun-runtimes.mjs [options]
+
+Options:
+  --dist-platform <dir>      Staging root. Defaults to dist-platform.
+  --platform <package-dir>   Verify one platform package directory only.
+  -h, --help                 Show this help.
+`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const platformPackages = options.platform
+    ? PLATFORM_PACKAGES.filter((platformPackage) => platformPackage.dir === options.platform)
+    : PLATFORM_PACKAGES;
+  if (options.platform && platformPackages.length === 0) {
+    throw new Error(`Unknown platform package directory: ${options.platform}`);
+  }
+
+  const distPlatformDir = path.resolve(repoRoot, options.distPlatform);
+  verifyStagedBunRuntimes({ distPlatformDir });
+  console.log(`Verified staged Bun runtimes in ${relativePath(repoRoot, distPlatformDir)}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/verify-staged-bun-runtimes.test.mjs
+++ b/scripts/verify-staged-bun-runtimes.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { PLATFORM_PACKAGES, readBunRuntimeManifest } from "./npm-package-config.mjs";
+import { verifyStagedBunRuntimes } from "./verify-staged-bun-runtimes.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const fakeRuntimeSha256 = crypto.createHash("sha256").update("fake runtime").digest("hex");
+
+function fakeRuntimeManifest() {
+  const manifest = structuredClone(readBunRuntimeManifest(repoRoot));
+  for (const asset of Object.values(manifest.assets)) {
+    asset.binarySha256 = fakeRuntimeSha256;
+  }
+  return manifest;
+}
+
+function stageFakeRuntime(distPlatformDir, platformPackage) {
+  const runtimePath = path.join(
+    distPlatformDir,
+    platformPackage.dir,
+    "bin",
+    platformPackage.bundledRuntimeName,
+  );
+  fs.mkdirSync(path.dirname(runtimePath), { recursive: true });
+  fs.writeFileSync(runtimePath, "fake runtime", "utf8");
+  fs.chmodSync(runtimePath, 0o755);
+}
+
+test("verifyStagedBunRuntimes accepts artifact tree rooted at dist-platform", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-staged-runtime-"));
+  try {
+    const distPlatformDir = path.join(tempDir, "dist-platform");
+    for (const platformPackage of PLATFORM_PACKAGES) {
+      stageFakeRuntime(distPlatformDir, platformPackage);
+    }
+
+    verifyStagedBunRuntimes({
+      distPlatformDir,
+      manifest: fakeRuntimeManifest(),
+      rootForMessages: tempDir,
+    });
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("verifyStagedBunRuntimes rejects generic bun filenames in package bin dirs", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-staged-runtime-"));
+  try {
+    const distPlatformDir = path.join(tempDir, "dist-platform");
+    const platformPackage = PLATFORM_PACKAGES.find((entry) => entry.dir === "linux-x64-gnu");
+    stageFakeRuntime(distPlatformDir, platformPackage);
+    fs.writeFileSync(path.join(distPlatformDir, platformPackage.dir, "bin", "bun"), "bad", "utf8");
+
+    assert.throws(
+      () =>
+        verifyStagedBunRuntimes({
+          distPlatformDir,
+          platformPackages: [platformPackage],
+          manifest: fakeRuntimeManifest(),
+          rootForMessages: tempDir,
+        }),
+      /forbidden generic Bun name/,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("verifyStagedBunRuntimes rejects root-level artifact extraction shape", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-staged-runtime-"));
+  try {
+    const platformPackage = PLATFORM_PACKAGES.find((entry) => entry.dir === "darwin-arm64");
+    stageFakeRuntime(tempDir, platformPackage);
+
+    assert.throws(
+      () =>
+        verifyStagedBunRuntimes({
+          distPlatformDir: path.join(tempDir, "dist-platform"),
+          platformPackages: [platformPackage],
+          manifest: fakeRuntimeManifest(),
+          rootForMessages: tempDir,
+        }),
+      /missing staged runtime/,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("verifyStagedBunRuntimes rejects staged runtime hash mismatch", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-staged-runtime-"));
+  try {
+    const distPlatformDir = path.join(tempDir, "dist-platform");
+    const platformPackage = PLATFORM_PACKAGES.find((entry) => entry.dir === "linux-x64-gnu");
+    stageFakeRuntime(distPlatformDir, platformPackage);
+    const manifest = fakeRuntimeManifest();
+    manifest.assets[platformPackage.dir].binarySha256 = "0".repeat(64);
+
+    assert.throws(
+      () =>
+        verifyStagedBunRuntimes({
+          distPlatformDir,
+          platformPackages: [platformPackage],
+          manifest,
+          rootForMessages: tempDir,
+        }),
+      /staged runtime SHA256 mismatch/,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify-third-party-notices.mjs
+++ b/scripts/verify-third-party-notices.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { PLATFORM_PACKAGES, readBunRuntimeManifest } from "./npm-package-config.mjs";
+import {
+  BUN_EMBEDDED_POLYFILLS,
+  BUN_LINKED_LIBRARIES,
+  buildThirdPartyNotices
+} from "./third-party-notices.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+export function verifyThirdPartyNoticeCoverage({
+  manifest = readBunRuntimeManifest(repoRoot),
+  notices,
+  noticesPath,
+} = {}) {
+  const noticeText = notices ?? (noticesPath ? fs.readFileSync(noticesPath, "utf8") : buildThirdPartyNotices({ manifest }));
+  const failures = [];
+
+  expectIncludes(noticeText, `Bun version: ${manifest.version}`, "Bun version", failures);
+  expectIncludes(noticeText, "https://bun.com/docs/project/license", "Bun license docs URL", failures);
+  expectIncludes(noticeText, "https://github.com/oven-sh/WebKit", "WebKit source URL", failures);
+  expectIncludes(noticeText, "LGPL-2", "WebKit LGPL notice", failures);
+  expectIncludes(noticeText, "Apache-2.0", "project Apache-2.0 notice", failures);
+  expectIncludes(noticeText, "MIT", "Bun MIT notice", failures);
+
+  for (const platformPackage of PLATFORM_PACKAGES) {
+    const asset = manifest.assets?.[platformPackage.dir];
+    if (!asset) {
+      failures.push(`manifest is missing ${platformPackage.dir}`);
+      continue;
+    }
+    expectIncludes(noticeText, platformPackage.dir, `${platformPackage.dir} package directory`, failures);
+    expectIncludes(noticeText, asset.assetName, `${platformPackage.dir} Bun asset`, failures);
+    expectIncludes(noticeText, asset.archiveBinaryPath, `${platformPackage.dir} archive binary path`, failures);
+    expectIncludes(noticeText, asset.sha256, `${platformPackage.dir} source archive SHA256`, failures);
+  }
+
+  for (const [linkedLibrary] of BUN_LINKED_LIBRARIES) {
+    expectIncludes(noticeText, linkedLibrary, `linked library ${linkedLibrary}`, failures);
+  }
+
+  for (const polyfill of BUN_EMBEDDED_POLYFILLS) {
+    expectIncludes(noticeText, polyfill, `embedded polyfill ${polyfill}`, failures);
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Third-party notice verification failed:\n- ${failures.join("\n- ")}`);
+  }
+}
+
+function expectIncludes(haystack, needle, label, failures) {
+  if (!haystack.includes(needle)) {
+    failures.push(`missing ${label}: ${needle}`);
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/verify-third-party-notices.mjs
+
+Verifies the generated third-party notice content covers the bundled Bun version,
+asset names, checksums, WebKit LGPL/source references, linked libraries, and
+embedded polyfills.
+`);
+}
+
+async function main() {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    printHelp();
+    return;
+  }
+  verifyThirdPartyNoticeCoverage();
+  console.log("Verified third-party notice coverage");
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/src/agent/bridge.rs
+++ b/src/agent/bridge.rs
@@ -8,12 +8,13 @@ use tokio::process::Command;
 
 pub const BRIDGE_SCRIPT_RELATIVE_PATH: &str = "agent-sdk/dist/bridge.js";
 pub const BRIDGE_SCRIPT_ENV_VAR: &str = "CLAUDE_RS_AGENT_BRIDGE";
-pub const BRIDGE_RUNTIME_ENV_VAR: &str = "CLAUDE_RS_AGENT_BRIDGE_NODE";
+pub const BRIDGE_RUNTIME_ENV_VAR: &str = "CLAUDE_RS_AGENT_BRIDGE_RUNTIME";
+const ROOT_NPM_PACKAGE_NAME: &str = "claude-code-rust";
 const MAX_BRIDGE_EXE_ANCESTORS: usize = 8;
 #[cfg(windows)]
-const RENAMED_BRIDGE_RUNTIME_FILE_NAME: &str = "claude-rs-bridge-node.exe";
+const BUNDLED_BUN_RUNTIME_FILE_NAME: &str = "claude-rs-bridge-bun.exe";
 #[cfg(not(windows))]
-const RENAMED_BRIDGE_RUNTIME_FILE_NAME: &str = "claude-rs-bridge-node";
+const BUNDLED_BUN_RUNTIME_FILE_NAME: &str = "claude-rs-bridge-bun";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BridgeLauncher {
@@ -26,6 +27,24 @@ pub struct BridgeCandidateInspection {
     pub source: String,
     pub path: PathBuf,
     pub is_file: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BridgeRuntimeKind {
+    Explicit,
+    BundledBun,
+    PathBun,
+}
+
+impl BridgeRuntimeKind {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::BundledBun => "bundled_bun",
+            Self::PathBun => "path_bun",
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -41,7 +60,8 @@ pub struct BridgeScriptInspection {
 pub struct BridgeRuntimeInspection {
     pub env_path: Option<PathBuf>,
     pub packaged_candidates: Vec<BridgeCandidateInspection>,
-    pub path_node: Option<PathBuf>,
+    pub path_bun: Option<PathBuf>,
+    pub resolved_kind: Option<BridgeRuntimeKind>,
     pub resolved_path: Option<PathBuf>,
     pub error: Option<String>,
 }
@@ -144,13 +164,13 @@ pub fn inspect_bridge_script(explicit_script: Option<&Path>) -> BridgeScriptInsp
 }
 
 pub fn inspect_bridge_runtime() -> BridgeRuntimeInspection {
-    let env_path = std::env::var_os(BRIDGE_RUNTIME_ENV_VAR).map(PathBuf::from);
-    let current_exe = std::env::current_exe().ok();
+    let env_path = runtime_override_from_env();
+    let current_exe = current_exe_path();
     inspect_bridge_runtime_with(
         env_path.as_deref(),
         current_exe.as_deref(),
         cfg!(debug_assertions),
-        || which::which("node"),
+        || which::which("bun"),
     )
 }
 
@@ -158,12 +178,12 @@ fn inspect_bridge_runtime_with(
     env_path: Option<&Path>,
     current_exe: Option<&Path>,
     allow_dev_fallbacks: bool,
-    node_lookup: impl FnOnce() -> Result<PathBuf, which::Error>,
+    bun_lookup: impl FnOnce() -> Result<PathBuf, which::Error>,
 ) -> BridgeRuntimeInspection {
-    let path_node = node_lookup().ok();
-    if let Some(path) = env_path {
+    if allow_dev_fallbacks && let Some(path) = env_path {
         let is_file = path.is_file();
         let resolved_path = is_file.then(|| path.to_path_buf());
+        let resolved_kind = is_file.then_some(BridgeRuntimeKind::Explicit);
         let error = (!is_file).then(|| {
             if path.exists() {
                 format!(
@@ -180,13 +200,14 @@ fn inspect_bridge_runtime_with(
         return BridgeRuntimeInspection {
             env_path: env_path.map(Path::to_path_buf),
             packaged_candidates: Vec::new(),
-            path_node,
+            path_bun: None,
+            resolved_kind,
             resolved_path,
             error,
         };
     }
 
-    let packaged_candidates = renamed_bridge_runtime_candidates(current_exe, allow_dev_fallbacks)
+    let packaged_candidates = bundled_bun_runtime_candidates(current_exe)
         .into_iter()
         .map(|path| BridgeCandidateInspection {
             source: "packaged-runtime".to_owned(),
@@ -198,13 +219,27 @@ fn inspect_bridge_runtime_with(
         .iter()
         .find(|candidate| candidate.is_file)
         .map(|candidate| candidate.path.clone());
-    let resolved_path = packaged_runtime.clone().or_else(|| path_node.clone());
+    if let Some(resolved_path) = packaged_runtime {
+        return BridgeRuntimeInspection {
+            env_path: env_path.map(Path::to_path_buf),
+            packaged_candidates,
+            path_bun: None,
+            resolved_kind: Some(BridgeRuntimeKind::BundledBun),
+            resolved_path: Some(resolved_path),
+            error: None,
+        };
+    }
+
+    let path_bun = allow_dev_fallbacks.then(bun_lookup).and_then(Result::ok);
+    let resolved_kind = path_bun.as_ref().map(|_| BridgeRuntimeKind::PathBun);
+    let resolved_path = path_bun.clone();
 
     BridgeRuntimeInspection {
-        env_path: None,
+        env_path: env_path.map(Path::to_path_buf),
         packaged_candidates,
-        path_node,
-        error: resolved_path.is_none().then(|| "Node.js runtime not found".to_owned()),
+        path_bun,
+        resolved_kind,
+        error: resolved_path.is_none().then(|| "bundled Bun bridge runtime not found".to_owned()),
         resolved_path,
     }
 }
@@ -223,13 +258,13 @@ fn resolve_bridge_script_path(explicit_script: Option<&Path>) -> anyhow::Result<
 }
 
 fn resolve_bridge_runtime_path() -> anyhow::Result<PathBuf> {
-    let env_runtime = std::env::var_os(BRIDGE_RUNTIME_ENV_VAR).map(PathBuf::from);
-    let current_exe = std::env::current_exe().ok();
+    let env_runtime = runtime_override_from_env();
+    let current_exe = current_exe_path();
     resolve_bridge_runtime_path_with(
         env_runtime.as_deref(),
         current_exe.as_deref(),
         cfg!(debug_assertions),
-        || which::which("node"),
+        || which::which("bun"),
     )
 }
 
@@ -237,22 +272,27 @@ fn resolve_bridge_runtime_path_with(
     env_runtime: Option<&Path>,
     current_exe: Option<&Path>,
     allow_dev_fallbacks: bool,
-    node_lookup: impl FnOnce() -> Result<PathBuf, which::Error>,
+    bun_lookup: impl FnOnce() -> Result<PathBuf, which::Error>,
 ) -> anyhow::Result<PathBuf> {
-    if let Some(path) = env_runtime {
+    if allow_dev_fallbacks && let Some(path) = env_runtime {
         return validate_runtime_path(path)
             .with_context(|| format!("invalid {BRIDGE_RUNTIME_ENV_VAR} runtime override"));
     }
 
-    for candidate in renamed_bridge_runtime_candidates(current_exe, allow_dev_fallbacks) {
+    for candidate in bundled_bun_runtime_candidates(current_exe) {
         if is_automatic_runtime_candidate(&candidate) {
             return Ok(candidate);
         }
     }
 
-    node_lookup()
-        .map_err(|_| anyhow::Error::new(AppError::NodeNotFound))
-        .context("failed to resolve `node` runtime")
+    if allow_dev_fallbacks {
+        return bun_lookup()
+            .map_err(|_| anyhow::Error::new(AppError::BridgeRuntimeNotFound))
+            .context("failed to resolve development `bun` runtime");
+    }
+
+    Err(anyhow::Error::new(AppError::BridgeRuntimeNotFound))
+        .context("failed to resolve bundled Bun bridge runtime")
 }
 
 fn validate_script_path(path: &Path) -> anyhow::Result<PathBuf> {
@@ -269,11 +309,11 @@ fn validate_script_path(path: &Path) -> anyhow::Result<PathBuf> {
 
 fn validate_runtime_path(path: &Path) -> anyhow::Result<PathBuf> {
     if !path.exists() {
-        return Err(anyhow::Error::new(AppError::NodeNotFound)
+        return Err(anyhow::Error::new(AppError::BridgeRuntimeNotFound)
             .context(format!("bridge runtime does not exist: {}", path.display())));
     }
     if !path.is_file() {
-        return Err(anyhow::Error::new(AppError::NodeNotFound)
+        return Err(anyhow::Error::new(AppError::BridgeRuntimeNotFound)
             .context(format!("bridge runtime is not a file: {}", path.display())));
     }
     Ok(path.to_path_buf())
@@ -330,7 +370,7 @@ impl<'a> BridgeScriptResolver<'a> {
         Self {
             explicit_script,
             env_script: std::env::var_os(BRIDGE_SCRIPT_ENV_VAR).map(PathBuf::from),
-            current_exe: std::env::current_exe().ok(),
+            current_exe: current_exe_path(),
             allow_dev_fallbacks: cfg!(debug_assertions),
             cwd_script: PathBuf::from(BRIDGE_SCRIPT_RELATIVE_PATH),
             manifest_script: PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -455,39 +495,49 @@ impl<'a> BridgeScriptResolver<'a> {
 }
 
 fn exe_relative_bridge_candidates(current_exe: &Path) -> Vec<PathBuf> {
-    current_exe
-        .ancestors()
-        .skip(1)
-        .take(MAX_BRIDGE_EXE_ANCESTORS)
-        .map(|ancestor| ancestor.join(BRIDGE_SCRIPT_RELATIVE_PATH))
-        .collect()
-}
-
-fn renamed_bridge_runtime_candidates(
-    current_exe: Option<&Path>,
-    allow_dev_fallbacks: bool,
-) -> Vec<PathBuf> {
+    let current_exe = canonicalize_executable_path(current_exe);
     let mut candidates = Vec::new();
 
-    if let Some(current_exe) = current_exe {
-        for ancestor in current_exe.ancestors().skip(1).take(MAX_BRIDGE_EXE_ANCESTORS) {
-            push_unique_path(&mut candidates, ancestor.join(RENAMED_BRIDGE_RUNTIME_FILE_NAME));
+    for ancestor in current_exe.ancestors().skip(1).take(MAX_BRIDGE_EXE_ANCESTORS) {
+        push_unique_path(&mut candidates, ancestor.join(BRIDGE_SCRIPT_RELATIVE_PATH));
+        if is_node_modules_dir(ancestor) {
+            push_unique_path(
+                &mut candidates,
+                ancestor.join(ROOT_NPM_PACKAGE_NAME).join(BRIDGE_SCRIPT_RELATIVE_PATH),
+            );
         }
     }
 
-    if allow_dev_fallbacks {
-        push_unique_path(&mut candidates, PathBuf::from(RENAMED_BRIDGE_RUNTIME_FILE_NAME));
-        push_unique_path(
-            &mut candidates,
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(RENAMED_BRIDGE_RUNTIME_FILE_NAME),
-        );
-    }
+    candidates
+}
 
-    if let Ok(path) = which::which(RENAMED_BRIDGE_RUNTIME_FILE_NAME) {
-        push_unique_path(&mut candidates, path);
+fn bundled_bun_runtime_candidates(current_exe: Option<&Path>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(current_exe) = current_exe {
+        let current_exe = canonicalize_executable_path(current_exe);
+        for ancestor in current_exe.ancestors().skip(1).take(MAX_BRIDGE_EXE_ANCESTORS) {
+            push_unique_path(&mut candidates, ancestor.join(BUNDLED_BUN_RUNTIME_FILE_NAME));
+        }
     }
 
     candidates
+}
+
+fn runtime_override_from_env() -> Option<PathBuf> {
+    if cfg!(debug_assertions) {
+        std::env::var_os(BRIDGE_RUNTIME_ENV_VAR).map(PathBuf::from)
+    } else {
+        None
+    }
+}
+
+fn current_exe_path() -> Option<PathBuf> {
+    std::env::current_exe().ok().map(|path| canonicalize_executable_path(&path))
+}
+
+fn canonicalize_executable_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn push_unique_path(candidates: &mut Vec<PathBuf>, path: PathBuf) {
@@ -501,6 +551,10 @@ fn manifest_root_from_script(manifest_script: &Path) -> Option<&Path> {
     manifest_script.parent()?.parent()?.parent()
 }
 
+fn is_node_modules_dir(path: &Path) -> bool {
+    path.file_name().is_some_and(|name| name == "node_modules")
+}
+
 fn is_automatic_script_candidate(path: &Path) -> bool {
     !path.as_os_str().is_empty() && path.is_file()
 }
@@ -512,10 +566,10 @@ fn is_automatic_runtime_candidate(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        AutomaticCandidateSource, BRIDGE_SCRIPT_RELATIVE_PATH, BridgeLauncher,
-        BridgeScriptResolver, RENAMED_BRIDGE_RUNTIME_FILE_NAME, exe_relative_bridge_candidates,
-        inspect_bridge_runtime_with, resolve_bridge_launcher, resolve_bridge_launcher_with_runtime,
-        resolve_bridge_runtime_path_with,
+        AutomaticCandidateSource, BRIDGE_SCRIPT_RELATIVE_PATH, BUNDLED_BUN_RUNTIME_FILE_NAME,
+        BridgeLauncher, BridgeRuntimeKind, BridgeScriptResolver, canonicalize_executable_path,
+        exe_relative_bridge_candidates, inspect_bridge_runtime_with, resolve_bridge_launcher,
+        resolve_bridge_launcher_with_runtime, resolve_bridge_runtime_path_with,
     };
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -819,27 +873,75 @@ mod tests {
     }
 
     #[test]
-    fn renamed_bridge_runtime_next_to_installed_exe_wins_over_node_path() {
+    fn sibling_npm_package_bridge_resolves_without_env_override() {
+        let fixture = resolver_fixture();
+
+        let resolved = BridgeScriptResolver {
+            explicit_script: None,
+            env_script: None,
+            current_exe: Some(fixture.npm_platform_exe.clone()),
+            allow_dev_fallbacks: false,
+            cwd_script: fixture.cwd_script.clone(),
+            manifest_script: fixture.manifest_script.clone(),
+        }
+        .resolve()
+        .expect("sibling npm root bridge should resolve");
+
+        assert_eq!(resolved, fixture.npm_sibling_bridge);
+    }
+
+    #[test]
+    fn executable_relative_candidates_include_sibling_npm_root_package() {
+        let fixture = resolver_fixture();
+        let candidates = exe_relative_bridge_candidates(&fixture.npm_platform_exe);
+
+        assert!(candidates.contains(&fixture.npm_sibling_bridge));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_current_exe_resolves_before_bridge_candidate_walk() {
+        let fixture = resolver_fixture();
+        let shim = fixture.dir.path().join("global-bin").join("claude-rs");
+        fs::create_dir_all(shim.parent().expect("shim parent")).expect("create shim parent");
+        std::os::unix::fs::symlink(&fixture.npm_platform_exe, &shim).expect("create symlink");
+
+        let resolved = BridgeScriptResolver {
+            explicit_script: None,
+            env_script: None,
+            current_exe: Some(canonicalize_executable_path(&shim)),
+            allow_dev_fallbacks: false,
+            cwd_script: fixture.cwd_script.clone(),
+            manifest_script: fixture.manifest_script.clone(),
+        }
+        .resolve()
+        .expect("canonicalized symlink should resolve sibling bridge");
+
+        assert_eq!(resolved, fixture.npm_sibling_bridge);
+    }
+
+    #[test]
+    fn bundled_bun_runtime_next_to_installed_exe_wins_over_path_bun() {
         let fixture = resolver_fixture();
 
         let resolved =
-            resolve_bridge_runtime_path_with(None, Some(&fixture.installed_exe), false, || {
-                Ok(fixture.node_runtime.clone())
+            resolve_bridge_runtime_path_with(None, Some(&fixture.installed_exe), true, || {
+                Ok(fixture.path_bun_runtime.clone())
             })
-            .expect("renamed bridge runtime should resolve");
+            .expect("bundled bridge runtime should resolve");
 
         assert_eq!(resolved, fixture.packaged_runtime);
     }
 
     #[test]
-    fn bridge_runtime_env_override_wins_over_packaged_runtime() {
+    fn bridge_runtime_env_override_wins_over_packaged_runtime_in_dev_resolution() {
         let fixture = resolver_fixture();
 
         let resolved = resolve_bridge_runtime_path_with(
             Some(&fixture.env_runtime),
             Some(&fixture.installed_exe),
-            false,
-            || Ok(fixture.node_runtime.clone()),
+            true,
+            || Ok(fixture.path_bun_runtime.clone()),
         )
         .expect("env bridge runtime should resolve");
 
@@ -847,32 +949,64 @@ mod tests {
     }
 
     #[test]
-    fn bridge_runtime_inspection_reports_path_node_when_env_override_is_set() {
+    fn release_bridge_runtime_resolution_ignores_env_override() {
+        let fixture = resolver_fixture();
+
+        let resolved = resolve_bridge_runtime_path_with(
+            Some(&fixture.env_runtime),
+            Some(&fixture.installed_exe),
+            false,
+            || Ok(fixture.path_bun_runtime.clone()),
+        )
+        .expect("release resolution should use bundled runtime");
+
+        assert_eq!(resolved, fixture.packaged_runtime);
+    }
+
+    #[test]
+    fn bridge_runtime_inspection_reports_explicit_kind_for_dev_override() {
         let fixture = resolver_fixture();
 
         let inspection = inspect_bridge_runtime_with(
             Some(&fixture.env_runtime),
             Some(&fixture.installed_exe),
-            false,
-            || Ok(fixture.node_runtime.clone()),
+            true,
+            || Ok(fixture.path_bun_runtime.clone()),
         );
 
         assert_eq!(inspection.resolved_path, Some(fixture.env_runtime));
-        assert_eq!(inspection.path_node, Some(fixture.node_runtime));
+        assert_eq!(inspection.resolved_kind, Some(BridgeRuntimeKind::Explicit));
+        assert_eq!(inspection.path_bun, None);
         assert!(inspection.error.is_none());
     }
 
     #[test]
-    fn node_path_is_fallback_when_renamed_bridge_runtime_is_missing() {
+    fn path_bun_is_dev_fallback_when_bundled_runtime_is_missing() {
         let fixture = resolver_fixture();
 
         let resolved =
-            resolve_bridge_runtime_path_with(None, Some(&fixture.unbundled_exe), false, || {
-                Ok(fixture.node_runtime.clone())
+            resolve_bridge_runtime_path_with(None, Some(&fixture.unbundled_exe), true, || {
+                Ok(fixture.path_bun_runtime.clone())
             })
-            .expect("node fallback should resolve");
+            .expect("dev bun fallback should resolve");
 
-        assert_eq!(resolved, fixture.node_runtime);
+        assert_eq!(resolved, fixture.path_bun_runtime);
+    }
+
+    #[test]
+    fn release_bridge_runtime_resolution_fails_without_bundled_runtime() {
+        let fixture = resolver_fixture();
+
+        let err =
+            resolve_bridge_runtime_path_with(None, Some(&fixture.unbundled_exe), false, || {
+                Ok(fixture.path_bun_runtime.clone())
+            })
+            .expect_err("release resolution should not use PATH bun");
+
+        assert!(
+            err.to_string().contains("failed to resolve bundled Bun bridge runtime"),
+            "unexpected error: {err:#}"
+        );
     }
 
     struct RuntimeFixture {
@@ -884,16 +1018,18 @@ mod tests {
     struct ResolverFixture {
         dir: TempDir,
         installed_exe: PathBuf,
+        npm_platform_exe: PathBuf,
         unbundled_exe: PathBuf,
         cargo_target_exe: PathBuf,
         packaged_bridge: PathBuf,
+        npm_sibling_bridge: PathBuf,
         packaged_runtime: PathBuf,
         cargo_target_bridge: PathBuf,
         cwd_script: PathBuf,
         manifest_script: PathBuf,
         env_script: PathBuf,
         env_runtime: PathBuf,
-        node_runtime: PathBuf,
+        path_bun_runtime: PathBuf,
     }
 
     fn runtime_fixture() -> std::io::Result<RuntimeFixture> {
@@ -911,48 +1047,80 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let installed_exe =
             dir.path().join("package").join("vendor").join("x86_64").join("claude-rs");
+        let npm_platform_exe = dir
+            .path()
+            .join("npm-prefix")
+            .join("node_modules")
+            .join("@srothgan")
+            .join("claude-code-rust-win32-x64-msvc")
+            .join("bin")
+            .join("claude-rs");
         let unbundled_exe =
             dir.path().join("other").join("vendor").join("x86_64").join("claude-rs");
         let cargo_target_exe =
             dir.path().join("manifest").join("target").join("debug").join("claude-rs");
         let packaged_bridge = dir.path().join("package").join(BRIDGE_SCRIPT_RELATIVE_PATH);
+        let npm_sibling_bridge = dir
+            .path()
+            .join("npm-prefix")
+            .join("node_modules")
+            .join("claude-code-rust")
+            .join(BRIDGE_SCRIPT_RELATIVE_PATH);
         let packaged_runtime = installed_exe
             .parent()
             .expect("installed exe parent")
-            .join(RENAMED_BRIDGE_RUNTIME_FILE_NAME);
+            .join(BUNDLED_BUN_RUNTIME_FILE_NAME);
         let cargo_target_bridge =
             dir.path().join("manifest").join("target").join(BRIDGE_SCRIPT_RELATIVE_PATH);
         let cwd_script = dir.path().join("repo").join(BRIDGE_SCRIPT_RELATIVE_PATH);
         let manifest_script = dir.path().join("manifest").join(BRIDGE_SCRIPT_RELATIVE_PATH);
         let env_script = dir.path().join("env").join("bridge.js");
-        let env_runtime = dir.path().join("env").join(RENAMED_BRIDGE_RUNTIME_FILE_NAME);
-        let node_runtime = dir.path().join("node").join(test_runtime_name());
+        let env_runtime = dir.path().join("env").join(BUNDLED_BUN_RUNTIME_FILE_NAME);
+        let path_bun_runtime = dir.path().join("bun").join(test_runtime_name());
 
         write_test_file(&installed_exe);
+        write_test_file(&npm_platform_exe);
         write_test_file(&unbundled_exe);
         write_test_file(&cargo_target_exe);
         write_test_file(&packaged_bridge);
+        write_test_file(&npm_sibling_bridge);
         write_test_file(&packaged_runtime);
         write_test_file(&cargo_target_bridge);
         write_test_file(&cwd_script);
         write_test_file(&manifest_script);
         write_test_file(&env_script);
         write_test_file(&env_runtime);
-        write_test_file(&node_runtime);
+        write_test_file(&path_bun_runtime);
+
+        let installed_exe = canonicalize_executable_path(&installed_exe);
+        let npm_platform_exe = canonicalize_executable_path(&npm_platform_exe);
+        let unbundled_exe = canonicalize_executable_path(&unbundled_exe);
+        let cargo_target_exe = canonicalize_executable_path(&cargo_target_exe);
+        let packaged_bridge = canonicalize_executable_path(&packaged_bridge);
+        let npm_sibling_bridge = canonicalize_executable_path(&npm_sibling_bridge);
+        let packaged_runtime = canonicalize_executable_path(&packaged_runtime);
+        let cargo_target_bridge = canonicalize_executable_path(&cargo_target_bridge);
+        let cwd_script = canonicalize_executable_path(&cwd_script);
+        let manifest_script = canonicalize_executable_path(&manifest_script);
+        let env_script = canonicalize_executable_path(&env_script);
+        let env_runtime = canonicalize_executable_path(&env_runtime);
+        let path_bun_runtime = canonicalize_executable_path(&path_bun_runtime);
 
         ResolverFixture {
             dir,
             installed_exe,
+            npm_platform_exe,
             unbundled_exe,
             cargo_target_exe,
             packaged_bridge,
+            npm_sibling_bridge,
             packaged_runtime,
             cargo_target_bridge,
             cwd_script,
             manifest_script,
             env_script,
             env_runtime,
-            node_runtime,
+            path_bun_runtime,
         }
     }
 

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -5,7 +5,8 @@ use crate::agent::bridge::BridgeLauncher;
 use crate::agent::wire::{BridgeCommand, CommandEnvelope, EventEnvelope, SessionLaunchSettings};
 use crate::error::AppError;
 use anyhow::Context as _;
-use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader, BufWriter};
+use std::fmt;
+use tokio::io::{AsyncBufReadExt as _, AsyncWrite, AsyncWriteExt as _, BufReader, BufWriter};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout};
 use tokio::sync::mpsc;
 use tracing::{Instrument as _, info_span};
@@ -106,53 +107,21 @@ impl BridgeClient {
             anyhow::Error::new(err).context("failed to serialize bridge command")
         })?;
         let size_bytes = line.len() + 1;
-        self.stdin.write_all(line.as_bytes()).await.map_err(|err| {
+        write_command_line(&mut self.stdin, &line).await.map_err(|err| {
             tracing::error!(
                 target: crate::logging::targets::BRIDGE_PROTOCOL,
                 event_name = "bridge_command_send_failed",
-                message = "failed to write bridge command",
+                message = "failed to write bridge command line",
                 outcome = "failure",
                 request_id,
                 bridge_command,
                 session_id,
                 tool_call_id,
                 size_bytes,
-                stage = "write",
+                stage = err.stage,
                 error = %err,
             );
-            anyhow::Error::new(err).context("failed to write bridge command")
-        })?;
-        self.stdin.write_all(b"\n").await.map_err(|err| {
-            tracing::error!(
-                target: crate::logging::targets::BRIDGE_PROTOCOL,
-                event_name = "bridge_command_send_failed",
-                message = "failed to write bridge newline",
-                outcome = "failure",
-                request_id,
-                bridge_command,
-                session_id,
-                tool_call_id,
-                size_bytes,
-                stage = "write_newline",
-                error = %err,
-            );
-            anyhow::Error::new(err).context("failed to write bridge newline")
-        })?;
-        self.stdin.flush().await.map_err(|err| {
-            tracing::error!(
-                target: crate::logging::targets::BRIDGE_PROTOCOL,
-                event_name = "bridge_command_send_failed",
-                message = "failed to flush bridge stdin",
-                outcome = "failure",
-                request_id,
-                bridge_command,
-                session_id,
-                tool_call_id,
-                size_bytes,
-                stage = "flush",
-                error = %err,
-            );
-            anyhow::Error::new(err).context("failed to flush bridge stdin")
+            anyhow::Error::new(err).context("failed to write bridge command line")
         })?;
         log_bridge_command_sent(bridge_command, request_id, session_id, tool_call_id, size_bytes);
         Ok(())
@@ -204,6 +173,39 @@ impl BridgeClient {
 
     pub async fn wait(mut self) -> anyhow::Result<std::process::ExitStatus> {
         self.child.wait().await.context("failed to wait for bridge process")
+    }
+}
+
+async fn write_command_line<W>(writer: &mut W, line: &str) -> Result<(), BridgeCommandWriteError>
+where
+    W: AsyncWrite + Unpin,
+{
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|source| BridgeCommandWriteError { stage: "write_payload", source })?;
+    writer
+        .write_all(b"\n")
+        .await
+        .map_err(|source| BridgeCommandWriteError { stage: "write_newline", source })?;
+    writer.flush().await.map_err(|source| BridgeCommandWriteError { stage: "flush", source })
+}
+
+#[derive(Debug)]
+struct BridgeCommandWriteError {
+    stage: &'static str,
+    source: std::io::Error,
+}
+
+impl fmt::Display for BridgeCommandWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.stage, self.source)
+    }
+}
+
+impl std::error::Error for BridgeCommandWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
     }
 }
 
@@ -596,10 +598,11 @@ impl AgentConnection {
 
 #[cfg(test)]
 mod tests {
-    use super::AgentConnection;
+    use super::{AgentConnection, write_command_line};
     use crate::agent::types::ElicitationAction;
     use crate::agent::wire::BridgeCommand;
     use std::collections::BTreeMap;
+    use tokio::io::AsyncReadExt as _;
 
     #[test]
     fn generate_session_title_sends_bridge_command() {
@@ -616,6 +619,24 @@ mod tests {
                 session_id: "session-1".to_owned(),
                 description: "Summarize work".to_owned(),
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn write_command_line_appends_exactly_one_newline() {
+        let (mut writer, mut reader) = tokio::io::duplex(128);
+
+        write_command_line(&mut writer, r#"{"command":"cancel_turn","session_id":"s1"}"#)
+            .await
+            .expect("write command");
+        drop(writer);
+
+        let mut output = Vec::new();
+        reader.read_to_end(&mut output).await.expect("read command");
+
+        assert_eq!(
+            String::from_utf8(output).expect("utf8"),
+            "{\"command\":\"cancel_turn\",\"session_id\":\"s1\"}\n"
         );
     }
 

--- a/src/agent/wire.rs
+++ b/src/agent/wire.rs
@@ -590,6 +590,25 @@ mod tests {
     }
 
     #[test]
+    fn cancel_turn_command_serializes_snake_case() {
+        let env = CommandEnvelope {
+            request_id: Some("request-1".to_owned()),
+            command: BridgeCommand::CancelTurn { session_id: "s1".to_owned() },
+        };
+
+        let json = serde_json::to_value(&env).expect("serialize");
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "request_id": "request-1",
+                "command": "cancel_turn",
+                "session_id": "s1"
+            })
+        );
+    }
+
+    #[test]
     fn get_rewind_targets_command_serializes_snake_case() {
         let env = CommandEnvelope {
             request_id: None,

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -443,8 +443,13 @@ pub(super) fn ensure_update_notice_message(app: &mut App) {
 
 fn format_update_available_message(latest_version: &str, current_version: &str) -> String {
     format!(
-        "Update available: current v{current_version}, latest v{latest_version}. Upgrade to latest version via {UPDATE_INSTALL_COMMAND}."
+        "Update available: current v{current_version}, latest v{latest_version}. Upgrade to latest version via {}.",
+        update_install_command()
     )
+}
+
+pub(crate) fn update_install_command() -> &'static str {
+    UPDATE_INSTALL_COMMAND
 }
 
 pub(super) fn handle_service_status_event(

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -103,6 +103,11 @@ fn user_msg(text: &str) -> ChatMessage {
     )
 }
 
+#[test]
+fn update_install_command_is_documented_npm_command() {
+    assert_eq!(session::update_install_command(), "npm install -g claude-code-rust");
+}
+
 fn source_text(text: &str, source_message_uuid: &str) -> MessageBlock {
     MessageBlock::Text(
         TextBlock::from_complete(text).with_source_message_uuid(Some(source_message_uuid)),
@@ -356,8 +361,7 @@ fn first_block_text(msg: &ChatMessage) -> &str {
 
 fn is_update_notice_message(msg: &ChatMessage) -> bool {
     matches!(msg.role, MessageRole::System(Some(SystemSeverity::Warning)))
-        && first_block_text(msg)
-            .contains("Upgrade to latest version via npm install -g claude-code-rust.")
+        && first_block_text(msg).contains(session::update_install_command())
 }
 
 // shorten_tool_title
@@ -1666,7 +1670,10 @@ fn update_available_pushes_warning_system_message_with_versions_and_install_comm
     ));
     assert_eq!(
         first_block_text(&app.transcript.messages[0]),
-        "Update available: current v0.2.0, latest v0.3.0. Upgrade to latest version via npm install -g claude-code-rust."
+        format!(
+            "Update available: current v0.2.0, latest v0.3.0. Upgrade to latest version via {}.",
+            session::update_install_command()
+        )
     );
     let Some(update_notice) = app.update_notice.as_ref() else {
         panic!("expected update notice state");
@@ -4323,7 +4330,10 @@ fn update_available_persists_across_connected_session_reset() {
         .expect("expected update notice message after connect");
     assert_eq!(
         first_block_text(notice),
-        "Update available: current v0.11.1, latest v0.11.2. Upgrade to latest version via npm install -g claude-code-rust."
+        format!(
+            "Update available: current v0.11.1, latest v0.11.2. Upgrade to latest version via {}.",
+            session::update_install_command()
+        )
     );
     assert_eq!(
         app.update_notice
@@ -4373,7 +4383,10 @@ fn update_available_persists_across_session_replaced_reset() {
         .expect("expected update notice message after replacement");
     assert_eq!(
         first_block_text(notice),
-        "Update available: current v0.11.1, latest v0.11.2. Upgrade to latest version via npm install -g claude-code-rust."
+        format!(
+            "Update available: current v0.11.1, latest v0.11.2. Upgrade to latest version via {}.",
+            session::update_install_command()
+        )
     );
     assert_eq!(
         app.update_notice

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -14,7 +14,6 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const MIN_NODE_MAJOR: u64 = 18;
 const ROOT_NPM_PACKAGE_NAME: &str = "claude-code-rust";
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
@@ -69,8 +68,8 @@ pub(crate) fn build_report(cli: &Cli) -> DoctorReport {
         binary_version_check(),
         platform_check(),
         current_exe_check(),
-        node_runtime_check(&runtime),
-        node_version_check(runtime.resolved_path.as_deref()),
+        bridge_runtime_check(&runtime),
+        bridge_runtime_version_check(runtime.resolved_path.as_deref()),
         bridge_script_check(&script),
     ];
     checks.extend(config_path_checks(cli.dir.as_deref()));
@@ -280,7 +279,7 @@ impl DoctorSection {
 
     fn for_check(id: &str) -> Self {
         match id {
-            "node_runtime" | "node_version" | "bridge_script" => Self::Runtime,
+            "bridge_runtime" | "bridge_runtime_version" | "bridge_script" => Self::Runtime,
             "config_settings" | "config_local_settings" | "config_preferences" | "config_paths" => {
                 Self::Configuration
             }
@@ -399,7 +398,7 @@ fn current_exe_check() -> DoctorCheck {
     }
 }
 
-fn node_runtime_check(inspection: &BridgeRuntimeInspection) -> DoctorCheck {
+fn bridge_runtime_check(inspection: &BridgeRuntimeInspection) -> DoctorCheck {
     let mut details = BTreeMap::new();
     details.insert(
         BRIDGE_RUNTIME_ENV_VAR.to_owned(),
@@ -408,8 +407,11 @@ fn node_runtime_check(inspection: &BridgeRuntimeInspection) -> DoctorCheck {
             .as_ref()
             .map_or_else(|| "unset".to_owned(), |path| path.display().to_string()),
     );
-    if let Some(path) = &inspection.path_node {
-        details.insert("path_node".to_owned(), path.display().to_string());
+    if let Some(kind) = inspection.resolved_kind {
+        details.insert("runtime_kind".to_owned(), kind.label().to_owned());
+    }
+    if let Some(path) = &inspection.path_bun {
+        details.insert("path_bun".to_owned(), path.display().to_string());
     }
     for (index, candidate) in inspection.packaged_candidates.iter().enumerate() {
         details.insert(
@@ -420,59 +422,59 @@ fn node_runtime_check(inspection: &BridgeRuntimeInspection) -> DoctorCheck {
 
     match (&inspection.resolved_path, &inspection.error) {
         (Some(path), _) => DoctorCheck::pass_with_details(
-            "node_runtime",
-            "Node runtime",
+            "bridge_runtime",
+            "Bridge runtime",
             format!("resolved {}", path.display()),
             details,
         ),
         (None, Some(error)) => DoctorCheck::fail_hard_with_details(
-            "node_runtime",
-            "Node runtime",
+            "bridge_runtime",
+            "Bridge runtime",
             error.clone(),
             details,
         ),
         (None, None) => DoctorCheck::fail_hard_with_details(
-            "node_runtime",
-            "Node runtime",
-            "Node.js runtime not found".to_owned(),
+            "bridge_runtime",
+            "Bridge runtime",
+            "bundled Bun bridge runtime not found".to_owned(),
             details,
         ),
     }
 }
 
-fn node_version_check(runtime: Option<&Path>) -> DoctorCheck {
+fn bridge_runtime_version_check(runtime: Option<&Path>) -> DoctorCheck {
     let Some(runtime) = runtime else {
         return DoctorCheck::fail_hard(
-            "node_version",
-            "Node version",
-            "cannot check Node version because no runtime was resolved",
+            "bridge_runtime_version",
+            "Bridge runtime version",
+            "cannot check Bun version because no runtime was resolved",
         );
     };
 
     match Command::new(runtime).arg("--version").output() {
         Ok(output) if output.status.success() => {
             let raw = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-            classify_node_version(&raw, runtime)
+            classify_bun_version(&raw, runtime)
         }
         Ok(output) => DoctorCheck::fail_hard(
-            "node_version",
-            "Node version",
+            "bridge_runtime_version",
+            "Bridge runtime version",
             format!("failed to run `{}` --version: {}", runtime.display(), output.status),
         ),
         Err(error) => DoctorCheck::fail_hard(
-            "node_version",
-            "Node version",
+            "bridge_runtime_version",
+            "Bridge runtime version",
             format!("failed to run `{}` --version: {error}", runtime.display()),
         ),
     }
 }
 
-fn classify_node_version(raw: &str, runtime: &Path) -> DoctorCheck {
-    let Some(major) = parse_node_major(raw) else {
+fn classify_bun_version(raw: &str, runtime: &Path) -> DoctorCheck {
+    let Some(version) = parse_bun_version(raw) else {
         return DoctorCheck::fail_hard_with_detail(
-            "node_version",
-            "Node version",
-            format!("could not parse Node version output `{raw}`"),
+            "bridge_runtime_version",
+            "Bridge runtime version",
+            format!("could not parse Bun version output `{raw}`"),
             "runtime",
             runtime.display().to_string(),
         );
@@ -480,23 +482,38 @@ fn classify_node_version(raw: &str, runtime: &Path) -> DoctorCheck {
 
     let mut details = BTreeMap::new();
     details.insert("runtime".to_owned(), runtime.display().to_string());
-    details.insert("version".to_owned(), raw.to_owned());
-    details.insert("minimum_major".to_owned(), MIN_NODE_MAJOR.to_string());
+    details.insert("version".to_owned(), version.to_owned());
 
-    if major >= MIN_NODE_MAJOR {
-        DoctorCheck::pass_with_details("node_version", "Node version", raw, details)
-    } else {
-        DoctorCheck::fail_hard_with_details(
-            "node_version",
-            "Node version",
-            format!("Node.js {raw} is older than required major version {MIN_NODE_MAJOR}"),
-            details,
-        )
-    }
+    DoctorCheck::pass_with_details(
+        "bridge_runtime_version",
+        "Bridge runtime version",
+        version,
+        details,
+    )
 }
 
-fn parse_node_major(raw: &str) -> Option<u64> {
-    raw.trim().strip_prefix('v').unwrap_or(raw.trim()).split('.').next()?.parse().ok()
+fn parse_bun_version(raw: &str) -> Option<&str> {
+    let version = raw.trim().strip_prefix('v').unwrap_or(raw.trim());
+    let core_end = version.find(['-', '+']).unwrap_or(version.len());
+    let core = &version[..core_end];
+    let suffix = &version[core_end..];
+    if !suffix.is_empty() && !is_valid_semver_suffix(suffix) {
+        return None;
+    }
+    let mut components = core.split('.');
+    components.next()?.parse::<u64>().ok()?;
+    components.next()?.parse::<u64>().ok()?;
+    components.next()?.parse::<u64>().ok()?;
+    if components.next().is_some() {
+        return None;
+    }
+    Some(version)
+}
+
+fn is_valid_semver_suffix(suffix: &str) -> bool {
+    suffix.len() > 1
+        && matches!(suffix.as_bytes()[0], b'-' | b'+')
+        && suffix[1..].chars().all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '+'))
 }
 
 fn bridge_script_check(inspection: &BridgeScriptInspection) -> DoctorCheck {
@@ -628,6 +645,38 @@ fn root_package_check(script: &BridgeScriptInspection) -> DoctorCheck {
 }
 
 fn platform_package_check(script: &BridgeScriptInspection) -> DoctorCheck {
+    match platform_package_selection() {
+        PlatformPackageSelection::Supported(package_name) => {
+            platform_package_metadata_check(script, package_name)
+        }
+        PlatformPackageSelection::UnsupportedLinuxLibc { arch, libc } => {
+            let mut details = BTreeMap::new();
+            details.insert("os".to_owned(), "linux".to_owned());
+            details.insert("arch".to_owned(), arch.to_owned());
+            details.insert("libc".to_owned(), libc.to_owned());
+            DoctorCheck::warn_with_details(
+                "npm_platform_package",
+                "npm platform package",
+                format!(
+                    "linux/{arch} {libc} is not supported by the current npm packages; Linux npm packages currently require glibc"
+                ),
+                details,
+            )
+        }
+        PlatformPackageSelection::UnsupportedPlatform => package_json_check(
+            "npm_platform_package",
+            "npm platform package",
+            Vec::new(),
+            None,
+            true,
+        ),
+    }
+}
+
+fn platform_package_metadata_check(
+    script: &BridgeScriptInspection,
+    package_name: &'static str,
+) -> DoctorCheck {
     let mut candidates = Vec::new();
     if let Ok(current_exe) = std::env::current_exe()
         && let Some(bin_dir) = current_exe.parent()
@@ -636,7 +685,7 @@ fn platform_package_check(script: &BridgeScriptInspection) -> DoctorCheck {
         candidates.push(package_root.join("package.json"));
     }
 
-    if let (Some(root), Some(package_name)) = (root_package_dir(script), platform_package_name()) {
+    if let Some(root) = root_package_dir(script) {
         candidates.push(root.join("node_modules").join(package_name).join("package.json"));
     }
 
@@ -644,7 +693,7 @@ fn platform_package_check(script: &BridgeScriptInspection) -> DoctorCheck {
         "npm_platform_package",
         "npm platform package",
         candidates,
-        platform_package_name(),
+        Some(package_name),
         true,
     )
 }
@@ -739,16 +788,78 @@ fn unique_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
     unique
 }
 
-fn platform_package_name() -> Option<&'static str> {
-    match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("macos", "aarch64") => Some("@srothgan/claude-code-rust-darwin-arm64"),
-        ("macos", "x86_64") => Some("@srothgan/claude-code-rust-darwin-x64"),
-        ("linux", "x86_64") => Some("@srothgan/claude-code-rust-linux-x64-gnu"),
-        ("linux", "aarch64") => Some("@srothgan/claude-code-rust-linux-arm64-gnu"),
-        ("windows", "x86_64") => Some("@srothgan/claude-code-rust-win32-x64-msvc"),
-        ("windows", "aarch64") => Some("@srothgan/claude-code-rust-win32-arm64-msvc"),
-        _ => None,
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PlatformPackageSelection {
+    Supported(&'static str),
+    UnsupportedLinuxLibc { arch: &'static str, libc: &'static str },
+    UnsupportedPlatform,
+}
+
+fn platform_package_selection() -> PlatformPackageSelection {
+    platform_package_selection_for(
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        current_linux_libc_kind(),
+    )
+}
+
+fn platform_package_selection_for(
+    os: &'static str,
+    arch: &'static str,
+    linux_libc: Option<&'static str>,
+) -> PlatformPackageSelection {
+    match (os, arch) {
+        ("macos", "aarch64") => {
+            PlatformPackageSelection::Supported("@srothgan/claude-code-rust-darwin-arm64")
+        }
+        ("macos", "x86_64") => {
+            PlatformPackageSelection::Supported("@srothgan/claude-code-rust-darwin-x64")
+        }
+        ("linux", "x86_64") if linux_libc == Some("glibc") => {
+            PlatformPackageSelection::Supported("@srothgan/claude-code-rust-linux-x64-gnu")
+        }
+        ("linux", "aarch64") if linux_libc == Some("glibc") => {
+            PlatformPackageSelection::Supported("@srothgan/claude-code-rust-linux-arm64-gnu")
+        }
+        ("linux", "x86_64" | "aarch64") => PlatformPackageSelection::UnsupportedLinuxLibc {
+            arch,
+            libc: linux_libc.unwrap_or("unknown"),
+        },
+        ("windows", "x86_64") => {
+            PlatformPackageSelection::Supported("@srothgan/claude-code-rust-win32-x64-msvc")
+        }
+        ("windows", "aarch64") => {
+            PlatformPackageSelection::Supported("@srothgan/claude-code-rust-win32-arm64-msvc")
+        }
+        _ => PlatformPackageSelection::UnsupportedPlatform,
     }
+}
+
+fn current_linux_libc_kind() -> Option<&'static str> {
+    if std::env::consts::OS != "linux" {
+        return None;
+    }
+    current_linux_libc_kind_for_target()
+}
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+fn current_linux_libc_kind_for_target() -> Option<&'static str> {
+    Some("glibc")
+}
+
+#[cfg(all(target_os = "linux", target_env = "musl"))]
+fn current_linux_libc_kind_for_target() -> Option<&'static str> {
+    Some("musl")
+}
+
+#[cfg(not(target_os = "linux"))]
+fn current_linux_libc_kind_for_target() -> Option<&'static str> {
+    None
+}
+
+#[cfg(all(target_os = "linux", not(any(target_env = "gnu", target_env = "musl"))))]
+fn current_linux_libc_kind_for_target() -> Option<&'static str> {
+    None
 }
 
 fn credentials_check() -> DoctorCheck {
@@ -866,23 +977,25 @@ impl DoctorCheck {
 #[cfg(test)]
 mod tests {
     use super::{
-        DoctorReport, DoctorStatus, MIN_NODE_MAJOR, PlatformReport, ROOT_NPM_PACKAGE_NAME,
-        classify_node_version, config_path_checks, package_json_check, parse_node_major,
-        write_human_report,
+        DoctorReport, DoctorStatus, PlatformPackageSelection, PlatformReport,
+        ROOT_NPM_PACKAGE_NAME, classify_bun_version, config_path_checks, package_json_check,
+        parse_bun_version, platform_package_selection_for, write_human_report,
     };
     use std::path::Path;
 
     #[test]
-    fn parses_node_major_versions() {
-        assert_eq!(parse_node_major("v20.11.1"), Some(20));
-        assert_eq!(parse_node_major("18.19.0"), Some(18));
-        assert_eq!(parse_node_major("not-node"), None);
+    fn parses_bun_versions() {
+        assert_eq!(parse_bun_version("1.3.14"), Some("1.3.14"));
+        assert_eq!(parse_bun_version("v1.3.14"), Some("1.3.14"));
+        assert_eq!(parse_bun_version("1.3.14-canary.1"), Some("1.3.14-canary.1"));
+        assert_eq!(parse_bun_version("v1.3.14+20260705"), Some("1.3.14+20260705"));
+        assert_eq!(parse_bun_version("not-bun"), None);
+        assert_eq!(parse_bun_version("1.3.14-"), None);
     }
 
     #[test]
-    fn node_version_below_minimum_is_hard_failure() {
-        let raw = format!("v{}.0.0", MIN_NODE_MAJOR - 1);
-        let check = classify_node_version(&raw, Path::new("node"));
+    fn invalid_bun_version_is_hard_failure() {
+        let check = classify_bun_version("not-bun", Path::new("bun"));
 
         assert_eq!(check.status, DoctorStatus::Fail);
         assert!(check.hard_failure);
@@ -979,5 +1092,33 @@ mod tests {
 
         assert_eq!(check.status, DoctorStatus::Warn);
         assert!(check.message.contains("expected claude-code-rust package metadata"));
+    }
+
+    #[test]
+    fn platform_package_selection_requires_glibc_for_linux_packages() {
+        assert_eq!(
+            platform_package_selection_for("linux", "x86_64", Some("glibc")),
+            PlatformPackageSelection::Supported("@srothgan/claude-code-rust-linux-x64-gnu")
+        );
+        assert_eq!(
+            platform_package_selection_for("linux", "aarch64", Some("glibc")),
+            PlatformPackageSelection::Supported("@srothgan/claude-code-rust-linux-arm64-gnu")
+        );
+        assert_eq!(
+            platform_package_selection_for("linux", "x86_64", Some("musl")),
+            PlatformPackageSelection::UnsupportedLinuxLibc { arch: "x86_64", libc: "musl" }
+        );
+    }
+
+    #[test]
+    fn platform_package_selection_handles_non_linux_targets() {
+        assert_eq!(
+            platform_package_selection_for("windows", "x86_64", None),
+            PlatformPackageSelection::Supported("@srothgan/claude-code-rust-win32-x64-msvc")
+        );
+        assert_eq!(
+            platform_package_selection_for("freebsd", "x86_64", None),
+            PlatformPackageSelection::UnsupportedPlatform
+        );
     }
 }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -799,7 +799,7 @@ fn platform_package_selection() -> PlatformPackageSelection {
     platform_package_selection_for(
         std::env::consts::OS,
         std::env::consts::ARCH,
-        current_linux_libc_kind(),
+        CURRENT_LINUX_LIBC_KIND,
     )
 }
 
@@ -835,32 +835,17 @@ fn platform_package_selection_for(
     }
 }
 
-fn current_linux_libc_kind() -> Option<&'static str> {
-    if std::env::consts::OS != "linux" {
-        return None;
-    }
-    current_linux_libc_kind_for_target()
-}
-
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
-fn current_linux_libc_kind_for_target() -> Option<&'static str> {
-    Some("glibc")
-}
+const CURRENT_LINUX_LIBC_KIND: Option<&'static str> = Some("glibc");
 
 #[cfg(all(target_os = "linux", target_env = "musl"))]
-fn current_linux_libc_kind_for_target() -> Option<&'static str> {
-    Some("musl")
-}
+const CURRENT_LINUX_LIBC_KIND: Option<&'static str> = Some("musl");
 
 #[cfg(not(target_os = "linux"))]
-fn current_linux_libc_kind_for_target() -> Option<&'static str> {
-    None
-}
+const CURRENT_LINUX_LIBC_KIND: Option<&'static str> = None;
 
 #[cfg(all(target_os = "linux", not(any(target_env = "gnu", target_env = "musl"))))]
-fn current_linux_libc_kind_for_target() -> Option<&'static str> {
-    None
-}
+const CURRENT_LINUX_LIBC_KIND: Option<&'static str> = None;
 
 fn credentials_check() -> DoctorCheck {
     let mut details = BTreeMap::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,8 +3,8 @@
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum AppError {
-    #[error("Node.js runtime not found")]
-    NodeNotFound,
+    #[error("Bundled bridge runtime not found")]
+    BridgeRuntimeNotFound,
     #[error("Agent bridge process failed to start")]
     BridgeSpawnFailed,
     #[error("Agent bridge initialization failed")]
@@ -26,7 +26,7 @@ pub enum AppError {
 }
 
 impl AppError {
-    pub const NODE_NOT_FOUND_EXIT_CODE: i32 = 20;
+    pub const BRIDGE_RUNTIME_NOT_FOUND_EXIT_CODE: i32 = 20;
     pub const ADAPTER_CRASHED_EXIT_CODE: i32 = 21;
     pub const CONNECTION_FAILED_EXIT_CODE: i32 = 22;
     pub const SESSION_NOT_FOUND_EXIT_CODE: i32 = 23;
@@ -35,7 +35,7 @@ impl AppError {
     #[must_use]
     pub fn exit_code(&self) -> i32 {
         match self {
-            Self::NodeNotFound => Self::NODE_NOT_FOUND_EXIT_CODE,
+            Self::BridgeRuntimeNotFound => Self::BRIDGE_RUNTIME_NOT_FOUND_EXIT_CODE,
             Self::BridgeSpawnFailed | Self::AdapterCrashed => Self::ADAPTER_CRASHED_EXIT_CODE,
             Self::BridgeInitializationFailed
             | Self::BridgeStdoutClosed
@@ -50,8 +50,8 @@ impl AppError {
     #[must_use]
     pub fn user_message(&self) -> &'static str {
         match self {
-            Self::NodeNotFound => {
-                "Node.js runtime not found. Install Node.js and ensure `node` is on PATH."
+            Self::BridgeRuntimeNotFound => {
+                "Bundled bridge runtime not found. Reinstall claude-rs or run `claude-rs doctor --strict`."
             }
             Self::BridgeSpawnFailed => {
                 "Agent bridge process failed to start. Run `claude-rs doctor --strict` to inspect the runtime and bridge script."
@@ -82,7 +82,7 @@ impl AppError {
     #[must_use]
     pub fn report_title(&self) -> &'static str {
         match self {
-            Self::NodeNotFound => "Environment problem",
+            Self::BridgeRuntimeNotFound => "Environment problem",
             Self::BridgeSpawnFailed | Self::AdapterCrashed => "Bridge spawn failure",
             Self::BridgeInitializationFailed => "Bridge initialization failure",
             Self::BridgeStdoutClosed => "Bridge process exited",
@@ -96,7 +96,7 @@ impl AppError {
     #[must_use]
     pub fn category_tag(&self) -> &'static str {
         match self {
-            Self::NodeNotFound => "environment",
+            Self::BridgeRuntimeNotFound => "environment",
             Self::BridgeSpawnFailed | Self::AdapterCrashed => "bridge_spawn",
             Self::BridgeInitializationFailed => "bridge_initialization",
             Self::BridgeStdoutClosed => "bridge_stdout_closed",
@@ -110,7 +110,7 @@ impl AppError {
     #[must_use]
     pub fn recommended_command(&self) -> &'static str {
         match self {
-            Self::NodeNotFound
+            Self::BridgeRuntimeNotFound
             | Self::BridgeSpawnFailed
             | Self::AdapterCrashed
             | Self::BridgeTimeout => "claude-rs doctor --strict",


### PR DESCRIPTION
## Summary

- Bundle a private Bun runtime into each platform npm package for the Agent SDK bridge.
- Keep `claude-code-rust` as the root npm package and public `claude-rs` bin owner while platform packages stay payload-only.
- Add package generation, runtime staging, third-party notice, publish dry-run, publish recovery, and smoke-test coverage.
- Update release/nightly/PR workflows to validate staged Bun runtimes and npm package invariants before publishing.

## Why

- Users should be able to install with `npm install -g claude-code-rust` without installing Bun separately.
- Release builds need deterministic bridge runtime resolution that prefers the packaged runtime over global PATH state.
- The release workflow needs stronger package-layout, no-system-runtime, and registry-style global install validation before npm publish.
- Platform package publication needs rerun-safe integrity checks so partial npm publishes can be recovered without publishing mismatched tarballs.

Closes #

## Validation

- Automated:
  - `go run github.com/rhysd/actionlint/cmd/actionlint@latest -oneline`
  - `git diff --check -- .github/workflows/release.yml .github/workflows/nightly.yml .github/workflows/_release-build.yml`
  - `node scripts/stage-bun-runtime.mjs --check`
  - `node --test scripts/verify-staged-bun-runtimes.test.mjs scripts/dry-run-npm-publish.test.mjs scripts/publish-npm-platform-packages.test.mjs scripts/smoke-npm-package-install.test.mjs`
- Manual:
  - Built Windows x64 release binary with `cargo build --release --locked --target x86_64-pc-windows-msvc --bin claude-rs`
  - Built Agent SDK bridge with `npm.cmd --prefix agent-sdk run build`
  - Staged `win32-x64-msvc` Bun runtime with `node scripts/stage-bun-runtime.mjs --download --platform win32-x64-msvc`
  - Smoke-tested local Windows package install with `--real-binary --no-system-runtime`
  - Verified installed Windows npm shims, `doctor --json --strict`, bundled Bun runtime detection, and bridge runtime contract
  - Manually verified registry-style global-prefix install after the registry smoke script timed out post-install
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: Yes
- `bun-plan.md`, `bun-fix.md`, and local generated artifacts are intentionally not part of this PR.
