### PR TITLE
fix(ui): stabilize markdown handoff and list wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixes
+
+- **Markdown list rendering** (#263, @srothgan): Keep streamed inline Markdown handoffs mutable only until delimiters resolve, let stable scrollback advance after resolved blocks, and preserve fenced code layout when code lines look like Markdown list items.
+
 ### Documentation
 
 - **Governance and source install docs** (#262, @srothgan): Document repository release controls and clarify source-build auth/runtime setup.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Claude Code Rust replaces the stock Claude Code terminal interface with a native
 
 ## Requisites
 
-- Installed Claude Code CLI. 
+- Installed Claude Code CLI, required for authentication and plugin management because the Agent SDK does not yet expose equivalent public APIs.
 
 ## Install
 

--- a/src/ui/inline_chat_rows.rs
+++ b/src/ui/inline_chat_rows.rs
@@ -19,7 +19,7 @@ use crate::ui::spinner_verbs::random_spinner_verb;
 use crate::ui::theme;
 use crate::ui::tool_call;
 use crate::ui::welcome;
-use crate::ui::wrap::wrap_lines_to_physical_rows;
+use crate::ui::wrap::{wrap_lines_to_physical_rows, wrap_markdown_lines_to_physical_rows};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use std::collections::BTreeSet;
@@ -529,10 +529,17 @@ impl PendingAssistantTextRun {
         !self.commit_ready && !commit_ready
     }
 
-    fn append(&mut self, id: HistoryOutputId, text: &str, trailing_spacing: TextBlockSpacing) {
+    fn append(
+        &mut self,
+        id: HistoryOutputId,
+        text: &str,
+        trailing_spacing: TextBlockSpacing,
+        commit_ready: bool,
+    ) {
         self.ids.push(id);
         append_text_run(&mut self.text, self.trailing_spacing, text);
         self.trailing_spacing = trailing_spacing;
+        self.commit_ready = commit_ready;
     }
 
     fn into_render_item(self) -> AssistantRenderItemSpec {
@@ -601,10 +608,17 @@ fn assistant_render_items_from_message(
                 if let Some(pending) = pending_text.as_mut()
                     && pending.can_merge(commit_ready)
                 {
+                    let merged_commit_ready = assistant_text_run_commit_ready(
+                        message,
+                        pending.block_idx,
+                        block_idx,
+                        active_tail_block_idx,
+                    );
                     pending.append(
                         HistoryOutputId::Block(text.id),
                         &text.text,
                         text.trailing_spacing,
+                        merged_commit_ready,
                     );
                 } else {
                     flush_pending_text_run(&mut pending_text, &mut items);
@@ -677,29 +691,91 @@ fn assistant_text_block_commit_ready(
     block_idx: usize,
     active_tail_block_idx: Option<usize>,
 ) -> bool {
+    assistant_text_run_commit_ready(message, block_idx, block_idx, active_tail_block_idx)
+}
+
+fn assistant_text_run_commit_ready(
+    message: &ChatMessage,
+    start_block_idx: usize,
+    end_block_idx: usize,
+    active_tail_block_idx: Option<usize>,
+) -> bool {
     let Some(active_tail_block_idx) = active_tail_block_idx else {
         return true;
     };
-    if active_tail_block_idx == block_idx {
+    if active_tail_block_idx >= start_block_idx && active_tail_block_idx <= end_block_idx {
         return false;
     }
-    if active_tail_block_idx < block_idx {
+    if active_tail_block_idx < start_block_idx {
         return true;
     }
 
-    !assistant_text_handoff_continues_open_table(message, block_idx)
+    !assistant_text_run_handoff_requires_markdown_context(message, start_block_idx, end_block_idx)
 }
 
-fn assistant_text_handoff_continues_open_table(message: &ChatMessage, block_idx: usize) -> bool {
-    let Some(MessageBlock::Text(text)) = message.blocks.get(block_idx) else {
+fn assistant_text_run_handoff_requires_markdown_context(
+    message: &ChatMessage,
+    start_block_idx: usize,
+    end_block_idx: usize,
+) -> bool {
+    let Some((text, trailing_spacing)) =
+        assistant_text_run_source(message, start_block_idx, end_block_idx)
+    else {
         return false;
     };
-    if !markdown_table_tail_is_open(&text.text) {
+    let Some(next) = next_visible_assistant_text(message, end_block_idx) else {
+        return false;
+    };
+
+    assistant_text_handoff_continues_open_table(&text, next)
+        || assistant_text_handoff_continues_list_item(&text, trailing_spacing, next)
+        || markdown_source_has_open_fence(&text)
+        || markdown_source_has_open_inline_delimiter(&text)
+}
+
+fn assistant_text_run_source(
+    message: &ChatMessage,
+    start_block_idx: usize,
+    end_block_idx: usize,
+) -> Option<(String, TextBlockSpacing)> {
+    let mut text = String::new();
+    let mut trailing_spacing = TextBlockSpacing::None;
+
+    for block in message.blocks.get(start_block_idx..=end_block_idx)? {
+        let MessageBlock::Text(block) = block else {
+            continue;
+        };
+        if block.text.is_empty() {
+            continue;
+        }
+        append_text_run(&mut text, trailing_spacing, &block.text);
+        trailing_spacing = block.trailing_spacing;
+    }
+
+    (!text.is_empty()).then_some((text, trailing_spacing))
+}
+
+fn assistant_text_handoff_continues_open_table(current: &str, next: &TextBlock) -> bool {
+    if !markdown_table_tail_is_open(current) {
         return false;
     }
 
-    next_visible_assistant_text(message, block_idx)
-        .is_some_and(|next| starts_with_markdown_table_row(&next.text))
+    starts_with_markdown_table_row(&next.text)
+}
+
+fn assistant_text_handoff_continues_list_item(
+    current: &str,
+    trailing_spacing: TextBlockSpacing,
+    next: &TextBlock,
+) -> bool {
+    trailing_spacing == TextBlockSpacing::None
+        && markdown_source_ends_with_list_item(current)
+        && markdown_source_starts_with_list_continuation(&next.text)
+}
+
+fn markdown_source_starts_with_list_continuation(text: &str) -> bool {
+    markdown_source_boundary_line(text, BoundaryLine::First)
+        .is_some_and(|line| !markdown_source_line_is_list_item(line))
 }
 
 fn next_visible_assistant_text(message: &ChatMessage, block_idx: usize) -> Option<&TextBlock> {
@@ -962,6 +1038,49 @@ fn markdown_source_starts_with_ordered_list_marker(text: &str) -> bool {
     digit_count > 0 && text[digit_count..].starts_with(". ")
 }
 
+fn markdown_source_has_open_fence(text: &str) -> bool {
+    let mut in_fenced_code = false;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_fenced_code = !in_fenced_code;
+        }
+    }
+    in_fenced_code
+}
+
+fn markdown_source_has_open_inline_delimiter(text: &str) -> bool {
+    let mut in_code = false;
+    let mut strong_asterisk_open = false;
+    let mut strong_underscore_open = false;
+    let mut chars = text.char_indices().peekable();
+
+    while let Some((idx, ch)) = chars.next() {
+        if ch == '\\' {
+            let _ = chars.next();
+            continue;
+        }
+        if ch == '`' {
+            in_code = !in_code;
+            continue;
+        }
+        if in_code {
+            continue;
+        }
+
+        let rest = &text[idx..];
+        if rest.starts_with("**") {
+            strong_asterisk_open = !strong_asterisk_open;
+            let _ = chars.next();
+        } else if rest.starts_with("__") {
+            strong_underscore_open = !strong_underscore_open;
+            let _ = chars.next();
+        }
+    }
+
+    in_code || strong_asterisk_open || strong_underscore_open
+}
+
 fn append_assistant_label_rows(
     rows: &mut Vec<Line<'static>>,
     boundaries: &mut Vec<LiveRowBoundary>,
@@ -1086,7 +1205,7 @@ fn render_assistant_text_block(
     } else {
         lines
     };
-    wrap_lines_to_physical_rows(&lines, width)
+    wrap_markdown_lines_to_physical_rows(&lines, width)
 }
 
 fn trim_trailing_blank_rows(mut rows: Vec<Line<'static>>) -> Vec<Line<'static>> {
@@ -1196,7 +1315,7 @@ fn segments_to_physical_rows(
         match segment {
             MessageRowSegment::Blank => rows.push(Line::default()),
             MessageRowSegment::Lines { lines } => {
-                rows.extend(wrap_lines_to_physical_rows(lines, width));
+                rows.extend(wrap_markdown_lines_to_physical_rows(lines, width));
             }
         }
     }
@@ -1797,6 +1916,121 @@ mod tests {
         assert!(
             !remaining_text.iter().any(|line| line.trim_start().starts_with("| Slow startup |")),
             "table continuation must not render as a raw pipe row: {remaining_text:?}"
+        );
+    }
+
+    #[test]
+    fn live_assistant_ordered_list_wraps_continuation_with_hanging_indent() {
+        let mut app = App::test_default();
+        app.transcript.messages.push(assistant_text_message(
+            "3. Keymap survey - mapping the keymap system, focus dispatch, and help generation.",
+        ));
+
+        let rows = serialize_live_rows(&mut app, 38);
+        let text = line_texts(&rows);
+
+        assert!(
+            text.iter().any(|line| line.starts_with("  3. Keymap survey")),
+            "missing ordered list prefix: {text:?}"
+        );
+        assert!(
+            text.iter().any(|line| line.starts_with("     keymap system")),
+            "list continuation lost hanging indent: {text:?}"
+        );
+    }
+
+    #[test]
+    fn active_assistant_list_handoff_keeps_context_prefix_mutable() {
+        let first = TextBlock::from_complete("3. Keymap survey maps the system.");
+        let second = TextBlock::from_complete(" Additional detail keeps streaming.");
+        let mut app = App::test_default();
+        app.transcript.messages.push(assistant_blocks_message(vec![
+            MessageBlock::Text(first),
+            MessageBlock::Text(second),
+        ]));
+        app.bind_active_turn_assistant(0);
+        app.status = AppStatus::Running;
+
+        let serialized = serialize_all_rows_with_boundaries(&mut app, 38);
+        let committed_ids = serialized
+            .segments()
+            .iter()
+            .filter(|segment| segment.commit_ready)
+            .flat_map(|segment| segment.ids.iter().cloned())
+            .collect::<BTreeSet<_>>();
+        let remaining = serialize_live_rows_with_boundaries_excluding(&mut app, 38, &committed_ids);
+        let remaining_text = line_texts(remaining.rows());
+
+        assert_eq!(serialized.stable_row_count(), 0);
+        assert!(
+            remaining_text.iter().any(|line| line.starts_with("  3. Keymap survey")),
+            "missing ordered list prefix: {remaining_text:?}"
+        );
+    }
+
+    #[test]
+    fn active_assistant_inline_bold_handoff_keeps_prefix_mutable_until_closed() {
+        let first = TextBlock::from_complete("This is **bold");
+        let second = TextBlock::from_complete(" text** done.");
+        let mut app = App::test_default();
+        app.transcript.messages.push(assistant_blocks_message(vec![
+            MessageBlock::Text(first),
+            MessageBlock::Text(second),
+        ]));
+        app.bind_active_turn_assistant(0);
+        app.status = AppStatus::Running;
+
+        let serialized = serialize_all_rows_with_boundaries(&mut app, 80);
+        let committed_ids = serialized
+            .segments()
+            .iter()
+            .filter(|segment| segment.commit_ready)
+            .flat_map(|segment| segment.ids.iter().cloned())
+            .collect::<BTreeSet<_>>();
+        let remaining = serialize_live_rows_with_boundaries_excluding(&mut app, 80, &committed_ids);
+        let remaining_text = line_texts(remaining.rows());
+
+        assert_eq!(serialized.stable_row_count(), 0);
+        assert!(remaining_text.iter().any(|line| line.contains("This is bold")));
+        assert!(remaining_text.iter().any(|line| line.contains("text done.")));
+        assert!(
+            !remaining_text.iter().any(|line| line.contains("**")),
+            "inline markdown marker leaked through handoff: {remaining_text:?}"
+        );
+    }
+
+    #[test]
+    fn active_assistant_inline_bold_handoff_commits_after_following_block_arrives() {
+        let first = TextBlock::from_complete("This is **bold");
+        let second = TextBlock::from_complete(" text** done.");
+        let third = TextBlock::from_complete("more");
+        let mut app = App::test_default();
+        app.transcript.messages.push(assistant_blocks_message(vec![
+            MessageBlock::Text(first),
+            MessageBlock::Text(second),
+            MessageBlock::Text(third),
+        ]));
+        app.bind_active_turn_assistant(0);
+        app.status = AppStatus::Running;
+
+        let serialized = serialize_all_rows_with_boundaries(&mut app, 80);
+        let stable_text = line_texts(&serialized.rows()[..serialized.stable_row_count()]);
+
+        assert!(
+            stable_text.iter().any(|line| line.contains("This is bold")),
+            "closed inline markdown handoff did not commit: {stable_text:?}"
+        );
+        assert!(
+            stable_text.iter().any(|line| line.contains("text done.")),
+            "closed inline markdown suffix did not commit: {stable_text:?}"
+        );
+        assert!(
+            !stable_text.iter().any(|line| line.contains("more")),
+            "active tail should remain mutable: {stable_text:?}"
+        );
+        assert!(
+            !stable_text.iter().any(|line| line.contains("**")),
+            "inline markdown marker leaked through committed handoff: {stable_text:?}"
         );
     }
 

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -5,9 +5,9 @@
 use crate::app::ChatMessage;
 use crate::app::{BlockCache, IncrementalMarkdown, MarkdownRenderKey, TextBlock};
 use crate::ui::tool_call;
+use crate::ui::wrap::wrap_markdown_lines_to_physical_rows;
 use ratatui::style::Color;
-use ratatui::text::{Line, Text};
-use ratatui::widgets::{Paragraph, Wrap};
+use ratatui::text::Line;
 
 #[cfg(test)]
 use super::message_rows::build_user_system_message_rows;
@@ -135,7 +135,7 @@ pub(super) fn render_text_cached(
     // but for completed messages it persists.
     let h = {
         let _t = crate::perf::start_with("msg::wrap_height", "lines", fresh.len());
-        Paragraph::new(Text::from(fresh.clone())).wrap(Wrap { trim: false }).line_count(width)
+        wrap_markdown_lines_to_physical_rows(&fresh, width).len()
     };
     cache.store(fresh);
     cache.set_height(h, width);

--- a/src/ui/wrap.rs
+++ b/src/ui/wrap.rs
@@ -75,6 +75,76 @@ pub(crate) fn wrap_lines_to_physical_rows(
 }
 
 #[must_use]
+pub(crate) fn wrap_markdown_lines_to_physical_rows(
+    lines: &[Line<'static>],
+    width: u16,
+) -> Vec<Line<'static>> {
+    if lines.is_empty() {
+        return Vec::new();
+    }
+
+    let mut rows = Vec::new();
+    let mut in_fenced_code = false;
+    for line in lines {
+        let text = line_text(line);
+        let starts_fence =
+            text.trim_start().starts_with("```") || text.trim_start().starts_with("~~~");
+        let in_code_line = in_fenced_code || starts_fence;
+        rows.extend(wrap_markdown_line_to_physical_rows(line, width, in_code_line));
+        if starts_fence {
+            in_fenced_code = !in_fenced_code;
+        }
+    }
+    rows
+}
+
+fn wrap_markdown_line_to_physical_rows(
+    line: &Line<'static>,
+    width: u16,
+    in_fenced_code: bool,
+) -> Vec<Line<'static>> {
+    if in_fenced_code {
+        return wrap_lines_to_physical_rows(std::slice::from_ref(line), width);
+    }
+
+    let Some(body_start) = markdown_list_body_start(&line_text(line)) else {
+        return wrap_lines_to_physical_rows(std::slice::from_ref(line), width);
+    };
+    if width == 0 {
+        return vec![Line::default()];
+    }
+
+    let (marker, body) = split_line_chunks_at_byte(line, body_start);
+    let marker_width = marker.iter().map(|chunk| display_width(&chunk.text)).sum::<usize>();
+    let width = usize::from(width);
+    if marker_width == 0 || marker_width >= width {
+        return wrap_lines_to_physical_rows(
+            std::slice::from_ref(line),
+            u16::try_from(width).unwrap_or(u16::MAX),
+        );
+    }
+
+    let body_rows = wrap_styled_chunks(&body, width.saturating_sub(marker_width));
+    let mut rows = Vec::with_capacity(body_rows.len().max(1));
+    let mut body_rows = body_rows.into_iter();
+
+    let mut first_spans =
+        marker.into_iter().map(|chunk| Span::styled(chunk.text, chunk.style)).collect::<Vec<_>>();
+    if let Some(first_body) = body_rows.next() {
+        first_spans.extend(first_body.spans);
+    }
+    rows.push(Line::from(first_spans).style(line.style));
+
+    let continuation_prefix = " ".repeat(marker_width);
+    for body_row in body_rows {
+        let mut spans = vec![Span::styled(continuation_prefix.clone(), line.style)];
+        spans.extend(body_row.spans);
+        rows.push(Line::from(spans).style(line.style));
+    }
+    rows
+}
+
+#[must_use]
 pub(crate) fn wrap_styled_chunks(chunks: &[StyledChunk], width: usize) -> Vec<Line<'static>> {
     if width == 0 || chunks.is_empty() {
         return vec![Line::default()];
@@ -127,6 +197,82 @@ pub(crate) fn wrap_styled_chunks(chunks: &[StyledChunk], width: usize) -> Vec<Li
         lines.push(Line::default());
     }
     lines
+}
+
+fn split_line_chunks_at_byte(
+    line: &Line<'static>,
+    split_at: usize,
+) -> (Vec<StyledChunk>, Vec<StyledChunk>) {
+    let mut left = Vec::new();
+    let mut right = Vec::new();
+    let mut seen = 0usize;
+
+    for span in &line.spans {
+        let text = span.content.as_ref();
+        let span_start = seen;
+        let span_end = seen + text.len();
+        if span_end <= split_at {
+            left.push(StyledChunk { text: text.to_owned(), style: span.style });
+        } else if span_start >= split_at {
+            right.push(StyledChunk { text: text.to_owned(), style: span.style });
+        } else {
+            let local_split = split_at - span_start;
+            let (prefix, suffix) = text.split_at(local_split);
+            if !prefix.is_empty() {
+                left.push(StyledChunk { text: prefix.to_owned(), style: span.style });
+            }
+            if !suffix.is_empty() {
+                right.push(StyledChunk { text: suffix.to_owned(), style: span.style });
+            }
+        }
+        seen = span_end;
+    }
+
+    (left, right)
+}
+
+fn markdown_list_body_start(text: &str) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let mut idx = bytes.iter().take_while(|byte| **byte == b' ').count();
+    if idx >= bytes.len() {
+        return None;
+    }
+
+    if matches!(bytes[idx], b'-' | b'*' | b'+')
+        && bytes.get(idx + 1).is_some_and(|byte| *byte == b' ')
+    {
+        idx += 2;
+        if task_list_marker_len(&bytes[idx..]).is_some() {
+            idx += 4;
+        }
+        return Some(idx);
+    }
+
+    let digit_start = idx;
+    while bytes.get(idx).is_some_and(u8::is_ascii_digit) {
+        idx += 1;
+    }
+    if idx > digit_start
+        && bytes.get(idx).is_some_and(|byte| *byte == b'.')
+        && bytes.get(idx + 1).is_some_and(|byte| *byte == b' ')
+    {
+        return Some(idx + 2);
+    }
+
+    None
+}
+
+fn task_list_marker_len(bytes: &[u8]) -> Option<usize> {
+    (bytes.len() >= 4
+        && bytes[0] == b'['
+        && matches!(bytes[1], b' ' | b'x' | b'X')
+        && bytes[2] == b']'
+        && bytes[3] == b' ')
+        .then_some(4)
+}
+
+fn line_text(line: &Line<'_>) -> String {
+    line.spans.iter().map(|span| span.content.as_ref()).collect()
 }
 
 #[must_use]
@@ -323,5 +469,75 @@ mod tests {
             32,
         );
         assert!(lines[0].spans[0].style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn markdown_ordered_list_wraps_with_hanging_indent() {
+        let rows = wrap_markdown_lines_to_physical_rows(
+            &[Line::from("  3. Keymap survey - mapping the keymap system")],
+            32,
+        );
+
+        assert_eq!(
+            rows.into_iter()
+                .map(|line| line
+                    .spans
+                    .into_iter()
+                    .map(|span| span.content.into_owned())
+                    .collect::<String>())
+                .collect::<Vec<_>>(),
+            vec!["  3. Keymap survey - mapping the", "     keymap system"]
+        );
+    }
+
+    #[test]
+    fn markdown_task_list_wraps_under_task_marker() {
+        let rows = wrap_markdown_lines_to_physical_rows(
+            &[Line::from("  - [x] completed task with extra words")],
+            24,
+        );
+
+        let text = rows
+            .into_iter()
+            .map(|line| {
+                line.spans
+                    .into_iter()
+                    .map(|span| span.content.into_owned())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_owned()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(text, vec!["  - [x] completed task", "        with extra words"]);
+    }
+
+    #[test]
+    fn markdown_list_wrapping_skips_fenced_code_lines() {
+        let rows = wrap_markdown_lines_to_physical_rows(
+            &[
+                Line::from("```md"),
+                Line::from("- code line that wraps without hanging indent"),
+                Line::from("```"),
+            ],
+            18,
+        );
+
+        let text = rows
+            .into_iter()
+            .map(|line| {
+                line.spans
+                    .into_iter()
+                    .map(|span| span.content.into_owned())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_owned()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            text,
+            vec!["```md", "- code line that", "wraps without", "hanging indent", "```"]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fix Markdown rendering stability for streamed assistant text and wrapped list rows.

- Recompute live assistant commit readiness after adjacent text blocks close Markdown context.
- Preserve stable scrollback advancement once inline Markdown handoffs are resolved.
- Apply Markdown-aware physical row wrapping consistently for live and cached message rows.
- Skip list-specific hanging indent wrapping inside fenced code blocks.

## Why

Streaming can split assistant text across cached text blocks. When an inline delimiter opens in one block and closes in the next, the earlier block was still treated as requiring Markdown context after another block arrived, keeping otherwise stable rows mutable. Separately, rendered fenced code lines that start with list-like text could be wrapped as Markdown lists, changing code block layout.

This change keeps unresolved Markdown handoffs mutable only while needed, then allows resolved prefixes to commit, and preserves code-block wrapping behavior.

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo check --offline`
  - `cargo test`
  - `cargo clippy --all-targets --all-features -- -D warnings`
- Manual:
  - Verified wrapped ordered-list continuation aligns under the list body.
  - Verified fenced code lines beginning with `- ` wrap without list hanging indent.
  - Verified a three-block inline bold handoff commits the resolved prefix while keeping the active tail mutable.
- Screenshot/video (if UI changed): `Screenshot 2026-07-09 174525.png`

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: N/A
