### PR TITLE
fix(release): skip already published npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
             status=$?
             set -e
             if [ "$status" -eq 0 ]; then
-              echo "NOTICE: ${package_name}@${VERSION} already exists; its publish job will verify tarball integrity before reusing it"
+              echo "NOTICE: ${package_name}@${VERSION} already exists; its publish job will skip it"
               return
             fi
             if ! printf '%s\n' "$output" | grep -q 'E404'; then
@@ -426,38 +426,28 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ needs.verify.outputs.version }}"
+          package_name="claude-code-rust"
           tarball="./dist-pack/claude-code-rust-${{ needs.verify.outputs.version }}.tgz"
           if [ ! -f "$tarball" ]; then
             echo "::error::Missing npm package tarball: $tarball"
             exit 1
           fi
-          local_integrity="$(
-            node -e "const fs = require('node:fs'); const crypto = require('node:crypto'); console.log('sha512-' + crypto.createHash('sha512').update(fs.readFileSync(process.argv[1])).digest('base64'))" "$tarball"
-          )"
+
           set +e
-          existing_integrity="$(npm view "claude-code-rust@${VERSION}" dist.integrity --json 2>&1)"
+          output="$(npm view "${package_name}@${VERSION}" version --json 2>&1)"
           status=$?
           set -e
           if [ "$status" -eq 0 ]; then
-            existing_integrity="$(printf '%s' "$existing_integrity" | node -e "let input=''; process.stdin.on('data', c => input += c); process.stdin.on('end', () => console.log(JSON.parse(input)))")"
-            if [ "$existing_integrity" != "$local_integrity" ]; then
-              echo "::error::claude-code-rust@${VERSION} already exists with different integrity: registry ${existing_integrity}, local ${local_integrity}"
-              exit 1
-            fi
-            echo "OK: claude-code-rust@${VERSION} already published with matching integrity"
+            echo "SKIP: ${package_name}@${VERSION} already published"
             exit 0
           fi
-          if ! printf '%s\n' "$existing_integrity" | grep -q 'E404'; then
-            echo "::error::Could not inspect npm registry integrity for claude-code-rust@${VERSION}"
-            echo "$existing_integrity"
+          if ! printf '%s\n' "$output" | grep -q 'E404'; then
+            echo "::error::Could not inspect npm package state for ${package_name}@${VERSION}"
+            echo "$output"
             exit 1
           fi
+
           npm publish "$tarball" --access public
-          registry_integrity="$(npm view "claude-code-rust@${VERSION}" dist.integrity --json | node -e "let input=''; process.stdin.on('data', c => input += c); process.stdin.on('end', () => console.log(JSON.parse(input)))")"
-          if [ "$registry_integrity" != "$local_integrity" ]; then
-            echo "::error::claude-code-rust@${VERSION} registry integrity mismatch after publish: registry ${registry_integrity}, local ${local_integrity}"
-            exit 1
-          fi
 
   create-github-release:
     needs: [verify, publish-root-package]

--- a/scripts/publish-npm-platform-packages.mjs
+++ b/scripts/publish-npm-platform-packages.mjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -13,10 +12,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
 
-export function tarballIntegrity(tarballPath) {
-  return `sha512-${crypto.createHash("sha512").update(fs.readFileSync(tarballPath)).digest("base64")}`;
-}
-
 export function platformPublishPlan(packDir, version) {
   return PLATFORM_PACKAGES.map((platformPackage) => ({
     packageName: platformPackage.packageName,
@@ -25,46 +20,41 @@ export function platformPublishPlan(packDir, version) {
   }));
 }
 
-function publishPlatformPackages({ packDir, version, ledgerDir }) {
-  fs.mkdirSync(ledgerDir, { recursive: true });
+export function publishPlatformPackages({
+  packDir,
+  version,
+  ledgerDir,
+  execNpm = execNpmSync,
+  existsSync = fs.existsSync,
+  mkdirSync = fs.mkdirSync,
+  writeFileSync = fs.writeFileSync,
+  now = () => new Date().toISOString(),
+}) {
+  mkdirSync(ledgerDir, { recursive: true });
   const ledgerEntries = [];
 
   for (const plan of platformPublishPlan(packDir, version)) {
-    if (!fs.existsSync(plan.tarball)) {
+    if (!existsSync(plan.tarball)) {
       throw new Error(`Missing npm package tarball for ${plan.packageName}: ${relativePath(plan.tarball)}`);
     }
 
-    const localIntegrity = tarballIntegrity(plan.tarball);
-    const existingIntegrity = npmViewIntegrity(plan.packageName, version);
-    if (existingIntegrity) {
-      if (existingIntegrity !== localIntegrity) {
-        throw new Error(
-          `${plan.packageName}@${version} already exists with different integrity: ` +
-            `registry ${existingIntegrity}, local ${localIntegrity}`
-        );
-      }
-      ledgerEntries.push(ledgerEntry(plan, localIntegrity, existingIntegrity, "already_published"));
-      console.log(`OK: ${plan.packageName}@${version} already published with matching integrity`);
+    if (npmPackageVersionExists(plan.packageName, version, { execNpm })) {
+      ledgerEntries.push(ledgerEntry(plan, "already_published", now()));
+      console.log(`SKIP: ${plan.packageName}@${version} already published`);
       continue;
     }
 
-    execNpmSync(["publish", plan.tarball, "--access", "public"], {
+    execNpm(["publish", plan.tarball, "--access", "public"], {
       cwd: repoRoot,
       stdio: "inherit",
       windowsHide: true,
     });
-    const registryIntegrity = npmViewIntegrity(plan.packageName, version);
-    if (registryIntegrity !== localIntegrity) {
-      throw new Error(
-        `${plan.packageName}@${version} registry integrity mismatch after publish: ` +
-          `registry ${registryIntegrity ?? "<missing>"}, local ${localIntegrity}`
-      );
-    }
-    ledgerEntries.push(ledgerEntry(plan, localIntegrity, registryIntegrity, "published"));
+    ledgerEntries.push(ledgerEntry(plan, "published", now()));
   }
 
   const ledgerPath = path.join(ledgerDir, `platform-packages-${version}.json`);
-  fs.writeFileSync(
+  mkdirSync(ledgerDir, { recursive: true });
+  writeFileSync(
     ledgerPath,
     `${JSON.stringify({ manifestVersion: 1, version, entries: ledgerEntries }, null, 2)}\n`,
     "utf8",
@@ -72,39 +62,43 @@ function publishPlatformPackages({ packDir, version, ledgerDir }) {
   console.log(`Wrote npm publish ledger to ${relativePath(ledgerPath)}`);
 }
 
-function ledgerEntry(plan, localIntegrity, registryIntegrity, status) {
+function ledgerEntry(plan, status, timestamp) {
   return {
     package_name: plan.packageName,
     version: plan.version,
     tarball_filename: path.basename(plan.tarball),
-    local_npm_pack_integrity: localIntegrity,
-    registry_dist_integrity: registryIntegrity,
     status,
-    timestamp: new Date().toISOString(),
+    timestamp,
   };
 }
 
-function npmViewIntegrity(packageName, version) {
+export function npmPackageVersionExists(packageName, version, { execNpm = execNpmSync } = {}) {
   try {
-    const output = execNpmSync(["view", `${packageName}@${version}`, "dist.integrity", "--json"], {
+    const output = execNpm(["view", `${packageName}@${version}`, "version", "--json"], {
       cwd: repoRoot,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     }).trim();
     if (!output) {
-      return undefined;
+      return false;
     }
     const parsed = JSON.parse(output);
-    return typeof parsed === "string" && parsed.length > 0 ? parsed : undefined;
+    if (parsed === version) {
+      return true;
+    }
+    throw new Error(`npm returned unexpected version for ${packageName}@${version}: ${output}`);
   } catch (error) {
+    if (error instanceof Error && error.message.startsWith("npm returned unexpected version")) {
+      throw error;
+    }
     const stderr = bufferToString(error.stderr);
     const stdout = bufferToString(error.stdout);
     if (`${stdout}\n${stderr}`.includes("E404")) {
-      return undefined;
+      return false;
     }
     throw new Error(
-      `Could not inspect npm registry integrity for ${packageName}@${version}:\n${stdout}\n${stderr}`.trim()
+      `Could not inspect npm package state for ${packageName}@${version}:\n${stdout}\n${stderr}`.trim(),
     );
   }
 }

--- a/scripts/publish-npm-platform-packages.test.mjs
+++ b/scripts/publish-npm-platform-packages.test.mjs
@@ -1,29 +1,14 @@
 import assert from "node:assert/strict";
-import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { PLATFORM_PACKAGES } from "./npm-package-config.mjs";
 import {
+  npmPackageVersionExists,
   platformPublishPlan,
-  tarballIntegrity,
+  publishPlatformPackages,
 } from "./publish-npm-platform-packages.mjs";
-
-test("tarballIntegrity returns npm dist integrity format", () => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-integrity-"));
-  try {
-    const tarball = path.join(tempDir, "pkg.tgz");
-    fs.writeFileSync(tarball, "package bytes", "utf8");
-
-    assert.equal(
-      tarballIntegrity(tarball),
-      `sha512-${crypto.createHash("sha512").update("package bytes").digest("base64")}`,
-    );
-  } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
-});
 
 test("platformPublishPlan covers only platform packages", () => {
   const plan = platformPublishPlan("dist-pack", "1.2.3");
@@ -35,3 +20,105 @@ test("platformPublishPlan covers only platform packages", () => {
   );
   assert.equal(plan.some((entry) => entry.packageName === "claude-code-rust"), false);
 });
+
+test("npmPackageVersionExists returns true when npm reports the requested version", () => {
+  const calls = [];
+
+  const exists = npmPackageVersionExists("@scope/pkg", "1.2.3", {
+    execNpm(args) {
+      calls.push(args);
+      return '"1.2.3"\n';
+    },
+  });
+
+  assert.equal(exists, true);
+  assert.deepEqual(calls, [["view", "@scope/pkg@1.2.3", "version", "--json"]]);
+});
+
+test("npmPackageVersionExists returns false for missing package versions", () => {
+  const exists = npmPackageVersionExists("@scope/pkg", "1.2.3", {
+    execNpm() {
+      throw npmError({ stderr: "npm error code E404\nNo match found for version 1.2.3" });
+    },
+  });
+
+  assert.equal(exists, false);
+});
+
+test("npmPackageVersionExists rejects unexpected npm lookup failures", () => {
+  assert.throws(
+    () =>
+      npmPackageVersionExists("@scope/pkg", "1.2.3", {
+        execNpm() {
+          throw npmError({ stderr: "npm error code E500\nregistry unavailable" });
+        },
+      }),
+    /Could not inspect npm package state for @scope\/pkg@1\.2\.3/,
+  );
+});
+
+test("publishPlatformPackages skips already published versions and publishes missing packages", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-publish-"));
+  try {
+    const packDir = path.join(tempDir, "dist-pack");
+    const ledgerDir = path.join(tempDir, "ledger");
+    const version = "1.2.3";
+    fs.mkdirSync(packDir, { recursive: true });
+
+    const plan = platformPublishPlan(packDir, version);
+    for (const entry of plan) {
+      fs.writeFileSync(entry.tarball, "package bytes", "utf8");
+    }
+
+    const alreadyPublished = plan[0].packageName;
+    const published = [];
+
+    publishPlatformPackages({
+      packDir,
+      ledgerDir,
+      version,
+      now: () => "2026-07-06T00:00:00.000Z",
+      execNpm(args) {
+        if (args[0] === "view") {
+          return args[1] === `${alreadyPublished}@${version}`
+            ? `"${version}"\n`
+            : (() => {
+                throw npmError({ stderr: "npm error code E404\nNo match found" });
+              })();
+        }
+        if (args[0] === "publish") {
+          published.push(path.basename(args[1]));
+          return "";
+        }
+        throw new Error(`unexpected npm command: ${args.join(" ")}`);
+      },
+    });
+
+    assert.deepEqual(
+      published,
+      plan.slice(1).map((entry) => path.basename(entry.tarball)),
+    );
+
+    const ledger = JSON.parse(fs.readFileSync(path.join(ledgerDir, `platform-packages-${version}.json`), "utf8"));
+    assert.equal(ledger.entries[0].status, "already_published");
+    assert.deepEqual(
+      ledger.entries.slice(1).map((entry) => entry.status),
+      plan.slice(1).map(() => "published"),
+    );
+    assert.equal(
+      ledger.entries.some(
+        (entry) => "local_npm_pack_integrity" in entry || "registry_dist_integrity" in entry,
+      ),
+      false,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function npmError({ stdout = "", stderr = "" }) {
+  const error = new Error("npm failed");
+  error.stdout = Buffer.from(stdout, "utf8");
+  error.stderr = Buffer.from(stderr, "utf8");
+  return error;
+}


### PR DESCRIPTION
## Summary

- Skip npm packages that already exist during release reruns.
- Remove post-publish registry integrity checks.

## Why

0.13.4 partially published `darwin-arm64`, then failed because npm metadata was not immediately readable after publish.

Closes N/A

## Validation

- Automated:
  - `node --test scripts/publish-npm-platform-packages.test.mjs scripts/dry-run-npm-publish.test.mjs`
  - `go run github.com/rhysd/actionlint/cmd/actionlint@latest -oneline .github/workflows/release.yml`
- Manual:
  - Checked failed release run `28788347323` with `gh`.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
