### PR TITLE
chore(node): require Node 24 for maintainer tooling

### DIFF
--- a/agent-sdk/README.md
+++ b/agent-sdk/README.md
@@ -6,6 +6,8 @@ Published npm platform packages run this bridge with the private `claude-rs-brid
 
 ## Local build
 
+Local maintainer builds require Node.js 24.
+
 ```bash
 npm install
 npm run build

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -16,6 +16,9 @@
         "@types/node": "26.0.1",
         "knip": "6.23.0",
         "typescript": "6.0.3"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -16,6 +16,9 @@
     "audit:raw": "npm audit --audit-level=moderate",
     "test": "npm run build && node --test dist/**/*.test.js"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.198"
   },

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -62,7 +62,7 @@ Release packaging is designed around immutable artifacts:
 - npm publication uses Trusted Publishing rather than a long-lived npm token.
 - The root package remains the user-facing npm install package and depends optionally on platform payload packages.
 
-Source builds are different: `cargo build` or `cargo install --path .` produce only the Rust binary. They do not build or install the JavaScript bridge or private Bun runtime. Build the bridge with npm and provide it through the checkout fallback, `--bridge-script`, or `CLAUDE_RS_AGENT_BRIDGE`. Debug builds can use `CLAUDE_RS_AGENT_BRIDGE_RUNTIME` to point at a local Bun runtime; release npm installs use only the bundled runtime.
+Source builds are different: `cargo build` or `cargo install --path .` produce only the Rust binary. They do not build or install the JavaScript bridge or private Bun runtime. Build the bridge with Node.js 24/npm and provide it through the checkout fallback, `--bridge-script`, or `CLAUDE_RS_AGENT_BRIDGE`. Debug builds can use `CLAUDE_RS_AGENT_BRIDGE_RUNTIME` to point at a local Bun runtime; release npm installs use only the bundled runtime.
 
 ## Boundaries
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -5,7 +5,7 @@
 Claude Code Rust needs:
 
 - Existing Claude Code authentication, currently read from `~/.claude/config.json`.
-- Rust 1.88.0 or newer, npm, and Bun only when building or running from source.
+- Rust 1.88.0 or newer, Node.js 24/npm, and Bun only when building or running from source.
 
 ## Install From npm
 
@@ -47,6 +47,8 @@ npm ci --prefix agent-sdk
 npm run build --prefix agent-sdk
 cargo run
 ```
+
+Maintainer and source-build npm tooling targets Node.js 24. Packaged npm installs use the bundled private Bun runtime for the Agent SDK bridge.
 
 Debug builds resolve `agent-sdk/dist/bridge.js` from the checkout after the bridge is built. They use `bun` from `PATH` unless `CLAUDE_RS_AGENT_BRIDGE_RUNTIME` points at a specific Bun executable.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "jscpd": "5.0.11"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=24"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jscpd": "5.0.11"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/verify-npm-packages.mjs
+++ b/scripts/verify-npm-packages.mjs
@@ -31,6 +31,7 @@ if (options.help) {
 const distDir = path.resolve(repoRoot, options.distDir ?? DIST_NPM_DIR);
 const manifestsDir = path.join(distDir, "manifests");
 const cargoPackage = readCargoPackageMetadata(path.join(repoRoot, "Cargo.toml"));
+const rootPackageJson = readJson(path.join(repoRoot, "package.json"));
 const expectedVersion = options.version ?? cargoPackage.version;
 const failures = [];
 const packageManifests = [];
@@ -90,7 +91,7 @@ function verifyRootPackage() {
     expectedPlatformOptionalDependencies(),
     `${context} optionalDependencies`
   );
-  expectDeepEqual(packageJson.engines, { node: ">=18" }, `${context} engines`);
+  expectDeepEqual(packageJson.engines, rootPackageJson.engines, `${context} engines`);
   expectNoLifecycleScripts(packageJson, context);
   expectNoForbiddenManifestFields(packageJson, context);
 


### PR DESCRIPTION
## Summary

- Require Node.js 24 for root npm package tooling and the private Agent SDK workspace.
- Refresh root and Agent SDK package lockfile engine metadata.
- Update source-build and Agent SDK docs to clarify that Node.js 24 is for maintainer npm tooling while packaged installs use the bundled Bun runtime.

## Why

The bundled Bun runtime is now responsible for running the Agent SDK bridge in packaged installs. Node.js is therefore a maintainer/source-build toolchain requirement, and the repo should advertise the same Node 24 floor already used by CI and newer Agent SDK dev tooling.

Closes N/A

## Validation

- Automated:
  - `npm install --package-lock-only --ignore-scripts`
  - `npm --prefix agent-sdk install --package-lock-only --ignore-scripts`
  - `npm --prefix agent-sdk run build`
- Manual:
  - Reviewed the branch diff against `origin/main`.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: Node.js 24 is now required for maintainer/source-build npm tooling. Packaged npm installs continue to use the bundled private Bun runtime for the Agent SDK bridge.
- Docs updated: Yes
