### PR TITLE
feat(release): add script install archive path

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -222,7 +222,7 @@ jobs:
 
   assemble-release-candidate:
     needs: [verify-release-candidate, agent-sdk-preflight, build-release-candidate, stage-release-candidate-runtimes]
-    name: Assemble and verify npm packages
+    name: Assemble release candidate package set
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -267,11 +267,17 @@ jobs:
           node scripts/stage-bun-runtime.mjs --check
           node scripts/verify-staged-bun-runtimes.mjs
 
-      - name: Assemble npm packages
+      - name: Assemble npm package directories
         run: node scripts/generate-npm-packages.mjs --version "${{ needs.verify-release-candidate.outputs.version }}"
 
       - name: Verify npm package layout
         run: node scripts/verify-npm-packages.mjs --version "${{ needs.verify-release-candidate.outputs.version }}"
+
+      - name: Generate install archives
+        run: node scripts/generate-install-archives.mjs --version "${{ needs.verify-release-candidate.outputs.version }}"
+
+      - name: Verify install archives
+        run: node scripts/verify-install-archives.mjs --version "${{ needs.verify-release-candidate.outputs.version }}"
 
       - name: Pack npm tarballs
         run: |
@@ -288,13 +294,20 @@ jobs:
       - name: Dry-run npm tarball publish
         run: node scripts/dry-run-npm-publish.mjs --pack-dir dist-pack --version "${{ needs.verify-release-candidate.outputs.version }}"
 
+      - name: Generate release bundle
+        run: node scripts/generate-release-bundle.mjs --version "${{ needs.verify-release-candidate.outputs.version }}"
+
+      - name: Verify release bundle
+        run: node scripts/verify-release-bundle.mjs --version "${{ needs.verify-release-candidate.outputs.version }}"
+
       - name: Generate SHA256SUMS
         shell: bash
         run: |
           set -euo pipefail
-          find dist-assets dist-pack dist-npm/manifests -type f -print0 \
-            | sort -z \
-            | xargs -0 sha256sum > SHA256SUMS
+          VERSION="${{ needs.verify-release-candidate.outputs.version }}"
+          mapfile -t public_assets < <(find dist-install -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' \) | sort)
+          public_assets+=("claude-code-rust-${VERSION}-release-bundle.tar.gz")
+          sha256sum "${public_assets[@]}" > SHA256SUMS
           cat SHA256SUMS
 
       - name: Upload release candidate artifact set
@@ -305,7 +318,11 @@ jobs:
             dist-assets/
             dist-npm/manifests/
             dist-pack/
+            dist-install/
+            claude-code-rust-${{ needs.verify-release-candidate.outputs.version }}-release-bundle.tar.gz
+            release-manifest.json
             SHA256SUMS
+            SHA256SUMS.internal
           if-no-files-found: error
 
   smoke-release-candidate-packages:
@@ -349,3 +366,6 @@ jobs:
 
       - name: Smoke-test global npm install from temp registry
         run: node scripts/smoke-npm-package-install.mjs --platform "${{ matrix.package_dir }}" --use-existing-tarballs --registry-smoke --real-binary --no-system-runtime
+
+      - name: Smoke-test install archive
+        run: node scripts/smoke-install-archive.mjs --platform "${{ matrix.package_dir }}" --real-binary --no-system-runtime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,8 +180,13 @@ jobs:
 
   assemble-npm-packages:
     needs: [verify, agent-sdk-preflight, build-binaries, stage-bun-runtimes]
-    name: Assemble npm packages
+    name: Assemble release package set
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -232,6 +237,12 @@ jobs:
       - name: Verify npm package layout
         run: node scripts/verify-npm-packages.mjs --version "${{ needs.verify.outputs.version }}"
 
+      - name: Generate install archives
+        run: node scripts/generate-install-archives.mjs --version "${{ needs.verify.outputs.version }}"
+
+      - name: Verify install archives
+        run: node scripts/verify-install-archives.mjs --version "${{ needs.verify.outputs.version }}"
+
       - name: Pack npm tarballs
         run: |
           set -euo pipefail
@@ -244,13 +255,29 @@ jobs:
           npm pack ./dist-npm/win32-x64-msvc --pack-destination ./dist-pack --json
           npm pack ./dist-npm/root --pack-destination ./dist-pack --json
 
+      - name: Generate release bundle
+        run: node scripts/generate-release-bundle.mjs --version "${{ needs.verify.outputs.version }}"
+
+      - name: Verify release bundle
+        run: node scripts/verify-release-bundle.mjs --version "${{ needs.verify.outputs.version }}"
+
       - name: Generate SHA256SUMS
         run: |
           set -euo pipefail
-          find dist-assets dist-pack dist-npm/manifests -type f -print0 \
-            | sort -z \
-            | xargs -0 sha256sum > SHA256SUMS
+          VERSION="${{ needs.verify.outputs.version }}"
+          mapfile -t public_assets < <(find dist-install -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' \) | sort)
+          public_assets+=("claude-code-rust-${VERSION}-release-bundle.tar.gz")
+          sha256sum "${public_assets[@]}" > SHA256SUMS
           cat SHA256SUMS
+
+      - name: Attest public release assets
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4
+        with:
+          subject-path: |
+            dist-install/*.tar.gz
+            dist-install/*.zip
+            claude-code-rust-${{ needs.verify.outputs.version }}-release-bundle.tar.gz
+            SHA256SUMS
 
       - name: Upload release package set
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -260,7 +287,11 @@ jobs:
             dist-assets/
             dist-npm/manifests/
             dist-pack/
+            dist-install/
+            claude-code-rust-${{ needs.verify.outputs.version }}-release-bundle.tar.gz
+            release-manifest.json
             SHA256SUMS
+            SHA256SUMS.internal
           if-no-files-found: error
 
   smoke-test-packages:
@@ -305,9 +336,12 @@ jobs:
       - name: Smoke-test global npm install from temp registry
         run: node scripts/smoke-npm-package-install.mjs --platform "${{ matrix.package_dir }}" --use-existing-tarballs --registry-smoke --real-binary --no-system-runtime
 
+      - name: Smoke-test install archive
+        run: node scripts/smoke-install-archive.mjs --platform "${{ matrix.package_dir }}" --real-binary --no-system-runtime
+
   verify-release-attestations:
     needs: [verify, smoke-test-packages]
-    name: Verify binary attestations
+    name: Verify release attestations
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -354,6 +388,26 @@ jobs:
             --signer-workflow "$signer_workflow" \
             --source-ref refs/heads/main \
             --deny-self-hosted-runners
+
+      - name: Verify public release asset attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          signer_workflow="srothgan/claude-code-rust/.github/workflows/release.yml@refs/heads/main"
+          VERSION="${{ needs.verify.outputs.version }}"
+          for subject in \
+            dist-install/*.tar.gz \
+            dist-install/*.zip \
+            "claude-code-rust-${VERSION}-release-bundle.tar.gz" \
+            SHA256SUMS
+          do
+            gh attestation verify "$subject" \
+              --repo srothgan/claude-code-rust \
+              --signer-workflow "$signer_workflow" \
+              --source-ref refs/heads/main \
+              --deny-self-hosted-runners
+          done
 
   publish-platform-packages:
     needs: [verify, verify-release-attestations]
@@ -485,6 +539,7 @@ jobs:
             echo
             echo "- npm platform packages include private Bun runtime files."
             echo "- Bun source asset names, source archive SHA256 checksums, runtime SHA256 checksums, and source URLs are recorded in dist-npm/manifests/*.json."
+            echo "- Install archives, install manifests, and release bundle metadata are recorded in dist-install/manifests/*.json and release-manifest.json."
           } >> release-notes.md
 
       - name: Create annotated tag
@@ -502,7 +557,9 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${{ needs.verify.outputs.tag }}"
-          mapfile -t release_assets < <(find dist-assets dist-pack dist-npm/manifests -type f | sort)
+          VERSION="${{ needs.verify.outputs.version }}"
+          mapfile -t release_assets < <(find dist-install -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' \) | sort)
+          release_assets+=("claude-code-rust-${VERSION}-release-bundle.tar.gz")
           release_assets+=(SHA256SUMS)
           gh release create "$TAG" "${release_assets[@]}" \
             --draft \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Release and Packaging
+
+- **Install scripts** (#259, @srothgan): Add optional macOS/Linux and Windows install scripts that install from GitHub Releases without requiring npm, Node.js, or Bun on the user's machine.
+
 ## [0.13.4] - 2026-07-06 [Changes][v0.13.4]
 
 ### Features

--- a/scripts/generate-install-archives.mjs
+++ b/scripts/generate-install-archives.mjs
@@ -1,0 +1,421 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  BUNDLED_BUN_RUNTIME_VERSION,
+  PLATFORM_PACKAGES,
+  ROOT_PACKAGE_NAME,
+  bunRuntimeAssetUrl,
+  expectedAgentSdkNativePackage,
+  installArchiveBaseName,
+  installArchiveFormat,
+  installArchiveName,
+  npmInstallPlatformArgs,
+  readBunRuntimeManifest,
+  readCargoPackageMetadata,
+  readJson
+} from "./npm-package-config.mjs";
+import { buildThirdPartyNotices } from "./third-party-notices.mjs";
+import {
+  assertNoSymlinks,
+  commandExists,
+  createTarGzArchive,
+  createZipArchive,
+  fileSha256,
+  listRelativeFiles,
+  readArgValue,
+  requireCommand,
+  writeJson
+} from "./install-archive-common.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const npmCliPath = resolveNpmCliPath();
+
+const options = parseArgs(process.argv.slice(2));
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const cargoPackage = readCargoPackageMetadata(path.join(repoRoot, "Cargo.toml"));
+const rootPackageJson = readJson(path.join(repoRoot, "package.json"));
+const bunRuntimeManifest = readBunRuntimeManifest(repoRoot);
+const version = options.version ?? cargoPackage.version;
+const binaryRoot = path.resolve(repoRoot, options.binaryRoot ?? "dist-platform");
+const outDir = path.resolve(repoRoot, options.outDir ?? "dist-install");
+const manifestsDir = path.join(outDir, "manifests");
+const keptTempRoots = [];
+
+if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+  throw new Error(`Invalid package version: ${version}`);
+}
+
+if (bunRuntimeManifest.version !== BUNDLED_BUN_RUNTIME_VERSION) {
+  throw new Error(
+    `Bun runtime manifest version ${bunRuntimeManifest.version} does not match ${BUNDLED_BUN_RUNTIME_VERSION}`
+  );
+}
+
+assertArchiveToolsAvailable();
+assertAgentSdkBridgeBuilt();
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(manifestsDir, { recursive: true });
+
+for (const platformPackage of PLATFORM_PACKAGES) {
+  generateInstallArchive(platformPackage);
+}
+
+if (keptTempRoots.length > 0) {
+  console.log(`Kept install archive staging roots:\n${keptTempRoots.map((entry) => `- ${entry}`).join("\n")}`);
+}
+
+console.log(`Generated install archives in ${path.relative(repoRoot, outDir)}`);
+
+function assertArchiveToolsAvailable() {
+  requireCommand("tar", "creating Unix install archives");
+  if (commandExists("zip")) {
+    return;
+  }
+  if (process.platform === "win32" && commandExists("powershell.exe")) {
+    return;
+  }
+  throw new Error(
+    "Missing required command 'zip' for creating Windows install archives. " +
+      "Install zip before running this script on non-Windows hosts."
+  );
+}
+
+function assertAgentSdkBridgeBuilt() {
+  const bridgePath = path.join(repoRoot, "agent-sdk", "dist", "bridge.js");
+  const typesPath = path.join(repoRoot, "agent-sdk", "dist", "types.js");
+  if (!fs.existsSync(bridgePath) || !fs.existsSync(typesPath)) {
+    throw new Error(
+      "Missing agent-sdk/dist bridge runtime. Run `npm --prefix agent-sdk run build` before generating install archives."
+    );
+  }
+}
+
+function generateInstallArchive(platformPackage) {
+  const archiveName = installArchiveName(platformPackage, version);
+  const archiveFormat = installArchiveFormat(platformPackage);
+  const appRootName = installArchiveBaseName(platformPackage, version);
+  const archivePath = path.join(outDir, archiveName);
+  const tempParent = fs.mkdtempSync(path.join(os.tmpdir(), `claude-rs-install-${platformPackage.dir}-`));
+  const appRoot = path.join(tempParent, appRootName);
+
+  try {
+    fs.mkdirSync(appRoot, { recursive: true });
+    installProductionDependencies(appRoot, platformPackage);
+    removeInstallOnlyFiles(appRoot);
+    writeJson(path.join(appRoot, "package.json"), buildInstallPackageJson());
+    copyBinaries(platformPackage, appRoot);
+    copyAgentSdkRuntime(path.join(appRoot, "agent-sdk"));
+    copyFileFromRepo("LICENSE", path.join(appRoot, "LICENSE"));
+    fs.writeFileSync(
+      path.join(appRoot, "THIRD-PARTY-NOTICES.md"),
+      buildThirdPartyNotices({ manifest: bunRuntimeManifest }),
+      "utf8"
+    );
+
+    assertNoSymlinks(appRoot, `${platformPackage.dir} install archive staging root`);
+    if (archiveFormat === "tar.gz") {
+      createTarGzArchive({ sourceParent: tempParent, rootName: appRootName, destination: archivePath });
+    } else {
+      createZipArchive({ sourceParent: tempParent, rootName: appRootName, destination: archivePath });
+    }
+
+    writeManifest(platformPackage, appRoot, archiveName, archiveFormat, archivePath);
+  } finally {
+    if (options.keepTemp) {
+      keptTempRoots.push(tempParent);
+    } else {
+      fs.rmSync(tempParent, { recursive: true, force: true });
+    }
+  }
+}
+
+function installProductionDependencies(appRoot, platformPackage) {
+  copyFileFromRepo("package.json", path.join(appRoot, "package.json"));
+  copyFileFromRepo("package-lock.json", path.join(appRoot, "package-lock.json"));
+  runNpm(["ci", "--omit=dev", "--ignore-scripts", ...npmInstallPlatformArgs(platformPackage)], appRoot);
+  pruneProductionNodeModules(appRoot);
+}
+
+function removeInstallOnlyFiles(appRoot) {
+  fs.rmSync(path.join(appRoot, "package-lock.json"), { force: true });
+  fs.rmSync(path.join(appRoot, "node_modules", ".package-lock.json"), { force: true });
+  fs.rmSync(path.join(appRoot, "node_modules", ".bin"), { recursive: true, force: true });
+}
+
+function pruneProductionNodeModules(appRoot) {
+  const nodeModulesDir = path.join(appRoot, "node_modules");
+  if (!fs.existsSync(nodeModulesDir)) {
+    return;
+  }
+  pruneTree(nodeModulesDir);
+}
+
+function pruneTree(currentDir) {
+  for (const entry of fs.readdirSync(currentDir, { withFileTypes: true }).sort(compareDirentNames)) {
+    const fullPath = path.join(currentDir, entry.name);
+
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Refusing to archive symlink from npm install: ${fullPath}`);
+    }
+
+    if (entry.isDirectory()) {
+      if (shouldPruneDirectory(entry.name)) {
+        fs.rmSync(fullPath, { recursive: true, force: true });
+        continue;
+      }
+      pruneTree(fullPath);
+      continue;
+    }
+
+    if (entry.isFile() && shouldPruneFile(entry.name)) {
+      fs.rmSync(fullPath, { force: true });
+    }
+  }
+}
+
+function shouldPruneDirectory(name) {
+  return [".bin", ".cache", ".github", "__tests__", "test", "tests", "src"].includes(name);
+}
+
+function shouldPruneFile(name) {
+  return (
+    name === ".package-lock.json" ||
+    name.endsWith(".log") ||
+    name.endsWith(".map") ||
+    name.endsWith(".test.js") ||
+    name.endsWith(".spec.js") ||
+    name.endsWith(".ts") ||
+    name.endsWith(".mts") ||
+    name.endsWith(".cts")
+  );
+}
+
+function buildInstallPackageJson() {
+  return {
+    name: ROOT_PACKAGE_NAME,
+    version,
+    private: true,
+    description: rootPackageJson.description,
+    license: rootPackageJson.license
+  };
+}
+
+function copyBinaries(platformPackage, appRoot) {
+  const binaryDestination = path.join(appRoot, platformPackage.binaryName);
+  const runtimeDestination = path.join(appRoot, platformPackage.bundledRuntimeName);
+
+  if (options.mockBinaries) {
+    writeMockBinary(platformPackage, binaryDestination, "claude-rs 0.0.0-mock");
+    writeMockBinary(platformPackage, runtimeDestination, bunRuntimeManifest.version);
+    return;
+  }
+
+  copyStagedBinary(
+    platformPackage,
+    path.join(binaryRoot, platformPackage.dir, "bin", platformPackage.binaryName),
+    binaryDestination,
+    "native binary"
+  );
+  copyStagedBinary(
+    platformPackage,
+    path.join(binaryRoot, platformPackage.dir, "bin", platformPackage.bundledRuntimeName),
+    runtimeDestination,
+    "bundled Bun runtime"
+  );
+}
+
+function copyStagedBinary(platformPackage, source, destination, label) {
+  if (!fs.existsSync(source)) {
+    throw new Error(
+      `Missing ${label} for ${platformPackage.dir}: ${path.relative(repoRoot, source)}. ` +
+        "Build/stage binaries first or pass --mock-binaries."
+    );
+  }
+
+  fs.copyFileSync(source, destination);
+  ensureExecutableMode(platformPackage, destination);
+}
+
+function writeMockBinary(platformPackage, destination, output) {
+  const content = platformPackage.os.includes("win32")
+    ? `@echo off\r\necho ${output}\r\n`
+    : `#!/usr/bin/env sh\necho "${output}"\n`;
+
+  fs.writeFileSync(destination, content, "utf8");
+  ensureExecutableMode(platformPackage, destination);
+}
+
+function ensureExecutableMode(platformPackage, destination) {
+  if (!platformPackage.os.includes("win32")) {
+    fs.chmodSync(destination, 0o755);
+  }
+}
+
+function copyAgentSdkRuntime(destinationDir) {
+  const sourceDist = path.join(repoRoot, "agent-sdk", "dist");
+  fs.mkdirSync(destinationDir, { recursive: true });
+  writeJson(path.join(destinationDir, "package.json"), {
+    private: true,
+    type: "module"
+  });
+  copyDirectoryFiltered(sourceDist, path.join(destinationDir, "dist"), (sourcePath) => {
+    const relativePath = path.relative(sourceDist, sourcePath).replaceAll(path.sep, "/");
+    return !relativePath.endsWith(".test.js") && !relativePath.endsWith(".map");
+  });
+}
+
+function copyDirectoryFiltered(sourceDir, destinationDir, includePath) {
+  fs.mkdirSync(destinationDir, { recursive: true });
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true }).sort(compareDirentNames)) {
+    const source = path.join(sourceDir, entry.name);
+    const destination = path.join(destinationDir, entry.name);
+
+    if (!includePath(source)) {
+      continue;
+    }
+
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Refusing to copy symlink into install archive: ${path.relative(repoRoot, source)}`);
+    }
+
+    if (entry.isDirectory()) {
+      copyDirectoryFiltered(source, destination, includePath);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.copyFileSync(source, destination);
+    }
+  }
+}
+
+function writeManifest(platformPackage, appRoot, archiveName, archiveFormat, archivePath) {
+  const runtimeAsset = bunRuntimeManifest.assets?.[platformPackage.dir];
+  if (!runtimeAsset) {
+    throw new Error(`Bun runtime manifest is missing ${platformPackage.dir}`);
+  }
+
+  const files = listRelativeFiles(appRoot);
+  writeJson(path.join(manifestsDir, `${platformPackage.dir}.json`), {
+    manifestVersion: 1,
+    platform: platformPackage.dir,
+    version,
+    archiveName,
+    archiveFormat,
+    archiveSha256: fileSha256(archivePath),
+    fileCount: files.length,
+    files,
+    binaryName: platformPackage.binaryName,
+    expectedAgentSdkNativePackage: expectedAgentSdkNativePackage(platformPackage),
+    bundledRuntime: {
+      name: platformPackage.bundledRuntimeName,
+      version: bunRuntimeManifest.version,
+      sourceAsset: runtimeAsset.assetName,
+      sourceUrl: bunRuntimeAssetUrl(bunRuntimeManifest.version, runtimeAsset.assetName),
+      checksumSourceUrl: bunRuntimeManifest.checksumSourceUrl,
+      archiveBinaryPath: runtimeAsset.archiveBinaryPath,
+      sourceArchiveSha256: runtimeAsset.sha256,
+      runtimeSha256: fileSha256(path.join(appRoot, platformPackage.bundledRuntimeName))
+    }
+  });
+}
+
+function copyFileFromRepo(relativeSource, destination) {
+  const source = path.join(repoRoot, relativeSource);
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(source, destination);
+}
+
+function runNpm(args, cwd) {
+  execFileSync(process.execPath, [npmCliPath, ...args], {
+    cwd,
+    stdio: "inherit",
+    windowsHide: true
+  });
+}
+
+function resolveNpmCliPath() {
+  const candidates = [
+    process.env.npm_execpath,
+    path.join(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js"),
+    path.resolve(path.dirname(process.execPath), "..", "lib", "node_modules", "npm", "bin", "npm-cli.js")
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error("Could not locate npm's CLI entrypoint. Re-run with npm_execpath set to npm-cli.js.");
+}
+
+function compareDirentNames(left, right) {
+  return left.name.localeCompare(right.name);
+}
+
+function parseArgs(args) {
+  const parsed = {
+    help: false,
+    version: undefined,
+    binaryRoot: undefined,
+    outDir: undefined,
+    mockBinaries: false,
+    keepTemp: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--version":
+        parsed.version = readArgValue(args, ++index, arg);
+        break;
+      case "--binary-root":
+        parsed.binaryRoot = readArgValue(args, ++index, arg);
+        break;
+      case "--out-dir":
+        parsed.outDir = readArgValue(args, ++index, arg);
+        break;
+      case "--mock-binaries":
+        parsed.mockBinaries = true;
+        break;
+      case "--keep-temp":
+        parsed.keepTemp = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/generate-install-archives.mjs [options]
+
+Options:
+  --version <version>       Override the package version. Defaults to Cargo.toml.
+  --binary-root <dir>       Directory containing staged platform binaries.
+                            Defaults to dist-platform.
+  --out-dir <dir>           Output directory. Defaults to dist-install.
+  --mock-binaries           Generate placeholder native and runtime binaries for layout tests.
+  --keep-temp               Keep temporary staging roots for debugging.
+  -h, --help                Show this help.
+`);
+}

--- a/scripts/generate-npm-packages.mjs
+++ b/scripts/generate-npm-packages.mjs
@@ -37,6 +37,9 @@ if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
 
 fs.rmSync(outDir, { recursive: true, force: true });
 fs.mkdirSync(outDir, { recursive: true });
+if (options.mockBinaries) {
+  fs.writeFileSync(path.join(outDir, ".mock-binaries"), "mock-binaries\n", "utf8");
+}
 
 generateRootPackage();
 for (const platformPackage of PLATFORM_PACKAGES) {

--- a/scripts/generate-release-bundle.mjs
+++ b/scripts/generate-release-bundle.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  PLATFORM_PACKAGES,
+  ROOT_PACKAGE_NAME,
+  installArchiveName,
+  nativeReleaseAssetName,
+  readBunRuntimeManifest,
+  readCargoPackageMetadata
+} from "./npm-package-config.mjs";
+import {
+  createTarGzArchive,
+  fileSha256,
+  listRelativeFiles,
+  normalizePath,
+  readArgValue,
+  writeJson
+} from "./install-archive-common.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const options = parseArgs(process.argv.slice(2));
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const cargoPackage = readCargoPackageMetadata(path.join(repoRoot, "Cargo.toml"));
+const bunRuntimeManifest = readBunRuntimeManifest(repoRoot);
+const version = options.version ?? cargoPackage.version;
+const assetsDir = path.resolve(repoRoot, options.assetsDir ?? "dist-assets");
+const packDir = path.resolve(repoRoot, options.packDir ?? "dist-pack");
+const npmManifestsDir = path.resolve(repoRoot, options.npmManifestsDir ?? path.join("dist-npm", "manifests"));
+const installManifestsDir = path.resolve(
+  repoRoot,
+  options.installManifestsDir ?? path.join("dist-install", "manifests")
+);
+const installArchivesDir = path.dirname(installManifestsDir);
+const outDir = path.resolve(repoRoot, options.outDir ?? ".");
+const bundleRootName = `${ROOT_PACKAGE_NAME}-${version}-release-bundle`;
+const bundleName = `${bundleRootName}.tar.gz`;
+const bundlePath = path.join(outDir, bundleName);
+const releaseManifestPath = path.join(outDir, "release-manifest.json");
+const internalShaPath = path.join(outDir, "SHA256SUMS.internal");
+const tempParent = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-release-bundle-"));
+const bundleRoot = path.join(tempParent, bundleRootName);
+
+fs.mkdirSync(outDir, { recursive: true });
+fs.rmSync(bundlePath, { force: true });
+fs.rmSync(releaseManifestPath, { force: true });
+fs.rmSync(internalShaPath, { force: true });
+
+try {
+  const inputs = verifyInputs();
+  fs.mkdirSync(bundleRoot, { recursive: true });
+  copyBundleInputs(inputs);
+
+  const releaseManifest = buildReleaseManifest(inputs);
+  writeJson(path.join(bundleRoot, "release-manifest.json"), releaseManifest);
+  writeJson(releaseManifestPath, releaseManifest);
+
+  const internalChecksums = buildInternalChecksums(bundleRoot);
+  fs.writeFileSync(path.join(bundleRoot, "SHA256SUMS.internal"), internalChecksums, "utf8");
+  fs.writeFileSync(internalShaPath, internalChecksums, "utf8");
+
+  verifyNoInstallArchivesInBundle();
+  createTarGzArchive({ sourceParent: tempParent, rootName: bundleRootName, destination: bundlePath });
+} finally {
+  fs.rmSync(tempParent, { recursive: true, force: true });
+}
+
+console.log(`Generated release bundle ${path.relative(repoRoot, bundlePath)}`);
+
+function verifyInputs() {
+  const nativeAssets = PLATFORM_PACKAGES.map((platformPackage) => {
+    const assetName = nativeReleaseAssetName(platformPackage);
+    const assetPath = path.join(assetsDir, assetName);
+    const metadataPath = `${assetPath}.build-metadata.txt`;
+    assertFile(assetPath, `${platformPackage.dir} native binary`);
+    assertFile(metadataPath, `${platformPackage.dir} build metadata`);
+    return {
+      platform: platformPackage.dir,
+      rustTarget: platformPackage.rustTarget,
+      binaryPath: assetPath,
+      metadataPath
+    };
+  });
+
+  const npmTarballs = [
+    {
+      directory: "root",
+      packageName: ROOT_PACKAGE_NAME,
+      tarballPath: path.join(packDir, `${ROOT_PACKAGE_NAME}-${version}.tgz`)
+    },
+    ...PLATFORM_PACKAGES.map((platformPackage) => ({
+      directory: platformPackage.dir,
+      packageName: platformPackage.packageName,
+      tarballPath: path.join(packDir, npmTarballName(platformPackage.packageName, version))
+    }))
+  ];
+  for (const npmTarball of npmTarballs) {
+    assertFile(npmTarball.tarballPath, `${npmTarball.directory} npm tarball`);
+  }
+
+  const npmManifests = ["summary.json", "root.json", ...PLATFORM_PACKAGES.map((entry) => `${entry.dir}.json`)].map(
+    (fileName) => {
+      const manifestPath = path.join(npmManifestsDir, fileName);
+      assertFile(manifestPath, `npm manifest ${fileName}`);
+      return manifestPath;
+    }
+  );
+
+  const installManifests = PLATFORM_PACKAGES.map((platformPackage) => {
+    const manifestPath = path.join(installManifestsDir, `${platformPackage.dir}.json`);
+    assertFile(manifestPath, `${platformPackage.dir} install manifest`);
+    return manifestPath;
+  });
+
+  const installArchives = PLATFORM_PACKAGES.map((platformPackage) => {
+    const archivePath = path.join(installArchivesDir, installArchiveName(platformPackage, version));
+    assertFile(archivePath, `${platformPackage.dir} public install archive`);
+    return {
+      platform: platformPackage.dir,
+      archivePath
+    };
+  });
+
+  return {
+    nativeAssets,
+    npmTarballs,
+    npmManifests,
+    installManifests,
+    installArchives
+  };
+}
+
+function copyBundleInputs(inputs) {
+  for (const nativeAsset of inputs.nativeAssets) {
+    copyIntoBundle(nativeAsset.binaryPath, path.join("dist-assets", path.basename(nativeAsset.binaryPath)));
+    copyIntoBundle(nativeAsset.metadataPath, path.join("dist-assets", path.basename(nativeAsset.metadataPath)));
+  }
+
+  for (const npmTarball of inputs.npmTarballs) {
+    copyIntoBundle(npmTarball.tarballPath, path.join("dist-pack", path.basename(npmTarball.tarballPath)));
+  }
+
+  for (const npmManifest of inputs.npmManifests) {
+    copyIntoBundle(npmManifest, path.join("dist-npm", "manifests", path.basename(npmManifest)));
+  }
+
+  for (const installManifest of inputs.installManifests) {
+    copyIntoBundle(installManifest, path.join("dist-install", "manifests", path.basename(installManifest)));
+  }
+}
+
+function buildReleaseManifest(inputs) {
+  return {
+    manifestVersion: 1,
+    version,
+    bunRuntimeVersion: bunRuntimeManifest.version,
+    generatedAt: new Date(0).toISOString(),
+    targets: PLATFORM_PACKAGES.map((platformPackage) => ({
+      platform: platformPackage.dir,
+      rustTarget: platformPackage.rustTarget,
+      installArchive: installArchiveName(platformPackage, version),
+      nativeBinary: nativeReleaseAssetName(platformPackage),
+      npmPlatformPackage: platformPackage.packageName
+    })),
+    publicAssets: [
+      ...inputs.installArchives.map(({ archivePath }) => ({
+        path: normalizePath(path.relative(repoRoot, archivePath)),
+        sha256: fileSha256(archivePath)
+      })),
+      {
+        path: bundleName,
+        sha256: null
+      },
+      {
+        path: "SHA256SUMS",
+        sha256: null
+      }
+    ],
+    internalBundle: {
+      name: bundleName,
+      rootDirectory: bundleRootName,
+      contents: {
+        nativeAssets: inputs.nativeAssets.map((entry) => ({
+          platform: entry.platform,
+          binaryPath: normalizePath(path.relative(assetsDir, entry.binaryPath)),
+          metadataPath: normalizePath(path.relative(assetsDir, entry.metadataPath))
+        })),
+        npmTarballs: inputs.npmTarballs.map((entry) => ({
+          directory: entry.directory,
+          packageName: entry.packageName,
+          path: normalizePath(path.relative(packDir, entry.tarballPath)),
+          sha256: fileSha256(entry.tarballPath)
+        })),
+        npmManifests: inputs.npmManifests.map((entry) => normalizePath(path.relative(npmManifestsDir, entry))),
+        installManifests: inputs.installManifests.map((entry) =>
+          normalizePath(path.relative(installManifestsDir, entry))
+        )
+      }
+    }
+  };
+}
+
+function buildInternalChecksums(rootDir) {
+  const lines = listRelativeFiles(rootDir)
+    .filter((file) => file !== "SHA256SUMS.internal")
+    .sort()
+    .map((file) => `${fileSha256(path.join(rootDir, ...file.split("/")))}  ${file}`);
+  return `${lines.join("\n")}\n`;
+}
+
+function verifyNoInstallArchivesInBundle() {
+  const files = listRelativeFiles(bundleRoot);
+  const duplicatedArchives = files.filter(
+    (file) => file.startsWith("dist-install/") && (file.endsWith(".tar.gz") || file.endsWith(".zip"))
+  );
+  if (duplicatedArchives.length > 0) {
+    throw new Error(
+      `Release bundle must not contain complete install archives:\n${duplicatedArchives
+        .map((file) => `- ${file}`)
+        .join("\n")}`
+    );
+  }
+}
+
+function copyIntoBundle(source, relativeDestination) {
+  const destination = path.join(bundleRoot, ...relativeDestination.split("/"));
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(source, destination);
+}
+
+function assertFile(filePath, label) {
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+    throw new Error(`Missing ${label}: ${path.relative(repoRoot, filePath)}`);
+  }
+}
+
+function npmTarballName(packageName, packageVersion) {
+  return `${packageName.replace(/^@/, "").replace("/", "-")}-${packageVersion}.tgz`;
+}
+
+function parseArgs(args) {
+  const parsed = {
+    help: false,
+    version: undefined,
+    assetsDir: undefined,
+    packDir: undefined,
+    npmManifestsDir: undefined,
+    installManifestsDir: undefined,
+    outDir: undefined
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--version":
+        parsed.version = readArgValue(args, ++index, arg);
+        break;
+      case "--assets-dir":
+        parsed.assetsDir = readArgValue(args, ++index, arg);
+        break;
+      case "--pack-dir":
+        parsed.packDir = readArgValue(args, ++index, arg);
+        break;
+      case "--npm-manifests-dir":
+        parsed.npmManifestsDir = readArgValue(args, ++index, arg);
+        break;
+      case "--install-manifests-dir":
+        parsed.installManifestsDir = readArgValue(args, ++index, arg);
+        break;
+      case "--out-dir":
+        parsed.outDir = readArgValue(args, ++index, arg);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/generate-release-bundle.mjs [options]
+
+Options:
+  --version <version>              Override the package version. Defaults to Cargo.toml.
+  --assets-dir <dir>               Native binary asset directory. Defaults to dist-assets.
+  --pack-dir <dir>                 npm tarball directory. Defaults to dist-pack.
+  --npm-manifests-dir <dir>        npm manifest directory. Defaults to dist-npm/manifests.
+  --install-manifests-dir <dir>    install manifest directory. Defaults to dist-install/manifests.
+  --out-dir <dir>                  Output directory. Defaults to repository root.
+  -h, --help                       Show this help.
+`);
+}

--- a/scripts/install-archive-common.mjs
+++ b/scripts/install-archive-common.mjs
@@ -1,0 +1,253 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+export function normalizePath(filePath) {
+  return filePath.replaceAll(path.sep, "/");
+}
+
+export function fileSha256(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+export function writeJson(destination, value) {
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(destination, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+export function readJson(jsonPath) {
+  return JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+}
+
+export function readArgValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+export function listRelativeFiles(rootDir) {
+  const files = [];
+  collectFiles(rootDir, rootDir, files);
+  return files.sort();
+}
+
+function collectFiles(rootDir, currentDir, files) {
+  for (const entry of fs.readdirSync(currentDir, { withFileTypes: true }).sort(compareDirentNames)) {
+    const fullPath = path.join(currentDir, entry.name);
+    const relativePath = normalizePath(path.relative(rootDir, fullPath));
+
+    if (entry.isDirectory()) {
+      collectFiles(rootDir, fullPath, files);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      files.push(relativePath);
+    }
+  }
+}
+
+export function findSymlinks(rootDir) {
+  const symlinks = [];
+  collectSymlinks(rootDir, rootDir, symlinks);
+  return symlinks.sort();
+}
+
+function collectSymlinks(rootDir, currentDir, symlinks) {
+  for (const entryName of fs.readdirSync(currentDir).sort()) {
+    const fullPath = path.join(currentDir, entryName);
+    const relativePath = normalizePath(path.relative(rootDir, fullPath));
+    const stat = fs.lstatSync(fullPath);
+
+    if (stat.isSymbolicLink()) {
+      symlinks.push(relativePath);
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      collectSymlinks(rootDir, fullPath, symlinks);
+    }
+  }
+}
+
+export function assertNoSymlinks(rootDir, context) {
+  const symlinks = findSymlinks(rootDir);
+  if (symlinks.length > 0) {
+    throw new Error(`${context} contains symlinks:\n${symlinks.map((entry) => `- ${entry}`).join("\n")}`);
+  }
+}
+
+export function commandExists(command) {
+  try {
+    if (process.platform === "win32") {
+      execFileSync("where.exe", [command], { stdio: "ignore", windowsHide: true });
+    } else {
+      execFileSync("sh", ["-c", `command -v "$1" >/dev/null 2>&1`, "sh", command], {
+        stdio: "ignore",
+        windowsHide: true
+      });
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function requireCommand(command, purpose) {
+  if (!commandExists(command)) {
+    throw new Error(`Missing required command '${command}' for ${purpose}`);
+  }
+}
+
+export function createTarGzArchive({ sourceParent, rootName, destination }) {
+  requireCommand("tar", "creating tar.gz install archives");
+  fs.rmSync(destination, { force: true });
+
+  if (tarSupportsDeterministicOptions()) {
+    const deterministicArgs = [
+      "--sort=name",
+      "--mtime=@0",
+      "--owner=0",
+      "--group=0",
+      "--numeric-owner",
+      "-czf",
+      destination,
+      rootName
+    ];
+
+    execFileSync("tar", deterministicArgs, {
+      cwd: sourceParent,
+      stdio: "inherit",
+      windowsHide: true
+    });
+    return;
+  }
+
+  execFileSync("tar", ["-czf", destination, rootName], {
+    cwd: sourceParent,
+    stdio: "inherit",
+    windowsHide: true
+  });
+}
+
+export function createZipArchive({ sourceParent, rootName, destination }) {
+  fs.rmSync(destination, { force: true });
+
+  if (commandExists("zip")) {
+    execFileSync("zip", ["-X", "-r", destination, rootName], {
+      cwd: sourceParent,
+      stdio: "inherit",
+      windowsHide: true
+    });
+    return;
+  }
+
+  if (process.platform === "win32" && commandExists("powershell.exe")) {
+    execFileSync(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        `Compress-Archive -LiteralPath ${powerShellSingleQuote(
+          path.join(sourceParent, rootName)
+        )} -DestinationPath ${powerShellSingleQuote(destination)} -Force`
+      ],
+      { stdio: "inherit", windowsHide: true }
+    );
+    return;
+  }
+
+  throw new Error(
+    "Missing required command 'zip' for creating Windows install archives. " +
+      "Install zip, or run this script on Windows where Compress-Archive is available."
+  );
+}
+
+export function extractArchive({ archivePath, destinationDir }) {
+  fs.rmSync(destinationDir, { recursive: true, force: true });
+  fs.mkdirSync(destinationDir, { recursive: true });
+
+  if (archivePath.endsWith(".tar.gz")) {
+    requireCommand("tar", "extracting tar.gz install archives");
+    execFileSync("tar", ["-xzf", archivePath, "-C", destinationDir], {
+      stdio: "inherit",
+      windowsHide: true
+    });
+    return;
+  }
+
+  if (archivePath.endsWith(".zip")) {
+    if (commandExists("unzip")) {
+      execFileSync("unzip", ["-q", archivePath, "-d", destinationDir], {
+        stdio: "inherit",
+        windowsHide: true
+      });
+      return;
+    }
+
+    if (process.platform === "win32" && commandExists("powershell.exe")) {
+      execFileSync(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-Command",
+          `Expand-Archive -LiteralPath ${powerShellSingleQuote(
+            archivePath
+          )} -DestinationPath ${powerShellSingleQuote(destinationDir)} -Force`
+        ],
+        { stdio: "inherit", windowsHide: true }
+      );
+      return;
+    }
+
+    throw new Error(
+      "Missing required command 'unzip' for extracting Windows install archives. " +
+        "Install unzip, or run this script on Windows where Expand-Archive is available."
+    );
+  }
+
+  throw new Error(`Unsupported archive format: ${archivePath}`);
+}
+
+export function findSingleTopLevelDirectory(extractDir) {
+  const entries = fs.readdirSync(extractDir, { withFileTypes: true });
+  const dirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  const otherEntries = entries.filter((entry) => !entry.isDirectory()).map((entry) => entry.name);
+
+  if (dirs.length !== 1 || otherEntries.length !== 0) {
+    throw new Error(
+      `Expected exactly one top-level directory in ${extractDir}; ` +
+        `dirs=${JSON.stringify(dirs)}, files=${JSON.stringify(otherEntries)}`
+    );
+  }
+
+  return path.join(extractDir, dirs[0]);
+}
+
+function compareDirentNames(left, right) {
+  return left.name.localeCompare(right.name);
+}
+
+function powerShellSingleQuote(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function tarSupportsDeterministicOptions() {
+  try {
+    const output = execFileSync("tar", ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true
+    });
+    return output.includes("GNU tar");
+  } catch {
+    return false;
+  }
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,285 @@
+param(
+    [string]$Release,
+    [string]$InstallDir,
+    [switch]$Yes,
+    [switch]$NoModifyPath,
+    [switch]$Help
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$RepoOwner = "srothgan"
+$RepoName = "claude-code-rust"
+$RepoSlug = "$RepoOwner/$RepoName"
+$RootPackage = "claude-code-rust"
+
+function Show-Usage {
+    @"
+Usage: install.ps1 [options]
+
+Options:
+  -Release <version>      Release tag or version. Defaults to latest.
+  -InstallDir <dir>      App install directory.
+  -Yes                   Accept prompts.
+  -NoModifyPath          Do not update the user PATH.
+  -Help                  Show this help.
+
+Environment:
+  CLAUDE_RS_RELEASE
+  CLAUDE_RS_INSTALL_DIR
+  CLAUDE_RS_NON_INTERACTIVE
+  CLAUDE_RS_NO_MODIFY_PATH
+"@
+}
+
+if ($Help) {
+    Show-Usage
+    exit 0
+}
+
+function Test-TruthyEnv {
+    param([string]$Name)
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    return $value -match "^(1|true|TRUE|yes|YES)$"
+}
+
+if (-not $PSBoundParameters.ContainsKey("Release") -or [string]::IsNullOrWhiteSpace($Release)) {
+    $Release = if ($env:CLAUDE_RS_RELEASE) { $env:CLAUDE_RS_RELEASE } else { "latest" }
+}
+
+if (-not $PSBoundParameters.ContainsKey("InstallDir") -or [string]::IsNullOrWhiteSpace($InstallDir)) {
+    if ($env:CLAUDE_RS_INSTALL_DIR) {
+        $InstallDir = $env:CLAUDE_RS_INSTALL_DIR
+    } else {
+        $localAppData = if ($env:LOCALAPPDATA) {
+            $env:LOCALAPPDATA
+        } else {
+            [Environment]::GetFolderPath([Environment+SpecialFolder]::LocalApplicationData)
+        }
+        $InstallDir = Join-Path $localAppData "Programs\claude-rs"
+    }
+}
+
+$NonInteractive = Test-TruthyEnv "CLAUDE_RS_NON_INTERACTIVE"
+if ($env:CI) {
+    $NonInteractive = $true
+}
+if (Test-TruthyEnv "CLAUDE_RS_NO_MODIFY_PATH") {
+    $NoModifyPath = $true
+}
+
+function Fail {
+    param([string]$Message)
+    throw $Message
+}
+
+function Fail-Unavailable {
+    [Console]::Error.WriteLine("install script is currently not available for this release")
+    exit 1
+}
+
+function Resolve-ReleaseTag {
+    param([string]$RequestedRelease, [string]$TempDir)
+    if ([string]::IsNullOrWhiteSpace($RequestedRelease) -or $RequestedRelease -eq "latest") {
+        $latestJson = Join-Path $TempDir "latest.json"
+        Invoke-WebRequest -Uri "https://api.github.com/repos/$RepoSlug/releases/latest" -OutFile $latestJson
+        $releaseInfo = Get-Content -LiteralPath $latestJson -Raw | ConvertFrom-Json
+        if (-not $releaseInfo.tag_name) {
+            Fail "could not parse latest GitHub Release tag"
+        }
+        return [string]$releaseInfo.tag_name
+    }
+    if ($RequestedRelease.StartsWith("v", [StringComparison]::Ordinal)) {
+        return $RequestedRelease
+    }
+    return "v$RequestedRelease"
+}
+
+function Get-Target {
+    $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    switch ($architecture) {
+        "X64" { return "win32-x64-msvc" }
+        "Arm64" { return "win32-arm64-msvc" }
+        default { Fail "unsupported Windows architecture: $architecture" }
+    }
+}
+
+function Get-ArchiveName {
+    param([string]$Target, [string]$Tag)
+    $version = $Tag.TrimStart("v")
+    return "$RootPackage-$version-$Target.zip"
+}
+
+function Get-ExpectedSha256 {
+    param([string]$ChecksumsPath, [string]$ArchiveName)
+    $expectedPath = "dist-install/$ArchiveName"
+    foreach ($line in Get-Content -LiteralPath $ChecksumsPath) {
+        if ($line -match "^([A-Fa-f0-9]{64})\s+\*?$([regex]::Escape($expectedPath))$") {
+            return $Matches[1].ToLowerInvariant()
+        }
+    }
+    Fail "SHA256SUMS does not contain $expectedPath"
+}
+
+function Assert-NoReparsePoints {
+    param([string]$Path)
+    $reparsePoints = Get-ChildItem -LiteralPath $Path -Recurse -Force |
+        Where-Object { ($_.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0 }
+    if ($reparsePoints) {
+        $joined = ($reparsePoints | ForEach-Object { $_.FullName }) -join [Environment]::NewLine
+        Fail "archive contains reparse points or symlinks:$([Environment]::NewLine)$joined"
+    }
+}
+
+function Assert-RequiredFiles {
+    param([string]$AppRoot)
+    $requiredFiles = @(
+        "claude-rs.exe",
+        "claude-rs-bridge-bun.exe",
+        "package.json",
+        "THIRD-PARTY-NOTICES.md",
+        "agent-sdk\package.json",
+        "agent-sdk\dist\bridge.js",
+        "agent-sdk\dist\types.js",
+        "node_modules\@anthropic-ai\claude-agent-sdk\package.json"
+    )
+    foreach ($relativePath in $requiredFiles) {
+        $fullPath = Join-Path $AppRoot $relativePath
+        if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+            Fail "archive is missing required file: $relativePath"
+        }
+    }
+}
+
+function Acquire-InstallLock {
+    param([string]$InstallParent)
+    New-Item -ItemType Directory -Path $InstallParent -Force | Out-Null
+    $lockPath = Join-Path $InstallParent ".claude-rs-install.lock"
+    return [System.IO.File]::Open($lockPath, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+}
+
+function Replace-AppDirectory {
+    param([string]$SourceApp, [string]$FinalApp)
+    $backup = $null
+    if (Test-Path -LiteralPath $FinalApp) {
+        $backup = "$FinalApp.backup.$PID"
+        Move-Item -LiteralPath $FinalApp -Destination $backup
+    }
+
+    try {
+        Move-Item -LiteralPath $SourceApp -Destination $FinalApp
+        if ($backup -and (Test-Path -LiteralPath $backup)) {
+            Remove-Item -LiteralPath $backup -Recurse -Force
+        }
+    } catch {
+        if ($backup -and (Test-Path -LiteralPath $backup) -and -not (Test-Path -LiteralPath $FinalApp)) {
+            Move-Item -LiteralPath $backup -Destination $FinalApp
+        }
+        throw
+    }
+}
+
+function Split-PathEntries {
+    param([string]$PathValue)
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        return @()
+    }
+    return $PathValue.Split([IO.Path]::PathSeparator, [StringSplitOptions]::RemoveEmptyEntries)
+}
+
+function Add-UserPath {
+    param([string]$Directory)
+    if ($NoModifyPath) {
+        return $false
+    }
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $entries = @(Split-PathEntries $userPath)
+    $alreadyPresent = $entries | Where-Object { $_.TrimEnd("\") -ieq $Directory.TrimEnd("\") }
+    if ($alreadyPresent) {
+        return $false
+    }
+    $newEntries = @($entries + $Directory)
+    [Environment]::SetEnvironmentVariable("Path", ($newEntries -join [IO.Path]::PathSeparator), "User")
+    return $true
+}
+
+function Prepend-ProcessPath {
+    param([string]$Directory)
+    $env:Path = "$Directory$([IO.Path]::PathSeparator)$env:Path"
+}
+
+function Invoke-ClaudeRs {
+    param([string[]]$CommandArgs)
+    & "claude-rs" @CommandArgs
+}
+
+$tempDir = Join-Path ([IO.Path]::GetTempPath()) "claude-rs-install-$PID"
+$lockStream = $null
+$pathChanged = $false
+
+try {
+    Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    $target = Get-Target
+    $tag = Resolve-ReleaseTag -RequestedRelease $Release -TempDir $tempDir
+    $archiveName = Get-ArchiveName -Target $target -Tag $tag
+    $baseUrl = "https://github.com/$RepoSlug/releases/download/$tag"
+    $checksumsPath = Join-Path $tempDir "SHA256SUMS"
+    $archivePath = Join-Path $tempDir $archiveName
+
+    Write-Host "Installing claude-rs $tag for $target"
+    Invoke-WebRequest -Uri "$baseUrl/SHA256SUMS" -OutFile $checksumsPath
+    try {
+        Invoke-WebRequest -Uri "$baseUrl/$archiveName" -OutFile $archivePath
+    } catch {
+        Fail-Unavailable
+    }
+
+    $expectedSha = Get-ExpectedSha256 -ChecksumsPath $checksumsPath -ArchiveName $archiveName
+    $actualSha = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualSha -ne $expectedSha) {
+        Fail "checksum mismatch for $archiveName"
+    }
+
+    $extractDir = Join-Path $tempDir "extract"
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir -Force
+    $topLevelDirs = @(Get-ChildItem -LiteralPath $extractDir -Directory)
+    $topLevelFiles = @(Get-ChildItem -LiteralPath $extractDir -File)
+    if ($topLevelDirs.Count -ne 1 -or $topLevelFiles.Count -ne 0) {
+        Fail "archive extraction did not produce exactly one app directory"
+    }
+
+    $extractedApp = $topLevelDirs[0].FullName
+    Assert-NoReparsePoints -Path $extractedApp
+    Assert-RequiredFiles -AppRoot $extractedApp
+
+    $installParent = Split-Path -Parent $InstallDir
+    $lockStream = Acquire-InstallLock -InstallParent $installParent
+    Replace-AppDirectory -SourceApp $extractedApp -FinalApp $InstallDir
+
+    $pathChanged = Add-UserPath -Directory $InstallDir
+    Prepend-ProcessPath -Directory $InstallDir
+
+    Invoke-ClaudeRs @("--version")
+    Invoke-ClaudeRs @("--help") | Out-Null
+    Invoke-ClaudeRs @("doctor", "--strict")
+
+    $resolvedCommand = Get-Command "claude-rs" -ErrorAction SilentlyContinue
+    $resolved = if ($resolvedCommand) { $resolvedCommand.Source } else { $null }
+    $expectedCommand = Join-Path $InstallDir "claude-rs.exe"
+    if ($resolved -and ($resolved.TrimEnd("\") -ine $expectedCommand.TrimEnd("\"))) {
+        Write-Warning "claude-rs resolves to $resolved instead of $expectedCommand"
+    }
+    if ($pathChanged) {
+        Write-Host "Updated the user PATH. Reopen your shell to use claude-rs in new sessions."
+    }
+    Write-Host "Installed claude-rs to $InstallDir"
+} finally {
+    if ($lockStream) {
+        $lockStream.Dispose()
+    }
+    Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,436 @@
+#!/bin/sh
+set -eu
+
+repo_owner="srothgan"
+repo_name="claude-code-rust"
+repo_slug="$repo_owner/$repo_name"
+root_package="claude-code-rust"
+
+release="${CLAUDE_RS_RELEASE:-latest}"
+install_dir="${CLAUDE_RS_INSTALL_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/claude-rs}"
+bin_dir="${CLAUDE_RS_BIN_DIR:-$HOME/.local/bin}"
+yes=0
+non_interactive=0
+no_modify_path=0
+
+case "${CLAUDE_RS_NON_INTERACTIVE:-}" in
+  1 | true | TRUE | yes | YES) non_interactive=1 ;;
+esac
+case "${CLAUDE_RS_NO_MODIFY_PATH:-}" in
+  1 | true | TRUE | yes | YES) no_modify_path=1 ;;
+esac
+if [ -n "${CI:-}" ]; then
+  non_interactive=1
+fi
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [options]
+
+Options:
+  --release <version>       Release tag or version. Defaults to latest.
+  --install-dir <dir>       App install directory.
+  --bin-dir <dir>           Directory for the claude-rs launcher.
+  --yes, -y                 Accept prompts.
+  --non-interactive         Do not prompt.
+  --no-modify-path          Do not update shell profile PATH.
+  --help                    Show this help.
+
+Environment:
+  CLAUDE_RS_RELEASE
+  CLAUDE_RS_INSTALL_DIR
+  CLAUDE_RS_BIN_DIR
+  CLAUDE_RS_NON_INTERACTIVE
+  CLAUDE_RS_NO_MODIFY_PATH
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --release)
+      shift
+      [ "$#" -gt 0 ] || { echo "missing value for --release" >&2; exit 1; }
+      release="$1"
+      ;;
+    --install-dir)
+      shift
+      [ "$#" -gt 0 ] || { echo "missing value for --install-dir" >&2; exit 1; }
+      install_dir="$1"
+      ;;
+    --bin-dir)
+      shift
+      [ "$#" -gt 0 ] || { echo "missing value for --bin-dir" >&2; exit 1; }
+      bin_dir="$1"
+      ;;
+    --yes | -y)
+      yes=1
+      ;;
+    --non-interactive)
+      non_interactive=1
+      ;;
+    --no-modify-path)
+      no_modify_path=1
+      ;;
+    --help | -h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+info() {
+  printf '%s\n' "$*"
+}
+
+warn() {
+  printf 'warning: %s\n' "$*" >&2
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+die_unavailable() {
+  printf '%s\n' "install script is currently not available for this release" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+download() {
+  url="$1"
+  destination="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$destination"
+    return $?
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -q -O "$destination" "$url"
+    return $?
+  fi
+  die "required command not found: curl or wget"
+}
+
+sha256_file() {
+  file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | sed 's/[ 	].*//'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | sed 's/[ 	].*//'
+    return
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$file" | sed 's/^.*= //'
+    return
+  fi
+  die "required command not found: sha256sum, shasum, or openssl"
+}
+
+json_tag_name() {
+  sed -n 's/.*"tag_name"[ 	]*:[ 	]*"\([^"]*\)".*/\1/p' "$1" | sed -n '1p'
+}
+
+resolve_tag() {
+  requested="$1"
+  case "$requested" in
+    latest | "")
+      latest_json="$tmpdir/latest.json"
+      download "https://api.github.com/repos/$repo_slug/releases/latest" "$latest_json" ||
+        die "could not resolve latest GitHub Release"
+      tag="$(json_tag_name "$latest_json")"
+      [ -n "$tag" ] || die "could not parse latest GitHub Release tag"
+      printf '%s\n' "$tag"
+      ;;
+    v*)
+      printf '%s\n' "$requested"
+      ;;
+    *)
+      printf 'v%s\n' "$requested"
+      ;;
+  esac
+}
+
+detect_target() {
+  os_name="$(uname -s)"
+  machine="$(uname -m)"
+  case "$os_name:$machine" in
+    Darwin:arm64 | Darwin:aarch64)
+      printf '%s\n' "darwin-arm64"
+      ;;
+    Darwin:x86_64)
+      if command -v sysctl >/dev/null 2>&1 && [ "$(sysctl -n hw.optional.arm64 2>/dev/null || printf 0)" = "1" ]; then
+        printf '%s\n' "darwin-arm64"
+      else
+        printf '%s\n' "darwin-x64"
+      fi
+      ;;
+    Linux:x86_64 | Linux:amd64)
+      require_glibc
+      printf '%s\n' "linux-x64-gnu"
+      ;;
+    Linux:aarch64 | Linux:arm64)
+      require_glibc
+      printf '%s\n' "linux-arm64-gnu"
+      ;;
+    Linux:*)
+      die "unsupported Linux architecture: $machine"
+      ;;
+    *)
+      die "unsupported platform: $os_name $machine"
+      ;;
+  esac
+}
+
+require_glibc() {
+  if command -v getconf >/dev/null 2>&1 && getconf GNU_LIBC_VERSION >/dev/null 2>&1; then
+    return
+  fi
+  if command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | sed -n '1p' | grep -qi 'glibc\|gnu libc'; then
+    return
+  fi
+  die "unsupported Linux libc: install script archives currently require glibc. Use npm or build from source on musl systems."
+}
+
+archive_name_for_target() {
+  target="$1"
+  version="${tag#v}"
+  case "$target" in
+    darwin-arm64 | darwin-x64 | linux-arm64-gnu | linux-x64-gnu)
+      printf '%s\n' "$root_package-$version-$target.tar.gz"
+      ;;
+    *)
+      die "unsupported Unix install target: $target"
+      ;;
+  esac
+}
+
+checksum_for_archive() {
+  checksum_file="$1"
+  archive="$2"
+  expected_path="dist-install/$archive"
+  while read -r sha file rest; do
+    [ -z "${rest:-}" ] || continue
+    case "$file" in
+      "$expected_path" | "*$expected_path")
+        printf '%s\n' "$sha"
+        return
+        ;;
+    esac
+  done < "$checksum_file"
+}
+
+validate_tar_listing() {
+  archive="$1"
+  top=""
+  tar -tzf "$archive" | while IFS= read -r entry; do
+    case "$entry" in
+      "" | /* | ../* | */../* | */..)
+        echo "unsafe archive path: $entry" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if tar -tvzf "$archive" | sed -n '/^l/p' | sed -n '1p' | grep . >/dev/null 2>&1; then
+    die "archive contains symlinks"
+  fi
+
+  top="$(tar -tzf "$archive" | sed 's|/.*||' | sed '/^$/d' | sort -u | sed -n '1p')"
+  top_count="$(tar -tzf "$archive" | sed 's|/.*||' | sed '/^$/d' | sort -u | wc -l | sed 's/[ 	]//g')"
+  [ "$top_count" = "1" ] || die "archive must contain exactly one top-level directory"
+  [ -n "$top" ] || die "archive top-level directory is empty"
+}
+
+validate_extracted_app() {
+  app="$1"
+  for required in \
+    "$binary_name" \
+    "$runtime_name" \
+    "package.json" \
+    "THIRD-PARTY-NOTICES.md" \
+    "agent-sdk/package.json" \
+    "agent-sdk/dist/bridge.js" \
+    "agent-sdk/dist/types.js" \
+    "node_modules/@anthropic-ai/claude-agent-sdk/package.json"
+  do
+    [ -f "$app/$required" ] || die "archive is missing required file: $required"
+  done
+  [ -x "$app/$binary_name" ] || die "installed binary is not executable"
+  [ -x "$app/$runtime_name" ] || die "bundled Bun runtime is not executable"
+}
+
+acquire_lock() {
+  parent="$1"
+  lock_dir="$parent/.claude-rs-install.lock"
+  if mkdir "$lock_dir" 2>/dev/null; then
+    printf '%s\n' "$lock_dir"
+    return
+  fi
+  die "another claude-rs installer appears to be running: $lock_dir"
+}
+
+replace_app_dir() {
+  source_app="$1"
+  final_app="$2"
+  backup=""
+  if [ -e "$final_app" ]; then
+    backup="$final_app.backup.$$"
+    mv "$final_app" "$backup" || die "could not move existing install directory to backup"
+  fi
+  if mv "$source_app" "$final_app"; then
+    [ -z "$backup" ] || rm -rf "$backup"
+    return
+  fi
+  if [ -n "$backup" ] && [ -e "$backup" ]; then
+    mv "$backup" "$final_app" || true
+  fi
+  die "could not move new app into install directory"
+}
+
+write_launcher() {
+  mkdir -p "$bin_dir"
+  launcher="$bin_dir/claude-rs"
+  tmp_launcher="$launcher.tmp.$$"
+  app_binary="$install_dir/$binary_name"
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf "exec '%s' \"\$@\"\n" "$(printf '%s' "$app_binary" | sed "s/'/'\\\\''/g")"
+  } > "$tmp_launcher"
+  chmod 755 "$tmp_launcher"
+  mv "$tmp_launcher" "$launcher"
+}
+
+manual_path_line() {
+  if [ "$bin_dir" = "$HOME/.local/bin" ]; then
+    # shellcheck disable=SC2016
+    printf '%s\n' 'export PATH="$HOME/.local/bin:$PATH"'
+  else
+    # shellcheck disable=SC2016
+    printf 'export PATH="%s:$PATH"\n' "$bin_dir"
+  fi
+}
+
+path_has_bin_dir() {
+  case ":$PATH:" in
+    *":$bin_dir:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+maybe_update_path() {
+  path_has_bin_dir && return
+  [ "$no_modify_path" -eq 1 ] && {
+    info "Add this to your shell profile:"
+    manual_path_line
+    return
+  }
+
+  should_modify=0
+  if [ "$yes" -eq 1 ]; then
+    should_modify=1
+  elif [ "$non_interactive" -eq 0 ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
+    printf 'Add %s to PATH in %s? [y/N] ' "$bin_dir" "$HOME/.profile" > /dev/tty
+    IFS= read -r answer < /dev/tty || answer=
+    case "$answer" in
+      y | Y | yes | YES) should_modify=1 ;;
+    esac
+  fi
+
+  if [ "$should_modify" -eq 1 ]; then
+    profile="$HOME/.profile"
+    {
+      printf '\n# claude-rs PATH start\n'
+      manual_path_line
+      printf '# claude-rs PATH end\n'
+    } >> "$profile"
+    info "Updated PATH in $profile"
+  else
+    info "Add this to your shell profile:"
+    manual_path_line
+  fi
+}
+
+need_cmd uname
+need_cmd mktemp
+need_cmd mkdir
+need_cmd mv
+need_cmd rm
+need_cmd tar
+need_cmd chmod
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/claude-rs-install.XXXXXX")"
+cleanup() {
+  [ -z "${lock_dir:-}" ] || rm -rf "$lock_dir"
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT HUP INT TERM
+
+target="$(detect_target)"
+case "$target" in
+  darwin-* | linux-*)
+    binary_name="claude-rs"
+    runtime_name="claude-rs-bridge-bun"
+    ;;
+  *)
+    die "unsupported Unix install target: $target"
+    ;;
+esac
+
+tag="$(resolve_tag "$release")"
+archive_name="$(archive_name_for_target "$target")"
+base_url="https://github.com/$repo_slug/releases/download/$tag"
+checksum_file="$tmpdir/SHA256SUMS"
+archive_file="$tmpdir/$archive_name"
+
+info "Installing claude-rs $tag for $target"
+download "$base_url/SHA256SUMS" "$checksum_file" || die "could not download SHA256SUMS for $tag"
+if ! download "$base_url/$archive_name" "$archive_file"; then
+  die_unavailable
+fi
+
+expected_sha="$(checksum_for_archive "$checksum_file" "$archive_name")"
+[ -n "$expected_sha" ] || die "SHA256SUMS does not contain dist-install/$archive_name"
+actual_sha="$(sha256_file "$archive_file")"
+[ "$actual_sha" = "$expected_sha" ] || die "checksum mismatch for $archive_name"
+
+validate_tar_listing "$archive_file"
+extract_dir="$tmpdir/extract"
+mkdir -p "$extract_dir"
+tar -xzf "$archive_file" -C "$extract_dir"
+set -- "$extract_dir"/*
+[ "$#" -eq 1 ] && [ -d "$1" ] || die "archive extraction did not produce exactly one app directory"
+extracted_app="$1"
+validate_extracted_app "$extracted_app"
+
+install_parent="$(dirname "$install_dir")"
+mkdir -p "$install_parent"
+lock_dir="$(acquire_lock "$install_parent")"
+replace_app_dir "$extracted_app" "$install_dir"
+write_launcher
+
+maybe_update_path
+PATH="$bin_dir:$PATH"
+export PATH
+
+claude-rs --version
+claude-rs --help >/dev/null
+claude-rs doctor --strict
+
+resolved="$(command -v claude-rs || true)"
+launcher="$bin_dir/claude-rs"
+if [ "$resolved" != "$launcher" ]; then
+  warn "claude-rs resolves to $resolved instead of $launcher"
+fi
+
+info "Installed claude-rs to $install_dir"

--- a/scripts/npm-package-config.mjs
+++ b/scripts/npm-package-config.mjs
@@ -185,6 +185,37 @@ export function buildPlatformPackageJson({ platformPackage, version, rootPackage
   });
 }
 
+export function installArchiveFormat(platformPackage) {
+  return platformPackage.os.includes("win32") ? "zip" : "tar.gz";
+}
+
+export function installArchiveName(platformPackage, version) {
+  return `${ROOT_PACKAGE_NAME}-${version}-${platformPackage.dir}.${installArchiveFormat(platformPackage)}`;
+}
+
+export function installArchiveBaseName(platformPackage, version) {
+  return `${ROOT_PACKAGE_NAME}-${version}-${platformPackage.dir}`;
+}
+
+export function expectedAgentSdkNativePackage(platformPackage) {
+  const osName = platformPackage.os[0];
+  const cpuName = platformPackage.cpu[0];
+  return `@anthropic-ai/claude-agent-sdk-${osName === "linux" ? "linux" : osName}-${cpuName}`;
+}
+
+export function npmInstallPlatformArgs(platformPackage) {
+  return [
+    `--os=${platformPackage.os[0]}`,
+    `--cpu=${platformPackage.cpu[0]}`,
+    platformPackage.libc?.[0] ? `--libc=${platformPackage.libc[0]}` : undefined
+  ].filter(Boolean);
+}
+
+export function nativeReleaseAssetName(platformPackage) {
+  const extension = platformPackage.os.includes("win32") ? ".exe" : "";
+  return `${ROOT_PACKAGE_NAME}-${platformPackage.rustTarget}${extension}`;
+}
+
 function removeUndefined(value) {
   if (Array.isArray(value)) {
     return value.map(removeUndefined);

--- a/scripts/smoke-install-archive.mjs
+++ b/scripts/smoke-install-archive.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  PLATFORM_PACKAGES,
+  installArchiveBaseName,
+  installArchiveName,
+  readCargoPackageMetadata
+} from "./npm-package-config.mjs";
+import { envWithoutSystemRuntimePath } from "./smoke-npm-package-install.mjs";
+import {
+  extractArchive,
+  findSingleTopLevelDirectory,
+  normalizePath,
+  readArgValue
+} from "./install-archive-common.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const options = parseArgs(process.argv.slice(2));
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const cargoPackage = readCargoPackageMetadata(path.join(repoRoot, "Cargo.toml"));
+const version = options.version ?? cargoPackage.version;
+const archiveRoot = path.resolve(repoRoot, options.archiveRoot ?? "dist-install");
+const platformDir = options.platform ?? "linux-x64-gnu";
+const platformPackage = PLATFORM_PACKAGES.find((entry) => entry.dir === platformDir);
+
+if (!platformPackage) {
+  throw new Error(
+    `Unknown platform package directory: ${platformDir}. Expected one of: ${PLATFORM_PACKAGES.map((entry) => entry.dir).join(", ")}`
+  );
+}
+
+assertHostCanSmokePlatform(platformPackage);
+
+const archiveName = installArchiveName(platformPackage, version);
+const archivePath = path.join(archiveRoot, archiveName);
+if (!fs.existsSync(archivePath)) {
+  throw new Error(`Missing install archive: ${path.relative(repoRoot, archivePath)}`);
+}
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-install-smoke-"));
+try {
+  const extractDir = path.join(tempDir, "extract");
+  extractArchive({ archivePath, destinationDir: extractDir });
+  const appRoot = findSingleTopLevelDirectory(extractDir);
+  if (path.basename(appRoot) !== installArchiveBaseName(platformPackage, version)) {
+    throw new Error(`Unexpected extracted app root: ${path.basename(appRoot)}`);
+  }
+
+  smokeExtractedApp(appRoot, platformPackage);
+} finally {
+  if (options.keepTemp) {
+    console.log(`Kept install archive smoke root at ${tempDir}`);
+  } else {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+console.log(`Smoke-tested install archive ${archiveName}`);
+
+function assertHostCanSmokePlatform(platformPackage) {
+  const expectedOs = platformPackage.os[0];
+  const expectedCpu = platformPackage.cpu[0];
+  if (process.platform !== expectedOs || process.arch !== expectedCpu) {
+    throw new Error(
+      `Cannot smoke-test ${platformPackage.dir} on ${process.platform}:${process.arch}. ` +
+        "Run this smoke on a matching host or pass a matching --platform."
+    );
+  }
+
+  if (expectedOs === "linux" && platformPackage.libc?.includes("glibc") && currentLinuxLibc() !== "glibc") {
+    throw new Error(`Cannot smoke-test ${platformPackage.dir} on a non-glibc Linux host`);
+  }
+}
+
+function smokeExtractedApp(appRoot, platformPackage) {
+  if (!options.realBinary && platformPackage.os.includes("win32")) {
+    assertWindowsMockBinary(appRoot, platformPackage.binaryName);
+    assertWindowsMockBinary(appRoot, platformPackage.bundledRuntimeName);
+    return;
+  }
+
+  const commandState = prepareCommandState(appRoot, platformPackage);
+  const versionOutput = runCommand(commandState, ["--version"]);
+  const helpOutput = runCommand(commandState, ["--help"]);
+
+  if (!options.realBinary) {
+    assertMockOutput(versionOutput.stdout, "claude-rs --version");
+    assertMockOutput(helpOutput.stdout, "claude-rs --help");
+    return;
+  }
+
+  printCommandOutput("claude-rs --version", versionOutput);
+  printCommandOutput("claude-rs --help", helpOutput);
+
+  const doctorOutput = runCommand(commandState, ["doctor", "--json", "--strict"]);
+  const doctorDetails = assertDoctorReportsArchiveRuntime(doctorOutput.stdout, appRoot);
+  printCommandOutput("claude-rs doctor --json --strict", doctorOutput);
+  runBridgeRuntimeContract(doctorDetails.runtimePath, doctorDetails.bridgeScriptPath, appRoot);
+}
+
+function prepareCommandState(appRoot, platformPackage) {
+  const baseEnv = options.noSystemRuntime ? envWithoutSystemRuntimePath() : { ...process.env };
+  const pathKey = Object.keys(baseEnv).find((key) => key.toLowerCase() === "path") ?? "PATH";
+  const commandEnv = { ...baseEnv };
+
+  if (platformPackage.os.includes("win32")) {
+    commandEnv[pathKey] = [appRoot, commandEnv[pathKey] ?? ""].filter(Boolean).join(path.delimiter);
+    return {
+      command: path.join(appRoot, platformPackage.binaryName),
+      args: (commandArgs) => commandArgs,
+      cwd: appRoot,
+      env: commandEnv
+    };
+  }
+
+  const binDir = path.join(path.dirname(appRoot), "bin");
+  const launcherPath = path.join(binDir, "claude-rs");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(
+    launcherPath,
+    `#!/bin/sh\nexec ${shellQuote(path.join(appRoot, platformPackage.binaryName))} "$@"\n`,
+    "utf8"
+  );
+  fs.chmodSync(launcherPath, 0o755);
+  commandEnv[pathKey] = [binDir, commandEnv[pathKey] ?? ""].filter(Boolean).join(path.delimiter);
+  return {
+    command: "claude-rs",
+    args: (commandArgs) => commandArgs,
+    cwd: appRoot,
+    env: commandEnv
+  };
+}
+
+function runCommand(commandState, args) {
+  try {
+    const stdout = execFileSync(commandState.command, commandState.args(args), {
+      cwd: commandState.cwd,
+      env: commandState.env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true
+    });
+    return { stdout, stderr: "" };
+  } catch (error) {
+    const stdout = bufferToString(error.stdout);
+    const stderr = bufferToString(error.stderr);
+    throw new Error(
+      `Install archive command failed: ${args.join(" ")}\n` +
+        `status: ${error.status ?? "unknown"}\nstdout:\n${stdout}\nstderr:\n${stderr}`
+    );
+  }
+}
+
+function assertDoctorReportsArchiveRuntime(stdout, appRoot) {
+  const report = JSON.parse(stdout);
+  const runtimeCheck = report.checks?.find((check) => check.id === "bridge_runtime");
+  const runtimeVersionCheck = report.checks?.find((check) => check.id === "bridge_runtime_version");
+  const bridgeCheck = report.checks?.find((check) => check.id === "bridge_script");
+
+  if (!runtimeCheck || runtimeCheck.status !== "pass") {
+    throw new Error(`bridge_runtime did not pass: ${runtimeCheck?.message ?? "missing"}`);
+  }
+  if (runtimeCheck.details?.runtime_kind !== "bundled_bun") {
+    throw new Error(`bridge_runtime kind was not bundled_bun: ${runtimeCheck.details?.runtime_kind}`);
+  }
+  if (!runtimeVersionCheck || runtimeVersionCheck.status !== "pass") {
+    throw new Error(`bridge_runtime_version did not pass: ${runtimeVersionCheck?.message ?? "missing"}`);
+  }
+  if (!bridgeCheck || bridgeCheck.status !== "pass") {
+    throw new Error(`bridge_script did not pass: ${bridgeCheck?.message ?? "missing"}`);
+  }
+
+  const runtimePath = resolvedDoctorPath(runtimeCheck.message, "bridge_runtime");
+  const bridgeScriptPath = resolvedDoctorPath(bridgeCheck.message, "bridge_script");
+  if (!pathInside(runtimePath, appRoot)) {
+    throw new Error(`bridge_runtime resolved outside extracted app: ${runtimePath}`);
+  }
+  if (!pathInside(bridgeScriptPath, appRoot)) {
+    throw new Error(`bridge_script resolved outside extracted app: ${bridgeScriptPath}`);
+  }
+
+  return {
+    runtimePath,
+    bridgeScriptPath
+  };
+}
+
+function runBridgeRuntimeContract(runtimePath, bridgeScriptPath, appRoot) {
+  const contractScript = path.join(repoRoot, "agent-sdk", "scripts", "bridge-runtime-contract.mjs");
+  execFileSync(process.execPath, [contractScript, "--runtime", runtimePath, "--bridge", bridgeScriptPath], {
+    cwd: appRoot,
+    stdio: "inherit",
+    windowsHide: true
+  });
+}
+
+function resolvedDoctorPath(message, checkId) {
+  const prefix = "resolved ";
+  if (typeof message !== "string" || !message.startsWith(prefix)) {
+    throw new Error(`${checkId} did not report a resolved path: ${message ?? "missing"}`);
+  }
+  const resolvedPath = message.slice(prefix.length);
+  if (resolvedPath.length === 0) {
+    throw new Error(`${checkId} reported an empty resolved path`);
+  }
+  return resolvedPath;
+}
+
+function assertMockOutput(output, commandName) {
+  if (!output.includes("claude-rs 0.0.0-mock")) {
+    throw new Error(`${commandName} did not run the mock binary. Output:\n${output}`);
+  }
+}
+
+function assertWindowsMockBinary(appRoot, fileName) {
+  const filePath = path.join(appRoot, fileName);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Windows mock binary is missing: ${fileName}`);
+  }
+  const content = fs.readFileSync(filePath, "utf8");
+  if (!content.startsWith("@echo off") || !content.includes("echo ")) {
+    throw new Error(`Windows mock binary does not contain expected mock content: ${fileName}`);
+  }
+}
+
+function printCommandOutput(commandName, output) {
+  const stdout = output.stdout.trim();
+  const stderr = output.stderr.trim();
+  if (stdout) {
+    console.log(`${commandName} stdout:\n${stdout}`);
+  }
+  if (stderr) {
+    console.log(`${commandName} stderr:\n${stderr}`);
+  }
+}
+
+function currentLinuxLibc() {
+  if (process.platform !== "linux") {
+    return undefined;
+  }
+  try {
+    const glibcVersion = process.report?.getReport?.()?.header?.glibcVersionRuntime;
+    return typeof glibcVersion === "string" && glibcVersion.length > 0 ? "glibc" : "musl";
+  } catch {
+    return "musl";
+  }
+}
+
+function pathInside(candidate, root) {
+  const normalizedCandidate = normalizePathForCompare(candidate);
+  const normalizedRoot = normalizePathForCompare(root);
+  return normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(`${normalizedRoot}${path.sep}`);
+}
+
+function normalizePathForCompare(filePath) {
+  const resolved = path.resolve(filePath);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function bufferToString(value) {
+  if (!value) {
+    return "";
+  }
+  return Buffer.isBuffer(value) ? value.toString("utf8") : String(value);
+}
+
+function parseArgs(args) {
+  const parsed = {
+    help: false,
+    platform: undefined,
+    archiveRoot: undefined,
+    version: undefined,
+    realBinary: false,
+    noSystemRuntime: false,
+    keepTemp: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--platform":
+        parsed.platform = readArgValue(args, ++index, arg);
+        break;
+      case "--archive-root":
+        parsed.archiveRoot = readArgValue(args, ++index, arg);
+        break;
+      case "--version":
+        parsed.version = readArgValue(args, ++index, arg);
+        break;
+      case "--real-binary":
+        parsed.realBinary = true;
+        break;
+      case "--no-system-runtime":
+        parsed.noSystemRuntime = true;
+        break;
+      case "--keep-temp":
+        parsed.keepTemp = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/smoke-install-archive.mjs [options]
+
+Options:
+  --platform <dir>        Platform archive to smoke. Defaults to linux-x64-gnu.
+  --archive-root <dir>    Directory containing install archives. Defaults to dist-install.
+  --version <version>     Expected package version. Defaults to Cargo.toml.
+  --real-binary           Run doctor and bridge-runtime-contract against a real binary.
+  --no-system-runtime     Strip directories containing bun from PATH before running claude-rs.
+  --keep-temp             Keep the temporary extraction root for inspection.
+  -h, --help              Show this help.
+`);
+}

--- a/scripts/verify-install-archives.mjs
+++ b/scripts/verify-install-archives.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  BUNDLED_BUN_RUNTIME_VERSION,
+  PLATFORM_PACKAGES,
+  expectedAgentSdkNativePackage,
+  installArchiveBaseName,
+  installArchiveFormat,
+  installArchiveName,
+  readBunRuntimeManifest,
+  readCargoPackageMetadata
+} from "./npm-package-config.mjs";
+import {
+  assertNoSymlinks,
+  extractArchive,
+  fileSha256,
+  findSingleTopLevelDirectory,
+  listRelativeFiles,
+  normalizePath,
+  readArgValue,
+  readJson
+} from "./install-archive-common.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const AGENT_SDK_NATIVE_PACKAGES = [
+  "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+  "@anthropic-ai/claude-agent-sdk-darwin-x64",
+  "@anthropic-ai/claude-agent-sdk-linux-arm64",
+  "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
+  "@anthropic-ai/claude-agent-sdk-linux-x64",
+  "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
+  "@anthropic-ai/claude-agent-sdk-win32-arm64",
+  "@anthropic-ai/claude-agent-sdk-win32-x64"
+];
+
+const options = parseArgs(process.argv.slice(2));
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const cargoPackage = readCargoPackageMetadata(path.join(repoRoot, "Cargo.toml"));
+const expectedVersion = options.version ?? cargoPackage.version;
+const archiveRoot = path.resolve(repoRoot, options.archiveRoot ?? "dist-install");
+const manifestsDir = path.resolve(repoRoot, options.manifestsDir ?? path.join(archiveRoot, "manifests"));
+const bunRuntimeManifest = readBunRuntimeManifest(repoRoot);
+const failures = [];
+
+expectEqual(bunRuntimeManifest.version, BUNDLED_BUN_RUNTIME_VERSION, "Bun runtime manifest version");
+
+for (const platformPackage of PLATFORM_PACKAGES) {
+  verifyPlatformArchive(platformPackage);
+}
+
+if (failures.length > 0) {
+  console.error(`Install archive verification failed with ${failures.length} issue(s):`);
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Verified ${PLATFORM_PACKAGES.length} install archives in ${path.relative(repoRoot, archiveRoot)}`);
+
+function verifyPlatformArchive(platformPackage) {
+  const archiveName = installArchiveName(platformPackage, expectedVersion);
+  const archivePath = path.join(archiveRoot, archiveName);
+  const context = `${platformPackage.dir} install archive`;
+
+  if (!fs.existsSync(archivePath)) {
+    fail(`${context} is missing: ${path.relative(repoRoot, archivePath)}`);
+    return;
+  }
+
+  const extractDir = fs.mkdtempSync(path.join(os.tmpdir(), `claude-rs-verify-${platformPackage.dir}-`));
+  try {
+    extractArchive({ archivePath, destinationDir: extractDir });
+    const appRoot = findSingleTopLevelDirectory(extractDir);
+    expectEqual(path.basename(appRoot), installArchiveBaseName(platformPackage, expectedVersion), `${context} app root name`);
+    verifyExtractedApp(platformPackage, appRoot, archivePath, archiveName, context);
+  } catch (error) {
+    fail(`${context}: ${error instanceof Error ? error.message : String(error)}`);
+  } finally {
+    fs.rmSync(extractDir, { recursive: true, force: true });
+  }
+}
+
+function verifyExtractedApp(platformPackage, appRoot, archivePath, archiveName, context) {
+  const files = listRelativeFiles(appRoot);
+  const requiredFiles = [
+    platformPackage.binaryName,
+    platformPackage.bundledRuntimeName,
+    "package.json",
+    "LICENSE",
+    "THIRD-PARTY-NOTICES.md",
+    "agent-sdk/package.json",
+    "agent-sdk/dist/bridge.js",
+    "agent-sdk/dist/types.js",
+    "node_modules/@anthropic-ai/claude-agent-sdk/package.json",
+    `${packagePath(expectedAgentSdkNativePackage(platformPackage))}/package.json`
+  ];
+
+  assertNoSymlinksWithFailures(appRoot, context);
+  expectFilesExist(files, requiredFiles, context);
+  expectNoWrongNativePackages(files, platformPackage, context);
+  expectNoForbiddenFiles(files, appRoot, context);
+  expectArchiveSpecifics(platformPackage, appRoot, context);
+  expectManifestMatches(platformPackage, appRoot, archivePath, archiveName, files, context);
+}
+
+function assertNoSymlinksWithFailures(appRoot, context) {
+  try {
+    assertNoSymlinks(appRoot, context);
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function expectNoWrongNativePackages(files, platformPackage, context) {
+  const expectedPackagePath = packagePath(expectedAgentSdkNativePackage(platformPackage));
+  for (const packageName of AGENT_SDK_NATIVE_PACKAGES) {
+    const nativePackagePath = packagePath(packageName);
+    const present = files.some((file) => file === `${nativePackagePath}/package.json`);
+    if (nativePackagePath === expectedPackagePath) {
+      if (!present) {
+        fail(`${context} is missing expected Agent SDK native package: ${packageName}`);
+      }
+      continue;
+    }
+    if (present) {
+      fail(`${context} contains wrong-platform Agent SDK native package: ${packageName}`);
+    }
+  }
+}
+
+function expectNoForbiddenFiles(files, appRoot, context) {
+  if (fs.existsSync(path.join(appRoot, "node_modules", ".bin"))) {
+    fail(`${context} contains node_modules/.bin`);
+  }
+
+  for (const file of files) {
+    if (isForbiddenFile(file)) {
+      fail(`${context} contains forbidden file: ${file}`);
+    }
+  }
+}
+
+function isForbiddenFile(file) {
+  const segments = file.split("/");
+  const basename = segments.at(-1) ?? "";
+
+  return (
+    basename === ".env" ||
+    basename === ".package-lock.json" ||
+    basename === "package-lock.json" ||
+    basename === "npm-shrinkwrap.json" ||
+    basename.endsWith(".log") ||
+    basename.endsWith(".map") ||
+    basename.endsWith(".test.js") ||
+    basename.endsWith(".spec.js") ||
+    basename.endsWith(".ts") ||
+    basename.endsWith(".mts") ||
+    basename.endsWith(".cts") ||
+    segments.includes(".git") ||
+    segments.includes(".cache") ||
+    segments.includes(".github") ||
+    segments.includes("__tests__") ||
+    segments.includes("test") ||
+    segments.includes("tests") ||
+    file.startsWith("agent-sdk/src/")
+  );
+}
+
+function expectArchiveSpecifics(platformPackage, appRoot, context) {
+  const isWindows = platformPackage.os.includes("win32");
+  if (isWindows) {
+    if (!platformPackage.binaryName.endsWith(".exe") || !platformPackage.bundledRuntimeName.endsWith(".exe")) {
+      fail(`${context} Windows platform metadata must use .exe names`);
+    }
+    if (fs.existsSync(path.join(appRoot, "claude-rs")) || fs.existsSync(path.join(appRoot, "claude-rs-bridge-bun"))) {
+      fail(`${context} contains Unix launcher names in Windows archive`);
+    }
+    return;
+  }
+
+  if (platformPackage.binaryName.endsWith(".exe") || platformPackage.bundledRuntimeName.endsWith(".exe")) {
+    fail(`${context} Unix platform metadata must not use .exe names`);
+  }
+  if (process.platform !== "win32") {
+    expectExecutable(path.join(appRoot, platformPackage.binaryName), `${context} native binary`);
+    expectExecutable(path.join(appRoot, platformPackage.bundledRuntimeName), `${context} bundled Bun runtime`);
+  }
+}
+
+function expectManifestMatches(platformPackage, appRoot, archivePath, archiveName, files, context) {
+  const manifestPath = path.join(manifestsDir, `${platformPackage.dir}.json`);
+  if (!fs.existsSync(manifestPath)) {
+    fail(`${context} manifest is missing: ${path.relative(repoRoot, manifestPath)}`);
+    return;
+  }
+
+  const manifest = readJson(manifestPath);
+  expectEqual(manifest.manifestVersion, 1, `${context} manifest version`);
+  expectEqual(manifest.platform, platformPackage.dir, `${context} manifest platform`);
+  expectEqual(manifest.version, expectedVersion, `${context} manifest package version`);
+  expectEqual(manifest.archiveName, archiveName, `${context} manifest archive name`);
+  expectEqual(manifest.archiveFormat, installArchiveFormat(platformPackage), `${context} manifest archive format`);
+  expectEqual(manifest.archiveSha256, fileSha256(archivePath), `${context} manifest archive SHA256`);
+  expectEqual(manifest.fileCount, files.length, `${context} manifest file count`);
+  expectDeepEqual(manifest.files, files, `${context} manifest files`);
+  expectEqual(
+    manifest.expectedAgentSdkNativePackage,
+    expectedAgentSdkNativePackage(platformPackage),
+    `${context} manifest expected native package`
+  );
+  expectEqual(manifest.bundledRuntime?.name, platformPackage.bundledRuntimeName, `${context} manifest runtime name`);
+  expectEqual(manifest.bundledRuntime?.version, bunRuntimeManifest.version, `${context} manifest runtime version`);
+  expectEqual(
+    manifest.bundledRuntime?.runtimeSha256,
+    fileSha256(path.join(appRoot, platformPackage.bundledRuntimeName)),
+    `${context} manifest runtime SHA256`
+  );
+}
+
+function expectFilesExist(files, expectedFiles, context) {
+  for (const expectedFile of expectedFiles) {
+    if (!files.includes(expectedFile)) {
+      fail(`${context} is missing required file: ${expectedFile}`);
+    }
+  }
+}
+
+function expectExecutable(filePath, label) {
+  if (!fs.existsSync(filePath)) {
+    fail(`${label} is missing`);
+    return;
+  }
+
+  const mode = fs.statSync(filePath).mode;
+  if ((mode & 0o111) === 0) {
+    fail(`${label} is not executable: ${normalizePath(path.relative(repoRoot, filePath))}`);
+  }
+}
+
+function packagePath(packageName) {
+  return normalizePath(path.join("node_modules", ...packageName.split("/")));
+}
+
+function expectEqual(actual, expected, label) {
+  if (actual !== expected) {
+    fail(`${label}: expected ${formatValue(expected)}, got ${formatValue(actual)}`);
+  }
+}
+
+function expectDeepEqual(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label}: expected ${formatValue(expected)}, got ${formatValue(actual)}`);
+  }
+}
+
+function fail(message) {
+  failures.push(message);
+}
+
+function formatValue(value) {
+  return JSON.stringify(value);
+}
+
+function parseArgs(args) {
+  const parsed = {
+    help: false,
+    archiveRoot: undefined,
+    manifestsDir: undefined,
+    version: undefined
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--archive-root":
+        parsed.archiveRoot = readArgValue(args, ++index, arg);
+        break;
+      case "--manifests-dir":
+        parsed.manifestsDir = readArgValue(args, ++index, arg);
+        break;
+      case "--version":
+        parsed.version = readArgValue(args, ++index, arg);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/verify-install-archives.mjs [options]
+
+Options:
+  --archive-root <dir>    Directory containing install archives. Defaults to dist-install.
+  --manifests-dir <dir>   Directory containing install manifests. Defaults to <archive-root>/manifests.
+  --version <version>     Expected package version. Defaults to Cargo.toml.
+  -h, --help              Show this help.
+`);
+}

--- a/scripts/verify-npm-packages.mjs
+++ b/scripts/verify-npm-packages.mjs
@@ -36,6 +36,7 @@ const expectedVersion = options.version ?? cargoPackage.version;
 const failures = [];
 const packageManifests = [];
 const bunRuntimeManifest = readBunRuntimeManifest(repoRoot);
+const allowMockBinaries = fs.existsSync(path.join(distDir, ".mock-binaries"));
 
 expectEqual(bunRuntimeManifest.version, BUNDLED_BUN_RUNTIME_VERSION, "Bun runtime manifest version");
 verifyDistDir();
@@ -287,11 +288,20 @@ function buildBunRuntimeProvenance(platformPackage, packageDir, runtimeFilePath,
     `${context} Bun archive binary path`
   );
   const actualRuntimeSha256 = fileSha256(path.join(packageDir, runtimeFilePath));
-  expectEqual(actualRuntimeSha256, runtimeAsset.binarySha256, `${context} bundled Bun runtime SHA256`);
+  if (actualRuntimeSha256 !== runtimeAsset.binarySha256) {
+    if (!allowMockBinaries || !isMockRuntimeFile(path.join(packageDir, runtimeFilePath))) {
+      fail(
+        `${context} bundled Bun runtime SHA256: expected ${formatValue(
+          runtimeAsset.binarySha256
+        )}, got ${formatValue(actualRuntimeSha256)}`
+      );
+    }
+  }
 
   return {
     name: platformPackage.bundledRuntimeName,
     version: bunRuntimeManifest.version,
+    mock: actualRuntimeSha256 !== runtimeAsset.binarySha256 ? true : undefined,
     sourceAsset: runtimeAsset.assetName,
     sourceUrl: bunRuntimeAssetUrl(bunRuntimeManifest.version, runtimeAsset.assetName),
     checksumSourceUrl: bunRuntimeManifest.checksumSourceUrl,
@@ -299,6 +309,11 @@ function buildBunRuntimeProvenance(platformPackage, packageDir, runtimeFilePath,
     sourceArchiveSha256: runtimeAsset.sha256,
     runtimeSha256: actualRuntimeSha256
   };
+}
+
+function isMockRuntimeFile(runtimePath) {
+  const content = fs.readFileSync(runtimePath, "utf8");
+  return content.includes(bunRuntimeManifest.version);
 }
 
 function fileSha256(filePath) {

--- a/scripts/verify-release-bundle.mjs
+++ b/scripts/verify-release-bundle.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { PLATFORM_PACKAGES, ROOT_PACKAGE_NAME, readCargoPackageMetadata } from "./npm-package-config.mjs";
+import {
+  extractArchive,
+  fileSha256,
+  findSingleTopLevelDirectory,
+  listRelativeFiles,
+  readArgValue,
+  readJson
+} from "./install-archive-common.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const options = parseArgs(process.argv.slice(2));
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const cargoPackage = readCargoPackageMetadata(path.join(repoRoot, "Cargo.toml"));
+const version = options.version ?? cargoPackage.version;
+const bundleRootName = `${ROOT_PACKAGE_NAME}-${version}-release-bundle`;
+const bundlePath = path.resolve(repoRoot, options.bundle ?? `${bundleRootName}.tar.gz`);
+const failures = [];
+
+if (!fs.existsSync(bundlePath)) {
+  fail(`Missing release bundle: ${path.relative(repoRoot, bundlePath)}`);
+} else {
+  verifyBundle();
+}
+
+if (failures.length > 0) {
+  console.error(`Release bundle verification failed with ${failures.length} issue(s):`);
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Verified release bundle ${path.relative(repoRoot, bundlePath)}`);
+
+function verifyBundle() {
+  const extractDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-bundle-verify-"));
+  try {
+    extractArchive({ archivePath: bundlePath, destinationDir: extractDir });
+    const bundleRoot = findSingleTopLevelDirectory(extractDir);
+    expectEqual(path.basename(bundleRoot), bundleRootName, "bundle root directory");
+
+    const files = listRelativeFiles(bundleRoot);
+    expectRequiredFiles(files);
+    expectNoCompleteInstallArchives(files);
+    expectReleaseManifest(bundleRoot);
+    expectInternalChecksums(bundleRoot);
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  } finally {
+    fs.rmSync(extractDir, { recursive: true, force: true });
+  }
+}
+
+function expectRequiredFiles(files) {
+  const requiredFiles = [
+    "release-manifest.json",
+    "SHA256SUMS.internal",
+    "dist-npm/manifests/summary.json",
+    "dist-npm/manifests/root.json"
+  ];
+
+  for (const platformPackage of PLATFORM_PACKAGES) {
+    requiredFiles.push(`dist-npm/manifests/${platformPackage.dir}.json`);
+    requiredFiles.push(`dist-install/manifests/${platformPackage.dir}.json`);
+  }
+
+  for (const requiredFile of requiredFiles) {
+    if (!files.includes(requiredFile)) {
+      fail(`bundle is missing required file: ${requiredFile}`);
+    }
+  }
+}
+
+function expectNoCompleteInstallArchives(files) {
+  for (const file of files) {
+    if (file.startsWith("dist-install/") && (file.endsWith(".tar.gz") || file.endsWith(".zip"))) {
+      fail(`bundle must not duplicate complete install archive: ${file}`);
+    }
+  }
+}
+
+function expectReleaseManifest(bundleRoot) {
+  const manifestPath = path.join(bundleRoot, "release-manifest.json");
+  if (!fs.existsSync(manifestPath)) {
+    return;
+  }
+
+  const manifest = readJson(manifestPath);
+  expectEqual(manifest.manifestVersion, 1, "release manifest version");
+  expectEqual(manifest.version, version, "release manifest package version");
+  expectEqual(manifest.internalBundle?.rootDirectory, bundleRootName, "release manifest bundle root");
+  expectEqual(manifest.targets?.length, PLATFORM_PACKAGES.length, "release manifest target count");
+}
+
+function expectInternalChecksums(bundleRoot) {
+  const checksumsPath = path.join(bundleRoot, "SHA256SUMS.internal");
+  if (!fs.existsSync(checksumsPath)) {
+    return;
+  }
+
+  const checksums = fs.readFileSync(checksumsPath, "utf8").trim().split(/\r?\n/).filter(Boolean);
+  const seen = new Set();
+  for (const line of checksums) {
+    const match = line.match(/^([a-fA-F0-9]{64}) [ *](.+)$/);
+    if (!match) {
+      fail(`invalid SHA256SUMS.internal line: ${line}`);
+      continue;
+    }
+    const [, expectedSha, relativePath] = match;
+    if (relativePath === "SHA256SUMS.internal") {
+      fail("SHA256SUMS.internal must not include itself");
+      continue;
+    }
+    if (relativePath === path.basename(bundlePath)) {
+      fail("SHA256SUMS.internal must not include the final release bundle archive");
+      continue;
+    }
+    const filePath = path.join(bundleRoot, ...relativePath.split("/"));
+    if (!fs.existsSync(filePath)) {
+      fail(`SHA256SUMS.internal references missing file: ${relativePath}`);
+      continue;
+    }
+    const actualSha = fileSha256(filePath);
+    if (actualSha !== expectedSha.toLowerCase()) {
+      fail(`SHA256SUMS.internal mismatch for ${relativePath}: expected ${expectedSha}, got ${actualSha}`);
+    }
+    seen.add(relativePath);
+  }
+
+  const files = listRelativeFiles(bundleRoot).filter((file) => file !== "SHA256SUMS.internal");
+  for (const file of files) {
+    if (!seen.has(file)) {
+      fail(`SHA256SUMS.internal is missing file: ${file}`);
+    }
+  }
+}
+
+function expectEqual(actual, expected, label) {
+  if (actual !== expected) {
+    fail(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function fail(message) {
+  failures.push(message);
+}
+
+function parseArgs(args) {
+  const parsed = {
+    help: false,
+    version: undefined,
+    bundle: undefined
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--version":
+        parsed.version = readArgValue(args, ++index, arg);
+        break;
+      case "--bundle":
+        parsed.bundle = readArgValue(args, ++index, arg);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/verify-release-bundle.mjs [options]
+
+Options:
+  --version <version>   Expected package version. Defaults to Cargo.toml.
+  --bundle <path>       Release bundle path. Defaults to claude-code-rust-<version>-release-bundle.tar.gz.
+  -h, --help            Show this help.
+`);
+}


### PR DESCRIPTION
## Summary

Adds an install-script release path alongside the existing npm distribution:

- Generates complete, versioned install archives for the six supported release targets.
- Verifies archive contents, platform-specific Agent SDK optional packages, forbidden files, symlinks, manifests, and executable bits.
- Generates and verifies a release bundle containing audit artifacts without duplicating complete install archives.
- Adds macOS/Linux and Windows installers that resolve a release tag, verify `SHA256SUMS`, and install an executable-relative app layout with the bundled Bun runtime and bridge files.
- Updates release and nightly workflows to assemble one release package set, smoke npm and direct release archive installs, attest public release assets, and publish only install archives, the release bundle, and `SHA256SUMS` to GitHub Releases.

## Why

Some users need an installation path that does not use npm as the installer. The new path keeps npm as the recommended install method while allowing direct installation from complete GitHub Release archives.

The archives are built in CI from the same release inputs as npm packages, so user installers do not run npm, do not resolve Agent SDK versions, and do not download bridge/runtime pieces independently.

Closes N/A

## Validation

- Automated:
  - `npm ci`
  - `npm ci --prefix agent-sdk`
  - `npm --prefix agent-sdk run build`
  - `node scripts/stage-bun-runtime.mjs --check`
  - `node scripts/generate-npm-packages.mjs --mock-binaries`
  - `node scripts/verify-npm-packages.mjs`
  - `node scripts/generate-install-archives.mjs --mock-binaries`
  - `node scripts/verify-install-archives.mjs`
  - `node scripts/smoke-install-archive.mjs --platform win32-x64-msvc`
  - `node scripts/generate-release-bundle.mjs`
  - `node scripts/verify-release-bundle.mjs`
  - `npx -y shellcheck -s sh scripts/install.sh`
  - JS parser checks for changed scripts
  - PowerShell parser check and `scripts/install.ps1 -Help`
  - `git diff --check`
  - `cargo fmt --all -- --check`
  - `cargo check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
- Manual:
  - Verified public docs were not activated before a release containing install archives.
  - Verified installer pinning uses `CLAUDE_RS_RELEASE` for pipe-to-shell and PowerShell `iex` usage.
  - Verified the archive smoke script strips `resolved ` doctor message prefixes before path containment checks and bridge runtime contract invocation.
  - Verified the Unix installer evaluates persistent PATH setup before prepending the launcher directory for current-process smoke checks.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: Not yet. Public install docs should be added only after a release with install archives is published and verified.
