### PR TITLE
fix(release): skip published packages during npm dry-run

### DIFF
--- a/scripts/dry-run-npm-publish.mjs
+++ b/scripts/dry-run-npm-publish.mjs
@@ -63,19 +63,59 @@ export function execNpmSync(args, options) {
   return execFileSync(invocation.command, invocation.args, options);
 }
 
-function dryRunNpmPublish({ packDir, version }) {
+export function dryRunNpmPublish({
+  packDir,
+  version,
+  execNpm = execNpmSync,
+  existsSync = fs.existsSync,
+  spawn = spawnSync,
+}) {
   for (const { packageName, tarball } of expectedPublishTarballs(packDir, version)) {
-    if (!fs.existsSync(tarball)) {
+    if (!existsSync(tarball)) {
       throw new Error(`Missing npm package tarball for ${packageName}: ${relativePath(tarball)}`);
     }
 
-    runNpmPublishDryRun({ packageName, tarball });
+    if (npmPackageVersionExists(packageName, version, { execNpm })) {
+      console.log(`SKIP: ${packageName}@${version} already published`);
+      continue;
+    }
+
+    runNpmPublishDryRun({ packageName, tarball, spawn });
   }
 }
 
-function runNpmPublishDryRun({ packageName, tarball }) {
+export function npmPackageVersionExists(packageName, version, { execNpm = execNpmSync } = {}) {
+  try {
+    const output = execNpm(["view", `${packageName}@${version}`, "version", "--json"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    }).trim();
+    if (!output) {
+      return false;
+    }
+    const parsed = JSON.parse(output);
+    if (parsed === version) {
+      return true;
+    }
+    throw new Error(`npm returned unexpected version for ${packageName}@${version}: ${output}`);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("npm returned unexpected version")) {
+      throw error;
+    }
+    const stderr = bufferToString(error.stderr);
+    const stdout = bufferToString(error.stdout);
+    if (`${stdout}\n${stderr}`.includes("E404")) {
+      return false;
+    }
+    throw new Error(`Could not inspect npm package state for ${packageName}@${version}:\n${stdout}\n${stderr}`.trim());
+  }
+}
+
+function runNpmPublishDryRun({ packageName, tarball, spawn = spawnSync }) {
   const invocation = resolveNpmInvocation(["publish", tarball, "--access", "public", "--dry-run"]);
-  const result = spawnSync(invocation.command, invocation.args, {
+  const result = spawn(invocation.command, invocation.args, {
     cwd: repoRoot,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
@@ -99,6 +139,13 @@ function runNpmPublishDryRun({ packageName, tarball }) {
   throw new Error(
     `npm publish --dry-run failed for ${packageName} with exit code ${result.status}\n${output}`.trim()
   );
+}
+
+function bufferToString(value) {
+  if (!value) {
+    return "";
+  }
+  return Buffer.isBuffer(value) ? value.toString("utf8") : String(value);
 }
 
 function parseArgs(args) {

--- a/scripts/dry-run-npm-publish.test.mjs
+++ b/scripts/dry-run-npm-publish.test.mjs
@@ -1,9 +1,13 @@
+import fs from "node:fs";
+import os from "node:os";
 import assert from "node:assert/strict";
 import path from "node:path";
 import test from "node:test";
 import { PLATFORM_PACKAGES, ROOT_PACKAGE_NAME } from "./npm-package-config.mjs";
 import {
+  dryRunNpmPublish,
   expectedPublishTarballs,
+  npmPackageVersionExists,
   npmTarballName,
   resolveNpmInvocation,
 } from "./dry-run-npm-publish.mjs";
@@ -70,3 +74,93 @@ test("resolveNpmInvocation prefers npm_execpath on Windows", () => {
     },
   );
 });
+
+test("npmPackageVersionExists returns true when npm reports the requested version", () => {
+  const calls = [];
+
+  const exists = npmPackageVersionExists("@scope/pkg", "1.2.3", {
+    execNpm(args) {
+      calls.push(args);
+      return '"1.2.3"\n';
+    },
+  });
+
+  assert.equal(exists, true);
+  assert.deepEqual(calls, [["view", "@scope/pkg@1.2.3", "version", "--json"]]);
+});
+
+test("npmPackageVersionExists returns false for missing package versions", () => {
+  const exists = npmPackageVersionExists("@scope/pkg", "1.2.3", {
+    execNpm() {
+      throw npmError({ stderr: "npm error code E404\nNo match found for version 1.2.3" });
+    },
+  });
+
+  assert.equal(exists, false);
+});
+
+test("npmPackageVersionExists rejects unexpected npm lookup failures", () => {
+  assert.throws(
+    () =>
+      npmPackageVersionExists("@scope/pkg", "1.2.3", {
+        execNpm() {
+          throw npmError({ stderr: "npm error code E500\nregistry unavailable" });
+        },
+      }),
+    /Could not inspect npm package state for @scope\/pkg@1\.2\.3/,
+  );
+});
+
+test("dryRunNpmPublish skips existing versions and dry-runs missing versions", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-dry-run-"));
+  try {
+    const packDir = path.join(tempDir, "dist-pack");
+    const version = "1.2.3";
+    fs.mkdirSync(packDir, { recursive: true });
+
+    const tarballs = expectedPublishTarballs(packDir, version);
+    for (const entry of tarballs) {
+      fs.writeFileSync(entry.tarball, "package bytes", "utf8");
+    }
+
+    const alreadyPublished = tarballs[0].packageName;
+    const dryRuns = [];
+
+    dryRunNpmPublish({
+      packDir,
+      version,
+      execNpm(args) {
+        if (args[0] !== "view") {
+          throw new Error(`unexpected npm command: ${args.join(" ")}`);
+        }
+        if (args[1] === `${alreadyPublished}@${version}`) {
+          return `"${version}"\n`;
+        }
+        throw npmError({ stderr: "npm error code E404\nNo match found" });
+      },
+      spawn(command, args) {
+        dryRuns.push({ command, args });
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    assert.equal(dryRuns.length, tarballs.length - 1);
+    assert.equal(
+      dryRuns.some((entry) => entry.args.includes(tarballs[0].tarball)),
+      false,
+    );
+    assert.equal(
+      dryRuns.every((entry) => entry.args.includes("--dry-run")),
+      true,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function npmError({ stdout = "", stderr = "" }) {
+  const error = new Error("npm failed");
+  error.stdout = Buffer.from(stdout, "utf8");
+  error.stderr = Buffer.from(stderr, "utf8");
+  return error;
+}


### PR DESCRIPTION
## Summary

- Keep the release npm dry-run gate.
- Skip already-published package versions before running `npm publish --dry-run`.

## Why

The 0.13.4 rerun failed because dry-run publishing rejects the already-published `darwin-arm64` package.

Closes N/A

## Validation

- Automated:
  - `node --test scripts/dry-run-npm-publish.test.mjs scripts/publish-npm-platform-packages.test.mjs`
  - `go run github.com/rhysd/actionlint/cmd/actionlint@latest -oneline .github/workflows/release.yml`
  - `git diff --check`
- Manual:
  - Checked failed release run `28790506119` with `gh`.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
