### PR TITLE
fix(tui): stop DSR cursor queries racing the event stream at startup

### DIFF
--- a/src/app/terminal_runtime/chat_session.rs
+++ b/src/app/terminal_runtime/chat_session.rs
@@ -28,21 +28,13 @@ pub(super) struct ChatTerminalSession {
 }
 
 impl ChatTerminalSession {
-    pub(super) fn new() -> anyhow::Result<Self> {
+    /// `known_cursor` must come from a probe taken before the app's `EventStream`
+    /// exists (see `TerminalRuntime::bootstrap`); querying here would race the
+    /// stream for the DSR reply. `None` anchors the session at the bottom row.
+    pub(super) fn new(known_cursor: Option<(u16, u16)>) -> anyhow::Result<Self> {
         let (width, height) =
             crossterm::terminal::size().context("failed to read chat terminal size")?;
-        // A DSR cursor query can fail when stdout is not a terminal (e.g. piped);
-        // anchor the session at the bottom row instead of aborting startup.
-        let (cursor_x, cursor_y) = crossterm::cursor::position().unwrap_or_else(|err| {
-            tracing::warn!(
-                target: crate::logging::targets::APP_RENDER,
-                event_name = "inline_chat_cursor_probe_failed",
-                message = "failed to read chat terminal cursor; using bottom-row fallback",
-                outcome = "fallback",
-                error_message = %err,
-            );
-            (0, height.saturating_sub(1))
-        });
+        let (cursor_x, cursor_y) = known_cursor.unwrap_or((0, height.saturating_sub(1)));
         let owned_top = cursor_y.min(height.saturating_sub(1));
 
         tracing::debug!(

--- a/src/app/terminal_runtime/chat_session.rs
+++ b/src/app/terminal_runtime/chat_session.rs
@@ -31,8 +31,18 @@ impl ChatTerminalSession {
     pub(super) fn new() -> anyhow::Result<Self> {
         let (width, height) =
             crossterm::terminal::size().context("failed to read chat terminal size")?;
-        let (cursor_x, cursor_y) =
-            crossterm::cursor::position().context("failed to read chat terminal cursor")?;
+        // A DSR cursor query can fail when stdout is not a terminal (e.g. piped);
+        // anchor the session at the bottom row instead of aborting startup.
+        let (cursor_x, cursor_y) = crossterm::cursor::position().unwrap_or_else(|err| {
+            tracing::warn!(
+                target: crate::logging::targets::APP_RENDER,
+                event_name = "inline_chat_cursor_probe_failed",
+                message = "failed to read chat terminal cursor; using bottom-row fallback",
+                outcome = "fallback",
+                error_message = %err,
+            );
+            (0, height.saturating_sub(1))
+        });
         let owned_top = cursor_y.min(height.saturating_sub(1));
 
         tracing::debug!(

--- a/src/app/terminal_runtime/chat_terminal.rs
+++ b/src/app/terminal_runtime/chat_terminal.rs
@@ -9,8 +9,8 @@ use crossterm::cursor::MoveTo;
 use crossterm::queue;
 use crossterm::style::Print;
 use crossterm::terminal::{Clear, ClearType, DisableLineWrap};
-use ratatui::backend::CrosstermBackend;
-use ratatui::layout::Rect;
+use ratatui::backend::{Backend, CrosstermBackend};
+use ratatui::layout::{Position, Rect, Size};
 use ratatui::text::Line;
 use ratatui::widgets::{Clear as RatatuiClear, Paragraph, Widget};
 use ratatui::{Terminal, TerminalOptions, Viewport};
@@ -20,7 +20,95 @@ use std::fmt;
 use std::io::{Stdout, Write};
 
 type StdoutBackend = CrosstermBackend<Stdout>;
-type StdoutTerminal = Terminal<StdoutBackend>;
+type StdoutTerminal = Terminal<TrackedCursorBackend>;
+
+/// Crossterm backend wrapper that answers ratatui's cursor-position queries from
+/// tracked state instead of issuing a DSR (`ESC[6n`) query. While the app loop's
+/// `EventStream` owns stdin, the DSR reply is consumed as an input event before
+/// `crossterm::cursor::position()` can read it, so a live query always times out.
+struct TrackedCursorBackend {
+    inner: StdoutBackend,
+    cursor: Position,
+}
+
+impl TrackedCursorBackend {
+    fn new(cursor: Position) -> Self {
+        Self { inner: CrosstermBackend::new(std::io::stdout()), cursor }
+    }
+}
+
+impl Backend for TrackedCursorBackend {
+    type Error = std::io::Error;
+
+    fn draw<'a, I>(&mut self, content: I) -> std::io::Result<()>
+    where
+        I: Iterator<Item = (u16, u16, &'a ratatui::buffer::Cell)>,
+    {
+        self.inner.draw(content)
+    }
+
+    fn append_lines(&mut self, n: u16) -> std::io::Result<()> {
+        self.inner.append_lines(n)?;
+        let max_row = self.inner.size()?.height.saturating_sub(1);
+        self.cursor.y = self.cursor.y.saturating_add(n).min(max_row);
+        Ok(())
+    }
+
+    fn hide_cursor(&mut self) -> std::io::Result<()> {
+        self.inner.hide_cursor()
+    }
+
+    fn show_cursor(&mut self) -> std::io::Result<()> {
+        self.inner.show_cursor()
+    }
+
+    fn get_cursor_position(&mut self) -> std::io::Result<Position> {
+        Ok(self.cursor)
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> std::io::Result<()> {
+        let position = position.into();
+        self.inner.set_cursor_position(position)?;
+        self.cursor = position;
+        Ok(())
+    }
+
+    fn clear(&mut self) -> std::io::Result<()> {
+        self.inner.clear()
+    }
+
+    fn clear_region(&mut self, clear_type: ratatui::backend::ClearType) -> std::io::Result<()> {
+        self.inner.clear_region(clear_type)
+    }
+
+    fn size(&self) -> std::io::Result<Size> {
+        self.inner.size()
+    }
+
+    fn window_size(&mut self) -> std::io::Result<ratatui::backend::WindowSize> {
+        self.inner.window_size()
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Backend::flush(&mut self.inner)
+    }
+
+    fn scroll_region_up(
+        &mut self,
+        region: std::ops::Range<u16>,
+        line_count: u16,
+    ) -> std::io::Result<()> {
+        self.inner.scroll_region_up(region, line_count)
+    }
+
+    fn scroll_region_down(
+        &mut self,
+        region: std::ops::Range<u16>,
+        line_count: u16,
+    ) -> std::io::Result<()> {
+        self.inner.scroll_region_down(region, line_count)
+    }
+}
 pub(super) const PURGE_REPLAY_CLEAR_ANSI: &str = "\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H";
 const MIN_REPLAY_BATCH_ROWS: usize = 32;
 const MAX_REPLAY_BATCH_ROWS: usize = 160;
@@ -461,10 +549,11 @@ impl ChatTerminal {
             return Ok(());
         }
 
-        let cursor_before = crossterm::cursor::position()
-            .context("failed to read cursor before inline terminal ensure")?;
+        // The app loop's EventStream owns stdin, so a live DSR cursor query here would
+        // never see its reply; fall back to the tracked owned_top row instead.
         let anchor = anchor_area.or(self.state.area);
-        let cursor_y = anchor.map_or(cursor_before.1, |area| area.y);
+        let fallback_row = self.state.owned_top.min(screen_height.saturating_sub(1));
+        let cursor_y = anchor.map_or(fallback_row, |area| area.y);
         let predicted_area = Rect::new(
             0,
             inline_viewport_top_after_create(cursor_y, next_height, screen_height),
@@ -491,8 +580,8 @@ impl ChatTerminal {
             event_name = "inline_chat_terminal_ensure",
             message = "inline terminal viewport ensured inside owned session region",
             outcome = "prepared",
-            cursor_before_x = cursor_before.0,
-            cursor_before_y = cursor_before.1,
+            cursor_before_x = anchor.map(Rect::left),
+            cursor_before_y = cursor_y,
             anchor_top = anchor.map(Rect::top),
             requested_height = desired_height,
             final_height = next_height,
@@ -502,7 +591,10 @@ impl ChatTerminal {
             owned_bottom = self.state.owned_bottom,
         );
 
-        let terminal = create_inline_terminal(next_height)?;
+        let terminal = create_inline_terminal(
+            next_height,
+            Position::new(anchor.map_or(0, |a| a.x), cursor_y),
+        )?;
         self.track_owned_region_scroll(
             inline_viewport_scroll_rows_after_create(cursor_y, next_height, screen_height),
             screen_height,
@@ -1091,9 +1183,9 @@ impl ChatTerminal {
     }
 }
 
-fn create_inline_terminal(height: u16) -> anyhow::Result<StdoutTerminal> {
+fn create_inline_terminal(height: u16, cursor: Position) -> anyhow::Result<StdoutTerminal> {
     Terminal::with_options(
-        CrosstermBackend::new(std::io::stdout()),
+        TrackedCursorBackend::new(cursor),
         TerminalOptions { viewport: Viewport::Inline(height.max(1)) },
     )
     .context("failed to construct ratatui inline chat terminal")

--- a/src/app/terminal_runtime/mod.rs
+++ b/src/app/terminal_runtime/mod.rs
@@ -39,6 +39,7 @@ enum SurfaceTransitionPlan {
 pub(crate) struct TerminalRuntime {
     session: Option<SurfaceTerminalSession>,
     suspended_chat_session: Option<ChatTerminalSession>,
+    startup_cursor: Option<(u16, u16)>,
     active_surface: SurfaceMode,
     alternate_screen_active: Arc<AtomicBool>,
     panic_hook: Option<PanicRestoreHook>,
@@ -58,8 +59,17 @@ impl TerminalRuntime {
             return Err(err).context("failed to configure terminal startup modes");
         }
 
+        // The only safe moment to issue a DSR cursor query: the app's EventStream
+        // does not exist yet, so the reply cannot be swallowed as an input event.
+        // The alternate screen (entered below for fullscreen surfaces) saves and
+        // restores the main-screen cursor, so this value stays valid for a later
+        // fullscreen-to-chat transition inside the live event loop.
+        let startup_cursor = probe_startup_cursor();
+
         let session = match target_surface {
-            SurfaceMode::Chat => ChatTerminalSession::new().map(SurfaceTerminalSession::Chat),
+            SurfaceMode::Chat => {
+                ChatTerminalSession::new(startup_cursor).map(SurfaceTerminalSession::Chat)
+            }
             SurfaceMode::Fullscreen(_) => {
                 if let Err(err) = apply_enter_fullscreen_actions() {
                     restore_once(restored.as_ref(), || {
@@ -98,6 +108,7 @@ impl TerminalRuntime {
         Ok(Self {
             session: Some(session),
             suspended_chat_session: None,
+            startup_cursor,
             active_surface: target_surface,
             alternate_screen_active,
             panic_hook: Some(panic_hook),
@@ -160,7 +171,7 @@ impl TerminalRuntime {
                 let reused_chat_session = self.suspended_chat_session.is_some();
                 let chat_session = match self.suspended_chat_session.take() {
                     Some(session) => session,
-                    None => ChatTerminalSession::new()?,
+                    None => ChatTerminalSession::new(self.startup_cursor)?,
                 };
                 self.session = Some(SurfaceTerminalSession::Chat(chat_session));
                 self.active_surface = SurfaceMode::Chat;
@@ -235,6 +246,25 @@ impl TerminalRuntime {
 fn apply_startup_actions() -> std::io::Result<()> {
     let mut stdout = std::io::stdout();
     apply_actions(&mut stdout, chat_startup_actions())
+}
+
+/// Must only run before the app's `EventStream` is created; afterwards the DSR
+/// reply would be consumed as an input event and the query would time out.
+/// `None` means the probe failed (e.g. stdout is piped, crossterm #919).
+fn probe_startup_cursor() -> Option<(u16, u16)> {
+    match crossterm::cursor::position() {
+        Ok(position) => Some(position),
+        Err(err) => {
+            tracing::warn!(
+                target: crate::logging::targets::APP_RENDER,
+                event_name = "inline_chat_cursor_probe_failed",
+                message = "failed to read startup cursor position; chat sessions will anchor at the bottom row",
+                outcome = "fallback",
+                error_message = %err,
+            );
+            None
+        }
+    }
 }
 
 fn apply_enter_fullscreen_actions() -> std::io::Result<()> {


### PR DESCRIPTION
## Summary

Removes every crossterm DSR (`ESC[6n`) cursor query that could run while the app's `crossterm::event::EventStream` is active. While the stream owns stdin, the `ESC[...R` reply is consumed as an input event before `cursor::position()` can read it, so the query times out and the app exits with:

```
The cursor position could not be read within a normal duration
```

Changes:

- `ensure_inline_terminal_height` no longer queries the cursor for its fallback anchor row; it uses the tracked `state.owned_top` (clamped to the screen). Tracing fields are kept, sourced from `anchor`/`cursor_y`.
- `ChatTerminalSession::new` no longer calls `crossterm::cursor::position()` at all. The single remaining probe runs in `TerminalRuntime::bootstrap` before `EventStream::new()` exists; the result is stashed on `TerminalRuntime` and reused when a chat session is created later from inside the event loop (trust accept, session-picker exit). This stays valid because the alternate screen (`?1049`) saves and restores the main-screen cursor. A failed probe (e.g. piped stdout) is non-fatal and falls back to a bottom-row anchor — startup never waits on crossterm's read timeout inside the loop.
- New `TrackedCursorBackend` wraps `CrosstermBackend<Stdout>` and answers `get_cursor_position()` from tracked state, because ratatui itself queries the backend cursor at times the app does not control. It is seeded with the anchor the caller already moves the real cursor to before constructing the terminal, stays in sync via `set_cursor_position`/`append_lines`, and delegates everything else (including the `scrolling-regions` methods) to the inner backend.

## Why

The crash reproduces deterministically on macOS whenever a DSR query runs while the event stream is live. With `ratatui 0.30.2` (`ratatui-core 0.1.2` per this repo's `Cargo.lock`), the reachable query paths were:

1. `ensure_inline_terminal_height` (`chat_terminal.rs`) queried the cursor on every inline viewport (re)creation inside the render loop.
2. `ChatTerminalSession::new` (`chat_session.rs`): on normal trusted startup this runs inside `bootstrap()` *before* the event stream and is safe. The racing path is the fullscreen→chat transition inside the live loop — trust accept on first launch, or leaving the session picker with no suspended chat session (`terminal_runtime/mod.rs`, `SurfaceTransitionPlan::ExitFullscreen`).
3. ratatui-core 0.1.2 internals, all reachable from the live loop:
   - `Terminal::with_options` with `Viewport::Inline` → `compute_inline_size` → `backend.get_cursor_position()` (`init.rs:130`, `inline.rs:396`) — hit via `create_inline_terminal`; after fixing (1) the crash moved here ("failed to construct ratatui inline chat terminal: The cursor position could not be read…").
   - `Terminal::clear` → `backend.get_cursor_position()` (`buffers.rs:148`) — hit via `clear_ratatui_inline_viewport`.
   - `Terminal::resize` → `compute_inline_size` → same query (`resize.rs:30`) — reachable via ratatui's `autoresize` if a size change lands mid-draw.

After this PR the only DSR query left in the codebase is the one bootstrap probe, which runs strictly before `EventStream::new()`.

Closes # — no tracker issue exists for this crash; upstream context is crossterm-rs/crossterm#672 / crossterm-rs/crossterm#963.

## Validation

- Automated: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` — all `app::terminal_runtime` tests pass (including `chat_startup_actions_do_not_enter_alternate_screen`). The only intermittent failures are the pre-existing timing-flaky `app::connect::bridge_lifecycle` tests, which also fail intermittently on a clean `main` checkout and pass on rerun.
- Manual, scripted PTY harness (`script(1)`, isolated `$HOME`, debug tracing):
  - Trusted dir (normal startup): reaches the chat UI; `ensure_inline_terminal_height` ran 183 times over 12s with zero cursor errors.
  - Fresh dir (trust dialog → `y` → chat): the fullscreen→chat transition creates the chat session and inline terminal inside the live loop with no error and no timeout wait — trace shows `inline_chat_terminal_initialized` → first draw transaction within ~1.3 ms of the accept.
  - Piped stdout / no TTY: exits with the expected `EnableRawMode` error instead of the cursor crash.
- Manual, real terminals (macOS only): verified in iTerm2, Terminal.app, xterm, herdr, Kitty, and Warp — launch and use in an already-trusted directory, launch in a new directory (trust dialog → chat transition), and pane/window resize. No cursor errors, no anchor drift or prompt overlap.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
