### PR TITLE
fix(ci): skip release when crate version is unchanged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
+      should_release: ${{ steps.gate.outputs.should_release }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -53,16 +54,21 @@ jobs:
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
           echo "Release version: $VERSION"
 
-      - name: Require new git tag
+      - name: Determine whether a release is needed
+        id: gate
         run: |
           set -euo pipefail
           TAG="${{ steps.version.outputs.tag }}"
           if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1 || git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
-            echo "::error::Release tag already exists: $TAG"
-            exit 1
+            echo "::notice::Crate version matches existing tag $TAG; nothing to release. Skipping."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Release tag $TAG is new; proceeding with release."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Require new npm versions
+        if: steps.gate.outputs.should_release == 'true'
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
@@ -95,10 +101,12 @@ jobs:
           check_recoverable "@srothgan/claude-code-rust-win32-x64-msvc"
 
       - name: Validate Bun runtime manifest
+        if: steps.gate.outputs.should_release == 'true'
         run: node scripts/runtime/stage-bun-runtime.mjs --check --verify-upstream
 
   agent-sdk-preflight:
     needs: [verify]
+    if: needs.verify.outputs.should_release == 'true'
     uses: ./.github/workflows/_agent-sdk.yml
     permissions:
       contents: read
@@ -158,6 +166,7 @@ jobs:
 
   stage-bun-runtimes:
     needs: [verify]
+    if: needs.verify.outputs.should_release == 'true'
     name: Stage bundled Bun runtimes
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 
 - **Duplicate-code gate** (#262, @srothgan): Add PR jscpd thresholds with a 1% warning, 2% failure, and `pr-gate` enforcement.
 - **Advisory and tooling updates** (#262, @srothgan): Refresh dependency advisory/tooling locks and remove resolved cargo-deny advisory ignores.
+- **Release skip on unchanged version** (#269, @srothgan): Skip the release workflow with a green no-op when a `Cargo.toml` push leaves the crate version unchanged.
 
 ## [0.13.4] - 2026-07-06 [Changes][v0.13.4]
 


### PR DESCRIPTION
## Summary

Make the `Release` workflow skip cleanly instead of failing when a push to `main` touches `Cargo.toml` without changing the package version (e.g. a dependency bump).

The `verify` job now compares the crate version's tag `v$VERSION` against existing tags:
- **Tag already exists** (version unchanged) → emits a `::notice::`, sets `should_release=false`, and the job finishes green.
- **Tag is new** (real version bump) → `should_release=true`, and the release proceeds as before.

All downstream jobs are gated on `should_release`, so on a no-op push they show as skipped rather than running or failing.

## Why

The release workflow triggers on any `Cargo.toml` change (path filters can't match a single line). PR #268 bumped a dependency (`tui-textarea-2` 0.12.0 → 0.12.1) without changing the package version, which armed the release. The old `Require new git tag` step then hard-failed with `exit 1` because `v0.13.4` already existed, producing a red run for what should have been a no-op.

Closes #

## Validation

- Automated: `verify` job now branches on tag existence; downstream publish jobs are gated on `needs.verify.outputs.should_release == 'true'`. Direct children of `verify` (`agent-sdk-preflight`, `stage-bun-runtimes`) carry the gate; all other jobs cascade-skip via `needs`.
- Manual: Re-inspected the #268 scenario — the run now detects the existing `v0.13.4` tag, logs "nothing to release. Skipping," and finishes green with downstream jobs skipped.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: Release workflow only skips when the version tag already exists; a genuine version bump still triggers the full publish pipeline unchanged.