### PR TITLE
fix(install): harden script install switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Release and Packaging
 
-- **Install scripts** (#259, #267, @srothgan): Add optional macOS/Linux and Windows install scripts that install from GitHub Releases without requiring npm, Node.js, or Bun on the user's machine.
+- **Install scripts** (#259, #267, @srothgan): Add macOS/Linux and Windows install scripts that install from GitHub Releases without requiring npm, Node.js, or Bun on the user's machine, and preserve the detected install method for in-app updates.
 - **Release script phases** (#260, @srothgan): Reorganize release tooling scripts into phase directories, add shared repository-root resolution, and expand PR validation for install archives and public installers.
 - **Windows npm mock smoke** (#262, @srothgan): Make local Windows mock package smoke tests use spawnable binaries and isolated npm cache state.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Release and Packaging
 
-- **Install scripts** (#259, @srothgan): Add optional macOS/Linux and Windows install scripts that install from GitHub Releases without requiring npm, Node.js, or Bun on the user's machine.
+- **Install scripts** (#259, #267, @srothgan): Add optional macOS/Linux and Windows install scripts that install from GitHub Releases without requiring npm, Node.js, or Bun on the user's machine.
 - **Release script phases** (#260, @srothgan): Reorganize release tooling scripts into phase directories, add shared repository-root resolution, and expand PR validation for install archives and public installers.
 - **Windows npm mock smoke** (#262, @srothgan): Make local Windows mock package smoke tests use spawnable binaries and isolated npm cache state.
 

--- a/README.md
+++ b/README.md
@@ -16,23 +16,15 @@ A native Rust terminal interface for Claude Code. Drop-in replacement for Anthro
 
 Claude Code Rust replaces the stock Claude Code terminal interface with a native Rust binary built on [Ratatui](https://ratatui.rs/). It connects to the same Claude API through a local Agent SDK bridge. Core Claude Code functionality - tool calls, file editing, terminal commands, and permissions - works unchanged.
 
-## Requisites
+## Prerequisite
 
-- Installed Claude Code CLI, required for authentication and plugin management because the Agent SDK does not yet expose equivalent public APIs.
+- Install the Claude Code CLI. You do not need to authenticate before installing or starting `claude-rs`; sign in later with `/login` or `claude auth login` when needed.
 
 ## Install
 
-### npm (global, recommended)
+### Install script (recommended, v0.14.0+)
 
-```bash
-npm install -g claude-code-rust
-```
-
-The npm package installs a small launcher plus a platform-specific optional dependency containing the prebuilt Rust binary, Agent SDK bridge, and bundled private Bun runtime for your OS and architecture.
-
-### Install script (optional, v0.14.0+)
-
-The install script downloads a complete GitHub Release archive and does not require Node.js, npm, or Bun on the user's machine.
+The install script downloads a complete GitHub Release archive. It does not require Rust, Node.js, npm, or Bun on the user's machine.
 
 **macOS/Linux:**
 
@@ -43,30 +35,20 @@ curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scri
 **Windows PowerShell:**
 
 ```powershell
-irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm 'https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1' | iex"
 ```
 
-**To pin a release:**
+### npm (global)
+
+npm remains supported for users who prefer package-manager ownership of the global command:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | CLAUDE_RS_RELEASE=v0.14.0 sh
-```
-
-```powershell
-$env:CLAUDE_RS_RELEASE = "v0.14.0"
-irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
-```
-
-### Troubleshooting npm installs
-
-If `claude-rs` reports a missing platform package, check whether optional dependencies were omitted:
-
-```bash
-npm config get omit
 npm install -g claude-code-rust
 ```
 
-If `claude-rs` resolves to an older global shim, ensure your npm global bin directory comes first on `PATH` or remove the stale shim before retrying.
+This option requires Node.js 24 and npm. The npm package installs a small launcher plus a platform-specific optional dependency containing the prebuilt Rust binary, Agent SDK bridge, and bundled private Bun runtime for your OS and architecture. A separate Rust toolchain or Bun installation is not required.
+
+See the [installation guide](https://srothgan.github.io/claude-code-rust/installation.html) for release pinning, custom locations, switching install methods, and troubleshooting.
 
 ## Usage
 
@@ -95,7 +77,7 @@ Claude Code Rust addresses these with a native terminal UI that uses diffed, dir
 
 ## Documentation
 
-The manual covers installation from npm and source, help, slash commands, keyboard shortcuts, settings, diagnostics, architecture, and the changelog:
+The manual covers installation with scripts, npm, and source builds, plus help, slash commands, keyboard shortcuts, settings, diagnostics, architecture, and the changelog:
 
 - [Installation](https://srothgan.github.io/claude-code-rust/installation.html)
 - [Usage](https://srothgan.github.io/claude-code-rust/usage.html)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,36 @@ Claude Code Rust replaces the stock Claude Code terminal interface with a native
 npm install -g claude-code-rust
 ```
 
-The npm package installs a small launcher plus a platform-specific optional dependency containing the prebuilt Rust binary for your OS and architecture.
+The npm package installs a small launcher plus a platform-specific optional dependency containing the prebuilt Rust binary, Agent SDK bridge, and bundled private Bun runtime for your OS and architecture.
+
+### Install script (optional, v0.14.0+)
+
+The install script downloads a complete GitHub Release archive and does not require Node.js, npm, or Bun on the user's machine.
+
+**macOS/Linux:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | sh
+```
+
+**Windows PowerShell:**
+
+```powershell
+irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+```
+
+**To pin a release:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | CLAUDE_RS_RELEASE=v0.14.0 sh
+```
+
+```powershell
+$env:CLAUDE_RS_RELEASE = "v0.14.0"
+irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+```
+
+### Troubleshooting npm installs
 
 If `claude-rs` reports a missing platform package, check whether optional dependencies were omitted:
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,29 +1,14 @@
 # Installation
 
-## Prerequisites
+## User Prerequisite
 
-Claude Code Rust needs:
+Install the Claude Code CLI before using Claude Code Rust. Authentication is not required before installation or startup; if you are not already signed in, use `/login` inside `claude-rs` or run `claude auth login` when needed.
 
-- Installed Claude Code CLI for authentication. Use `claude auth login` before starting, or run `/login` inside `claude-rs`.
-- Rust 1.88.0 or newer, Node.js 24/npm, and Bun only when building or running from source.
-
-## Install From npm
-
-The recommended npm install path is the root package:
-
-```bash
-npm install -g claude-code-rust
-claude-rs --version
-claude-rs
-```
-
-The npm package owns the `claude-rs` command, selects the matching platform payload with npm optional dependencies, and includes the private Bun runtime used by the Agent SDK bridge. A separate Bun install is not required for npm installs. No install-time binary download or `postinstall` script is used.
-
-Supported npm platforms are Linux x64/arm64 with glibc, Windows x64/arm64, and macOS x64/arm64.
+The recommended script install includes the application and its runtime dependencies. It does not require a Rust toolchain, Node.js, npm, or a separate Bun installation.
 
 ## Install Script
 
-Install scripts are available in GitHub Releases starting with `v0.14.0`. This is an optional install path for users who do not want npm to own the global command. The npm package remains the recommended install path.
+Install scripts are available in GitHub Releases starting with `v0.14.0` and are the recommended install path. They install a self-contained release without requiring npm, Node.js, or Bun on the user's machine.
 
 The scripts download a complete release archive from GitHub, verify the release archive integrity, install the native binary with the bundled private Bun runtime, Agent SDK bridge, and production `node_modules`, then run a quiet `claude-rs --version` check. Strict runtime diagnostics are available with the opt-in verify flag.
 
@@ -36,7 +21,7 @@ curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scri
 **Windows PowerShell:**
 
 ```powershell
-irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm 'https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1' | iex"
 ```
 
 **The default Unix install layout is:**
@@ -56,6 +41,20 @@ The app directory contains `claude-rs`, `claude-rs-bridge-bun`, `agent-sdk/`, an
 
 The Windows app directory is added to the user `Path` unless path modification is disabled.
 
+## Install From npm
+
+npm remains supported for users who prefer package-manager ownership of the global command:
+
+```bash
+npm install -g claude-code-rust
+claude-rs --version
+claude-rs
+```
+
+The npm option requires Node.js 24 and npm to install and run its JavaScript launcher. The package owns the `claude-rs` command, selects the matching platform payload with npm optional dependencies, and includes the private Bun runtime used by the Agent SDK bridge. A Rust toolchain and separate Bun installation are not required. No install-time binary download or `postinstall` script is used.
+
+Supported npm platforms are Linux x64/arm64 with glibc, Windows x64/arm64, and macOS x64/arm64.
+
 ### Pinning a Release
 
 Use `CLAUDE_RS_RELEASE` to install a specific release:
@@ -66,7 +65,7 @@ curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scri
 
 ```powershell
 $env:CLAUDE_RS_RELEASE = "v0.14.0"
-irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm 'https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1' | iex"
 ```
 
 The version can include or omit the `v` prefix.
@@ -98,13 +97,14 @@ The Unix installer also accepts:
 - `--remove-npm`
 - `--keep-npm`
 - `--uninstall`
+- `--update`
 
 When using the PowerShell one-liner, configure the installer with environment variables because arguments cannot be passed through `iex`:
 
 ```powershell
 $env:CLAUDE_RS_INSTALL_DIR = "$env:LOCALAPPDATA\Programs\claude-rs"
 $env:CLAUDE_RS_NO_MODIFY_PATH = "1"
-irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm 'https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1' | iex"
 ```
 
 If you download the script first, PowerShell flags are also available:
@@ -117,15 +117,17 @@ PowerShell also supports `-Uninstall` when the script is downloaded first. With 
 
 ```powershell
 $env:CLAUDE_RS_UNINSTALL = "1"
-irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm 'https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1' | iex"
 ```
 
 Other PowerShell flags available when the script is downloaded first:
 
+- `-Yes`
 - `-Verify`
 - `-Run`
 - `-RemoveNpm`
 - `-KeepNpm`
+- `-Update`
 
 With the PowerShell one-liner, use the matching environment variables:
 
@@ -135,6 +137,8 @@ With the PowerShell one-liner, use the matching environment variables:
 - `CLAUDE_RS_KEEP_NPM=1`
 
 After a successful install, an interactive run asks whether to start `claude-rs` immediately. This runs the installed binary directly, so it works even before a new shell picks up PATH changes. Use `--run`, `-Run`, or `CLAUDE_RS_RUN=1` to start it automatically after install.
+
+When the startup update screen offers **Install update**, it detects whether the running executable is owned by a script or npm install and uses the same method. Script updates replace the existing app directory while preserving its launcher and PATH configuration. If the executable is not in a recognized install layout, the screen offers separate script and npm choices instead of guessing from PATH order.
 
 ### Supported Script Platforms
 
@@ -173,7 +177,7 @@ curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scri
 
 ```powershell
 $env:CLAUDE_RS_REMOVE_NPM = "1"
-irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm 'https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1' | iex"
 Remove-Item Env:\CLAUDE_RS_REMOVE_NPM
 ```
 
@@ -186,7 +190,7 @@ npm install -g claude-code-rust
 
 ```powershell
 $env:CLAUDE_RS_UNINSTALL = "1"
-irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm 'https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1' | iex"
 Remove-Item Env:\CLAUDE_RS_UNINSTALL
 npm install -g claude-code-rust
 ```
@@ -214,6 +218,8 @@ If `claude-rs` resolves to an older global shim, ensure your npm global bin dire
 
 Use this path when developing the project or testing a fork without installing a global `claude-rs` command:
 
+Source development requires Rust 1.88.0 or newer, Node.js 24 with npm, and Bun. These are developer toolchain requirements, not requirements for script-installed users.
+
 ```bash
 git clone https://github.com/srothgan/claude-code-rust.git
 cd claude-code-rust
@@ -222,7 +228,7 @@ npm run build --prefix agent-sdk
 cargo run
 ```
 
-Maintainer and source-build npm tooling targets Node.js 24. Packaged npm installs use the bundled private Bun runtime for the Agent SDK bridge.
+Maintainer and source-build npm tooling targets Node.js 24. Packaged installs use the bundled private Bun runtime for the Agent SDK bridge.
 
 Debug builds resolve `agent-sdk/dist/bridge.js` from the checkout after the bridge is built. They use `bun` from `PATH` unless `CLAUDE_RS_AGENT_BRIDGE_RUNTIME` points at a specific Bun executable.
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -21,6 +21,160 @@ The npm package owns the `claude-rs` command, selects the matching platform payl
 
 Supported npm platforms are Linux x64/arm64 with glibc, Windows x64/arm64, and macOS x64/arm64.
 
+## Install Script
+
+Install scripts are available in GitHub Releases starting with `v0.14.0`. This is an optional install path for users who do not want npm to own the global command. The npm package remains the recommended install path.
+
+The scripts download a complete release archive from GitHub, verify it against the release `SHA256SUMS`, install the native binary with the bundled private Bun runtime, Agent SDK bridge, and production `node_modules`, then run `claude-rs doctor --strict`.
+
+**macOS/Linux:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | sh
+```
+
+**Windows PowerShell:**
+
+```powershell
+irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+```
+
+**The default Unix install layout is:**
+
+```text
+${XDG_DATA_HOME:-$HOME/.local/share}/claude-rs/
+$HOME/.local/bin/claude-rs
+```
+
+The app directory contains `claude-rs`, `claude-rs-bridge-bun`, `agent-sdk/`, and `node_modules/`. The file in `$HOME/.local/bin` is a launcher script that executes the app binary.
+
+**The default Windows install layout is:**
+
+```text
+%LOCALAPPDATA%\Programs\claude-rs\
+```
+
+The Windows app directory is added to the user `Path` unless path modification is disabled.
+
+### Pinning a Release
+
+Use `CLAUDE_RS_RELEASE` to install a specific release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | CLAUDE_RS_RELEASE=v0.14.0 sh
+```
+
+```powershell
+$env:CLAUDE_RS_RELEASE = "v0.14.0"
+irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+```
+
+The version can include or omit the `v` prefix.
+
+### Custom Install Locations
+
+On macOS/Linux, pass installer flags after `sh -s --`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | sh -s -- --install-dir "$HOME/.local/share/claude-rs" --bin-dir "$HOME/.local/bin"
+```
+
+For non-interactive Unix installs:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | sh -s -- --yes
+```
+
+The Unix installer also accepts:
+
+- `--release <version>`
+- `--install-dir <dir>`
+- `--bin-dir <dir>`
+- `--yes` or `-y`
+- `--non-interactive`
+- `--no-modify-path`
+- `--uninstall`
+
+When using the PowerShell one-liner, configure the installer with environment variables because arguments cannot be passed through `iex`:
+
+```powershell
+$env:CLAUDE_RS_INSTALL_DIR = "$env:LOCALAPPDATA\Programs\claude-rs"
+$env:CLAUDE_RS_NO_MODIFY_PATH = "1"
+irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+```
+
+If you download the script first, PowerShell flags are also available:
+
+```powershell
+.\install.ps1 -Release v0.14.0 -InstallDir "$env:LOCALAPPDATA\Programs\claude-rs" -NoModifyPath
+```
+
+PowerShell also supports `-Uninstall` when the script is downloaded first. With the one-liner, use `CLAUDE_RS_UNINSTALL`:
+
+```powershell
+$env:CLAUDE_RS_UNINSTALL = "1"
+irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+```
+
+### Supported Script Platforms
+
+Install archives are published for Linux x64/arm64 with glibc, Windows x64/arm64, and macOS x64/arm64.
+
+Linux musl distributions are not supported by the install archives yet. Use npm if your platform has a matching package, or build from source.
+
+The scripts do not run npm, do not query npm, and do not require user-installed Node.js or Bun. If the selected release does not contain install archives, the installer exits with:
+
+```text
+install script is currently not available for this release
+```
+
+### Switching Install Methods
+
+`claude-rs` is resolved by normal `PATH` order. npm and script installs use different app layouts, and one method does not automatically own files created by the other. If both are installed, whichever `claude-rs` appears first on `PATH` runs.
+
+To see every visible `claude-rs` on macOS/Linux:
+
+```bash
+command -v claude-rs
+which -a claude-rs
+```
+
+To see every visible `claude-rs` on Windows:
+
+```powershell
+Get-Command claude-rs -All
+```
+
+To switch from npm to the install script, remove the npm package first when you want a clean handoff:
+
+```bash
+npm uninstall -g claude-code-rust
+curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | sh
+```
+
+```powershell
+npm uninstall -g claude-code-rust
+irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+```
+
+To switch from the install script back to npm, uninstall the script layout first:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | sh -s -- --uninstall
+npm install -g claude-code-rust
+```
+
+```powershell
+$env:CLAUDE_RS_UNINSTALL = "1"
+irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+Remove-Item Env:\CLAUDE_RS_UNINSTALL
+npm install -g claude-code-rust
+```
+
+The script uninstall path removes the script install directory, removes the Unix launcher when it points at that directory, and removes installer-managed PATH entries where supported. It refuses to delete an app directory that does not look like a `claude-code-rust` script install.
+
+Simple opposite-method uninstall commands are the safest fix: use `npm uninstall -g claude-code-rust` before switching to the script installer, and use the script installer's uninstall mode before switching to npm. The installers do not silently remove the other install method because that would delete files outside their ownership and can be surprising in managed environments.
+
 ## Troubleshooting npm Installs
 
 If npm omitted optional dependencies, the launcher cannot find the native platform package. Check your npm config and reinstall:
@@ -100,8 +254,8 @@ Include:
 - install method
 - OS and architecture
 - terminal
-- `npm --version`
-- `npm config get omit`
+- `npm --version`, for npm installs
+- `npm config get omit`, for npm installs
 - `claude-rs --version`
 - `claude-rs doctor --json`
 - the command you ran

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -25,7 +25,7 @@ Supported npm platforms are Linux x64/arm64 with glibc, Windows x64/arm64, and m
 
 Install scripts are available in GitHub Releases starting with `v0.14.0`. This is an optional install path for users who do not want npm to own the global command. The npm package remains the recommended install path.
 
-The scripts download a complete release archive from GitHub, verify it against the release `SHA256SUMS`, install the native binary with the bundled private Bun runtime, Agent SDK bridge, and production `node_modules`, then run `claude-rs doctor --strict`.
+The scripts download a complete release archive from GitHub, verify the release archive integrity, install the native binary with the bundled private Bun runtime, Agent SDK bridge, and production `node_modules`, then run a quiet `claude-rs --version` check. Strict runtime diagnostics are available with the opt-in verify flag.
 
 **macOS/Linux:**
 
@@ -93,6 +93,10 @@ The Unix installer also accepts:
 - `--yes` or `-y`
 - `--non-interactive`
 - `--no-modify-path`
+- `--verify`
+- `--run`
+- `--remove-npm`
+- `--keep-npm`
 - `--uninstall`
 
 When using the PowerShell one-liner, configure the installer with environment variables because arguments cannot be passed through `iex`:
@@ -116,13 +120,29 @@ $env:CLAUDE_RS_UNINSTALL = "1"
 irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
 ```
 
+Other PowerShell flags available when the script is downloaded first:
+
+- `-Verify`
+- `-Run`
+- `-RemoveNpm`
+- `-KeepNpm`
+
+With the PowerShell one-liner, use the matching environment variables:
+
+- `CLAUDE_RS_VERIFY=1`
+- `CLAUDE_RS_RUN=1`
+- `CLAUDE_RS_REMOVE_NPM=1`
+- `CLAUDE_RS_KEEP_NPM=1`
+
+After a successful install, an interactive run asks whether to start `claude-rs` immediately. This runs the installed binary directly, so it works even before a new shell picks up PATH changes. Use `--run`, `-Run`, or `CLAUDE_RS_RUN=1` to start it automatically after install.
+
 ### Supported Script Platforms
 
 Install archives are published for Linux x64/arm64 with glibc, Windows x64/arm64, and macOS x64/arm64.
 
 Linux musl distributions are not supported by the install archives yet. Use npm if your platform has a matching package, or build from source.
 
-The scripts do not run npm, do not query npm, and do not require user-installed Node.js or Bun. If the selected release does not contain install archives, the installer exits with:
+The scripts do not require user-installed Node.js or Bun. If npm is available and a global `claude-code-rust` install is present, the installer reports it and can remove it after explicit confirmation so the script install owns `claude-rs` on `PATH`. If the selected release does not contain install archives, the installer exits with:
 
 ```text
 install script is currently not available for this release
@@ -145,16 +165,16 @@ To see every visible `claude-rs` on Windows:
 Get-Command claude-rs -All
 ```
 
-To switch from npm to the install script, remove the npm package first when you want a clean handoff:
+To switch from npm to the install script, either let the installer prompt you or pass the explicit removal flag:
 
 ```bash
-npm uninstall -g claude-code-rust
-curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | sh -s -- --remove-npm
 ```
 
 ```powershell
-npm uninstall -g claude-code-rust
+$env:CLAUDE_RS_REMOVE_NPM = "1"
 irm https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1 | iex
+Remove-Item Env:\CLAUDE_RS_REMOVE_NPM
 ```
 
 To switch from the install script back to npm, uninstall the script layout first:
@@ -173,7 +193,7 @@ npm install -g claude-code-rust
 
 The script uninstall path removes the script install directory, removes the Unix launcher when it points at that directory, and removes installer-managed PATH entries where supported. It refuses to delete an app directory that does not look like a `claude-code-rust` script install.
 
-Simple opposite-method uninstall commands are the safest fix: use `npm uninstall -g claude-code-rust` before switching to the script installer, and use the script installer's uninstall mode before switching to npm. The installers do not silently remove the other install method because that would delete files outside their ownership and can be surprising in managed environments.
+The installers do not silently remove the other install method because that would delete files outside their ownership and can be surprising in managed environments. For non-interactive installs, use `--remove-npm` / `CLAUDE_RS_REMOVE_NPM=1` when you want the script installer to remove the npm install, or `--keep-npm` / `CLAUDE_RS_KEEP_NPM=1` when you want it kept without prompting.
 
 ## Troubleshooting npm Installs
 

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -1,8 +1,11 @@
 param(
     [string]$Release,
     [string]$InstallDir,
-    [switch]$Yes,
     [switch]$NoModifyPath,
+    [switch]$Verify,
+    [switch]$Run,
+    [switch]$RemoveNpm,
+    [switch]$KeepNpm,
     [switch]$Uninstall,
     [switch]$Help
 )
@@ -23,8 +26,11 @@ Usage: install.ps1 [options]
 Options:
   -Release <version>      Release tag or version. Defaults to latest.
   -InstallDir <dir>      App install directory.
-  -Yes                   Accept prompts.
   -NoModifyPath          Do not update the user PATH.
+  -Verify                Run strict runtime diagnostics after install.
+  -Run                   Start claude-rs after a successful install.
+  -RemoveNpm             Remove an existing global npm install when found.
+  -KeepNpm               Keep an existing global npm install without prompting.
   -Uninstall             Remove the script install layout and user PATH entry.
   -Help                  Show this help.
 
@@ -33,6 +39,10 @@ Environment:
   CLAUDE_RS_INSTALL_DIR
   CLAUDE_RS_NON_INTERACTIVE
   CLAUDE_RS_NO_MODIFY_PATH
+  CLAUDE_RS_VERIFY
+  CLAUDE_RS_RUN
+  CLAUDE_RS_REMOVE_NPM
+  CLAUDE_RS_KEEP_NPM
   CLAUDE_RS_UNINSTALL
 "@
 }
@@ -72,12 +82,93 @@ if ($env:CI) {
 if (Test-TruthyEnv "CLAUDE_RS_NO_MODIFY_PATH") {
     $NoModifyPath = $true
 }
+if (Test-TruthyEnv "CLAUDE_RS_VERIFY") {
+    $Verify = $true
+}
+if (Test-TruthyEnv "CLAUDE_RS_RUN") {
+    $Run = $true
+}
+if (Test-TruthyEnv "CLAUDE_RS_REMOVE_NPM") {
+    $RemoveNpm = $true
+}
+if (Test-TruthyEnv "CLAUDE_RS_KEEP_NPM") {
+    $KeepNpm = $true
+}
 if (Test-TruthyEnv "CLAUDE_RS_UNINSTALL") {
     $Uninstall = $true
+}
+if ($RemoveNpm -and $KeepNpm) {
+    throw "-RemoveNpm and -KeepNpm cannot be used together"
+}
+
+$UseColor = -not $env:NO_COLOR
+$OkMark = [char]0x2713
+$FailMark = [char]0x2717
+
+function Write-InstallerLine {
+    param(
+        [string]$Mark,
+        [string]$Message,
+        [ConsoleColor]$Color
+    )
+    if ($UseColor) {
+        Write-Host "$Mark $Message" -ForegroundColor $Color
+    } else {
+        Write-Host "$Mark $Message"
+    }
+}
+
+function Write-Ok {
+    param([string]$Message)
+    Write-InstallerLine -Mark $OkMark -Message $Message -Color Green
+}
+
+function Write-WarnLine {
+    param([string]$Message)
+    if ($UseColor) {
+        $previousColor = [Console]::ForegroundColor
+        [Console]::ForegroundColor = [ConsoleColor]::Yellow
+        [Console]::Error.WriteLine("! $Message")
+        [Console]::ForegroundColor = $previousColor
+    } else {
+        [Console]::Error.WriteLine("! $Message")
+    }
+}
+
+function Write-WarnDetail {
+    param([string]$Message)
+    [Console]::Error.WriteLine($Message)
+}
+
+function Write-FailLine {
+    param([string]$Message)
+    if ($UseColor) {
+        $previousColor = [Console]::ForegroundColor
+        [Console]::ForegroundColor = [ConsoleColor]::Red
+        [Console]::Error.WriteLine("$FailMark $Message")
+        [Console]::ForegroundColor = $previousColor
+    } else {
+        [Console]::Error.WriteLine("$FailMark $Message")
+    }
+}
+
+function Test-CanPrompt {
+    return (-not $NonInteractive) -and (-not [Console]::IsInputRedirected)
+}
+
+function Confirm-DefaultNo {
+    param([string]$Prompt)
+    if (-not (Test-CanPrompt)) {
+        return $false
+    }
+    Write-Host -NoNewline "$Prompt [y/N] "
+    $answer = [Console]::ReadLine()
+    return $answer -match "^(y|Y|yes|YES)$"
 }
 
 function Fail {
     param([string]$Message)
+    Write-FailLine $Message
     throw $Message
 }
 
@@ -212,6 +303,92 @@ function Test-ScriptInstallDirectory {
     }
 }
 
+function Get-NpmCommand {
+    $npm = Get-Command "npm.cmd" -ErrorAction SilentlyContinue
+    if (-not $npm) {
+        $npm = Get-Command "npm" -ErrorAction SilentlyContinue
+    }
+    if (-not $npm) {
+        return $null
+    }
+    if ($npm.Source) {
+        return $npm.Source
+    }
+    return $npm.Name
+}
+
+function Get-NpmInstall {
+    $npm = Get-NpmCommand
+    if (-not $npm) {
+        return $null
+    }
+
+    try {
+        $npmRoot = (& $npm "root" "-g" 2>$null | Select-Object -First 1).Trim()
+    } catch {
+        return $null
+    }
+    if ([string]::IsNullOrWhiteSpace($npmRoot)) {
+        return $null
+    }
+
+    $packageJsonPath = Join-Path (Join-Path $npmRoot $RootPackage) "package.json"
+    if (-not (Test-Path -LiteralPath $packageJsonPath -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        $packageJson = Get-Content -LiteralPath $packageJsonPath -Raw | ConvertFrom-Json
+        $version = if ($packageJson.PSObject.Properties.Name -contains "version") {
+            [string]$packageJson.version
+        } else {
+            "unknown"
+        }
+        return [pscustomobject]@{
+            Npm = $npm
+            Root = $npmRoot
+            PackageJson = $packageJsonPath
+            Version = $version
+        }
+    } catch {
+        return [pscustomobject]@{
+            Npm = $npm
+            Root = $npmRoot
+            PackageJson = $packageJsonPath
+            Version = "unknown"
+        }
+    }
+}
+
+function Remove-NpmInstall {
+    param($NpmInstall)
+    & $NpmInstall.Npm "uninstall" "-g" $RootPackage | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Fail "could not remove npm install. Run manually: npm uninstall -g $RootPackage"
+    }
+    Write-Ok "Removed npm install"
+}
+
+function Resolve-NpmInstallChoice {
+    $npmInstall = Get-NpmInstall
+    if (-not $npmInstall) {
+        return
+    }
+
+    Write-WarnLine "Existing npm install found: $RootPackage $($npmInstall.Version)"
+    if ($RemoveNpm) {
+        Remove-NpmInstall -NpmInstall $npmInstall
+        return
+    }
+
+    if (-not $KeepNpm -and (Confirm-DefaultNo "Remove the npm install so only this installer owns ``claude-rs`` on PATH?")) {
+        Remove-NpmInstall -NpmInstall $npmInstall
+        return
+    }
+
+    Write-WarnLine "Existing npm install kept. Remove later with: npm uninstall -g $RootPackage"
+}
+
 function Split-PathEntries {
     param([string]$PathValue)
     if ([string]::IsNullOrWhiteSpace($PathValue)) {
@@ -255,9 +432,33 @@ function Prepend-ProcessPath {
     $env:Path = "$Directory$([IO.Path]::PathSeparator)$env:Path"
 }
 
-function Invoke-ClaudeRs {
+function Invoke-InstalledClaudeRs {
     param([string[]]$CommandArgs)
-    & "claude-rs" @CommandArgs
+    $installedExe = Join-Path $InstallDir "claude-rs.exe"
+    & $installedExe @CommandArgs
+}
+
+function Assert-InstalledCommand {
+    $versionOutput = (Invoke-InstalledClaudeRs @("--version") | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($versionOutput)) {
+        Fail "installed claude-rs did not run successfully"
+    }
+    Invoke-InstalledClaudeRs @("--help") | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Fail "installed claude-rs help check failed"
+    }
+    Write-Ok "Verified $versionOutput"
+}
+
+function Invoke-InstallDoctor {
+    $doctorOutput = (Invoke-InstalledClaudeRs @("doctor", "--strict") 2>&1 | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        if (-not [string]::IsNullOrWhiteSpace($doctorOutput)) {
+            Write-Host $doctorOutput
+        }
+        Fail "runtime diagnostics failed"
+    }
+    Write-Ok "Runtime diagnostics passed"
 }
 
 function Warn-OtherClaudeRsCommands {
@@ -270,7 +471,8 @@ function Warn-OtherClaudeRsCommands {
         if ($command.Source.TrimEnd("\") -ieq $ExpectedCommand.TrimEnd("\")) {
             continue
         }
-        Write-Warning "another claude-rs is on PATH at $($command.Source); remove the old install if it takes precedence in new shells"
+        Write-WarnLine "Another claude-rs is also on PATH: $($command.Source)"
+        Write-WarnDetail "  If a new shell runs that copy, remove it with: npm uninstall -g $RootPackage"
     }
 }
 
@@ -279,22 +481,22 @@ function Uninstall-ScriptInstall {
     $lock = Acquire-InstallLock -InstallParent $installParent
     try {
         if (Remove-UserPath -Directory $InstallDir) {
-            Write-Host "Removed $InstallDir from the user PATH. Reopen your shell for new sessions to see the change."
+            Write-Ok "Removed $InstallDir from the user PATH"
         }
 
         if (Test-Path -LiteralPath $InstallDir) {
             if (Test-ScriptInstallDirectory -Path $InstallDir) {
                 Remove-Item -LiteralPath $InstallDir -Recurse -Force
-                Write-Host "Removed script install directory $InstallDir"
+                Write-Ok "Removed script install directory $InstallDir"
             } else {
-                Write-Warning "not removing $InstallDir because it does not look like a claude-rs script install"
+                Write-WarnLine "Not removing $InstallDir because it does not look like a claude-rs script install"
             }
         }
     } finally {
         $lock.Dispose()
     }
 
-    Write-Host "Script install uninstall complete"
+    Write-Ok "Script install uninstall complete"
 }
 
 if ($Uninstall) {
@@ -311,25 +513,35 @@ try {
     New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 
     $target = Get-Target
+    $targetLabel = if ($target -eq "win32-x64-msvc") { "Windows x64" } else { "Windows arm64" }
+    Write-Host "Installing claude-rs"
+    Write-Host
+    Write-Ok "$targetLabel detected"
+    Write-Ok "Install location: $InstallDir"
+
     $tag = Resolve-ReleaseTag -RequestedRelease $Release -TempDir $tempDir
     $archiveName = Get-ArchiveName -Target $target -Tag $tag
     $baseUrl = "https://github.com/$RepoSlug/releases/download/$tag"
     $checksumsPath = Join-Path $tempDir "SHA256SUMS"
     $archivePath = Join-Path $tempDir $archiveName
 
-    Write-Host "Installing claude-rs $tag for $target"
+    Write-Ok "Release $tag selected"
+    Resolve-NpmInstallChoice
+
     Invoke-WebRequest -Uri "$baseUrl/SHA256SUMS" -OutFile $checksumsPath
     try {
         Invoke-WebRequest -Uri "$baseUrl/$archiveName" -OutFile $archivePath
     } catch {
         Fail-Unavailable
     }
+    Write-Ok "Downloaded release archive"
 
     $expectedSha = Get-ExpectedSha256 -ChecksumsPath $checksumsPath -ArchiveName $archiveName
     $actualSha = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
     if ($actualSha -ne $expectedSha) {
         Fail "checksum mismatch for $archiveName"
     }
+    Write-Ok "Verified release archive integrity"
 
     $extractDir = Join-Path $tempDir "extract"
     Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir -Force
@@ -346,25 +558,43 @@ try {
     $installParent = Split-Path -Parent $InstallDir
     $lockStream = Acquire-InstallLock -InstallParent $installParent
     Replace-AppDirectory -SourceApp $extractedApp -FinalApp $InstallDir
+    Write-Ok "Installed files"
 
     $pathChanged = Add-UserPath -Directory $InstallDir
     Prepend-ProcessPath -Directory $InstallDir
+    if ($pathChanged) {
+        Write-Ok "Updated PATH for new shells"
+    } elseif ($NoModifyPath) {
+        Write-WarnLine "PATH update skipped"
+    } else {
+        Write-Ok "PATH already points to this script install"
+    }
 
-    Invoke-ClaudeRs @("--version")
-    Invoke-ClaudeRs @("--help") | Out-Null
-    Invoke-ClaudeRs @("doctor", "--strict")
+    Assert-InstalledCommand
+    if ($Verify) {
+        Invoke-InstallDoctor
+    }
 
     $resolvedCommand = Get-Command "claude-rs" -ErrorAction SilentlyContinue
     $resolved = if ($resolvedCommand) { $resolvedCommand.Source } else { $null }
     $expectedCommand = Join-Path $InstallDir "claude-rs.exe"
     if ($resolved -and ($resolved.TrimEnd("\") -ine $expectedCommand.TrimEnd("\"))) {
-        Write-Warning "claude-rs resolves to $resolved instead of $expectedCommand"
+        Write-WarnLine "claude-rs resolves to $resolved instead of $expectedCommand"
     }
     Warn-OtherClaudeRsCommands -ExpectedCommand $expectedCommand
+
+    Write-Host
+    Write-Host "claude-rs is installed."
     if ($pathChanged) {
-        Write-Host "Updated the user PATH. Reopen your shell to use this script install in new sessions."
+        Write-Host "PATH is updated for new shells."
     }
-    Write-Host "Installed claude-rs to $InstallDir"
+    if ($Run -or (Confirm-DefaultNo "Start claude-rs now?")) {
+        Invoke-InstalledClaudeRs @()
+    } elseif ($NoModifyPath) {
+        Write-Host "Run directly: $(Join-Path $InstallDir "claude-rs.exe")"
+    } else {
+        Write-Host "Run in a new shell: claude-rs"
+    }
 } finally {
     if ($lockStream) {
         $lockStream.Dispose()

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -1,12 +1,15 @@
 param(
     [string]$Release,
     [string]$InstallDir,
+    [switch]$Yes,
     [switch]$NoModifyPath,
     [switch]$Verify,
     [switch]$Run,
     [switch]$RemoveNpm,
     [switch]$KeepNpm,
     [switch]$Uninstall,
+    [switch]$Update,
+    [int]$UpdateParentProcessId,
     [switch]$Help
 )
 
@@ -26,12 +29,14 @@ Usage: install.ps1 [options]
 Options:
   -Release <version>      Release tag or version. Defaults to latest.
   -InstallDir <dir>      App install directory.
+  -Yes                   Skip optional installer prompts.
   -NoModifyPath          Do not update the user PATH.
   -Verify                Run strict runtime diagnostics after install.
   -Run                   Start claude-rs after a successful install.
   -RemoveNpm             Remove an existing global npm install when found.
   -KeepNpm               Keep an existing global npm install without prompting.
   -Uninstall             Remove the script install layout and user PATH entry.
+  -Update                Update an existing script install in place.
   -Help                  Show this help.
 
 Environment:
@@ -44,6 +49,8 @@ Environment:
   CLAUDE_RS_REMOVE_NPM
   CLAUDE_RS_KEEP_NPM
   CLAUDE_RS_UNINSTALL
+  CLAUDE_RS_UPDATE
+  CLAUDE_RS_UPDATE_PARENT_PID
 "@
 }
 
@@ -96,6 +103,21 @@ if (Test-TruthyEnv "CLAUDE_RS_KEEP_NPM") {
 }
 if (Test-TruthyEnv "CLAUDE_RS_UNINSTALL") {
     $Uninstall = $true
+}
+if (Test-TruthyEnv "CLAUDE_RS_UPDATE") {
+    $Update = $true
+}
+if (-not $PSBoundParameters.ContainsKey("UpdateParentProcessId") -and $env:CLAUDE_RS_UPDATE_PARENT_PID) {
+    $UpdateParentProcessId = [int]$env:CLAUDE_RS_UPDATE_PARENT_PID
+}
+if ($Update -and $Uninstall) {
+    throw "-Update and -Uninstall cannot be used together"
+}
+if ($Update) {
+    $Yes = $true
+    $NonInteractive = $true
+    $NoModifyPath = $true
+    $KeepNpm = $true
 }
 if ($RemoveNpm -and $KeepNpm) {
     throw "-RemoveNpm and -KeepNpm cannot be used together"
@@ -254,7 +276,13 @@ function Acquire-InstallLock {
     param([string]$InstallParent)
     New-Item -ItemType Directory -Path $InstallParent -Force | Out-Null
     $lockPath = Join-Path $InstallParent ".claude-rs-install.lock"
-    return [System.IO.File]::Open($lockPath, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+    try {
+        # DeleteOnClose removes the lock file when it is released, even when
+        # the installer exits abnormally.
+        return New-Object System.IO.FileStream($lockPath, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None, 4096, [System.IO.FileOptions]::DeleteOnClose)
+    } catch {
+        Fail "another claude-rs installer appears to be running: $lockPath"
+    }
 }
 
 function Replace-AppDirectory {
@@ -268,7 +296,23 @@ function Replace-AppDirectory {
     try {
         Move-Item -LiteralPath $SourceApp -Destination $FinalApp
         if ($backup -and (Test-Path -LiteralPath $backup)) {
-            Remove-Item -LiteralPath $backup -Recurse -Force
+            try {
+                Remove-Item -LiteralPath $backup -Recurse -Force
+            } catch {
+                if (-not $Update) {
+                    throw
+                }
+                if ($UpdateParentProcessId -gt 0) {
+                    try {
+                        Start-BackupCleanup -BackupPath $backup -ParentProcessId $UpdateParentProcessId
+                        Write-Ok "Scheduled old install cleanup after claude-rs exits"
+                    } catch {
+                        Write-WarnLine "Updated successfully, but could not schedule cleanup of $backup"
+                    }
+                } else {
+                    Write-WarnLine "Updated successfully. Remove the old install backup after claude-rs exits: $backup"
+                }
+            }
         }
     } catch {
         if ($backup -and (Test-Path -LiteralPath $backup) -and -not (Test-Path -LiteralPath $FinalApp)) {
@@ -276,6 +320,37 @@ function Replace-AppDirectory {
         }
         throw
     }
+}
+
+function Start-BackupCleanup {
+    param([string]$BackupPath, [int]$ParentProcessId)
+    $workerScript = @'
+$ErrorActionPreference = "SilentlyContinue"
+$parentId = [int]$env:CLAUDE_RS_CLEANUP_PARENT_PID
+Wait-Process -Id $parentId -ErrorAction SilentlyContinue
+$backup = $env:CLAUDE_RS_CLEANUP_BACKUP
+for ($attempt = 0; $attempt -lt 20; $attempt++) {
+    Remove-Item -LiteralPath $backup -Recurse -Force -ErrorAction SilentlyContinue
+    if (-not (Test-Path -LiteralPath $backup)) {
+        break
+    }
+    Start-Sleep -Milliseconds 250
+}
+'@
+    $encodedWorker = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($workerScript))
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = (Get-Process -Id $PID).Path
+    $startInfo.Arguments = "-NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -EncodedCommand $encodedWorker"
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden
+    $startInfo.EnvironmentVariables["CLAUDE_RS_CLEANUP_PARENT_PID"] = [string]$ParentProcessId
+    $startInfo.EnvironmentVariables["CLAUDE_RS_CLEANUP_BACKUP"] = $BackupPath
+    $worker = [System.Diagnostics.Process]::Start($startInfo)
+    if (-not $worker) {
+        throw "could not start update cleanup worker"
+    }
+    $worker.Dispose()
 }
 
 function Test-ScriptInstallDirectory {
@@ -362,9 +437,12 @@ function Get-NpmInstall {
 
 function Remove-NpmInstall {
     param($NpmInstall)
+    # The script install is already complete at this point; a failed npm
+    # removal must not fail the install.
     & $NpmInstall.Npm "uninstall" "-g" $RootPackage | Out-Null
     if ($LASTEXITCODE -ne 0) {
-        Fail "could not remove npm install. Run manually: npm uninstall -g $RootPackage"
+        Write-WarnLine "Could not remove npm install. Remove manually: npm uninstall -g $RootPackage"
+        return
     }
     Write-Ok "Removed npm install"
 }
@@ -381,7 +459,7 @@ function Resolve-NpmInstallChoice {
         return
     }
 
-    if (-not $KeepNpm -and (Confirm-DefaultNo "Remove the npm install so only this installer owns ``claude-rs`` on PATH?")) {
+    if (-not $KeepNpm -and -not $Yes -and (Confirm-DefaultNo "Remove the npm install so only this installer owns ``claude-rs`` on PATH?")) {
         Remove-NpmInstall -NpmInstall $npmInstall
         return
     }
@@ -397,31 +475,88 @@ function Split-PathEntries {
     return $PathValue.Split([IO.Path]::PathSeparator, [StringSplitOptions]::RemoveEmptyEntries)
 }
 
+# The user PATH is read and written through the registry with unexpanded
+# values. [Environment]::GetEnvironmentVariable expands %VAR% entries and
+# SetEnvironmentVariable writes plain REG_SZ, which would permanently freeze
+# REG_EXPAND_SZ entries to their current expansion. Writes preserve an existing
+# string value's registry kind.
+function Get-UserPathRaw {
+    $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment")
+    if (-not $key) {
+        return ""
+    }
+    try {
+        return [string]$key.GetValue("Path", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+    } finally {
+        $key.Close()
+    }
+}
+
+function Set-UserPathRaw {
+    param([string]$Value)
+    $key = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey("Environment")
+    try {
+        if ([string]::IsNullOrEmpty($Value)) {
+            $key.DeleteValue("Path", $false)
+        } else {
+            $valueKind = [Microsoft.Win32.RegistryValueKind]::ExpandString
+            if ($key.GetValueNames() -contains "Path") {
+                $existingKind = $key.GetValueKind("Path")
+                if ($existingKind -eq [Microsoft.Win32.RegistryValueKind]::String -or
+                    $existingKind -eq [Microsoft.Win32.RegistryValueKind]::ExpandString) {
+                    $valueKind = $existingKind
+                }
+            }
+            $key.SetValue("Path", $Value, $valueKind)
+        }
+    } finally {
+        $key.Close()
+    }
+    Send-EnvironmentChange
+}
+
+function Send-EnvironmentChange {
+    try {
+        if (-not ("ClaudeRsInstall.NativeMethods" -as [type])) {
+            Add-Type -Namespace ClaudeRsInstall -Name NativeMethods -MemberDefinition '[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)] public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);'
+        }
+        $result = [UIntPtr]::Zero
+        # HWND_BROADCAST WM_SETTINGCHANGE "Environment" so Explorer and new
+        # shells re-read the user PATH without a logoff. Writing the registry
+        # directly skips the broadcast SetEnvironmentVariable would have sent.
+        [void]([ClaudeRsInstall.NativeMethods]::SendMessageTimeout([IntPtr]0xFFFF, 0x001A, [UIntPtr]::Zero, "Environment", 2, 5000, [ref]$result))
+    } catch {
+        # Best effort; a missed broadcast only delays PATH pickup until logon.
+    }
+}
+
+function Expand-PathEntry {
+    param([string]$Entry)
+    return [Environment]::ExpandEnvironmentVariables($Entry).TrimEnd("\")
+}
+
 function Add-UserPath {
     param([string]$Directory)
     if ($NoModifyPath) {
         return $false
     }
-    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    $entries = @(Split-PathEntries $userPath)
+    $entries = @(Split-PathEntries (Get-UserPathRaw))
     $normalizedDirectory = $Directory.TrimEnd("\")
-    $remainingEntries = @($entries | Where-Object { $_.TrimEnd("\") -ine $normalizedDirectory })
-    if ($entries.Count -gt 0 -and $entries[0].TrimEnd("\") -ieq $normalizedDirectory) {
+    $remainingEntries = @($entries | Where-Object { (Expand-PathEntry $_) -ine $normalizedDirectory })
+    if ($entries.Count -gt 0 -and (Expand-PathEntry $entries[0]) -ieq $normalizedDirectory) {
         return $false
     }
-    $newEntries = @($Directory) + $remainingEntries
-    [Environment]::SetEnvironmentVariable("Path", ($newEntries -join [IO.Path]::PathSeparator), "User")
+    Set-UserPathRaw -Value ((@($Directory) + $remainingEntries) -join [IO.Path]::PathSeparator)
     return $true
 }
 
 function Remove-UserPath {
     param([string]$Directory)
-    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    $entries = @(Split-PathEntries $userPath)
+    $entries = @(Split-PathEntries (Get-UserPathRaw))
     $normalizedDirectory = $Directory.TrimEnd("\")
-    $newEntries = @($entries | Where-Object { $_.TrimEnd("\") -ine $normalizedDirectory })
+    $newEntries = @($entries | Where-Object { (Expand-PathEntry $_) -ine $normalizedDirectory })
     if ($newEntries.Count -ne $entries.Count) {
-        [Environment]::SetEnvironmentVariable("Path", ($newEntries -join [IO.Path]::PathSeparator), "User")
+        Set-UserPathRaw -Value ($newEntries -join [IO.Path]::PathSeparator)
         return $true
     }
     return $false
@@ -451,7 +586,16 @@ function Assert-InstalledCommand {
 }
 
 function Invoke-InstallDoctor {
-    $doctorOutput = (Invoke-InstalledClaudeRs @("doctor", "--strict") 2>&1 | Out-String).Trim()
+    # Windows PowerShell 5.1 turns native stderr into terminating errors when
+    # merged with 2>&1 under "Stop"; relax the preference while capturing.
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $doctorLines = @(Invoke-InstalledClaudeRs @("doctor", "--strict") 2>&1 | ForEach-Object { "$_" })
+    } finally {
+        $ErrorActionPreference = $previousPreference
+    }
+    $doctorOutput = ($doctorLines -join [Environment]::NewLine).Trim()
     if ($LASTEXITCODE -ne 0) {
         if (-not [string]::IsNullOrWhiteSpace($doctorOutput)) {
             Write-Host $doctorOutput
@@ -504,6 +648,10 @@ if ($Uninstall) {
     exit 0
 }
 
+if ($Update -and -not (Test-ScriptInstallDirectory -Path $InstallDir)) {
+    Fail "-Update requires an existing claude-rs script install: $InstallDir"
+}
+
 $tempDir = Join-Path ([IO.Path]::GetTempPath()) "claude-rs-install-$PID"
 $lockStream = $null
 $pathChanged = $false
@@ -526,7 +674,6 @@ try {
     $archivePath = Join-Path $tempDir $archiveName
 
     Write-Ok "Release $tag selected"
-    Resolve-NpmInstallChoice
 
     Invoke-WebRequest -Uri "$baseUrl/SHA256SUMS" -OutFile $checksumsPath
     try {
@@ -560,19 +707,30 @@ try {
     Replace-AppDirectory -SourceApp $extractedApp -FinalApp $InstallDir
     Write-Ok "Installed files"
 
-    $pathChanged = Add-UserPath -Directory $InstallDir
     Prepend-ProcessPath -Directory $InstallDir
-    if ($pathChanged) {
-        Write-Ok "Updated PATH for new shells"
-    } elseif ($NoModifyPath) {
-        Write-WarnLine "PATH update skipped"
+    if ($Update) {
+        Write-Ok "Preserved existing PATH configuration"
     } else {
-        Write-Ok "PATH already points to this script install"
+        $pathChanged = Add-UserPath -Directory $InstallDir
+        if ($pathChanged) {
+            Write-Ok "Updated PATH for new shells"
+        } elseif ($NoModifyPath) {
+            Write-WarnLine "PATH update skipped"
+        } else {
+            Write-Ok "PATH already points to this script install"
+        }
     }
 
     Assert-InstalledCommand
     if ($Verify) {
         Invoke-InstallDoctor
+    }
+
+    # Only offer to remove an existing npm install after the script install
+    # has fully succeeded, so a failed install never leaves the user without
+    # claude-rs.
+    if (-not $Update) {
+        Resolve-NpmInstallChoice
     }
 
     $resolvedCommand = Get-Command "claude-rs" -ErrorAction SilentlyContinue
@@ -584,16 +742,20 @@ try {
     Warn-OtherClaudeRsCommands -ExpectedCommand $expectedCommand
 
     Write-Host
-    Write-Host "claude-rs is installed."
-    if ($pathChanged) {
-        Write-Host "PATH is updated for new shells."
-    }
-    if ($Run -or (Confirm-DefaultNo "Start claude-rs now?")) {
-        Invoke-InstalledClaudeRs @()
-    } elseif ($NoModifyPath) {
-        Write-Host "Run directly: $(Join-Path $InstallDir "claude-rs.exe")"
+    if ($Update) {
+        Write-Host "claude-rs is updated. Start claude-rs again to use v$($tag.TrimStart('v'))."
     } else {
-        Write-Host "Run in a new shell: claude-rs"
+        Write-Host "claude-rs is installed."
+        if ($pathChanged) {
+            Write-Host "PATH is updated for new shells."
+        }
+        if ($Run -or ((-not $Yes) -and (Confirm-DefaultNo "Start claude-rs now?"))) {
+            Invoke-InstalledClaudeRs @()
+        } elseif ($NoModifyPath) {
+            Write-Host "Run directly: $(Join-Path $InstallDir "claude-rs.exe")"
+        } else {
+            Write-Host "Run in a new shell: claude-rs"
+        }
     }
 } finally {
     if ($lockStream) {

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -3,6 +3,7 @@ param(
     [string]$InstallDir,
     [switch]$Yes,
     [switch]$NoModifyPath,
+    [switch]$Uninstall,
     [switch]$Help
 )
 
@@ -24,6 +25,7 @@ Options:
   -InstallDir <dir>      App install directory.
   -Yes                   Accept prompts.
   -NoModifyPath          Do not update the user PATH.
+  -Uninstall             Remove the script install layout and user PATH entry.
   -Help                  Show this help.
 
 Environment:
@@ -31,6 +33,7 @@ Environment:
   CLAUDE_RS_INSTALL_DIR
   CLAUDE_RS_NON_INTERACTIVE
   CLAUDE_RS_NO_MODIFY_PATH
+  CLAUDE_RS_UNINSTALL
 "@
 }
 
@@ -68,6 +71,9 @@ if ($env:CI) {
 }
 if (Test-TruthyEnv "CLAUDE_RS_NO_MODIFY_PATH") {
     $NoModifyPath = $true
+}
+if (Test-TruthyEnv "CLAUDE_RS_UNINSTALL") {
+    $Uninstall = $true
 }
 
 function Fail {
@@ -181,6 +187,31 @@ function Replace-AppDirectory {
     }
 }
 
+function Test-ScriptInstallDirectory {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        return $false
+    }
+
+    $packageJsonPath = Join-Path $Path "package.json"
+    if (-not (Test-Path -LiteralPath $packageJsonPath -PathType Leaf)) {
+        return $false
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $Path "claude-rs.exe") -PathType Leaf)) {
+        return $false
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $Path "claude-rs-bridge-bun.exe") -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        $packageJson = Get-Content -LiteralPath $packageJsonPath -Raw | ConvertFrom-Json
+        return ($packageJson.PSObject.Properties.Name -contains "name") -and $packageJson.name -eq $RootPackage
+    } catch {
+        return $false
+    }
+}
+
 function Split-PathEntries {
     param([string]$PathValue)
     if ([string]::IsNullOrWhiteSpace($PathValue)) {
@@ -196,13 +227,27 @@ function Add-UserPath {
     }
     $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
     $entries = @(Split-PathEntries $userPath)
-    $alreadyPresent = $entries | Where-Object { $_.TrimEnd("\") -ieq $Directory.TrimEnd("\") }
-    if ($alreadyPresent) {
+    $normalizedDirectory = $Directory.TrimEnd("\")
+    $remainingEntries = @($entries | Where-Object { $_.TrimEnd("\") -ine $normalizedDirectory })
+    if ($entries.Count -gt 0 -and $entries[0].TrimEnd("\") -ieq $normalizedDirectory) {
         return $false
     }
-    $newEntries = @($entries + $Directory)
+    $newEntries = @($Directory) + $remainingEntries
     [Environment]::SetEnvironmentVariable("Path", ($newEntries -join [IO.Path]::PathSeparator), "User")
     return $true
+}
+
+function Remove-UserPath {
+    param([string]$Directory)
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $entries = @(Split-PathEntries $userPath)
+    $normalizedDirectory = $Directory.TrimEnd("\")
+    $newEntries = @($entries | Where-Object { $_.TrimEnd("\") -ine $normalizedDirectory })
+    if ($newEntries.Count -ne $entries.Count) {
+        [Environment]::SetEnvironmentVariable("Path", ($newEntries -join [IO.Path]::PathSeparator), "User")
+        return $true
+    }
+    return $false
 }
 
 function Prepend-ProcessPath {
@@ -213,6 +258,48 @@ function Prepend-ProcessPath {
 function Invoke-ClaudeRs {
     param([string[]]$CommandArgs)
     & "claude-rs" @CommandArgs
+}
+
+function Warn-OtherClaudeRsCommands {
+    param([string]$ExpectedCommand)
+    $commands = @(Get-Command "claude-rs" -All -ErrorAction SilentlyContinue)
+    foreach ($command in $commands) {
+        if (-not $command.Source) {
+            continue
+        }
+        if ($command.Source.TrimEnd("\") -ieq $ExpectedCommand.TrimEnd("\")) {
+            continue
+        }
+        Write-Warning "another claude-rs is on PATH at $($command.Source); remove the old install if it takes precedence in new shells"
+    }
+}
+
+function Uninstall-ScriptInstall {
+    $installParent = Split-Path -Parent $InstallDir
+    $lock = Acquire-InstallLock -InstallParent $installParent
+    try {
+        if (Remove-UserPath -Directory $InstallDir) {
+            Write-Host "Removed $InstallDir from the user PATH. Reopen your shell for new sessions to see the change."
+        }
+
+        if (Test-Path -LiteralPath $InstallDir) {
+            if (Test-ScriptInstallDirectory -Path $InstallDir) {
+                Remove-Item -LiteralPath $InstallDir -Recurse -Force
+                Write-Host "Removed script install directory $InstallDir"
+            } else {
+                Write-Warning "not removing $InstallDir because it does not look like a claude-rs script install"
+            }
+        }
+    } finally {
+        $lock.Dispose()
+    }
+
+    Write-Host "Script install uninstall complete"
+}
+
+if ($Uninstall) {
+    Uninstall-ScriptInstall
+    exit 0
 }
 
 $tempDir = Join-Path ([IO.Path]::GetTempPath()) "claude-rs-install-$PID"
@@ -273,8 +360,9 @@ try {
     if ($resolved -and ($resolved.TrimEnd("\") -ine $expectedCommand.TrimEnd("\"))) {
         Write-Warning "claude-rs resolves to $resolved instead of $expectedCommand"
     }
+    Warn-OtherClaudeRsCommands -ExpectedCommand $expectedCommand
     if ($pathChanged) {
-        Write-Host "Updated the user PATH. Reopen your shell to use claude-rs in new sessions."
+        Write-Host "Updated the user PATH. Reopen your shell to use this script install in new sessions."
     }
     Write-Host "Installed claude-rs to $InstallDir"
 } finally {

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -12,6 +12,10 @@ bin_dir="${CLAUDE_RS_BIN_DIR:-$HOME/.local/bin}"
 yes=0
 non_interactive=0
 no_modify_path=0
+verify=0
+run_after_install=0
+remove_npm=0
+keep_npm=0
 uninstall=0
 
 case "${CLAUDE_RS_NON_INTERACTIVE:-}" in
@@ -19,6 +23,18 @@ case "${CLAUDE_RS_NON_INTERACTIVE:-}" in
 esac
 case "${CLAUDE_RS_NO_MODIFY_PATH:-}" in
   1 | true | TRUE | yes | YES) no_modify_path=1 ;;
+esac
+case "${CLAUDE_RS_VERIFY:-}" in
+  1 | true | TRUE | yes | YES) verify=1 ;;
+esac
+case "${CLAUDE_RS_RUN:-}" in
+  1 | true | TRUE | yes | YES) run_after_install=1 ;;
+esac
+case "${CLAUDE_RS_REMOVE_NPM:-}" in
+  1 | true | TRUE | yes | YES) remove_npm=1 ;;
+esac
+case "${CLAUDE_RS_KEEP_NPM:-}" in
+  1 | true | TRUE | yes | YES) keep_npm=1 ;;
 esac
 case "${CLAUDE_RS_UNINSTALL:-}" in
   1 | true | TRUE | yes | YES) uninstall=1 ;;
@@ -35,9 +51,13 @@ Options:
   --release <version>       Release tag or version. Defaults to latest.
   --install-dir <dir>       App install directory.
   --bin-dir <dir>           Directory for the claude-rs launcher.
-  --yes, -y                 Accept prompts.
+  --yes, -y                 Accept safe installer prompts.
   --non-interactive         Do not prompt.
   --no-modify-path          Do not update shell profile PATH.
+  --verify                  Run strict runtime diagnostics after install.
+  --run                     Start claude-rs after a successful install.
+  --remove-npm              Remove an existing global npm install when found.
+  --keep-npm                Keep an existing global npm install without prompting.
   --uninstall               Remove the script install layout and managed PATH block.
   --help                    Show this help.
 
@@ -47,6 +67,10 @@ Environment:
   CLAUDE_RS_BIN_DIR
   CLAUDE_RS_NON_INTERACTIVE
   CLAUDE_RS_NO_MODIFY_PATH
+  CLAUDE_RS_VERIFY
+  CLAUDE_RS_RUN
+  CLAUDE_RS_REMOVE_NPM
+  CLAUDE_RS_KEEP_NPM
   CLAUDE_RS_UNINSTALL
 EOF
 }
@@ -77,6 +101,18 @@ while [ "$#" -gt 0 ]; do
     --no-modify-path)
       no_modify_path=1
       ;;
+    --verify)
+      verify=1
+      ;;
+    --run)
+      run_after_install=1
+      ;;
+    --remove-npm)
+      remove_npm=1
+      ;;
+    --keep-npm)
+      keep_npm=1
+      ;;
     --uninstall)
       uninstall=1
       ;;
@@ -93,17 +129,77 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
+[ "$remove_npm" -eq 0 ] || [ "$keep_npm" -eq 0 ] || {
+  echo "error: --remove-npm and --keep-npm cannot be used together" >&2
+  exit 1
+}
+
+green=""
+yellow=""
+red=""
+reset=""
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  green="$(printf '\033[32m')"
+  yellow="$(printf '\033[33m')"
+  red="$(printf '\033[31m')"
+  reset="$(printf '\033[0m')"
+fi
+
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+  C | POSIX)
+    ok_mark="OK"
+    warn_mark="WARN"
+    fail_mark="ERROR"
+    ;;
+  *)
+    ok_mark="$(printf '\342\234\223')"
+    warn_mark="!"
+    fail_mark="$(printf '\342\234\227')"
+    ;;
+esac
+
 info() {
   printf '%s\n' "$*"
 }
 
+ok() {
+  printf '%s%s%s %s\n' "$green" "$ok_mark" "$reset" "$*"
+}
+
 warn() {
-  printf 'warning: %s\n' "$*" >&2
+  printf '%s%s%s %s\n' "$yellow" "$warn_mark" "$reset" "$*" >&2
+}
+
+warn_detail() {
+  printf '%s\n' "$*" >&2
 }
 
 die() {
-  printf 'error: %s\n' "$*" >&2
+  printf '%s%s%s %s\n' "$red" "$fail_mark" "$reset" "$*" >&2
   exit 1
+}
+
+can_prompt() {
+  [ "$non_interactive" -eq 0 ] && [ -r /dev/tty ] && [ -w /dev/tty ]
+}
+
+launch_installed() {
+  if [ -r /dev/tty ]; then
+    "$install_dir/$binary_name" < /dev/tty
+  else
+    "$install_dir/$binary_name"
+  fi
+}
+
+confirm_default_no() {
+  prompt="$1"
+  can_prompt || return 1
+  printf '%s [y/N] ' "$prompt" > /dev/tty
+  IFS= read -r answer < /dev/tty || answer=
+  case "$answer" in
+    y | Y | yes | YES) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 die_unavailable() {
@@ -320,6 +416,46 @@ write_launcher() {
   mv "$tmp_launcher" "$launcher"
 }
 
+detect_npm_install() {
+  command -v npm >/dev/null 2>&1 || return 1
+  npm_root="$(npm root -g 2>/dev/null || true)"
+  [ -n "$npm_root" ] || return 1
+  npm_package_json="$npm_root/$root_package/package.json"
+  [ -f "$npm_package_json" ] || return 1
+  npm_package_version="$(
+    sed -n 's/.*"version"[ 	]*:[ 	]*"\([^"]*\)".*/\1/p' "$npm_package_json" | sed -n '1p'
+  )"
+  [ -n "$npm_package_version" ] || npm_package_version="unknown"
+  return 0
+}
+
+remove_npm_install() {
+  npm uninstall -g "$root_package" >/dev/null 2>&1 ||
+    die "could not remove npm install. Run manually: npm uninstall -g $root_package"
+  ok "Removed npm install"
+}
+
+resolve_npm_install_choice() {
+  if ! detect_npm_install; then
+    return
+  fi
+
+  warn "Existing npm install found: $root_package $npm_package_version"
+  if [ "$remove_npm" -eq 1 ]; then
+    remove_npm_install
+    return
+  fi
+
+  if [ "$keep_npm" -eq 0 ] &&
+    confirm_default_no 'Remove the npm install so only this installer owns `claude-rs` on PATH?'
+  then
+    remove_npm_install
+    return
+  fi
+
+  warn "Existing npm install kept. Remove later with: npm uninstall -g $root_package"
+}
+
 is_script_install_dir() {
   app="$1"
   [ -d "$app" ] || return 1
@@ -335,7 +471,7 @@ remove_launcher_if_owned() {
   [ -f "$launcher" ] || return
   if grep -F "$app_binary" "$launcher" >/dev/null 2>&1; then
     rm -f "$launcher"
-    info "Removed launcher $launcher"
+    ok "Removed launcher $launcher"
   else
     warn "not removing $launcher because it does not point at $app_binary"
   fi
@@ -363,13 +499,13 @@ uninstall_script_install() {
   if [ -e "$install_dir" ]; then
     if is_script_install_dir "$install_dir"; then
       rm -rf "$install_dir"
-      info "Removed script install directory $install_dir"
+      ok "Removed script install directory $install_dir"
     else
       warn "not removing $install_dir because it does not look like a claude-rs script install"
     fi
   fi
 
-  info "Script install uninstall complete"
+  ok "Script install uninstall complete"
 }
 
 manual_path_line() {
@@ -397,8 +533,12 @@ path_starts_with_bin_dir() {
 }
 
 maybe_update_path() {
-  path_starts_with_bin_dir && return
+  if path_starts_with_bin_dir; then
+    ok "PATH already points to this script install"
+    return
+  fi
   [ "$no_modify_path" -eq 1 ] && {
+    warn "PATH update skipped"
     info "Add this to your shell profile:"
     manual_path_line
     if path_has_bin_dir; then
@@ -426,8 +566,9 @@ maybe_update_path() {
       manual_path_line
       printf '# claude-rs PATH end\n'
     } >> "$profile"
-    info "Updated PATH in $profile"
+    ok "Updated PATH for new shells"
   else
+    warn "PATH update skipped"
     info "Add this to your shell profile:"
     manual_path_line
   fi
@@ -439,7 +580,8 @@ warn_other_claude_rs_commands() {
     which -a claude-rs 2>/dev/null | while IFS= read -r candidate; do
       [ -n "$candidate" ] || continue
       [ "$candidate" = "$launcher" ] && continue
-      warn "another claude-rs is on PATH at $candidate; remove the old install if it takes precedence in new shells"
+      warn "Another claude-rs is also on PATH: $candidate"
+      warn_detail "  If a new shell runs that copy, remove it with: npm uninstall -g $root_package"
     done
   fi
 }
@@ -474,7 +616,23 @@ trap cleanup EXIT HUP INT TERM
 
 target="$(detect_target)"
 case "$target" in
-  darwin-* | linux-*)
+  darwin-arm64)
+    target_label="macOS arm64"
+    binary_name="claude-rs"
+    runtime_name="claude-rs-bridge-bun"
+    ;;
+  darwin-x64)
+    target_label="macOS x64"
+    binary_name="claude-rs"
+    runtime_name="claude-rs-bridge-bun"
+    ;;
+  linux-arm64-gnu)
+    target_label="Linux arm64 glibc"
+    binary_name="claude-rs"
+    runtime_name="claude-rs-bridge-bun"
+    ;;
+  linux-x64-gnu)
+    target_label="Linux x64 glibc"
     binary_name="claude-rs"
     runtime_name="claude-rs-bridge-bun"
     ;;
@@ -483,22 +641,31 @@ case "$target" in
     ;;
 esac
 
+info "Installing claude-rs"
+info ""
+ok "$target_label detected"
+ok "Install location: $install_dir"
+
 tag="$(resolve_tag "$release")"
 archive_name="$(archive_name_for_target "$target")"
 base_url="https://github.com/$repo_slug/releases/download/$tag"
 checksum_file="$tmpdir/SHA256SUMS"
 archive_file="$tmpdir/$archive_name"
 
-info "Installing claude-rs $tag for $target"
+ok "Release $tag selected"
+resolve_npm_install_choice
+
 download "$base_url/SHA256SUMS" "$checksum_file" || die "could not download SHA256SUMS for $tag"
 if ! download "$base_url/$archive_name" "$archive_file"; then
   die_unavailable
 fi
+ok "Downloaded release archive"
 
 expected_sha="$(checksum_for_archive "$checksum_file" "$archive_name")"
 [ -n "$expected_sha" ] || die "SHA256SUMS does not contain dist-install/$archive_name"
 actual_sha="$(sha256_file "$archive_file")"
 [ "$actual_sha" = "$expected_sha" ] || die "checksum mismatch for $archive_name"
+ok "Verified release archive integrity"
 
 validate_tar_listing "$archive_file"
 extract_dir="$tmpdir/extract"
@@ -516,14 +683,26 @@ mkdir -p "$install_parent"
 lock_dir="$(acquire_lock "$install_parent")"
 replace_app_dir "$extracted_app" "$install_dir"
 write_launcher
+ok "Installed files"
 
 maybe_update_path
 PATH="$bin_dir:$PATH"
 export PATH
 
-claude-rs --version
-claude-rs --help >/dev/null
-claude-rs doctor --strict
+version_output="$("$install_dir/$binary_name" --version)" ||
+  die "installed claude-rs did not run successfully"
+[ -n "$version_output" ] || die "installed claude-rs did not print a version"
+"$install_dir/$binary_name" --help >/dev/null ||
+  die "installed claude-rs help check failed"
+ok "Verified $version_output"
+
+if [ "$verify" -eq 1 ]; then
+  doctor_output="$("$install_dir/$binary_name" doctor --strict 2>&1)" || {
+    [ -z "$doctor_output" ] || printf '%s\n' "$doctor_output"
+    die "runtime diagnostics failed"
+  }
+  ok "Runtime diagnostics passed"
+fi
 
 resolved="$(command -v claude-rs || true)"
 launcher="$bin_dir/claude-rs"
@@ -532,4 +711,14 @@ if [ "$resolved" != "$launcher" ]; then
 fi
 warn_other_claude_rs_commands
 
-info "Installed claude-rs to $install_dir"
+info ""
+info "claude-rs is installed."
+if [ "$run_after_install" -eq 1 ] || confirm_default_no "Start claude-rs now?"; then
+  launch_installed
+else
+  if [ "$no_modify_path" -eq 1 ]; then
+    info "Run directly: $install_dir/$binary_name"
+  else
+    info "Run in a new shell: claude-rs"
+  fi
+fi

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -12,12 +12,16 @@ bin_dir="${CLAUDE_RS_BIN_DIR:-$HOME/.local/bin}"
 yes=0
 non_interactive=0
 no_modify_path=0
+uninstall=0
 
 case "${CLAUDE_RS_NON_INTERACTIVE:-}" in
   1 | true | TRUE | yes | YES) non_interactive=1 ;;
 esac
 case "${CLAUDE_RS_NO_MODIFY_PATH:-}" in
   1 | true | TRUE | yes | YES) no_modify_path=1 ;;
+esac
+case "${CLAUDE_RS_UNINSTALL:-}" in
+  1 | true | TRUE | yes | YES) uninstall=1 ;;
 esac
 if [ -n "${CI:-}" ]; then
   non_interactive=1
@@ -34,6 +38,7 @@ Options:
   --yes, -y                 Accept prompts.
   --non-interactive         Do not prompt.
   --no-modify-path          Do not update shell profile PATH.
+  --uninstall               Remove the script install layout and managed PATH block.
   --help                    Show this help.
 
 Environment:
@@ -42,6 +47,7 @@ Environment:
   CLAUDE_RS_BIN_DIR
   CLAUDE_RS_NON_INTERACTIVE
   CLAUDE_RS_NO_MODIFY_PATH
+  CLAUDE_RS_UNINSTALL
 EOF
 }
 
@@ -70,6 +76,9 @@ while [ "$#" -gt 0 ]; do
       ;;
     --no-modify-path)
       no_modify_path=1
+      ;;
+    --uninstall)
+      uninstall=1
       ;;
     --help | -h)
       usage
@@ -311,6 +320,58 @@ write_launcher() {
   mv "$tmp_launcher" "$launcher"
 }
 
+is_script_install_dir() {
+  app="$1"
+  [ -d "$app" ] || return 1
+  [ -f "$app/package.json" ] || return 1
+  [ -f "$app/claude-rs" ] || return 1
+  [ -f "$app/claude-rs-bridge-bun" ] || return 1
+  grep -q '"name"[ 	]*:[ 	]*"claude-code-rust"' "$app/package.json" 2>/dev/null
+}
+
+remove_launcher_if_owned() {
+  launcher="$bin_dir/claude-rs"
+  app_binary="$install_dir/claude-rs"
+  [ -f "$launcher" ] || return
+  if grep -F "$app_binary" "$launcher" >/dev/null 2>&1; then
+    rm -f "$launcher"
+    info "Removed launcher $launcher"
+  else
+    warn "not removing $launcher because it does not point at $app_binary"
+  fi
+}
+
+remove_managed_path_block() {
+  profile="$HOME/.profile"
+  [ -f "$profile" ] || return
+  tmp_profile="$profile.tmp.$$"
+  awk '
+    /^# claude-rs PATH start$/ { skip = 1; next }
+    /^# claude-rs PATH end$/ { skip = 0; next }
+    skip != 1 { print }
+  ' "$profile" > "$tmp_profile" && mv "$tmp_profile" "$profile"
+}
+
+uninstall_script_install() {
+  install_parent="$(dirname "$install_dir")"
+  mkdir -p "$install_parent"
+  lock_dir="$(acquire_lock "$install_parent")"
+
+  remove_launcher_if_owned
+  remove_managed_path_block
+
+  if [ -e "$install_dir" ]; then
+    if is_script_install_dir "$install_dir"; then
+      rm -rf "$install_dir"
+      info "Removed script install directory $install_dir"
+    else
+      warn "not removing $install_dir because it does not look like a claude-rs script install"
+    fi
+  fi
+
+  info "Script install uninstall complete"
+}
+
 manual_path_line() {
   if [ "$bin_dir" = "$HOME/.local/bin" ]; then
     # shellcheck disable=SC2016
@@ -328,11 +389,21 @@ path_has_bin_dir() {
   esac
 }
 
+path_starts_with_bin_dir() {
+  case "$PATH:" in
+    "$bin_dir:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 maybe_update_path() {
-  path_has_bin_dir && return
+  path_starts_with_bin_dir && return
   [ "$no_modify_path" -eq 1 ] && {
     info "Add this to your shell profile:"
     manual_path_line
+    if path_has_bin_dir; then
+      warn "$bin_dir is already on PATH but not first; another claude-rs may take precedence in new shells"
+    fi
     return
   }
 
@@ -349,6 +420,7 @@ maybe_update_path() {
 
   if [ "$should_modify" -eq 1 ]; then
     profile="$HOME/.profile"
+    remove_managed_path_block
     {
       printf '\n# claude-rs PATH start\n'
       manual_path_line
@@ -361,6 +433,28 @@ maybe_update_path() {
   fi
 }
 
+warn_other_claude_rs_commands() {
+  launcher="$bin_dir/claude-rs"
+  if command -v which >/dev/null 2>&1; then
+    which -a claude-rs 2>/dev/null | while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      [ "$candidate" = "$launcher" ] && continue
+      warn "another claude-rs is on PATH at $candidate; remove the old install if it takes precedence in new shells"
+    done
+  fi
+}
+
+if [ "$uninstall" -eq 1 ]; then
+  need_cmd mkdir
+  need_cmd rm
+  need_cmd grep
+  need_cmd awk
+  need_cmd mv
+  trap 'rm -rf "${lock_dir:-}"' EXIT HUP INT TERM
+  uninstall_script_install
+  exit 0
+fi
+
 need_cmd uname
 need_cmd mktemp
 need_cmd mkdir
@@ -368,6 +462,8 @@ need_cmd mv
 need_cmd rm
 need_cmd tar
 need_cmd chmod
+need_cmd grep
+need_cmd awk
 
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/claude-rs-install.XXXXXX")"
 cleanup() {
@@ -434,5 +530,6 @@ launcher="$bin_dir/claude-rs"
 if [ "$resolved" != "$launcher" ]; then
   warn "claude-rs resolves to $resolved instead of $launcher"
 fi
+warn_other_claude_rs_commands
 
 info "Installed claude-rs to $install_dir"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -17,6 +17,8 @@ run_after_install=0
 remove_npm=0
 keep_npm=0
 uninstall=0
+update=0
+path_updated=0
 
 case "${CLAUDE_RS_NON_INTERACTIVE:-}" in
   1 | true | TRUE | yes | YES) non_interactive=1 ;;
@@ -39,6 +41,9 @@ esac
 case "${CLAUDE_RS_UNINSTALL:-}" in
   1 | true | TRUE | yes | YES) uninstall=1 ;;
 esac
+case "${CLAUDE_RS_UPDATE:-}" in
+  1 | true | TRUE | yes | YES) update=1 ;;
+esac
 if [ -n "${CI:-}" ]; then
   non_interactive=1
 fi
@@ -51,7 +56,7 @@ Options:
   --release <version>       Release tag or version. Defaults to latest.
   --install-dir <dir>       App install directory.
   --bin-dir <dir>           Directory for the claude-rs launcher.
-  --yes, -y                 Accept safe installer prompts.
+  --yes, -y                 Accept safe installer prompts; optional prompts are skipped.
   --non-interactive         Do not prompt.
   --no-modify-path          Do not update shell profile PATH.
   --verify                  Run strict runtime diagnostics after install.
@@ -59,6 +64,7 @@ Options:
   --remove-npm              Remove an existing global npm install when found.
   --keep-npm                Keep an existing global npm install without prompting.
   --uninstall               Remove the script install layout and managed PATH block.
+  --update                  Update an existing script install in place.
   --help                    Show this help.
 
 Environment:
@@ -72,6 +78,7 @@ Environment:
   CLAUDE_RS_REMOVE_NPM
   CLAUDE_RS_KEEP_NPM
   CLAUDE_RS_UNINSTALL
+  CLAUDE_RS_UPDATE
 EOF
 }
 
@@ -116,6 +123,9 @@ while [ "$#" -gt 0 ]; do
     --uninstall)
       uninstall=1
       ;;
+    --update)
+      update=1
+      ;;
     --help | -h)
       usage
       exit 0
@@ -129,6 +139,16 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
+[ "$update" -eq 0 ] || [ "$uninstall" -eq 0 ] || {
+  echo "error: --update and --uninstall cannot be used together" >&2
+  exit 1
+}
+if [ "$update" -eq 1 ]; then
+  yes=1
+  non_interactive=1
+  no_modify_path=1
+  keep_npm=1
+fi
 [ "$remove_npm" -eq 0 ] || [ "$keep_npm" -eq 0 ] || {
   echo "error: --remove-npm and --keep-npm cannot be used together" >&2
   exit 1
@@ -382,7 +402,7 @@ acquire_lock() {
     printf '%s\n' "$lock_dir"
     return
   fi
-  die "another claude-rs installer appears to be running: $lock_dir"
+  die "another claude-rs installer appears to be running: $lock_dir (remove this directory if no installer is running)"
 }
 
 replace_app_dir() {
@@ -430,9 +450,13 @@ detect_npm_install() {
 }
 
 remove_npm_install() {
-  npm uninstall -g "$root_package" >/dev/null 2>&1 ||
-    die "could not remove npm install. Run manually: npm uninstall -g $root_package"
-  ok "Removed npm install"
+  # The script install is already complete at this point; a failed npm
+  # removal must not fail the install.
+  if npm uninstall -g "$root_package" >/dev/null 2>&1; then
+    ok "Removed npm install"
+  else
+    warn "could not remove npm install. Remove manually: npm uninstall -g $root_package"
+  fi
 }
 
 resolve_npm_install_choice() {
@@ -446,7 +470,7 @@ resolve_npm_install_choice() {
     return
   fi
 
-  if [ "$keep_npm" -eq 0 ] &&
+  if [ "$keep_npm" -eq 0 ] && [ "$yes" -eq 0 ] &&
     confirm_default_no "Remove the npm install so only this installer owns \`claude-rs\` on PATH?"
   then
     remove_npm_install
@@ -477,9 +501,48 @@ remove_launcher_if_owned() {
   fi
 }
 
+zsh_profile_file() {
+  printf '%s\n' "${ZDOTDIR:-$HOME}/.zprofile"
+}
+
+zsh_rc_file() {
+  printf '%s\n' "${ZDOTDIR:-$HOME}/.zshrc"
+}
+
+# Cover login and interactive shells. A guarded managed block prevents a
+# duplicate prepend when a login profile also sources its shell's rc file.
+profile_targets() {
+  printf '%s\n' "$HOME/.profile"
+  if [ -f "$HOME/.bash_profile" ]; then
+    printf '%s\n' "$HOME/.bash_profile"
+  elif [ -f "$HOME/.bash_login" ]; then
+    printf '%s\n' "$HOME/.bash_login"
+  fi
+  case "${SHELL:-}" in
+    */bash) printf '%s\n' "$HOME/.bashrc" ;;
+    *) [ ! -f "$HOME/.bashrc" ] || printf '%s\n' "$HOME/.bashrc" ;;
+  esac
+  zprofile="$(zsh_profile_file)"
+  zshrc="$(zsh_rc_file)"
+  case "${SHELL:-}" in
+    */zsh)
+      printf '%s\n' "$zprofile"
+      printf '%s\n' "$zshrc"
+      ;;
+    *)
+      if [ -f "$zprofile" ]; then
+        printf '%s\n' "$zprofile"
+      fi
+      if [ -f "$zshrc" ]; then
+        printf '%s\n' "$zshrc"
+      fi
+      ;;
+  esac
+}
+
 remove_managed_path_block() {
-  profile="$HOME/.profile"
-  [ -f "$profile" ] || return
+  profile="$1"
+  [ -f "$profile" ] || return 0
   tmp_profile="$profile.tmp.$$"
   awk '
     /^# claude-rs PATH start$/ { skip = 1; next }
@@ -488,13 +551,22 @@ remove_managed_path_block() {
   ' "$profile" > "$tmp_profile" && mv "$tmp_profile" "$profile"
 }
 
+remove_managed_path_blocks() {
+  remove_managed_path_block "$HOME/.profile"
+  remove_managed_path_block "$HOME/.bash_profile"
+  remove_managed_path_block "$HOME/.bash_login"
+  remove_managed_path_block "$HOME/.bashrc"
+  remove_managed_path_block "$(zsh_profile_file)"
+  remove_managed_path_block "$(zsh_rc_file)"
+}
+
 uninstall_script_install() {
   install_parent="$(dirname "$install_dir")"
   mkdir -p "$install_parent"
   lock_dir="$(acquire_lock "$install_parent")"
 
   remove_launcher_if_owned
-  remove_managed_path_block
+  remove_managed_path_blocks
 
   if [ -e "$install_dir" ]; then
     if is_script_install_dir "$install_dir"; then
@@ -518,6 +590,14 @@ manual_path_line() {
   fi
 }
 
+managed_path_lines() {
+  quoted_bin_dir="'$(printf '%s' "$bin_dir" | sed "s/'/'\\\\''/g")'"
+  printf 'case "$PATH:" in\n'
+  printf '  %s:*) ;;\n' "$quoted_bin_dir"
+  printf '  *) export PATH=%s:"$PATH" ;;\n' "$quoted_bin_dir"
+  printf 'esac\n'
+}
+
 path_has_bin_dir() {
   case ":$PATH:" in
     *":$bin_dir:"*) return 0 ;;
@@ -534,6 +614,7 @@ path_starts_with_bin_dir() {
 
 maybe_update_path() {
   if path_starts_with_bin_dir; then
+    path_updated=1
     ok "PATH already points to this script install"
     return
   fi
@@ -551,7 +632,7 @@ maybe_update_path() {
   if [ "$yes" -eq 1 ]; then
     should_modify=1
   elif [ "$non_interactive" -eq 0 ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
-    printf 'Add %s to PATH in %s? [y/N] ' "$bin_dir" "$HOME/.profile" > /dev/tty
+    printf 'Add %s to PATH in your shell profile? [y/N] ' "$bin_dir" > /dev/tty
     IFS= read -r answer < /dev/tty || answer=
     case "$answer" in
       y | Y | yes | YES) should_modify=1 ;;
@@ -559,13 +640,15 @@ maybe_update_path() {
   fi
 
   if [ "$should_modify" -eq 1 ]; then
-    profile="$HOME/.profile"
-    remove_managed_path_block
-    {
-      printf '\n# claude-rs PATH start\n'
-      manual_path_line
-      printf '# claude-rs PATH end\n'
-    } >> "$profile"
+    remove_managed_path_blocks
+    profile_targets | while IFS= read -r profile_file; do
+      {
+        printf '\n# claude-rs PATH start\n'
+        managed_path_lines
+        printf '# claude-rs PATH end\n'
+      } >> "$profile_file"
+    done
+    path_updated=1
     ok "Updated PATH for new shells"
   else
     warn "PATH update skipped"
@@ -595,6 +678,10 @@ if [ "$uninstall" -eq 1 ]; then
   trap 'rm -rf "${lock_dir:-}"' EXIT HUP INT TERM
   uninstall_script_install
   exit 0
+fi
+
+if [ "$update" -eq 1 ] && ! is_script_install_dir "$install_dir"; then
+  die "--update requires an existing claude-rs script install: $install_dir"
 fi
 
 need_cmd uname
@@ -653,7 +740,6 @@ checksum_file="$tmpdir/SHA256SUMS"
 archive_file="$tmpdir/$archive_name"
 
 ok "Release $tag selected"
-resolve_npm_install_choice
 
 download "$base_url/SHA256SUMS" "$checksum_file" || die "could not download SHA256SUMS for $tag"
 if ! download "$base_url/$archive_name" "$archive_file"; then
@@ -682,10 +768,17 @@ install_parent="$(dirname "$install_dir")"
 mkdir -p "$install_parent"
 lock_dir="$(acquire_lock "$install_parent")"
 replace_app_dir "$extracted_app" "$install_dir"
-write_launcher
+if [ "$update" -eq 0 ]; then
+  write_launcher
+fi
 ok "Installed files"
 
-maybe_update_path
+if [ "$update" -eq 0 ]; then
+  maybe_update_path
+else
+  path_updated=1
+  ok "Preserved existing launcher and PATH configuration"
+fi
 PATH="$bin_dir:$PATH"
 export PATH
 
@@ -704,6 +797,12 @@ if [ "$verify" -eq 1 ]; then
   ok "Runtime diagnostics passed"
 fi
 
+# Only offer to remove an existing npm install after the script install has
+# fully succeeded, so a failed install never leaves the user without claude-rs.
+if [ "$update" -eq 0 ]; then
+  resolve_npm_install_choice
+fi
+
 resolved="$(command -v claude-rs || true)"
 launcher="$bin_dir/claude-rs"
 if [ "$resolved" != "$launcher" ]; then
@@ -712,13 +811,17 @@ fi
 warn_other_claude_rs_commands
 
 info ""
-info "claude-rs is installed."
-if [ "$run_after_install" -eq 1 ] || confirm_default_no "Start claude-rs now?"; then
-  launch_installed
+if [ "$update" -eq 1 ]; then
+  info "claude-rs is updated. Start claude-rs again to use ${tag#v}."
 else
-  if [ "$no_modify_path" -eq 1 ]; then
-    info "Run directly: $install_dir/$binary_name"
+  info "claude-rs is installed."
+  if [ "$run_after_install" -eq 1 ] || { [ "$yes" -eq 0 ] && confirm_default_no "Start claude-rs now?"; }; then
+    launch_installed
   else
-    info "Run in a new shell: claude-rs"
+    if [ "$path_updated" -eq 1 ]; then
+      info "Run in a new shell: claude-rs"
+    else
+      info "Run directly: $install_dir/$binary_name"
+    fi
   fi
 fi

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -447,7 +447,7 @@ resolve_npm_install_choice() {
   fi
 
   if [ "$keep_npm" -eq 0 ] &&
-    confirm_default_no 'Remove the npm install so only this installer owns `claude-rs` on PATH?'
+    confirm_default_no "Remove the npm install so only this installer owns \`claude-rs\` on PATH?"
   then
     remove_npm_install
     return

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -592,9 +592,9 @@ manual_path_line() {
 
 managed_path_lines() {
   quoted_bin_dir="'$(printf '%s' "$bin_dir" | sed "s/'/'\\\\''/g")'"
-  printf 'case "$PATH:" in\n'
+  printf "case \"\$PATH:\" in\n"
   printf '  %s:*) ;;\n' "$quoted_bin_dir"
-  printf '  *) export PATH=%s:"$PATH" ;;\n' "$quoted_bin_dir"
+  printf "  *) export PATH=%s:\"\$PATH\" ;;\n" "$quoted_bin_dir"
   printf 'esac\n'
 }
 

--- a/scripts/install/smoke-install-archive.mjs
+++ b/scripts/install/smoke-install-archive.mjs
@@ -262,8 +262,31 @@ function pathInside(candidate, root) {
 }
 
 function normalizePathForCompare(filePath) {
-  const resolved = path.resolve(filePath);
+  let resolved = path.resolve(stripExtendedLengthPrefix(filePath));
+  try {
+    // Canonicalize so both sides match how `doctor` reports the resolved path:
+    // it resolves the macOS `/var` -> `/private/var` symlink and Windows 8.3
+    // short names, which a plain `path.resolve` leaves divergent from the raw
+    // mkdtemp path.
+    resolved = fs.realpathSync.native(resolved);
+  } catch {
+    // The path may not exist in mock scenarios; fall back to the resolved form.
+  }
+  resolved = stripExtendedLengthPrefix(resolved);
   return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function stripExtendedLengthPrefix(filePath) {
+  if (process.platform !== "win32") {
+    return filePath;
+  }
+  if (filePath.startsWith("\\\\?\\UNC\\")) {
+    return `\\\\${filePath.slice("\\\\?\\UNC\\".length)}`;
+  }
+  if (filePath.startsWith("\\\\?\\")) {
+    return filePath.slice("\\\\?\\".length);
+  }
+  return filePath;
 }
 
 function shellQuote(value) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -81,6 +81,7 @@ pub use state::{
 };
 pub use trust::TrustSelection;
 pub use update_check::start_update_check;
+pub(crate) use update_prompt::actions_for as update_prompt_actions;
 pub use view::{FullscreenView, SurfaceMode};
 
 pub fn record_update_install_failure(app: &mut App, message: String) {

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -35,6 +35,8 @@ pub enum PendingCommandAck {
 pub enum UpdatePromptAction {
     #[default]
     Install,
+    InstallScript,
+    InstallNpm,
     SkipNow,
     SkipVersion,
     ReleaseNotes,
@@ -45,13 +47,14 @@ pub struct UpdatePromptState {
     pub current_version: String,
     pub latest_version: String,
     pub release_url: String,
+    pub install_method: crate::install_method::InstallMethod,
     pub selected: UpdatePromptAction,
     pub last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PostExitAction {
-    InstallUpdate { latest_version: String },
+    InstallUpdate { latest_version: String, method: crate::install_method::InstallMethod },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/app/trust/tests.rs
+++ b/src/app/trust/tests.rs
@@ -123,6 +123,7 @@ fn accept_routes_update_prompt_before_resume_picker() {
         current_version: "0.13.4".to_owned(),
         latest_version: "0.14.0".to_owned(),
         release_url: "https://example.invalid".to_owned(),
+        install_method: crate::install_method::InstallMethod::Npm,
         selected: crate::app::UpdatePromptAction::Install,
         last_error: None,
     });

--- a/src/app/update_prompt.rs
+++ b/src/app/update_prompt.rs
@@ -4,15 +4,23 @@
 use super::settings;
 use super::view::{self, FullscreenView, SurfaceMode};
 use super::{App, PostExitAction, UpdatePrompt, UpdatePromptAction, UpdatePromptState};
+use crate::install_method::{InstallMethod, detect_install_method};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 impl From<UpdatePrompt> for UpdatePromptState {
     fn from(prompt: UpdatePrompt) -> Self {
+        let install_method = detect_install_method();
+        let selected = if install_method == InstallMethod::Unknown {
+            UpdatePromptAction::InstallScript
+        } else {
+            UpdatePromptAction::Install
+        };
         Self {
             current_version: prompt.current_version,
             latest_version: prompt.latest_version,
             release_url: prompt.release_url,
-            selected: UpdatePromptAction::Install,
+            install_method,
+            selected,
             last_error: prompt.last_error,
         }
     }
@@ -47,9 +55,10 @@ fn move_selection(app: &mut App, delta: isize) {
     let Some(prompt) = app.update_prompt.as_mut() else {
         return;
     };
-    let current = action_index(prompt.selected);
-    let next = current.saturating_add_signed(delta).min(ACTIONS.len().saturating_sub(1));
-    prompt.selected = ACTIONS[next];
+    let actions = actions_for(&prompt.install_method);
+    let current = action_index(actions, prompt.selected);
+    let next = current.saturating_add_signed(delta).min(actions.len().saturating_sub(1));
+    prompt.selected = actions[next];
 }
 
 fn activate_selection(app: &mut App) {
@@ -59,19 +68,29 @@ fn activate_selection(app: &mut App) {
     };
 
     match selected {
-        UpdatePromptAction::Install => install(app),
+        UpdatePromptAction::Install => install(app, None),
+        UpdatePromptAction::InstallScript => {
+            install(app, Some(InstallMethod::Script { install_dir: None }));
+        }
+        UpdatePromptAction::InstallNpm => install(app, Some(InstallMethod::Npm)),
         UpdatePromptAction::SkipNow => skip_now(app),
         UpdatePromptAction::SkipVersion => skip_version(app),
         UpdatePromptAction::ReleaseNotes => open_release_notes(app),
     }
 }
 
-fn install(app: &mut App) {
+fn install(app: &mut App, method_override: Option<InstallMethod>) {
     let Some(prompt) = app.update_prompt.as_ref() else {
         return;
     };
-    app.post_exit_action =
-        Some(PostExitAction::InstallUpdate { latest_version: prompt.latest_version.clone() });
+    let method = method_override.unwrap_or_else(|| prompt.install_method.clone());
+    if method == InstallMethod::Unknown {
+        return;
+    }
+    app.post_exit_action = Some(PostExitAction::InstallUpdate {
+        latest_version: prompt.latest_version.clone(),
+        method,
+    });
     app.should_quit = true;
 }
 
@@ -143,12 +162,24 @@ fn is_ctrl(key: KeyEvent, ch: char) -> bool {
     matches!(key.code, KeyCode::Char(c) if c == ch) && key.modifiers == KeyModifiers::CONTROL
 }
 
-fn action_index(action: UpdatePromptAction) -> usize {
-    ACTIONS.iter().position(|candidate| *candidate == action).unwrap_or(0)
+fn action_index(actions: &[UpdatePromptAction], action: UpdatePromptAction) -> usize {
+    actions.iter().position(|candidate| *candidate == action).unwrap_or(0)
 }
 
-const ACTIONS: [UpdatePromptAction; 4] = [
+pub(crate) fn actions_for(method: &InstallMethod) -> &'static [UpdatePromptAction] {
+    if *method == InstallMethod::Unknown { &UNKNOWN_ACTIONS } else { &KNOWN_ACTIONS }
+}
+
+const KNOWN_ACTIONS: [UpdatePromptAction; 4] = [
     UpdatePromptAction::Install,
+    UpdatePromptAction::SkipNow,
+    UpdatePromptAction::SkipVersion,
+    UpdatePromptAction::ReleaseNotes,
+];
+
+const UNKNOWN_ACTIONS: [UpdatePromptAction; 5] = [
+    UpdatePromptAction::InstallScript,
+    UpdatePromptAction::InstallNpm,
     UpdatePromptAction::SkipNow,
     UpdatePromptAction::SkipVersion,
     UpdatePromptAction::ReleaseNotes,
@@ -165,6 +196,7 @@ mod tests {
             current_version: "0.13.4".to_owned(),
             latest_version: "0.14.0".to_owned(),
             release_url: "https://example.invalid/v0.14.0".to_owned(),
+            install_method: InstallMethod::Npm,
             selected: UpdatePromptAction::Install,
             last_error: None,
         });
@@ -181,7 +213,34 @@ mod tests {
         assert!(app.should_quit);
         assert_eq!(
             app.post_exit_action,
-            Some(PostExitAction::InstallUpdate { latest_version: "0.14.0".to_owned() })
+            Some(PostExitAction::InstallUpdate {
+                latest_version: "0.14.0".to_owned(),
+                method: InstallMethod::Npm,
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_layout_offers_script_and_npm_install_actions() {
+        let mut app = app_with_prompt();
+        let prompt = app.update_prompt.as_mut().expect("prompt");
+        prompt.install_method = InstallMethod::Unknown;
+        prompt.selected = UpdatePromptAction::InstallScript;
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(
+            app.update_prompt.as_ref().map(|prompt| prompt.selected),
+            Some(UpdatePromptAction::InstallNpm)
+        );
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(
+            app.post_exit_action,
+            Some(PostExitAction::InstallUpdate {
+                latest_version: "0.14.0".to_owned(),
+                method: InstallMethod::Script { install_dir: None },
+            })
         );
     }
 

--- a/src/install_method.rs
+++ b/src/install_method.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Simon Peter Rothgang
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+const ROOT_PACKAGE_NAME: &str = "claude-code-rust";
+const NPM_PLATFORM_PACKAGE_NAMES: [&str; 6] = [
+    "@srothgan/claude-code-rust-darwin-arm64",
+    "@srothgan/claude-code-rust-darwin-x64",
+    "@srothgan/claude-code-rust-linux-arm64-gnu",
+    "@srothgan/claude-code-rust-linux-x64-gnu",
+    "@srothgan/claude-code-rust-win32-arm64-msvc",
+    "@srothgan/claude-code-rust-win32-x64-msvc",
+];
+
+#[cfg(target_os = "windows")]
+const BUNDLED_RUNTIME_NAME: &str = "claude-rs-bridge-bun.exe";
+#[cfg(not(target_os = "windows"))]
+const BUNDLED_RUNTIME_NAME: &str = "claude-rs-bridge-bun";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallMethod {
+    Script { install_dir: Option<PathBuf> },
+    Npm,
+    Unknown,
+}
+
+impl InstallMethod {
+    #[must_use]
+    pub const fn label(&self) -> &'static str {
+        match self {
+            Self::Script { .. } => "install script",
+            Self::Npm => "npm",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[must_use]
+pub fn detect_install_method() -> InstallMethod {
+    std::env::current_exe()
+        .ok()
+        .map_or(InstallMethod::Unknown, |current_exe| detect_install_method_for_exe(&current_exe))
+}
+
+fn detect_install_method_for_exe(current_exe: &Path) -> InstallMethod {
+    let Some(exe_dir) = current_exe.parent() else {
+        return InstallMethod::Unknown;
+    };
+
+    if is_script_install_root(exe_dir) {
+        return InstallMethod::Script { install_dir: Some(exe_dir.to_owned()) };
+    }
+
+    if exe_dir.file_name().is_some_and(|name| name == "bin")
+        && let Some(package_root) = exe_dir.parent()
+        && package_name(package_root)
+            .is_some_and(|name| NPM_PLATFORM_PACKAGE_NAMES.contains(&name.as_str()))
+    {
+        return InstallMethod::Npm;
+    }
+
+    InstallMethod::Unknown
+}
+
+fn is_script_install_root(root: &Path) -> bool {
+    package_name(root).as_deref() == Some(ROOT_PACKAGE_NAME)
+        && root.join(BUNDLED_RUNTIME_NAME).is_file()
+        && root.join("agent-sdk").join("dist").join("bridge.js").is_file()
+}
+
+fn package_name(root: &Path) -> Option<String> {
+    #[derive(Deserialize)]
+    struct PackageIdentity {
+        name: String,
+    }
+
+    let raw = std::fs::read_to_string(root.join("package.json")).ok()?;
+    serde_json::from_str::<PackageIdentity>(&raw).ok().map(|package| package.name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_script_archive_layout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("claude-rs");
+        let exe = root.join(format!("claude-rs{}", std::env::consts::EXE_SUFFIX));
+        write_file(&exe, "binary");
+        write_file(&root.join(BUNDLED_RUNTIME_NAME), "runtime");
+        write_file(&root.join("agent-sdk/dist/bridge.js"), "bridge");
+        write_file(&root.join("package.json"), r#"{"name":"claude-code-rust"}"#);
+
+        assert_eq!(
+            detect_install_method_for_exe(&exe),
+            InstallMethod::Script { install_dir: Some(root) }
+        );
+    }
+
+    #[test]
+    fn detects_npm_platform_package_layout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("node_modules/@srothgan/claude-code-rust-win32-x64-msvc");
+        let exe = root.join("bin").join(format!("claude-rs{}", std::env::consts::EXE_SUFFIX));
+        write_file(&exe, "binary");
+        write_file(
+            &root.join("package.json"),
+            r#"{"name":"@srothgan/claude-code-rust-win32-x64-msvc"}"#,
+        );
+
+        assert_eq!(detect_install_method_for_exe(&exe), InstallMethod::Npm);
+    }
+
+    #[test]
+    fn rejects_unowned_binary_layout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let exe = temp.path().join(format!("claude-rs{}", std::env::consts::EXE_SUFFIX));
+        write_file(&exe, "binary");
+
+        assert_eq!(detect_install_method_for_exe(&exe), InstallMethod::Unknown);
+    }
+
+    #[test]
+    fn rejects_unknown_package_in_npm_namespace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("node_modules/@srothgan/claude-code-rust-unofficial");
+        let exe = root.join("bin").join(format!("claude-rs{}", std::env::consts::EXE_SUFFIX));
+        write_file(&exe, "binary");
+        write_file(
+            &root.join("package.json"),
+            r#"{"name":"@srothgan/claude-code-rust-unofficial"}"#,
+        );
+
+        assert_eq!(detect_install_method_for_exe(&exe), InstallMethod::Unknown);
+    }
+
+    fn write_file(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        std::fs::write(path, contents).expect("write fixture");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod app;
 pub mod cli;
 pub mod error;
 pub mod failure;
+pub mod install_method;
 pub mod logging;
 pub mod perf;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,18 @@ use clap::Parser;
 use claude_code_rust::Cli;
 use claude_code_rust::app::PostExitAction;
 use claude_code_rust::error::AppError;
-use std::process::Stdio;
+use claude_code_rust::install_method::InstallMethod;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus, Stdio};
 use std::time::Instant;
 use tracing::info_span;
+
+#[cfg(not(target_os = "windows"))]
+const UNIX_INSTALLER_URL: &str =
+    "https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh";
+#[cfg(target_os = "windows")]
+const WINDOWS_INSTALLER_URL: &str =
+    "https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.ps1";
 
 #[allow(clippy::exit)]
 fn main() {
@@ -117,50 +126,205 @@ fn run() -> anyhow::Result<i32> {
 
 fn run_post_exit_action(app: &mut claude_code_rust::app::App, action: PostExitAction) -> i32 {
     match action {
-        PostExitAction::InstallUpdate { latest_version } => {
-            run_update_install(app, &latest_version)
+        PostExitAction::InstallUpdate { latest_version, method } => {
+            run_update_install(app, &latest_version, method)
         }
     }
 }
 
-fn run_update_install(app: &mut claude_code_rust::app::App, latest_version: &str) -> i32 {
-    let npm = match resolve_npm() {
-        Ok(path) => path,
-        Err(error) => {
-            let message = format!("Failed to resolve npm for update install: {error}");
-            eprintln!("{message}");
-            record_install_failure(app, message);
-            return 1;
+fn run_update_install(
+    app: &mut claude_code_rust::app::App,
+    latest_version: &str,
+    method: InstallMethod,
+) -> i32 {
+    let method_label = method.label();
+    let result = match method {
+        InstallMethod::Npm => run_npm_update(),
+        InstallMethod::Script { install_dir } => {
+            run_script_update(latest_version, install_dir.as_deref())
         }
+        InstallMethod::Unknown => Err("no update install method was selected".to_owned()),
     };
 
-    let status = std::process::Command::new(&npm)
-        .args(["install", "-g", "claude-code-rust"])
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status();
-
-    match status {
+    match result {
         Ok(status) if status.success() => {
             clear_install_failure(app);
             0
         }
         Ok(status) => {
             let code = status.code().unwrap_or(1);
-            let message =
-                format!("Update install for v{latest_version} exited with status {status}.");
+            let message = format!(
+                "{method_label} update install for v{latest_version} exited with status {status}."
+            );
             eprintln!("{message}");
             record_install_failure(app, message);
             code
         }
         Err(error) => {
-            let message = format!("Failed to run update install for v{latest_version}: {error}");
+            let message = format!(
+                "Failed to run {method_label} update install for v{latest_version}: {error}"
+            );
             eprintln!("{message}");
             record_install_failure(app, message);
             1
         }
     }
+}
+
+fn run_npm_update() -> Result<ExitStatus, String> {
+    let npm = resolve_npm().map_err(|error| format!("failed to resolve npm: {error}"))?;
+    Command::new(&npm)
+        .args(["install", "-g", "claude-code-rust"])
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .map_err(|error| format!("failed to start {}: {error}", npm.display()))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn run_script_update(
+    latest_version: &str,
+    install_dir: Option<&Path>,
+) -> Result<ExitStatus, String> {
+    let installer = download_unix_installer()?;
+    let mut command = Command::new("sh");
+    command
+        .arg(&installer.script)
+        .args(["--release", latest_version, "--yes", "--keep-npm"])
+        .env_remove("CLAUDE_RS_RELEASE")
+        .env_remove("CLAUDE_RS_INSTALL_DIR")
+        .env_remove("CLAUDE_RS_BIN_DIR")
+        .env_remove("CLAUDE_RS_NO_MODIFY_PATH")
+        .env_remove("CLAUDE_RS_REMOVE_NPM")
+        .env_remove("CLAUDE_RS_RUN")
+        .env_remove("CLAUDE_RS_UNINSTALL")
+        .env_remove("CLAUDE_RS_UPDATE")
+        .env_remove("CLAUDE_RS_VERIFY")
+        .env("CLAUDE_RS_NON_INTERACTIVE", "1")
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    if let Some(install_dir) = install_dir {
+        command.arg("--update").arg("--install-dir").arg(install_dir);
+    }
+    command.status().map_err(|error| format!("failed to start install script: {error}"))
+}
+
+#[cfg(target_os = "windows")]
+fn run_script_update(
+    latest_version: &str,
+    install_dir: Option<&Path>,
+) -> Result<ExitStatus, String> {
+    let powershell = resolve_powershell()?;
+    let mut command = Command::new(&powershell);
+    command
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            &format!(
+                "$ProgressPreference='SilentlyContinue'; Invoke-Expression (Invoke-RestMethod -Uri '{WINDOWS_INSTALLER_URL}')"
+            ),
+        ])
+        .env_remove("CLAUDE_RS_INSTALL_DIR")
+        .env_remove("CLAUDE_RS_NO_MODIFY_PATH")
+        .env_remove("CLAUDE_RS_REMOVE_NPM")
+        .env_remove("CLAUDE_RS_RUN")
+        .env_remove("CLAUDE_RS_UNINSTALL")
+        .env_remove("CLAUDE_RS_UPDATE")
+        .env_remove("CLAUDE_RS_UPDATE_PARENT_PID")
+        .env_remove("CLAUDE_RS_VERIFY")
+        .env("CLAUDE_RS_RELEASE", latest_version)
+        .env("CLAUDE_RS_NON_INTERACTIVE", "1")
+        .env("CLAUDE_RS_KEEP_NPM", "1")
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    if let Some(install_dir) = install_dir {
+        command
+            .env("CLAUDE_RS_INSTALL_DIR", install_dir)
+            .env("CLAUDE_RS_UPDATE", "1")
+            .env("CLAUDE_RS_UPDATE_PARENT_PID", std::process::id().to_string());
+    }
+    command.status().map_err(|error| format!("failed to start {}: {error}", powershell.display()))
+}
+
+#[cfg(not(target_os = "windows"))]
+struct DownloadedInstaller {
+    root: PathBuf,
+    script: PathBuf,
+}
+
+#[cfg(not(target_os = "windows"))]
+impl Drop for DownloadedInstaller {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn download_unix_installer() -> Result<DownloadedInstaller, String> {
+    let root = create_update_temp_dir()?;
+    let script = root.join("install.sh");
+    let installer = DownloadedInstaller { root, script };
+    let (downloader, args): (PathBuf, Vec<std::ffi::OsString>) =
+        if let Ok(curl) = which::which("curl") {
+            (
+                curl,
+                vec![
+                    "-fsSL".into(),
+                    UNIX_INSTALLER_URL.into(),
+                    "-o".into(),
+                    installer.script.as_os_str().to_owned(),
+                ],
+            )
+        } else if let Ok(wget) = which::which("wget") {
+            (
+                wget,
+                vec![
+                    "-q".into(),
+                    "-O".into(),
+                    installer.script.as_os_str().to_owned(),
+                    UNIX_INSTALLER_URL.into(),
+                ],
+            )
+        } else {
+            return Err("neither curl nor wget was found in PATH".to_owned());
+        };
+
+    let status = Command::new(&downloader)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .map_err(|error| format!("failed to start {}: {error}", downloader.display()))?;
+    if !status.success() {
+        return Err(format!("installer download exited with status {status}"));
+    }
+    if !installer.script.is_file() {
+        return Err("installer download did not create install.sh".to_owned());
+    }
+    Ok(installer)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn create_update_temp_dir() -> Result<PathBuf, String> {
+    let base = std::env::temp_dir();
+    for attempt in 0..100_u32 {
+        let candidate = base.join(format!("claude-rs-update-{}-{attempt}", std::process::id()));
+        match std::fs::create_dir(&candidate) {
+            Ok(()) => return Ok(candidate),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => {
+                return Err(format!("failed to create {}: {error}", candidate.display()));
+            }
+        }
+    }
+    Err("could not allocate a temporary update directory".to_owned())
 }
 
 fn resolve_npm() -> Result<std::path::PathBuf, String> {
@@ -173,6 +337,14 @@ fn resolve_npm() -> Result<std::path::PathBuf, String> {
         .iter()
         .find_map(|candidate| which::which(candidate).ok())
         .ok_or_else(|| format!("none of {} were found in PATH", candidates.join(", ")))
+}
+
+#[cfg(target_os = "windows")]
+fn resolve_powershell() -> Result<PathBuf, String> {
+    ["powershell.exe", "pwsh.exe"]
+        .iter()
+        .find_map(|candidate| which::which(candidate).ok())
+        .ok_or_else(|| "neither powershell.exe nor pwsh.exe was found in PATH".to_owned())
 }
 
 fn record_install_failure(app: &mut claude_code_rust::app::App, message: String) {

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -64,6 +64,7 @@ fn render_fullscreen_surface_draws_update_view() {
         current_version: "0.13.4".to_owned(),
         latest_version: "0.14.0".to_owned(),
         release_url: "https://example.invalid".to_owned(),
+        install_method: crate::install_method::InstallMethod::Npm,
         selected: UpdatePromptAction::Install,
         last_error: None,
     });

--- a/src/ui/update.rs
+++ b/src/ui/update.rs
@@ -10,8 +10,6 @@ use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use super::theme;
 
-const INSTALL_COMMAND: &str = "npm install -g claude-code-rust";
-
 pub fn render(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
     let outer = Block::default()
@@ -33,7 +31,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     let detail = vec![
         Line::from(format!("Current version: v{}", prompt.current_version)),
         Line::from(format!("Latest version:  v{}", prompt.latest_version)),
-        Line::from(format!("Install command: {INSTALL_COMMAND}")),
+        Line::from(format!("Install method:  {}", prompt.install_method.label())),
     ];
     let error_height = prompt.last_error.as_deref().map_or(0, |error| {
         wrapped_line_count(Text::from(Line::from(error.to_owned())), inner.width)
@@ -73,25 +71,31 @@ fn action_lines(app: &App) -> Vec<Line<'static>> {
     let Some(prompt) = app.update_prompt.as_ref() else {
         return Vec::new();
     };
-    [
-        (UpdatePromptAction::Install, "Install update".to_owned()),
-        (UpdatePromptAction::SkipNow, "Skip now".to_owned()),
-        (UpdatePromptAction::SkipVersion, "Skip this version".to_owned()),
-        (
-            UpdatePromptAction::ReleaseNotes,
-            format!("Read release notes for v{} (on GitHub)", prompt.latest_version),
-        ),
-    ]
-    .into_iter()
-    .flat_map(|(action, label)| {
-        let mut lines = Vec::with_capacity(2);
-        if action == UpdatePromptAction::ReleaseNotes {
-            lines.push(Line::default());
-        }
-        lines.push(action_line(&label, prompt.selected == action));
-        lines
-    })
-    .collect()
+    crate::app::update_prompt_actions(&prompt.install_method)
+        .iter()
+        .copied()
+        .map(|action| {
+            let label = match action {
+                UpdatePromptAction::Install => "Install update".to_owned(),
+                UpdatePromptAction::InstallScript => "Install update with script".to_owned(),
+                UpdatePromptAction::InstallNpm => "Install update with npm".to_owned(),
+                UpdatePromptAction::SkipNow => "Skip now".to_owned(),
+                UpdatePromptAction::SkipVersion => "Skip this version".to_owned(),
+                UpdatePromptAction::ReleaseNotes => {
+                    format!("Read release notes for v{} (on GitHub)", prompt.latest_version)
+                }
+            };
+            (action, label)
+        })
+        .flat_map(|(action, label)| {
+            let mut lines = Vec::with_capacity(2);
+            if action == UpdatePromptAction::ReleaseNotes {
+                lines.push(Line::default());
+            }
+            lines.push(action_line(&label, prompt.selected == action));
+            lines
+        })
+        .collect()
 }
 
 fn action_line(label: &str, selected: bool) -> Line<'static> {
@@ -141,6 +145,7 @@ mod tests {
             current_version: "0.13.4".to_owned(),
             latest_version: "0.14.0".to_owned(),
             release_url: "https://example.invalid".to_owned(),
+            install_method: crate::install_method::InstallMethod::Npm,
             selected: UpdatePromptAction::Install,
             last_error: None,
         });
@@ -150,7 +155,26 @@ mod tests {
         assert!(text.contains("Update Available!"));
         assert!(text.contains("Current version: v0.13.4"));
         assert!(text.contains("Latest version:  v0.14.0"));
-        assert!(text.contains(INSTALL_COMMAND));
+        assert!(text.contains("Install method:  npm"));
         assert!(text.contains("Read release notes for v0.14.0 (on GitHub)"));
+    }
+
+    #[test]
+    fn unknown_install_method_renders_both_install_options() {
+        let mut app = App::test_default();
+        app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::Update);
+        app.update_prompt = Some(UpdatePromptState {
+            current_version: "0.13.4".to_owned(),
+            latest_version: "0.14.0".to_owned(),
+            release_url: "https://example.invalid".to_owned(),
+            install_method: crate::install_method::InstallMethod::Unknown,
+            selected: UpdatePromptAction::InstallScript,
+            last_error: None,
+        });
+
+        let text = draw_text(&mut app);
+
+        assert!(text.contains("Install update with script"));
+        assert!(text.contains("Install update with npm"));
     }
 }


### PR DESCRIPTION
## Summary

- Add ownership-aware install, uninstall, and npm-switching flows to the macOS/Linux and Windows installers, with checksum verification, atomic replacement, locking, and refusal to remove unrecognized layouts.
- Harden installer behavior across platforms: defer npm removal until installation succeeds, make npm cleanup failures non-fatal, preserve raw Windows user `Path` values, cover bash and zsh startup files, clean installer locks, and retain Windows PowerShell 5.1 compatibility.
- Add non-interactive in-place script updates that preserve the existing launcher and PATH configuration, including deferred cleanup of a running Windows installation after `claude-rs` exits.
- Detect script and npm installations from the running executable layout, show the detected method on the update screen, offer both methods when ownership is unknown, and dispatch the selected installer after the TUI exits.
- Make install scripts the recommended `v0.14.0+` installation path, keep npm as a supported alternative, clarify user versus developer prerequisites, use a reliable PowerShell invocation, and move detailed installation guidance into the documentation site.

## Why

`v0.14.0` is the first release intended to support public script installation and script-managed updates. The scripts therefore need to be a complete installation lifecycle rather than only an alternative initial download path.

Script and npm installs can both expose `claude-rs`, but they own different files and have different update mechanisms. Detecting ownership from the executable layout lets the update screen preserve the user's chosen method without guessing from PATH order. Unknown or source layouts remain explicit by offering both supported install choices.

The installer hardening prevents failed downloads or verification from removing a working npm installation, protects unrelated directories from deletion, preserves expandable Windows PATH entries, supports the startup files used by common macOS and Linux shells, and handles replacement of a running Windows executable safely.

Closes: N/A

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test` (1,657 library tests plus binary, integration, and documentation tests)
  - `mdbook build docs`
  - `git diff --check`
  - `C:\Program Files\Git\bin\sh.exe -n scripts/install/install.sh`
  - PowerShell parser and help checks for `scripts/install/install.ps1`
  - generated and verified mock install archives for all six supported platform targets
  - Windows x64 install-archive smoke test with the generated mock archive
- Manual:
  - completed an offline Unix update simulation covering archive verification, ownership checks, atomic replacement, launcher/profile preservation, installed-command verification, and lock cleanup
  - completed a Windows PowerShell 5.1 update simulation with a live old executable, checksum verification, replacement, post-update verification, deferred backup cleanup, and PATH/lock preservation
  - reproduced and verified raw `REG_EXPAND_SZ` user-PATH preservation, exclusive installer locking, and PowerShell 5.1 native stderr capture
  - exercised installer help, uninstall ownership guards, invalid update ownership guards, and npm switching behavior on both installer implementations
- Screenshot/video (if UI changed): Not captured; update-screen method labels and known/unknown action sets are covered by render and interaction tests.

## Notes

- Breaking changes: N/A
- Docs updated: `README.md`, `docs/src/installation.md`, and `CHANGELOG.md`
- Governance/release impact: Script installation becomes the recommended path starting with `v0.14.0`; release archives remain required for all six supported targets, and in-app script updates download the public installer from the repository. No version bump or release publication is included.
- Platform note: Published archives support macOS x64/arm64, Windows x64/arm64, and Linux x64/arm64 with glibc. Linux musl remains unsupported by the script archives.