### PR TITLE
feat(update): add startup update screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Features
+
+- **Startup update screen** (#264, @srothgan): Show available updates in a startup screen with install, skip, and release-notes actions.
+
 ### Fixes
 
 - **Markdown list rendering** (#263, @srothgan): Keep streamed inline Markdown handoffs mutable only until delimiters resolve, let stable scrollback advance after resolved blocks, and preserve fenced code layout when code lines look like Markdown list items.

--- a/src/app/config/mcp.rs
+++ b/src/app/config/mcp.rs
@@ -16,7 +16,8 @@ pub(crate) use actions::{
     is_mcp_action_available, reconnect_mcp_server, set_mcp_server_enabled,
 };
 pub(crate) use auth::{
-    copy_text_to_clipboard, present_mcp_auth_redirect, submit_mcp_oauth_callback_url,
+    copy_text_to_clipboard, open_url_in_browser, present_mcp_auth_redirect,
+    submit_mcp_oauth_callback_url,
 };
 pub(crate) use elicitation::{
     handle_mcp_elicitation_completed, present_mcp_elicitation_request,

--- a/src/app/config/mcp/auth.rs
+++ b/src/app/config/mcp/auth.rs
@@ -74,7 +74,7 @@ pub(crate) fn present_mcp_auth_redirect(
     );
 }
 
-pub(super) fn open_url_in_browser(url: &str) -> Result<(), String> {
+pub(crate) fn open_url_in_browser(url: &str) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     let mut command = {
         let mut cmd = std::process::Command::new("rundll32.exe");

--- a/src/app/config/mod.rs
+++ b/src/app/config/mod.rs
@@ -29,7 +29,7 @@ pub(crate) use mcp::{
     apply_removed_config_mcp_server_confirmation_failures, available_mcp_actions,
     filter_removed_config_mcp_servers, filter_stale_plugin_mcp_servers,
     handle_mcp_elicitation_completed, handle_mcp_operation_error, handle_mcp_set_servers_result,
-    is_mcp_action_available, mcp_server_owner_summary,
+    is_mcp_action_available, mcp_server_owner_summary, open_url_in_browser,
     pending_dynamic_mcp_removal_confirmation_from_snapshot, present_mcp_auth_redirect,
     present_mcp_elicitation_request, reconcile_removed_config_mcp_server_guards,
     reconcile_stale_plugin_mcp_servers, refresh_mcp_snapshot,

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -15,6 +15,7 @@ mod type_converters;
 
 use super::config::ConfigState;
 use super::plugins::PluginsState;
+use super::settings;
 use super::state::{
     CacheMetrics, HistoryRetentionPolicy, HistoryRetentionStats, RenderCacheBudget,
     SdkInventoryState, SessionPickerState, SessionRuntimeState, StartupState, Transcript,
@@ -121,12 +122,41 @@ pub fn create_app(cli: &Cli) -> App {
         logger
     });
 
+    let loaded_settings = match settings::load_global_settings(env!("CARGO_PKG_VERSION")) {
+        Ok(loaded) => loaded,
+        Err(err) => {
+            tracing::warn!(
+                target: crate::logging::targets::APP_UPDATE,
+                event_name = "global_settings_load_failed",
+                message = "failed to load app settings",
+                outcome = "failure",
+                error_message = %err,
+            );
+            settings::LoadedAppSettings {
+                path: settings::global_settings_path(),
+                settings: settings::AppSettings::default(),
+            }
+        }
+    };
+    let update_prompt = if super::update_check::update_check_disabled(cli.no_update_check) {
+        None
+    } else {
+        settings::update_prompt_candidate(
+            &loaded_settings.settings,
+            env!("CARGO_PKG_VERSION"),
+            super::update_check::unix_now_secs().unwrap_or(0),
+        )
+        .map(super::UpdatePromptState::from)
+    };
+
     let cwd_display = shorten_cwd(&cwd);
     let mut app = App {
         surface_mode: SurfaceMode::Chat,
         terminal_lifecycle: TerminalLifecycleState::Bootstrapping,
         surface_dirty: SurfaceDirtyState::initial_chat(),
         config: ConfigState::default(),
+        global_settings: loaded_settings.settings,
+        global_settings_path: loaded_settings.path,
         trust: trust::TrustState::default(),
         settings_home_override: None,
         transcript: Transcript::new(vec![super::ChatMessage::welcome(
@@ -173,7 +203,8 @@ pub fn create_app(cli: &Cli) -> App {
         paste: super::state::PasteState::default(),
         pending_images: Vec::new(),
         git_context: super::git_context::GitContextState::default(),
-        update_notice: None,
+        update_prompt,
+        post_exit_action: None,
         usage: super::UsageState::default(),
         mcp: super::McpState::default(),
         notifications: super::notify::NotificationManager::new(),

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -190,6 +190,10 @@ fn dispatch_key_by_view(app: &mut App, key: crossterm::event::KeyEvent) -> Termi
             super::session_picker::handle_key(app, key);
             TerminalEventOutcome::handled(true)
         }
+        SurfaceMode::Fullscreen(FullscreenView::Update) => {
+            super::update_prompt::handle_key(app, key);
+            TerminalEventOutcome::handled(true)
+        }
     }
 }
 
@@ -219,7 +223,9 @@ fn dispatch_paste_by_view(app: &mut App, text: &str) -> bool {
             false
         }
         SurfaceMode::Fullscreen(FullscreenView::Config) => super::config::handle_paste(app, text),
-        SurfaceMode::Fullscreen(FullscreenView::Trusted | FullscreenView::SessionPicker) => false,
+        SurfaceMode::Fullscreen(
+            FullscreenView::Trusted | FullscreenView::SessionPicker | FullscreenView::Update,
+        ) => false,
     }
 }
 

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -5,7 +5,7 @@ use super::super::connect::take_connection_slot;
 use super::super::connect::{SessionStartReason, start_new_session};
 use super::super::state::RecentSessionInfo;
 use super::super::view::{self, FullscreenView};
-use super::super::{App, AppStatus, LoginHint, SystemSeverity, UpdateNoticeState};
+use super::super::{App, AppStatus, LoginHint, SystemSeverity};
 use super::push_system_message_with_severity;
 use super::session_reset::{ChatResetRenderMode, load_resume_history, reset_for_new_session};
 use crate::agent::client::AgentConnection;
@@ -16,7 +16,6 @@ use std::rc::Rc;
 
 const TURN_ERROR_INPUT_LOCK_HINT: &str =
     "Input disabled after an error. Press Ctrl+Q to quit and try again.";
-const UPDATE_INSTALL_COMMAND: &str = "npm install -g claude-code-rust";
 
 pub(super) struct SessionReplacedEventData {
     pub session_id: model::SessionId,
@@ -57,7 +56,6 @@ pub(super) fn handle_connected_client_event(
     if !history_updates.is_empty() {
         load_resume_history(app, history_updates);
     }
-    ensure_update_notice_message(app);
     clear_pending_command(app);
     app.resuming_session_id = None;
     crate::app::file_index::restart(app);
@@ -321,7 +319,6 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
     if !history_updates.is_empty() {
         load_resume_history(app, &history_updates);
     }
-    ensure_update_notice_message(app);
     clear_pending_command(app);
     if let Some(restored_input) = restored_input.as_deref() {
         app.input.set_text(restored_input);
@@ -410,12 +407,28 @@ pub(super) fn handle_update_available_event(
     latest_version: &str,
     current_version: &str,
 ) {
-    app.update_notice = Some(UpdateNoticeState {
-        current_version: current_version.to_owned(),
-        latest_version: latest_version.to_owned(),
-        emitted_session_scope_epoch: None,
-    });
-    ensure_update_notice_message(app);
+    let Some(release_url) = crate::app::settings::release_url_for_version(latest_version) else {
+        return;
+    };
+    crate::app::settings::record_update_check_result(
+        &mut app.global_settings,
+        current_version,
+        latest_version,
+        &release_url,
+        crate::app::update_check::unix_now_secs().unwrap_or(0),
+    );
+    if let Some(path) = app.global_settings_path.as_ref()
+        && let Err(err) = crate::app::settings::save_global_settings(path, &app.global_settings)
+    {
+        tracing::warn!(
+            target: crate::logging::targets::APP_UPDATE,
+            event_name = "update_available_settings_save_failed",
+            message = "failed to persist update availability",
+            outcome = "failure",
+            settings_path = %path.display(),
+            error_message = %err,
+        );
+    }
     tracing::info!(
         target: crate::logging::targets::APP_UPDATE,
         event_name = "update_available_applied",
@@ -424,32 +437,6 @@ pub(super) fn handle_update_available_event(
         latest_version = %latest_version,
         current_version = %current_version,
     );
-}
-
-pub(super) fn ensure_update_notice_message(app: &mut App) {
-    let Some(notice) = app.update_notice.as_ref() else {
-        return;
-    };
-    if notice.emitted_session_scope_epoch == Some(app.session_runtime.session_scope_epoch) {
-        return;
-    }
-
-    let message = format_update_available_message(&notice.latest_version, &notice.current_version);
-    push_system_message_with_severity(app, Some(SystemSeverity::Warning), &message);
-    if let Some(notice) = app.update_notice.as_mut() {
-        notice.emitted_session_scope_epoch = Some(app.session_runtime.session_scope_epoch);
-    }
-}
-
-fn format_update_available_message(latest_version: &str, current_version: &str) -> String {
-    format!(
-        "Update available: current v{current_version}, latest v{latest_version}. Upgrade to latest version via {}.",
-        update_install_command()
-    )
-}
-
-pub(crate) fn update_install_command() -> &'static str {
-    UPDATE_INSTALL_COMMAND
 }
 
 pub(super) fn handle_service_status_event(
@@ -550,6 +537,9 @@ fn reconcile_session_picker_selection(app: &mut App, selected_session_id: Option
 }
 
 fn maybe_open_startup_session_picker(app: &mut App) {
+    if app.update_prompt.is_some() {
+        return;
+    }
     if app.session_runtime.conn.is_none() || !app.startup.startup_picker_is_ready() {
         return;
     }

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -104,11 +104,6 @@ fn user_msg(text: &str) -> ChatMessage {
     )
 }
 
-#[test]
-fn update_install_command_is_documented_npm_command() {
-    assert_eq!(session::update_install_command(), "npm install -g claude-code-rust");
-}
-
 fn source_text(text: &str, source_message_uuid: &str) -> MessageBlock {
     MessageBlock::Text(
         TextBlock::from_complete(text).with_source_message_uuid(Some(source_message_uuid)),
@@ -358,11 +353,6 @@ fn first_block_text(msg: &ChatMessage) -> &str {
         }
         None => panic!("expected message block"),
     }
-}
-
-fn is_update_notice_message(msg: &ChatMessage) -> bool {
-    matches!(msg.role, MessageRole::System(Some(SystemSeverity::Warning)))
-        && first_block_text(msg).contains(session::update_install_command())
 }
 
 // shorten_tool_title
@@ -1652,9 +1642,9 @@ fn auth_required_sets_hint_without_prefilling_login_command() {
 }
 
 #[test]
-fn update_available_pushes_warning_system_message_with_versions_and_install_command() {
+fn update_available_records_settings_without_transcript_message() {
     let mut app = make_test_app();
-    assert!(app.update_notice.is_none());
+    assert!(app.global_settings.updates.last_result.is_none());
 
     handle_client_event(
         &mut app,
@@ -1664,26 +1654,15 @@ fn update_available_pushes_warning_system_message_with_versions_and_install_comm
         },
     );
 
-    assert_eq!(app.transcript.messages.len(), 1);
-    assert!(matches!(
-        app.transcript.messages[0].role,
-        MessageRole::System(Some(SystemSeverity::Warning))
-    ));
-    assert_eq!(
-        first_block_text(&app.transcript.messages[0]),
-        format!(
-            "Update available: current v0.2.0, latest v0.3.0. Upgrade to latest version via {}.",
-            session::update_install_command()
-        )
-    );
-    let Some(update_notice) = app.update_notice.as_ref() else {
-        panic!("expected update notice state");
+    assert!(app.transcript.messages.is_empty());
+    let Some(last_result) = app.global_settings.updates.last_result.as_ref() else {
+        panic!("expected update result");
     };
-    assert_eq!(update_notice.current_version, "0.2.0");
-    assert_eq!(update_notice.latest_version, "0.3.0");
+    assert_eq!(last_result.current_version, "0.2.0");
+    assert_eq!(last_result.latest_version, "0.3.0");
     assert_eq!(
-        update_notice.emitted_session_scope_epoch,
-        Some(app.session_runtime.session_scope_epoch)
+        last_result.release_url,
+        "https://github.com/srothgan/claude-code-rust/releases/tag/v0.3.0"
     );
 }
 
@@ -4258,52 +4237,7 @@ fn permission_focus_tab_returns_focus_to_input() {
 }
 
 #[test]
-fn update_notice_is_not_duplicated_within_same_session_epoch() {
-    let mut app = make_test_app();
-    app.update_notice = Some(crate::app::UpdateNoticeState {
-        current_version: "0.11.1".into(),
-        latest_version: "0.11.2".into(),
-        emitted_session_scope_epoch: None,
-    });
-
-    session::ensure_update_notice_message(&mut app);
-    session::ensure_update_notice_message(&mut app);
-
-    assert_eq!(
-        app.transcript.messages.iter().filter(|msg| is_update_notice_message(msg)).count(),
-        1
-    );
-    assert_eq!(
-        app.update_notice.as_ref().and_then(|notice| notice.emitted_session_scope_epoch),
-        Some(app.session_runtime.session_scope_epoch)
-    );
-}
-
-#[test]
-fn update_notice_is_re_emitted_after_epoch_change() {
-    let mut app = make_test_app();
-    app.update_notice = Some(crate::app::UpdateNoticeState {
-        current_version: "0.11.1".into(),
-        latest_version: "0.11.2".into(),
-        emitted_session_scope_epoch: None,
-    });
-
-    session::ensure_update_notice_message(&mut app);
-    app.bump_session_scope_epoch();
-    session::ensure_update_notice_message(&mut app);
-
-    assert_eq!(
-        app.transcript.messages.iter().filter(|msg| is_update_notice_message(msg)).count(),
-        2
-    );
-    assert_eq!(
-        app.update_notice.as_ref().and_then(|notice| notice.emitted_session_scope_epoch),
-        Some(app.session_runtime.session_scope_epoch)
-    );
-}
-
-#[test]
-fn update_available_persists_across_connected_session_reset() {
+fn update_result_persists_across_connected_session_reset_without_notice() {
     let mut app = make_test_app();
 
     handle_client_event(
@@ -4315,37 +4249,18 @@ fn update_available_persists_across_connected_session_reset() {
     );
     handle_client_event(&mut app, connected_event("claude-updated"));
 
-    assert_eq!(
-        app.transcript.messages.iter().filter(|msg| is_update_notice_message(msg)).count(),
-        1
-    );
     assert!(matches!(
         app.transcript.messages.first().map(|msg| &msg.role),
         Some(MessageRole::Welcome)
     ));
-    let notice = app
-        .transcript
-        .messages
-        .iter()
-        .find(|msg| is_update_notice_message(msg))
-        .expect("expected update notice message after connect");
-    assert_eq!(
-        first_block_text(notice),
-        format!(
-            "Update available: current v0.11.1, latest v0.11.2. Upgrade to latest version via {}.",
-            session::update_install_command()
-        )
-    );
-    assert_eq!(
-        app.update_notice
-            .as_ref()
-            .and_then(|update_notice| update_notice.emitted_session_scope_epoch),
-        Some(app.session_runtime.session_scope_epoch)
-    );
+    assert_eq!(app.transcript.messages.len(), 1);
+    let last_result = app.global_settings.updates.last_result.as_ref().expect("update result");
+    assert_eq!(last_result.current_version, "0.11.1");
+    assert_eq!(last_result.latest_version, "0.11.2");
 }
 
 #[test]
-fn update_available_persists_across_session_replaced_reset() {
+fn update_result_persists_across_session_replaced_reset_without_notice() {
     let mut app = make_test_app();
 
     handle_client_event(
@@ -4368,33 +4283,14 @@ fn update_available_persists_across_session_replaced_reset() {
         },
     );
 
-    assert_eq!(
-        app.transcript.messages.iter().filter(|msg| is_update_notice_message(msg)).count(),
-        1
-    );
     assert!(matches!(
         app.transcript.messages.first().map(|msg| &msg.role),
         Some(MessageRole::Welcome)
     ));
-    let notice = app
-        .transcript
-        .messages
-        .iter()
-        .find(|msg| is_update_notice_message(msg))
-        .expect("expected update notice message after replacement");
-    assert_eq!(
-        first_block_text(notice),
-        format!(
-            "Update available: current v0.11.1, latest v0.11.2. Upgrade to latest version via {}.",
-            session::update_install_command()
-        )
-    );
-    assert_eq!(
-        app.update_notice
-            .as_ref()
-            .and_then(|update_notice| update_notice.emitted_session_scope_epoch),
-        Some(app.session_runtime.session_scope_epoch)
-    );
+    assert_eq!(app.transcript.messages.len(), 1);
+    let last_result = app.global_settings.updates.last_result.as_ref().expect("update result");
+    assert_eq!(last_result.current_version, "0.11.1");
+    assert_eq!(last_result.latest_version, "0.11.2");
 }
 
 fn attach_pending_permission(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -28,6 +28,7 @@ mod questions;
 mod service_status_check;
 pub(crate) mod session_picker;
 mod session_runtime;
+pub(crate) mod settings;
 pub(crate) mod slash;
 mod state;
 pub(crate) mod subagent;
@@ -36,7 +37,8 @@ pub(crate) mod tasks;
 mod terminal;
 pub(crate) mod terminal_runtime;
 mod trust;
-mod update_check;
+pub(crate) mod update_check;
+mod update_prompt;
 pub(crate) mod usage;
 mod user_dialog;
 mod view;
@@ -61,6 +63,7 @@ pub use lifecycle::{
     TerminalLifecycleState,
 };
 pub use service_status_check::start_service_status_check;
+pub use settings::{AppSettings, UpdatePrompt};
 pub(crate) use state::MarkdownRenderKey;
 pub use state::{
     App, AppStatus, AutocompleteKind, BlockCache, CacheMetrics, CancelOrigin, ChatMessage,
@@ -68,17 +71,36 @@ pub use state::{
     HistoryOutputId, ImageAttachmentBlock, IncrementalMarkdown, InlinePermission, InlineQuestion,
     InvalidationLevel, LayoutInvalidation, LiveRegionRenderState, LoginHint, McpState,
     MessageBlock, MessageBlockId, MessageRole, MessageUsage, ModeInfo, ModeState, NoticeBlock,
-    NoticeDedupKey, NoticeStage, PasteSessionState, PendingCommandAck, RateLimitIncidentKey,
-    RecentSessionInfo, SelectionPoint, SessionPickerState, SessionUsageState,
+    NoticeDedupKey, NoticeStage, PasteSessionState, PendingCommandAck, PostExitAction,
+    RateLimitIncidentKey, RecentSessionInfo, SelectionPoint, SessionPickerState, SessionUsageState,
     SubagentPermissionContext, SystemSeverity, TerminalSize, TerminalSizeChange,
     TerminalSnapshotMode, TextBlock, TextBlockSpacing, ToolCallInfo, ToolCallScope,
-    TurnNoticeLocation, TurnNoticeRef, UpdateNoticeState, UsageSnapshot, UsageSourceKind,
-    UsageSourceMode, UsageState, UsageWindow, UserDialogBlock, WelcomeBlock,
+    TurnNoticeLocation, TurnNoticeRef, UpdatePromptAction, UpdatePromptState, UsageSnapshot,
+    UsageSourceKind, UsageSourceMode, UsageState, UsageWindow, UserDialogBlock, WelcomeBlock,
     hash_text_block_content, hash_welcome_block_content, is_execute_tool_name,
 };
 pub use trust::TrustSelection;
 pub use update_check::start_update_check;
 pub use view::{FullscreenView, SurfaceMode};
+
+pub fn record_update_install_failure(app: &mut App, message: String) {
+    settings::record_install_failure(&mut app.global_settings, message);
+    save_update_install_result(app);
+}
+
+pub fn clear_update_install_failure(app: &mut App) {
+    settings::clear_install_failure(&mut app.global_settings);
+    save_update_install_result(app);
+}
+
+fn save_update_install_result(app: &App) {
+    let Some(path) = app.global_settings_path.as_ref() else {
+        return;
+    };
+    if let Err(error) = settings::save_global_settings(path, &app.global_settings) {
+        eprintln!("Failed to update app settings after install: {error}");
+    }
+}
 
 use crate::agent::events::ClientEvent;
 use crate::agent::model;

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Simon Peter Rothgang
+
+use serde::{Deserialize, Serialize};
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SETTINGS_DIR_NAME: &str = "claude-code-rust";
+const SETTINGS_FILE: &str = "settings.json";
+const OLD_UPDATE_CACHE_FILE: &str = "update-check.json";
+const UPDATE_SOURCE_GITHUB_RELEASE: &str = "github_release";
+const GITHUB_RELEASE_BASE_URL: &str = "https://github.com/srothgan/claude-code-rust/releases/tag";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppSettings {
+    #[serde(default)]
+    pub updates: UpdateSettings,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_result: Option<UpdateCheckResult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_until_unix_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skipped_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_install_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateCheckResult {
+    pub checked_at_unix_secs: u64,
+    pub current_version: String,
+    pub latest_version: String,
+    pub release_url: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdatePrompt {
+    pub current_version: String,
+    pub latest_version: String,
+    pub release_url: String,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedAppSettings {
+    pub path: Option<PathBuf>,
+    pub settings: AppSettings,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct OldUpdateCheckCache {
+    checked_at_unix_secs: u64,
+    latest_version: String,
+}
+
+pub fn load_global_settings(current_version: &str) -> Result<LoadedAppSettings, String> {
+    let Some(path) = global_settings_path() else {
+        return Ok(LoadedAppSettings { path: None, settings: AppSettings::default() });
+    };
+
+    let mut settings = load_from_path(&path)?;
+    migrate_old_update_cache(
+        &path,
+        old_update_cache_path().as_deref(),
+        &mut settings,
+        current_version,
+    )?;
+
+    Ok(LoadedAppSettings { path: Some(path), settings })
+}
+
+#[cfg(test)]
+fn load_global_settings_from_paths(
+    settings_path: &Path,
+    old_cache_path: Option<&Path>,
+    current_version: &str,
+) -> Result<AppSettings, String> {
+    let mut settings = load_from_path(settings_path)?;
+    migrate_old_update_cache(settings_path, old_cache_path, &mut settings, current_version)?;
+    Ok(settings)
+}
+
+pub fn save_global_settings(path: &Path, settings: &AppSettings) -> Result<(), String> {
+    let parent =
+        path.parent().ok_or_else(|| "App settings path has no parent directory".to_owned())?;
+    std::fs::create_dir_all(parent)
+        .map_err(|err| format!("Failed to create app settings directory: {err}"))?;
+
+    let temp_path = unique_temp_path(parent, path.file_name().and_then(std::ffi::OsStr::to_str));
+    let mut temp = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+        .map_err(|err| format!("Failed to create app settings temp file: {err}"))?;
+    serde_json::to_writer_pretty(&mut temp, settings)
+        .map_err(|err| format!("Failed to serialize app settings: {err}"))?;
+    temp.write_all(b"\n").map_err(|err| format!("Failed to finalize app settings file: {err}"))?;
+    temp.flush().map_err(|err| format!("Failed to flush app settings file: {err}"))?;
+    temp.sync_all().map_err(|err| format!("Failed to sync app settings file: {err}"))?;
+    drop(temp);
+    std::fs::rename(&temp_path, path)
+        .map_err(|err| format!("Failed to move app settings file into place: {err}"))?;
+    Ok(())
+}
+
+pub fn global_settings_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|dir| dir.join(SETTINGS_DIR_NAME).join(SETTINGS_FILE))
+}
+
+pub fn old_update_cache_path() -> Option<PathBuf> {
+    dirs::cache_dir().map(|dir| dir.join(SETTINGS_DIR_NAME).join(OLD_UPDATE_CACHE_FILE))
+}
+
+pub fn update_prompt_candidate(
+    settings: &AppSettings,
+    current_version: &str,
+    now_unix_secs: u64,
+) -> Option<UpdatePrompt> {
+    let result = settings.updates.last_result.as_ref()?;
+    if !super::update_check::is_newer_version(&result.latest_version, current_version) {
+        return None;
+    }
+    if settings.updates.skipped_version.as_deref() == Some(result.latest_version.as_str()) {
+        return None;
+    }
+    if settings.updates.skip_until_unix_secs.is_some_and(|skip_until| skip_until > now_unix_secs) {
+        return None;
+    }
+    let release_url = release_url_for_version(&result.latest_version)?;
+    let release_url =
+        if result.release_url.trim().is_empty() { release_url } else { result.release_url.clone() };
+    Some(UpdatePrompt {
+        current_version: current_version.to_owned(),
+        latest_version: result.latest_version.clone(),
+        release_url,
+        last_error: settings.updates.last_install_error.clone(),
+    })
+}
+
+pub fn record_update_check_result(
+    settings: &mut AppSettings,
+    current_version: &str,
+    latest_version: &str,
+    release_url: &str,
+    checked_at_unix_secs: u64,
+) {
+    settings.updates.last_result = Some(UpdateCheckResult {
+        checked_at_unix_secs,
+        current_version: current_version.to_owned(),
+        latest_version: latest_version.to_owned(),
+        release_url: release_url.to_owned(),
+        source: UPDATE_SOURCE_GITHUB_RELEASE.to_owned(),
+    });
+    if !super::update_check::is_newer_version(latest_version, current_version) {
+        settings.updates.skip_until_unix_secs = None;
+        settings.updates.skipped_version = None;
+        settings.updates.last_install_error = None;
+    }
+}
+
+pub fn record_skip_now(settings: &mut AppSettings, now_unix_secs: u64) {
+    settings.updates.skip_until_unix_secs = Some(now_unix_secs.saturating_add(6 * 60 * 60));
+}
+
+pub fn record_skip_version(settings: &mut AppSettings, latest_version: &str) {
+    settings.updates.skipped_version = Some(latest_version.to_owned());
+    settings.updates.skip_until_unix_secs = None;
+}
+
+pub fn record_install_failure(settings: &mut AppSettings, message: String) {
+    settings.updates.last_install_error = Some(message);
+}
+
+pub fn clear_install_failure(settings: &mut AppSettings) {
+    settings.updates.last_install_error = None;
+}
+
+pub fn release_url_for_version(version: &str) -> Option<String> {
+    super::update_check::is_valid_version(version)
+        .then(|| format!("{GITHUB_RELEASE_BASE_URL}/v{version}"))
+}
+
+fn load_from_path(path: &Path) -> Result<AppSettings, String> {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => serde_json::from_str::<AppSettings>(&raw)
+            .map_err(|err| format!("Failed to parse app settings: {err}")),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(AppSettings::default()),
+        Err(err) => Err(format!("Failed to read app settings: {err}")),
+    }
+}
+
+fn migrate_old_update_cache(
+    settings_path: &Path,
+    old_path: Option<&Path>,
+    settings: &mut AppSettings,
+    current_version: &str,
+) -> Result<(), String> {
+    if settings.updates.last_result.is_some() {
+        return Ok(());
+    }
+    let Some(old_path) = old_path else {
+        return Ok(());
+    };
+    let raw = match std::fs::read_to_string(old_path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            tracing::warn!(
+                target: crate::logging::targets::APP_UPDATE,
+                event_name = "old_update_cache_read_failed",
+                message = "failed to read old update cache during migration",
+                outcome = "failure",
+                cache_path = %old_path.display(),
+                error_message = %err,
+            );
+            return Ok(());
+        }
+    };
+    let Ok(cache) = serde_json::from_str::<OldUpdateCheckCache>(&raw) else {
+        tracing::warn!(
+            target: crate::logging::targets::APP_UPDATE,
+            event_name = "old_update_cache_parse_failed",
+            message = "failed to parse old update cache during migration",
+            outcome = "failure",
+            cache_path = %old_path.display(),
+        );
+        return Ok(());
+    };
+    if !super::update_check::is_valid_version(&cache.latest_version) {
+        return Ok(());
+    }
+    let Some(release_url) = release_url_for_version(&cache.latest_version) else {
+        return Ok(());
+    };
+
+    record_update_check_result(
+        settings,
+        current_version,
+        &cache.latest_version,
+        &release_url,
+        cache.checked_at_unix_secs,
+    );
+    save_global_settings(settings_path, settings)?;
+    if let Err(err) = std::fs::remove_file(old_path)
+        && err.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            target: crate::logging::targets::APP_UPDATE,
+            event_name = "old_update_cache_cleanup_failed",
+            message = "failed to delete old update cache after migration",
+            outcome = "failure",
+            cache_path = %old_path.display(),
+            error_message = %err,
+        );
+    }
+    Ok(())
+}
+
+fn unique_temp_path(parent: &Path, filename_hint: Option<&str>) -> PathBuf {
+    let stamp =
+        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |duration| duration.as_nanos());
+    let filename = filename_hint.unwrap_or(SETTINGS_FILE);
+    parent.join(format!(".{filename}.{stamp}.tmp"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_candidate_requires_newer_version() {
+        let mut settings = AppSettings::default();
+        record_update_check_result(
+            &mut settings,
+            "0.13.4",
+            "0.14.0",
+            "https://example.invalid/v0.14.0",
+            10,
+        );
+
+        assert!(update_prompt_candidate(&settings, "0.13.4", 20).is_some());
+        assert!(update_prompt_candidate(&settings, "0.14.0", 20).is_none());
+    }
+
+    #[test]
+    fn prompt_candidate_respects_skip_until() {
+        let mut settings = AppSettings::default();
+        record_update_check_result(&mut settings, "0.13.4", "0.14.0", "url", 10);
+        record_skip_now(&mut settings, 20);
+
+        assert!(update_prompt_candidate(&settings, "0.13.4", 30).is_none());
+        assert!(update_prompt_candidate(&settings, "0.13.4", 22_000).is_some());
+    }
+
+    #[test]
+    fn prompt_candidate_respects_skipped_version() {
+        let mut settings = AppSettings::default();
+        record_update_check_result(&mut settings, "0.13.4", "0.14.0", "url", 10);
+        record_skip_version(&mut settings, "0.14.0");
+
+        assert!(update_prompt_candidate(&settings, "0.13.4", 20).is_none());
+    }
+
+    #[test]
+    fn release_url_is_derived_from_version() {
+        assert_eq!(
+            release_url_for_version("0.14.0").as_deref(),
+            Some("https://github.com/srothgan/claude-code-rust/releases/tag/v0.14.0")
+        );
+    }
+
+    #[test]
+    fn migrates_old_update_cache_into_global_settings_and_deletes_old_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = dir.path().join("config").join("settings.json");
+        let old_cache_path = dir.path().join("cache").join("update-check.json");
+        std::fs::create_dir_all(old_cache_path.parent().expect("old cache parent"))
+            .expect("create cache dir");
+        std::fs::write(
+            &old_cache_path,
+            r#"{"checked_at_unix_secs":1783580000,"latest_version":"0.14.0"}"#,
+        )
+        .expect("write old cache");
+
+        let settings =
+            load_global_settings_from_paths(&settings_path, Some(&old_cache_path), "0.13.4")
+                .expect("load settings");
+
+        let result = settings.updates.last_result.expect("last result");
+        assert_eq!(result.checked_at_unix_secs, 1_783_580_000);
+        assert_eq!(result.current_version, "0.13.4");
+        assert_eq!(result.latest_version, "0.14.0");
+        assert_eq!(
+            result.release_url,
+            "https://github.com/srothgan/claude-code-rust/releases/tag/v0.14.0"
+        );
+        assert!(!old_cache_path.exists());
+        assert!(settings_path.exists());
+    }
+}

--- a/src/app/state/app.rs
+++ b/src/app/state/app.rs
@@ -9,6 +9,8 @@ pub struct App {
     pub terminal_lifecycle: TerminalLifecycleState,
     pub surface_dirty: SurfaceDirtyState,
     pub config: ConfigState,
+    pub global_settings: crate::app::AppSettings,
+    pub global_settings_path: Option<PathBuf>,
     pub trust: TrustState,
     pub settings_home_override: Option<PathBuf>,
     pub transcript: Transcript,
@@ -76,8 +78,10 @@ pub struct App {
     pub pending_images: Vec<crate::app::clipboard_image::ImageAttachment>,
     /// Git repo context used by footer/status rendering and live branch tracking.
     pub(crate) git_context: GitContextState,
-    /// Update availability state for the current app lifetime.
-    pub update_notice: Option<UpdateNoticeState>,
+    /// Update prompt state for the startup fullscreen surface.
+    pub update_prompt: Option<UpdatePromptState>,
+    /// Work to run after the TUI has restored the user's terminal.
+    pub post_exit_action: Option<super::PostExitAction>,
     /// Config > Usage snapshot and refresh lifecycle.
     pub usage: UsageState,
     /// Config > MCP live server snapshot and refresh lifecycle.
@@ -156,6 +160,8 @@ impl App {
             terminal_lifecycle: TerminalLifecycleState::Running(SurfaceMode::Chat),
             surface_dirty: SurfaceDirtyState::initial_chat(),
             config: ConfigState::default(),
+            global_settings: crate::app::AppSettings::default(),
+            global_settings_path: None,
             trust: TrustState::default(),
             settings_home_override: None,
             transcript: Transcript::default(),
@@ -194,7 +200,8 @@ impl App {
             paste: PasteState::default(),
             pending_images: Vec::new(),
             git_context: GitContextState::default(),
-            update_notice: None,
+            update_prompt: None,
+            post_exit_action: None,
             usage: UsageState::default(),
             mcp: McpState::default(),
             notifications: notify::NotificationManager::new(),

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -58,9 +58,9 @@ pub use turn_notices::{NoticeStage, TurnNoticeLocation, TurnNoticeRef};
 pub use types::{
     AppStatus, CancelOrigin, ExtraUsage, HistoryRetentionPolicy, HistoryRetentionStats, LoginHint,
     McpState, MessageUsage, ModeInfo, ModeState, PasteSessionState, PendingCommandAck,
-    RecentSessionInfo, RenderCacheBudget, SelectionPoint, SessionPickerState, SessionUsageState,
-    ToolCallScope, UpdateNoticeState, UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState,
-    UsageWindow,
+    PostExitAction, RecentSessionInfo, RenderCacheBudget, SelectionPoint, SessionPickerState,
+    SessionUsageState, ToolCallScope, UpdatePromptAction, UpdatePromptState, UsageSnapshot,
+    UsageSourceKind, UsageSourceMode, UsageState, UsageWindow,
 };
 
 #[allow(unused_imports)]
@@ -88,7 +88,7 @@ mod prelude {
         AppStatus, CancelOrigin, HistoryRetentionPolicy, HistoryRetentionStats, LoginHint,
         McpState, ModeState, PasteSessionState, PendingCommandAck, RecentSessionInfo,
         RenderCacheBudget, SelectionPoint, SessionPickerState, SessionUsageState, ToolCallScope,
-        UpdateNoticeState, UsageState,
+        UpdatePromptState, UsageState,
     };
     pub(super) use super::{BlockCache, CacheMetrics};
     pub(super) use crate::agent::events::ClientEvent;

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -31,11 +31,27 @@ pub enum PendingCommandAck {
     ConfigOption { option_id: String },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UpdatePromptAction {
+    #[default]
+    Install,
+    SkipNow,
+    SkipVersion,
+    ReleaseNotes,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UpdateNoticeState {
+pub struct UpdatePromptState {
     pub current_version: String,
     pub latest_version: String,
-    pub emitted_session_scope_epoch: Option<u64>,
+    pub release_url: String,
+    pub selected: UpdatePromptAction,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PostExitAction {
+    InstallUpdate { latest_version: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/app/trust/mod.rs
+++ b/src/app/trust/mod.rs
@@ -2,7 +2,7 @@
 pub(crate) mod store;
 
 use super::App;
-use super::view::{self, FullscreenView, SurfaceMode};
+use super::view::{self, FullscreenView};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -52,12 +52,7 @@ pub fn initialize(app: &mut App) {
         app.startup.request_connection();
     }
     if app.trust.is_trusted() {
-        let next_view = if app.startup.session_picker_requested() {
-            SurfaceMode::Fullscreen(FullscreenView::SessionPicker)
-        } else {
-            SurfaceMode::Chat
-        };
-        view::set_surface_mode(app, next_view);
+        view::set_surface_mode(app, super::update_prompt::post_trust_surface(app));
     } else {
         view::set_fullscreen_view(app, FullscreenView::Trusted);
     }
@@ -99,12 +94,7 @@ pub fn accept(app: &mut App) -> Result<(), String> {
     app.trust.status = TrustStatus::Trusted;
     app.trust.last_error = None;
     app.startup.request_connection();
-    let next_view = if app.startup.session_picker_requested() {
-        SurfaceMode::Fullscreen(FullscreenView::SessionPicker)
-    } else {
-        SurfaceMode::Chat
-    };
-    view::set_surface_mode(app, next_view);
+    view::set_surface_mode(app, super::update_prompt::post_trust_surface(app));
     Ok(())
 }
 

--- a/src/app/trust/tests.rs
+++ b/src/app/trust/tests.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
+use crate::app::{FullscreenView, SurfaceMode};
 use serde_json::json;
 
 #[test]
@@ -102,6 +103,33 @@ fn accept_routes_resume_picker_startup_to_picker_view() {
     accept(&mut app).expect("accept");
 
     assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::SessionPicker));
+    assert!(app.startup.connection_requested());
+}
+
+#[test]
+fn accept_routes_update_prompt_before_resume_picker() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join(".claude.json");
+    std::fs::write(&path, "{\n  \"projects\": {}\n}\n").expect("write");
+
+    let mut app = App::test_default();
+    app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::Trusted);
+    app.startup = crate::app::state::StartupState::new(None, None, true);
+    app.cwd_raw = dir.path().join("project").to_string_lossy().to_string();
+    app.config.preferences_path = Some(path);
+    app.trust.status = TrustStatus::Untrusted;
+    app.trust.project_key = store::normalize_project_key(std::path::Path::new(&app.cwd_raw));
+    app.update_prompt = Some(crate::app::UpdatePromptState {
+        current_version: "0.13.4".to_owned(),
+        latest_version: "0.14.0".to_owned(),
+        release_url: "https://example.invalid".to_owned(),
+        selected: crate::app::UpdatePromptAction::Install,
+        last_error: None,
+    });
+
+    accept(&mut app).expect("accept");
+
+    assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::Update));
     assert!(app.startup.connection_requested());
 }
 

--- a/src/app/update_check.rs
+++ b/src/app/update_check.rs
@@ -2,11 +2,10 @@
 // Copyright 2025 Simon Peter Rothgang
 
 use super::App;
+use super::settings;
 use crate::Cli;
-use crate::agent::events::ClientEvent;
 use reqwest::header::{ACCEPT, HeaderMap, HeaderValue, USER_AGENT};
-use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use serde::Deserialize;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::{Instrument as _, info_span};
 
@@ -18,25 +17,24 @@ const GITHUB_LATEST_RELEASE_API_URL: &str =
 const GITHUB_API_ACCEPT_VALUE: &str = "application/vnd.github+json";
 const GITHUB_API_VERSION_VALUE: &str = "2022-11-28";
 const GITHUB_USER_AGENT_VALUE: &str = "claude-code-rust-update-check";
-const CACHE_FILE: &str = "update-check.json";
-const CACHE_DIR_NAME: &str = "claude-code-rust";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct SimpleVersion {
+pub(crate) struct SimpleVersion {
     major: u64,
     minor: u64,
     patch: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct UpdateCheckCache {
-    checked_at_unix_secs: u64,
-    latest_version: String,
-}
-
 #[derive(Debug, Clone, Deserialize)]
 struct GithubLatestRelease {
     tag_name: String,
+    html_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct LatestRelease {
+    latest_version: String,
+    release_url: String,
 }
 
 pub fn start_update_check(app: &App, cli: &Cli) {
@@ -51,8 +49,9 @@ pub fn start_update_check(app: &App, cli: &Cli) {
         return;
     }
 
-    let event_tx = app.event_tx.clone();
     let current_version = env!("CARGO_PKG_VERSION").to_owned();
+    let settings_path = app.global_settings_path.clone();
+    let settings_snapshot = app.global_settings.clone();
     tracing::info!(
         target: crate::logging::targets::APP_UPDATE,
         event_name = "update_check_started",
@@ -69,21 +68,37 @@ pub fn start_update_check(app: &App, cli: &Cli) {
 
     tokio::task::spawn_local(
         async move {
-            let latest_version = resolve_latest_version().await;
-            let Some(latest_version) = latest_version else {
+            let Some((mut global_settings, release)) =
+                resolve_latest_release(settings_snapshot).await
+            else {
                 return;
             };
 
-            if is_newer_version(&latest_version, &current_version) {
-                let _ =
-                    event_tx.send(ClientEvent::UpdateAvailable { latest_version, current_version });
+            settings::record_update_check_result(
+                &mut global_settings,
+                &current_version,
+                &release.latest_version,
+                &release.release_url,
+                unix_now_secs().unwrap_or(0),
+            );
+            if let Some(path) = settings_path.as_ref()
+                && let Err(err) = settings::save_global_settings(path, &global_settings)
+            {
+                tracing::warn!(
+                    target: crate::logging::targets::APP_UPDATE,
+                    event_name = "update_settings_write_failed",
+                    message = "failed to write update check result",
+                    outcome = "failure",
+                    settings_path = %path.display(),
+                    error_message = %err,
+                );
             }
         }
         .instrument(update_check_span),
     );
 }
 
-fn update_check_disabled(no_update_check_flag: bool) -> bool {
+pub(crate) fn update_check_disabled(no_update_check_flag: bool) -> bool {
     if no_update_check_flag {
         return true;
     }
@@ -92,69 +107,34 @@ fn update_check_disabled(no_update_check_flag: bool) -> bool {
         .is_some_and(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
 }
 
-async fn resolve_latest_version() -> Option<String> {
-    let cache_path = update_cache_path()?;
+async fn resolve_latest_release(
+    settings: settings::AppSettings,
+) -> Option<(settings::AppSettings, LatestRelease)> {
     let now = unix_now_secs()?;
-    let cached = read_cache(&cache_path).await;
 
-    if let Some(cache) = cached.as_ref()
-        && now.saturating_sub(cache.checked_at_unix_secs) <= UPDATE_CHECK_TTL_SECS
-        && is_valid_version(&cache.latest_version)
+    if let Some(result) = settings.updates.last_result.as_ref()
+        && now.saturating_sub(result.checked_at_unix_secs) <= UPDATE_CHECK_TTL_SECS
+        && is_valid_version(&result.latest_version)
     {
         tracing::debug!(
             target: crate::logging::targets::APP_UPDATE,
             event_name = "update_check_cache_hit",
             message = "update check cache hit",
             outcome = "success",
-            latest_version = %cache.latest_version,
+            latest_version = %result.latest_version,
         );
-        return Some(cache.latest_version.clone());
+        return None;
     }
 
-    match fetch_latest_release_tag().await {
-        Some(latest_version) => {
-            let cache = UpdateCheckCache { checked_at_unix_secs: now, latest_version };
-            if let Err(err) = write_cache(&cache_path, &cache).await {
-                tracing::warn!(
-                    target: crate::logging::targets::APP_UPDATE,
-                    event_name = "update_check_cache_write_failed",
-                    message = "failed to write update check cache",
-                    outcome = "failure",
-                    cache_path = %cache_path.display(),
-                    error_message = %err,
-                );
-            }
-            Some(cache.latest_version)
-        }
-        None => cached.and_then(|cache| {
-            is_valid_version(&cache.latest_version).then_some(cache.latest_version)
-        }),
-    }
+    let release = fetch_latest_release().await?;
+    Some((settings, release))
 }
 
-fn update_cache_path() -> Option<PathBuf> {
-    dirs::cache_dir().map(|dir| dir.join(CACHE_DIR_NAME).join(CACHE_FILE))
-}
-
-fn unix_now_secs() -> Option<u64> {
+pub(crate) fn unix_now_secs() -> Option<u64> {
     SystemTime::now().duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs())
 }
 
-async fn read_cache(path: &Path) -> Option<UpdateCheckCache> {
-    let content = tokio::fs::read_to_string(path).await.ok()?;
-    serde_json::from_str::<UpdateCheckCache>(&content).ok()
-}
-
-async fn write_cache(path: &Path, cache: &UpdateCheckCache) -> anyhow::Result<()> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-    let content = serde_json::to_vec(cache)?;
-    tokio::fs::write(path, content).await?;
-    Ok(())
-}
-
-async fn fetch_latest_release_tag() -> Option<String> {
+async fn fetch_latest_release() -> Option<LatestRelease> {
     let client = reqwest::Client::builder().timeout(UPDATE_CHECK_TIMEOUT).build().ok()?;
 
     let response = client
@@ -177,7 +157,12 @@ async fn fetch_latest_release_tag() -> Option<String> {
     }
 
     let release = response.json::<GithubLatestRelease>().await.ok()?;
-    normalize_version_string(&release.tag_name)
+    let latest_version = normalize_version_string(&release.tag_name)?;
+    let release_url = release
+        .html_url
+        .filter(|url| !url.trim().is_empty())
+        .or_else(|| settings::release_url_for_version(&latest_version))?;
+    Some(LatestRelease { latest_version, release_url })
 }
 
 fn github_api_headers() -> HeaderMap {
@@ -188,11 +173,11 @@ fn github_api_headers() -> HeaderMap {
     headers
 }
 
-fn normalize_version_string(raw: &str) -> Option<String> {
+pub(crate) fn normalize_version_string(raw: &str) -> Option<String> {
     parse_simple_version(raw).map(|v| format!("{}.{}.{}", v.major, v.minor, v.patch))
 }
 
-fn parse_simple_version(raw: &str) -> Option<SimpleVersion> {
+pub(crate) fn parse_simple_version(raw: &str) -> Option<SimpleVersion> {
     let trimmed = raw.trim();
     let without_prefix = trimmed.strip_prefix('v').unwrap_or(trimmed);
     let core = without_prefix.split_once('-').map_or(without_prefix, |(c, _)| c);
@@ -207,11 +192,11 @@ fn parse_simple_version(raw: &str) -> Option<SimpleVersion> {
     Some(SimpleVersion { major, minor, patch })
 }
 
-fn is_valid_version(version: &str) -> bool {
+pub(crate) fn is_valid_version(version: &str) -> bool {
     parse_simple_version(version).is_some()
 }
 
-fn is_newer_version(candidate: &str, current: &str) -> bool {
+pub(crate) fn is_newer_version(candidate: &str, current: &str) -> bool {
     let Some(candidate) = parse_simple_version(candidate) else {
         return false;
     };

--- a/src/app/update_prompt.rs
+++ b/src/app/update_prompt.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Simon Peter Rothgang
+
+use super::settings;
+use super::view::{self, FullscreenView, SurfaceMode};
+use super::{App, PostExitAction, UpdatePrompt, UpdatePromptAction, UpdatePromptState};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+impl From<UpdatePrompt> for UpdatePromptState {
+    fn from(prompt: UpdatePrompt) -> Self {
+        Self {
+            current_version: prompt.current_version,
+            latest_version: prompt.latest_version,
+            release_url: prompt.release_url,
+            selected: UpdatePromptAction::Install,
+            last_error: prompt.last_error,
+        }
+    }
+}
+
+pub fn post_trust_surface(app: &App) -> SurfaceMode {
+    if app.update_prompt.is_some() {
+        SurfaceMode::Fullscreen(FullscreenView::Update)
+    } else if app.startup.session_picker_requested() {
+        SurfaceMode::Fullscreen(FullscreenView::SessionPicker)
+    } else {
+        SurfaceMode::Chat
+    }
+}
+
+pub fn handle_key(app: &mut App, key: KeyEvent) {
+    if is_ctrl(key, 'q') || is_ctrl(key, 'c') {
+        app.should_quit = true;
+        return;
+    }
+
+    match (key.code, key.modifiers) {
+        (KeyCode::Up | KeyCode::Char('k'), KeyModifiers::NONE) => move_selection(app, -1),
+        (KeyCode::Down | KeyCode::Char('j'), KeyModifiers::NONE) => move_selection(app, 1),
+        (KeyCode::Enter, KeyModifiers::NONE) => activate_selection(app),
+        (KeyCode::Esc, KeyModifiers::NONE) => skip_now(app),
+        _ => {}
+    }
+}
+
+fn move_selection(app: &mut App, delta: isize) {
+    let Some(prompt) = app.update_prompt.as_mut() else {
+        return;
+    };
+    let current = action_index(prompt.selected);
+    let next = current.saturating_add_signed(delta).min(ACTIONS.len().saturating_sub(1));
+    prompt.selected = ACTIONS[next];
+}
+
+fn activate_selection(app: &mut App) {
+    let Some(selected) = app.update_prompt.as_ref().map(|prompt| prompt.selected) else {
+        continue_startup(app);
+        return;
+    };
+
+    match selected {
+        UpdatePromptAction::Install => install(app),
+        UpdatePromptAction::SkipNow => skip_now(app),
+        UpdatePromptAction::SkipVersion => skip_version(app),
+        UpdatePromptAction::ReleaseNotes => open_release_notes(app),
+    }
+}
+
+fn install(app: &mut App) {
+    let Some(prompt) = app.update_prompt.as_ref() else {
+        return;
+    };
+    app.post_exit_action =
+        Some(PostExitAction::InstallUpdate { latest_version: prompt.latest_version.clone() });
+    app.should_quit = true;
+}
+
+fn skip_now(app: &mut App) {
+    let now = super::update_check::unix_now_secs().unwrap_or(0);
+    settings::record_skip_now(&mut app.global_settings, now);
+    persist_settings(app);
+    continue_startup(app);
+}
+
+fn skip_version(app: &mut App) {
+    let Some(latest_version) =
+        app.update_prompt.as_ref().map(|prompt| prompt.latest_version.clone())
+    else {
+        continue_startup(app);
+        return;
+    };
+    settings::record_skip_version(&mut app.global_settings, &latest_version);
+    persist_settings(app);
+    continue_startup(app);
+}
+
+fn open_release_notes(app: &mut App) {
+    let Some(release_url) = app.update_prompt.as_ref().map(|prompt| prompt.release_url.clone())
+    else {
+        return;
+    };
+    match crate::app::config::open_url_in_browser(&release_url) {
+        Ok(()) => {
+            if let Some(prompt) = app.update_prompt.as_mut() {
+                prompt.last_error = None;
+            }
+        }
+        Err(err) => {
+            if let Some(prompt) = app.update_prompt.as_mut() {
+                prompt.last_error = Some(format!("{err}. URL: {release_url}"));
+            }
+        }
+    }
+}
+
+fn persist_settings(app: &mut App) {
+    let Some(path) = app.global_settings_path.as_ref() else {
+        return;
+    };
+    if let Err(err) = settings::save_global_settings(path, &app.global_settings) {
+        tracing::warn!(
+            target: crate::logging::targets::APP_UPDATE,
+            event_name = "update_prompt_settings_save_failed",
+            message = "failed to persist update prompt choice",
+            outcome = "failure",
+            settings_path = %path.display(),
+            error_message = %err,
+        );
+    }
+}
+
+fn continue_startup(app: &mut App) {
+    app.update_prompt = None;
+    let next = if app.startup.session_picker_requested() {
+        SurfaceMode::Fullscreen(FullscreenView::SessionPicker)
+    } else {
+        SurfaceMode::Chat
+    };
+    view::set_surface_mode(app, next);
+}
+
+fn is_ctrl(key: KeyEvent, ch: char) -> bool {
+    matches!(key.code, KeyCode::Char(c) if c == ch) && key.modifiers == KeyModifiers::CONTROL
+}
+
+fn action_index(action: UpdatePromptAction) -> usize {
+    ACTIONS.iter().position(|candidate| *candidate == action).unwrap_or(0)
+}
+
+const ACTIONS: [UpdatePromptAction; 4] = [
+    UpdatePromptAction::Install,
+    UpdatePromptAction::SkipNow,
+    UpdatePromptAction::SkipVersion,
+    UpdatePromptAction::ReleaseNotes,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{App, FullscreenView, SurfaceMode};
+
+    fn app_with_prompt() -> App {
+        let mut app = App::test_default();
+        app.update_prompt = Some(UpdatePromptState {
+            current_version: "0.13.4".to_owned(),
+            latest_version: "0.14.0".to_owned(),
+            release_url: "https://example.invalid/v0.14.0".to_owned(),
+            selected: UpdatePromptAction::Install,
+            last_error: None,
+        });
+        app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::Update);
+        app
+    }
+
+    #[test]
+    fn install_sets_post_exit_action_and_quits() {
+        let mut app = app_with_prompt();
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert!(app.should_quit);
+        assert_eq!(
+            app.post_exit_action,
+            Some(PostExitAction::InstallUpdate { latest_version: "0.14.0".to_owned() })
+        );
+    }
+
+    #[test]
+    fn down_changes_selection() {
+        let mut app = app_with_prompt();
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+
+        assert_eq!(
+            app.update_prompt.as_ref().map(|prompt| prompt.selected),
+            Some(UpdatePromptAction::SkipNow)
+        );
+    }
+
+    #[test]
+    fn esc_skips_now_and_returns_to_chat() {
+        let mut app = app_with_prompt();
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert_eq!(app.surface_mode, SurfaceMode::Chat);
+        assert!(app.update_prompt.is_none());
+        assert!(app.global_settings.updates.skip_until_unix_secs.is_some());
+    }
+}

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -10,6 +10,7 @@ pub enum FullscreenView {
     Config,
     Trusted,
     SessionPicker,
+    Update,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@
 
 use clap::Parser;
 use claude_code_rust::Cli;
+use claude_code_rust::app::PostExitAction;
 use claude_code_rust::error::AppError;
+use std::process::Stdio;
 use std::time::Instant;
 use tracing::info_span;
 
@@ -83,7 +85,7 @@ fn run() -> anyhow::Result<i32> {
     let rt = tokio::runtime::Runtime::new()?;
     let local_set = tokio::task::LocalSet::new();
 
-    rt.block_on(local_set.run_until(async move {
+    let exit_code = rt.block_on(local_set.run_until(async move {
         // Phase 1: create app in Connecting state (instant, no I/O)
         let mut app = claude_code_rust::app::create_app(&cli);
 
@@ -91,7 +93,8 @@ fn run() -> anyhow::Result<i32> {
         // The bridge itself is started from the TUI loop only after trust is accepted.
         claude_code_rust::app::start_update_check(&app, &cli);
         let result = claude_code_rust::app::run_tui(&mut app).await;
-        maybe_print_resume_hint(&app, result.is_ok());
+        let post_exit_action = app.post_exit_action.take();
+        maybe_print_resume_hint(&app, result.is_ok() && post_exit_action.is_none());
 
         // Kill any spawned terminal child processes before exiting
         claude_code_rust::agent::events::kill_all_terminals(&app.terminals);
@@ -100,10 +103,84 @@ fn run() -> anyhow::Result<i32> {
             return Err(anyhow::Error::new(app_error));
         }
 
-        result
+        result?;
+
+        if let Some(action) = post_exit_action {
+            return Ok(run_post_exit_action(&mut app, action));
+        }
+
+        Ok(0)
     }))?;
 
-    Ok(0)
+    Ok(exit_code)
+}
+
+fn run_post_exit_action(app: &mut claude_code_rust::app::App, action: PostExitAction) -> i32 {
+    match action {
+        PostExitAction::InstallUpdate { latest_version } => {
+            run_update_install(app, &latest_version)
+        }
+    }
+}
+
+fn run_update_install(app: &mut claude_code_rust::app::App, latest_version: &str) -> i32 {
+    let npm = match resolve_npm() {
+        Ok(path) => path,
+        Err(error) => {
+            let message = format!("Failed to resolve npm for update install: {error}");
+            eprintln!("{message}");
+            record_install_failure(app, message);
+            return 1;
+        }
+    };
+
+    let status = std::process::Command::new(&npm)
+        .args(["install", "-g", "claude-code-rust"])
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status();
+
+    match status {
+        Ok(status) if status.success() => {
+            clear_install_failure(app);
+            0
+        }
+        Ok(status) => {
+            let code = status.code().unwrap_or(1);
+            let message =
+                format!("Update install for v{latest_version} exited with status {status}.");
+            eprintln!("{message}");
+            record_install_failure(app, message);
+            code
+        }
+        Err(error) => {
+            let message = format!("Failed to run update install for v{latest_version}: {error}");
+            eprintln!("{message}");
+            record_install_failure(app, message);
+            1
+        }
+    }
+}
+
+fn resolve_npm() -> Result<std::path::PathBuf, String> {
+    #[cfg(target_os = "windows")]
+    let candidates = ["npm.cmd", "npm"];
+    #[cfg(not(target_os = "windows"))]
+    let candidates = ["npm"];
+
+    candidates
+        .iter()
+        .find_map(|candidate| which::which(candidate).ok())
+        .ok_or_else(|| format!("none of {} were found in PATH", candidates.join(", ")))
+}
+
+fn record_install_failure(app: &mut claude_code_rust::app::App, message: String) {
+    claude_code_rust::app::record_update_install_failure(app, message);
+}
+
+fn clear_install_failure(app: &mut claude_code_rust::app::App) {
+    claude_code_rust::app::clear_update_install_failure(app);
 }
 
 fn extract_app_error(err: &anyhow::Error) -> Option<AppError> {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -22,6 +22,7 @@ mod tool_call;
 pub(crate) mod tool_display;
 mod trusted;
 mod two_column_list;
+mod update;
 mod welcome;
 mod wrap;
 
@@ -38,6 +39,7 @@ pub fn render_fullscreen_surface(frame: &mut Frame, app: &mut App) {
         SurfaceMode::Fullscreen(FullscreenView::SessionPicker) => {
             session_picker::render(frame, app);
         }
+        SurfaceMode::Fullscreen(FullscreenView::Update) => update::render(frame, app),
         SurfaceMode::Chat => {
             debug_assert!(false, "chat is rendered by the inline terminal session");
         }

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
-use crate::app::{App, FullscreenView, SurfaceMode};
+use crate::app::{App, FullscreenView, SurfaceMode, UpdatePromptAction, UpdatePromptState};
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 
@@ -52,4 +52,24 @@ fn render_fullscreen_surface_draws_session_picker_view() {
 
     let rendered = buffer_text(&terminal);
     assert!(rendered.contains("Resume Session"));
+}
+
+#[test]
+fn render_fullscreen_surface_draws_update_view() {
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("terminal");
+    let mut app = App::test_default();
+    app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::Update);
+    app.update_prompt = Some(UpdatePromptState {
+        current_version: "0.13.4".to_owned(),
+        latest_version: "0.14.0".to_owned(),
+        release_url: "https://example.invalid".to_owned(),
+        selected: UpdatePromptAction::Install,
+        last_error: None,
+    });
+
+    terminal.draw(|frame| render_fullscreen_surface(frame, &mut app)).expect("draw");
+
+    let rendered = buffer_text(&terminal);
+    assert!(rendered.contains("Update Available"));
 }

--- a/src/ui/update.rs
+++ b/src/ui/update.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Simon Peter Rothgang
+
+use crate::app::{App, UpdatePromptAction};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Margin};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use super::theme;
+
+const INSTALL_COMMAND: &str = "npm install -g claude-code-rust";
+
+pub fn render(frame: &mut Frame, app: &mut App) {
+    let area = frame.area();
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .title("Update Available!")
+        .border_style(Style::default().fg(theme::DIM));
+    frame.render_widget(outer, area);
+
+    let inner = area.inner(Margin { vertical: 1, horizontal: 2 });
+    let Some(prompt) = app.update_prompt.as_ref() else {
+        frame.render_widget(Paragraph::new("No update prompt is active."), inner);
+        return;
+    };
+
+    let title = Line::from(Span::styled(
+        format!("Claude Rust v{} is available", prompt.latest_version),
+        Style::default().fg(theme::RUST_ORANGE).add_modifier(Modifier::BOLD),
+    ));
+    let detail = vec![
+        Line::from(format!("Current version: v{}", prompt.current_version)),
+        Line::from(format!("Latest version:  v{}", prompt.latest_version)),
+        Line::from(format!("Install command: {INSTALL_COMMAND}")),
+    ];
+    let error_height = prompt.last_error.as_deref().map_or(0, |error| {
+        wrapped_line_count(Text::from(Line::from(error.to_owned())), inner.width)
+    });
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(4),
+            Constraint::Length(error_height),
+            Constraint::Min(4),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    frame.render_widget(Paragraph::new(title).wrap(Wrap { trim: false }), chunks[0]);
+    frame.render_widget(Paragraph::new(detail).wrap(Wrap { trim: false }), chunks[1]);
+
+    if let Some(error) = prompt.last_error.as_deref() {
+        frame.render_widget(
+            Paragraph::new(error.to_owned())
+                .style(Style::default().fg(theme::STATUS_ERROR))
+                .wrap(Wrap { trim: false }),
+            chunks[2],
+        );
+    }
+
+    frame.render_widget(Paragraph::new(action_lines(app)).wrap(Wrap { trim: false }), chunks[3]);
+    frame.render_widget(
+        Paragraph::new("Enter select | Esc skip now | Ctrl+Q quit")
+            .style(Style::default().fg(theme::DIM)),
+        chunks[4],
+    );
+}
+
+fn action_lines(app: &App) -> Vec<Line<'static>> {
+    let Some(prompt) = app.update_prompt.as_ref() else {
+        return Vec::new();
+    };
+    [
+        (UpdatePromptAction::Install, "Install update".to_owned()),
+        (UpdatePromptAction::SkipNow, "Skip now".to_owned()),
+        (UpdatePromptAction::SkipVersion, "Skip this version".to_owned()),
+        (
+            UpdatePromptAction::ReleaseNotes,
+            format!("Read release notes for v{} (on GitHub)", prompt.latest_version),
+        ),
+    ]
+    .into_iter()
+    .flat_map(|(action, label)| {
+        let mut lines = Vec::with_capacity(2);
+        if action == UpdatePromptAction::ReleaseNotes {
+            lines.push(Line::default());
+        }
+        lines.push(action_line(&label, prompt.selected == action));
+        lines
+    })
+    .collect()
+}
+
+fn action_line(label: &str, selected: bool) -> Line<'static> {
+    let marker = if selected { ">" } else { " " };
+    let style = if selected {
+        Style::default().fg(theme::RUST_ORANGE)
+    } else {
+        Style::default().fg(theme::DIM)
+    }
+    .add_modifier(Modifier::BOLD);
+
+    Line::from(Span::styled(format!("{marker} {label}"), style))
+}
+
+fn wrapped_line_count(text: Text<'static>, width: u16) -> u16 {
+    u16::try_from(Paragraph::new(text).wrap(Wrap { trim: false }).line_count(width))
+        .unwrap_or(u16::MAX)
+        .max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{App, FullscreenView, SurfaceMode, UpdatePromptState};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn draw_text(app: &mut App) -> String {
+        let backend = TestBackend::new(80, 14);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal.draw(|frame| render(frame, app)).expect("draw");
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .chunks(80)
+            .map(|row| row.iter().map(ratatui::buffer::Cell::symbol).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn update_view_renders_versions_command_and_release_notes() {
+        let mut app = App::test_default();
+        app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::Update);
+        app.update_prompt = Some(UpdatePromptState {
+            current_version: "0.13.4".to_owned(),
+            latest_version: "0.14.0".to_owned(),
+            release_url: "https://example.invalid".to_owned(),
+            selected: UpdatePromptAction::Install,
+            last_error: None,
+        });
+
+        let text = draw_text(&mut app);
+
+        assert!(text.contains("Update Available!"));
+        assert!(text.contains("Current version: v0.13.4"));
+        assert!(text.contains("Latest version:  v0.14.0"));
+        assert!(text.contains(INSTALL_COMMAND));
+        assert!(text.contains("Read release notes for v0.14.0 (on GitHub)"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a startup update screen that replaces the previous transcript warning message.

- Stores update metadata and suppression state in the global app settings file.
- Migrates the old `update-check.json` cache into `settings.json`.
- Adds a fullscreen update prompt with install, skip now, skip version, and release notes actions.
- Runs `npm install -g claude-code-rust` only after the TUI has restored the terminal.
- Keeps trust as the first startup surface, then shows the update prompt before session picker/chat.

## Why

The previous update warning was stored as conversation state and re-emitted as a system message. That made update prompting session-scoped, mixed app lifecycle state into transcripts, and made user suppression awkward.

This moves update availability into app-owned settings and gives users a dedicated startup surface for update choices.

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `cargo check --offline`
- Manual:
  - Lowered local package version and verified the update screen appears from persisted GitHub release metadata on the next launch.
  - Verified trusted project startup shows the update screen before chat.
  - Verified untrusted project startup shows trust first, then update screen after accepting trust.
  - Verified `CLAUDE_RUST_NO_UPDATE_CHECK=1` / `--no-update-check` suppresses the persisted update screen and refresh.
  - Verified old cache migration removes `update-check.json` and writes update metadata under global `settings.json`.
- Screenshot/video (if UI changed): Manual local TUI verification; screenshot not included.

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: N/A
