### PR TITLE
feat(ui): use native textarea cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- **Native textarea cursor** (#268, @srothgan): Use `tui-textarea-2` native cursor positioning for the chat composer, hide the textarea-drawn cursor, and restore terminal cursor shape when leaving chat surfaces.
 - **Startup update screen** (#264, @srothgan): Show available updates in a startup screen with install, skip, and release-notes actions.
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3909,9 +3909,9 @@ dependencies = [
 
 [[package]]
 name = "tui-textarea-2"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6223d7c35c182bccd9af9e3e2ae695312b1c295617a2c3ed34a643176ee256e"
+checksum = "4296a13cbcb20abd7b62f96154cad81053eb82ee8d24db3d7fdca16b31f118e9"
 dependencies = [
  "crossterm",
  "portable-atomic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter", "json"] }
 time = { version = "0.3.47", features = ["formatting", "macros"] }
 two-face = { version = "0.5.1", default-features = false, features = ["syntect-fancy"] }
 tui-markdown = { version = "0.3.7" }
-tui-textarea-2 = "0.12.0"
+tui-textarea-2 = "0.12.1"
 unicode-segmentation = "1.13.3"
 unicode-width = "0.2.2"
 uuid = { version = "1.23.2", features = ["v4"] }

--- a/src/app/terminal_runtime/chat_session.rs
+++ b/src/app/terminal_runtime/chat_session.rs
@@ -1055,6 +1055,11 @@ fn render_textarea_editor(frame: &mut ratatui::Frame<'_>, app: &mut App, area: R
 
     input::configure_input_textarea(app);
     frame.render_widget(app.input.editor(), geometry.text);
+    if input::should_show_native_textarea_cursor(app)
+        && let Some(position) = app.input.editor().rendered_cursor_position()
+    {
+        frame.set_cursor_position(position);
+    }
 }
 
 struct InlineViewportDrawMetrics {
@@ -1187,13 +1192,16 @@ mod tests {
     use crate::app::terminal_runtime::chat_terminal::ChatTerminal;
     use crate::app::terminal_runtime::chat_terminal::plan_inline_geometry;
     use crate::app::{
-        App, AppStatus, ChatMessage, ChatMessageId, HistoryOutputId, MessageBlock, MessageRole,
-        TextBlock, TextBlockSpacing,
+        App, AppStatus, ChatMessage, ChatMessageId, FocusTarget, HistoryOutputId, MessageBlock,
+        MessageRole, TextBlock, TextBlockSpacing,
     };
     use crate::ui::inline_chat_rows::{
         LiveRowBoundaryKind, LiveRowSegment, SerializedLiveRows,
         serialize_live_rows_with_boundaries_excluding,
     };
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Position;
     use ratatui::layout::Rect;
     use ratatui::text::Line;
     use std::collections::BTreeSet;
@@ -1240,6 +1248,53 @@ mod tests {
 
     fn session_with_history(history: HistoryCommitState) -> ChatTerminalSession {
         ChatTerminalSession { terminal: ChatTerminal::new(0), history }
+    }
+
+    fn render_textarea_to_test_backend(app: &mut App, area: Rect) -> TestBackend {
+        let backend = TestBackend::new(area.width.max(1), area.height.max(1));
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        terminal
+            .draw(|frame| {
+                super::render_textarea_editor(frame, app, area);
+            })
+            .expect("test draw should succeed");
+        terminal.backend().clone()
+    }
+
+    #[test]
+    fn render_textarea_editor_sets_native_cursor_when_input_has_focus() {
+        let mut app = App::test_default();
+        app.input.set_text("hello");
+        let _ = app.input.set_cursor(0, 5);
+
+        let backend = render_textarea_to_test_backend(&mut app, Rect::new(0, 0, 20, 1));
+
+        assert!(backend.cursor_visible());
+        assert_eq!(backend.cursor_position(), Position { x: 9, y: 0 });
+    }
+
+    #[test]
+    fn render_textarea_editor_hides_native_cursor_when_permission_has_focus() {
+        let mut app = App::test_default();
+        app.input.set_text("hello");
+        let _ = app.input.set_cursor(0, 5);
+        app.turn.pending_interaction_ids.push("perm-1".to_owned());
+        app.claim_focus_target(FocusTarget::Permission);
+
+        let backend = render_textarea_to_test_backend(&mut app, Rect::new(0, 0, 20, 1));
+
+        assert!(!backend.cursor_visible());
+    }
+
+    #[test]
+    fn render_textarea_editor_hides_native_cursor_when_text_area_is_empty() {
+        let mut app = App::test_default();
+        app.input.set_text("hello");
+        let _ = app.input.set_cursor(0, 5);
+
+        let backend = render_textarea_to_test_backend(&mut app, Rect::new(0, 0, 4, 1));
+
+        assert!(!backend.cursor_visible());
     }
 
     #[test]

--- a/src/app/terminal_runtime/modes.rs
+++ b/src/app/terminal_runtime/modes.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 Simon Peter Rothgang
 
-use crossterm::cursor::{Hide, Show};
+use crossterm::cursor::{Hide, SetCursorStyle, Show};
 use crossterm::event::{DisableFocusChange, DisableMouseCapture, EnableFocusChange};
 #[cfg(target_os = "macos")]
 use crossterm::event::{
@@ -24,6 +24,8 @@ pub(super) enum TerminalModeAction {
     DisableFocusChange,
     HideCursor,
     ShowCursor,
+    SetBlinkingBarCursor,
+    RestoreDefaultCursorShape,
     DisableLineWrap,
     EnableLineWrap,
     #[cfg(target_os = "macos")]
@@ -38,10 +40,12 @@ const CHAT_STARTUP_ACTIONS: &[TerminalModeAction] = &[
     TerminalModeAction::PushKeyboardEnhancement,
     TerminalModeAction::EnableFocusChange,
     TerminalModeAction::DisableLineWrap,
+    TerminalModeAction::SetBlinkingBarCursor,
     TerminalModeAction::ShowCursor,
 ];
 
 const ENTER_FULLSCREEN_ACTIONS: &[TerminalModeAction] = &[
+    TerminalModeAction::RestoreDefaultCursorShape,
     TerminalModeAction::HideCursor,
     TerminalModeAction::EnableLineWrap,
     TerminalModeAction::EnterAlternateScreen,
@@ -50,10 +54,12 @@ const ENTER_FULLSCREEN_ACTIONS: &[TerminalModeAction] = &[
 const EXIT_FULLSCREEN_ACTIONS: &[TerminalModeAction] = &[
     TerminalModeAction::LeaveAlternateScreen,
     TerminalModeAction::DisableLineWrap,
+    TerminalModeAction::SetBlinkingBarCursor,
     TerminalModeAction::ShowCursor,
 ];
 
 const SHUTDOWN_RESTORE_ACTIONS: &[TerminalModeAction] = &[
+    TerminalModeAction::RestoreDefaultCursorShape,
     TerminalModeAction::ShowCursor,
     TerminalModeAction::EnableLineWrap,
     TerminalModeAction::DisableMouseCapture,
@@ -64,6 +70,7 @@ const SHUTDOWN_RESTORE_ACTIONS: &[TerminalModeAction] = &[
 ];
 
 const RELEASE_TO_CHILD_ACTIONS: &[TerminalModeAction] = &[
+    TerminalModeAction::RestoreDefaultCursorShape,
     TerminalModeAction::ShowCursor,
     TerminalModeAction::EnableLineWrap,
     TerminalModeAction::DisableFocusChange,
@@ -115,6 +122,12 @@ pub(super) fn apply_actions(
             TerminalModeAction::DisableFocusChange => execute!(stdout, DisableFocusChange),
             TerminalModeAction::HideCursor => execute!(stdout, Hide),
             TerminalModeAction::ShowCursor => execute!(stdout, Show),
+            TerminalModeAction::SetBlinkingBarCursor => {
+                execute!(stdout, SetCursorStyle::BlinkingBar)
+            }
+            TerminalModeAction::RestoreDefaultCursorShape => {
+                execute!(stdout, SetCursorStyle::DefaultUserShape)
+            }
             TerminalModeAction::DisableLineWrap => execute!(stdout, DisableLineWrap),
             TerminalModeAction::EnableLineWrap => {
                 execute!(stdout, crossterm::terminal::EnableLineWrap)
@@ -161,6 +174,7 @@ mod tests {
                 TerminalModeAction::PushKeyboardEnhancement,
                 TerminalModeAction::EnableFocusChange,
                 TerminalModeAction::DisableLineWrap,
+                TerminalModeAction::SetBlinkingBarCursor,
                 TerminalModeAction::ShowCursor,
             ]
         );
@@ -171,6 +185,7 @@ mod tests {
         assert_eq!(
             enter_fullscreen_actions(),
             &[
+                TerminalModeAction::RestoreDefaultCursorShape,
                 TerminalModeAction::HideCursor,
                 TerminalModeAction::EnableLineWrap,
                 TerminalModeAction::EnterAlternateScreen,
@@ -185,6 +200,7 @@ mod tests {
             &[
                 TerminalModeAction::LeaveAlternateScreen,
                 TerminalModeAction::DisableLineWrap,
+                TerminalModeAction::SetBlinkingBarCursor,
                 TerminalModeAction::ShowCursor,
             ]
         );
@@ -195,6 +211,7 @@ mod tests {
         assert_eq!(
             shutdown_restore_actions(),
             &[
+                TerminalModeAction::RestoreDefaultCursorShape,
                 TerminalModeAction::ShowCursor,
                 TerminalModeAction::EnableLineWrap,
                 TerminalModeAction::DisableMouseCapture,
@@ -211,6 +228,7 @@ mod tests {
         assert_eq!(
             release_to_child_actions(),
             &[
+                TerminalModeAction::RestoreDefaultCursorShape,
                 TerminalModeAction::ShowCursor,
                 TerminalModeAction::EnableLineWrap,
                 TerminalModeAction::DisableFocusChange,
@@ -241,10 +259,29 @@ mod tests {
 
     #[test]
     fn shutdown_restore_actions_restore_shell_friendly_defaults() {
+        assert!(
+            shutdown_restore_actions().contains(&TerminalModeAction::RestoreDefaultCursorShape)
+        );
         assert!(shutdown_restore_actions().contains(&TerminalModeAction::ShowCursor));
         assert!(shutdown_restore_actions().contains(&TerminalModeAction::EnableLineWrap));
         #[cfg(target_os = "macos")]
         assert!(shutdown_restore_actions().contains(&TerminalModeAction::PopKeyboardEnhancement));
+    }
+
+    #[test]
+    fn chat_cursor_shape_actions_are_restored_on_surface_changes() {
+        assert!(chat_startup_actions().contains(&TerminalModeAction::SetBlinkingBarCursor));
+        assert!(return_from_child_actions().contains(&TerminalModeAction::SetBlinkingBarCursor));
+        assert!(exit_fullscreen_actions().contains(&TerminalModeAction::SetBlinkingBarCursor));
+        assert!(
+            enter_fullscreen_actions().contains(&TerminalModeAction::RestoreDefaultCursorShape)
+        );
+        assert!(
+            release_to_child_actions().contains(&TerminalModeAction::RestoreDefaultCursorShape)
+        );
+        assert!(
+            shutdown_restore_actions().contains(&TerminalModeAction::RestoreDefaultCursorShape)
+        );
     }
 
     #[test]

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -8,7 +8,7 @@ use crate::app::{App, FocusOwner};
 use crate::ui::theme;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
-use tui_textarea::TextArea;
+use tui_textarea::{CursorRenderMode, TextArea};
 
 use super::autocomplete;
 
@@ -103,6 +103,7 @@ pub(crate) fn configure_input_textarea(app: &mut App) {
         textarea.set_placeholder_text("Type a message...");
         textarea.set_placeholder_style(Style::default().fg(theme::DIM));
         textarea.set_cursor_line_style(Style::default());
+        textarea.set_cursor_render_mode(CursorRenderMode::Hidden);
         textarea.set_cursor_style(Style::default().add_modifier(Modifier::REVERSED));
     }
 
@@ -123,6 +124,10 @@ pub(crate) fn configure_input_textarea(app: &mut App) {
         );
         app.input.highlight_version = app.input.content_version;
     }
+}
+
+pub(crate) fn should_show_native_textarea_cursor(app: &App) -> bool {
+    app.focus_owner() == FocusOwner::Input
 }
 
 fn apply_textarea_highlights(
@@ -225,6 +230,7 @@ mod tests {
     use ratatui::layout::Rect;
     use ratatui::style::{Color, Modifier};
     use ratatui::widgets::Widget;
+    use tui_textarea::CursorRenderMode;
 
     #[test]
     fn slash_range_matches_leading_command_token() {
@@ -312,7 +318,16 @@ mod tests {
     }
 
     #[test]
-    fn direct_textarea_render_preserves_cursor_cell_at_line_end() {
+    fn configure_input_textarea_uses_hidden_cursor_render_mode() {
+        let mut app = App::test_default();
+
+        configure_input_textarea(&mut app);
+
+        assert_eq!(app.input.editor().cursor_render_mode(), CursorRenderMode::Hidden);
+    }
+
+    #[test]
+    fn direct_textarea_render_hides_cursor_cell_at_line_end() {
         let mut app = App::test_default();
         app.input.set_text("hello");
         let _ = app.input.set_cursor(0, 5);
@@ -324,7 +339,8 @@ mod tests {
 
         let cursor_cell = buffer.cell((5, 0)).expect("cursor cell");
         assert_eq!(cursor_cell.symbol(), " ");
-        assert!(cursor_cell.style().add_modifier.contains(Modifier::REVERSED));
+        assert!(!cursor_cell.style().add_modifier.contains(Modifier::REVERSED));
+        assert_eq!(app.input.editor().rendered_cursor_position(), Some((5, 0).into()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Enable the chat input textarea to use the native terminal cursor.

- Update `tui-textarea-2` to `0.12.1`.
- Configure the input textarea to hide its buffer-drawn cursor.
- Place Ratatui's native cursor from the textarea's rendered cursor position when input owns focus.
- Set a blinking bar cursor for chat surfaces and restore the user's default cursor shape when leaving them.
- Add focused tests for textarea cursor rendering, focus gating, empty render areas, and terminal mode cursor-shape actions.

## Why

The textarea crate now exposes opt-in native cursor support. Using that API lets the app show a thin terminal cursor in the composer while preserving correct cursor placement across wrapping, padding, placeholders, and Unicode handling owned by the textarea render plan.

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `cargo check --offline`
- Manual:
  - N/A
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: N/A
