### PR TITLE
chore(release): publish 0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.4] - 2026-07-06 [Changes][v0.13.4]
+
+### Features
+
+- **Bundled Bun bridge runtime** (#245, @srothgan): Ship a private Bun runtime in each platform npm package so the Agent SDK bridge no longer needs a separately installed Node runtime to run.
+
+### CI and Dependencies
+
+- **Node 24 maintainer floor** (#254, @srothgan): Raise root and Agent SDK npm engine metadata to Node 24 for source-build tooling.
+
 ## [0.13.3] - 2026-07-04 [Changes][v0.13.3]
 
 ### Features
@@ -714,6 +724,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.13.4]: https://github.com/srothgan/claude-code-rust/compare/v0.13.3...v0.13.4
 [v0.13.3]: https://github.com/srothgan/claude-code-rust/compare/v0.13.2...v0.13.3
 [v0.13.2]: https://github.com/srothgan/claude-code-rust/compare/v0.13.0...v0.13.2
 [v0.13.0]: https://github.com/srothgan/claude-code-rust/compare/v0.12.4...v0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rust",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rust",
-      "version": "0.13.3",
+      "version": "0.13.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.198"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-rust",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Claude Code Rust - native Rust terminal interface for Claude Code",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary

- Prepare release 0.13.4.
- Bump Cargo and npm package metadata from 0.13.3 to 0.13.4.
- Add changelog notes for the bundled Bun bridge runtime and Node 24 maintainer tooling floor.

## Why

0.13.4 releases the npm packaging/runtime changes from #245 and #254:

- Packaged npm installs now ship a private Bun runtime in each platform package so the Agent SDK bridge does not require a separately installed Node runtime.
- Maintainer and source-build npm tooling now advertises Node 24 as the supported floor.

Closes N/A

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `cargo check --offline`
- Manual:
  - Reviewed the release diff for package version bumps and 0.13.4 changelog coverage.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: Node.js 24 is now required for maintainer/source-build npm tooling. Packaged npm installs use the bundled private Bun bridge runtime.
- Docs updated: Changelog only.
