### PR TITLE
chore(sdk): update Claude Agent SDK to 0.3.207

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
+- **Inline cursor tracking** (#266, @srothgan): Avoid Unix/macOS live-loop DSR cursor reads in inline chat by using tracked cursor state for the ratatui viewport and invalidating cached seeds after external terminal ownership boundaries.
 - **Markdown list rendering** (#263, @srothgan): Keep streamed inline Markdown handoffs mutable only until delimiters resolve, let stable scrollback advance after resolved blocks, and preserve fenced code layout when code lines look like Markdown list items.
 
 ### Documentation
@@ -32,6 +33,7 @@ All notable changes to this project will be documented in this file.
 
 - **Duplicate-code gate** (#262, @srothgan): Add PR jscpd thresholds with a 1% warning, 2% failure, and `pr-gate` enforcement.
 - **Advisory and tooling updates** (#262, @srothgan): Refresh dependency advisory/tooling locks and remove resolved cargo-deny advisory ignores.
+- **Claude Agent SDK update** (#272, @srothgan): Bump the bundled bridge packages to Agent SDK `0.3.207`, preserve new task metadata and terminal reason values, normalize the new permission-mode alias, and remove the unmatched mouse-capture restore action.
 - **Release skip on unchanged version** (#269, @srothgan): Skip the release workflow with a green no-op when a `Cargo.toml` push leaves the crate version unchanged.
 
 ## [0.13.4] - 2026-07-06 [Changes][v0.13.4]

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.198"
+        "@anthropic-ai/claude-agent-sdk": "0.3.207"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.3",
@@ -22,22 +22,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.198.tgz",
-      "integrity": "sha512-xt469sSCyclTPtzpLAg0Aschy665GiRMgZKabSmESbGUA5/H56HcILVOiFxclXswkeMUk2fQxfHJUY9UZfiTnA==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.207.tgz",
+      "integrity": "sha512-y0PkQRmQBi96MHiN5Xzfq+GaddxCZCqI/cXEQBLYBLXGa4i1nDSlulQqkMBj2RorrrSGQJ6Wdw+uhu6OfHNPzA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.198"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.207"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.198.tgz",
-      "integrity": "sha512-ZmiAybQKIKcP1qEAE/vfXvfxtKxG9CnJn98QTXC5Zxiwuy7Mllx2ALXh9dfmsf0V87CGEodlZQmMgUJotNIsUw==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.207.tgz",
+      "integrity": "sha512-08xSo1FDx8h0aLhL5tvcRxa2SMmcUV3aDWeZiEJVTclyiDAs61BgTjAxCg+SZcu1CndjJO8cfO0yM5dhamxz3g==",
       "cpu": [
         "arm64"
       ],
@@ -59,9 +59,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.198.tgz",
-      "integrity": "sha512-XwH5vgN46WSwg8aC1OagNofnJpV/G1ciEu118GEKer8ZhVkq/dvK/DqShxMkb6r1jV7u5IJ7zPXu9uKliyNJAw==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.207.tgz",
+      "integrity": "sha512-1o7K4EYqyCixZ/oeOZSh7AzSy6TM86xoOuf4VuORjPSS31hBnoqY0NGZd27+2VDs9LGtsdksmsTqcNGx9xd1hA==",
       "cpu": [
         "x64"
       ],
@@ -72,9 +72,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.198.tgz",
-      "integrity": "sha512-qmz8dxEtDIlKntU5qYe0R4aWTxTue5S7zIQknatLX7aJ6HN/nq1aCNXWn5smTH2FViBkUPPR+sCIsNwSk6AT6Q==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.207.tgz",
+      "integrity": "sha512-X4uezYOifDiNTTmmugfRCdg3nNamrr1LFRY9hg30vWYTShL+bbN+nfC3KaFfSYCl4GTtsEEUbYdOTC2F3bBpcA==",
       "cpu": [
         "arm64"
       ],
@@ -88,9 +88,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.198.tgz",
-      "integrity": "sha512-Q7lKVNjIrUQ2B/AR77OvRf0zeOdEjonFVaR9FYrrwtzGeEqum69WSht5nM7Y7el3wjbNi0/eV0QTUM0DlsTEfw==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.207.tgz",
+      "integrity": "sha512-oPj+g2DslhH4Y9nCTs7al4t9wZv78FZwLFQwOCg99BXuz1o0ZOpKmxyvR7J9eBR+GPszeMMS8gYplQTiZC9o2w==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.198.tgz",
-      "integrity": "sha512-Zqxyz2AT1UM5WlOOoLJhLssZDgZo8rBK5ku6daveK12zp+UTJGZhGsjFghz1/ASxH08KqOTbUePNTORnPhHAEQ==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.207.tgz",
+      "integrity": "sha512-Kg6BPH8Ee0ny/oEUWJmvT1jCRBne4jVpRSOMsJcYp1Fav1rMEgpU219oJJs+LWwx4ifuuLtNWedqJNnVw7mnKg==",
       "cpu": [
         "x64"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.198.tgz",
-      "integrity": "sha512-h1SrWVIMjLInYNPlf+TxXuKTOdoiOfJLBSoQG97315Z2Nh0IpBfqWExlqYTtPCgKE7q2iga31U283QfHpIDlSQ==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.207.tgz",
+      "integrity": "sha512-uRv+D5oG/7EYr41FAJ9IPo2pZYBe2ZMaA6nSHCeizsgPxCSMtl5bNppmU21+jZJvo4hivObEgkGFERAhdGqygg==",
       "cpu": [
         "x64"
       ],
@@ -136,9 +136,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.198.tgz",
-      "integrity": "sha512-mjIHf1HFiRuXefewWTaNZFlTZlCaEt/xsRjc1nSTCEEpFolZayVhrDKz+O2QFVcDtPl8x8GeYSL0kiikg1DZjQ==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.207.tgz",
+      "integrity": "sha512-9fWpUzfkXlPAg2tf8JpQe7w9avFaomAUbfAwyAmykQgSIf66LwaJjvI5hNqhNqczRKyfsXPn3ei2S5HKlmFP+Q==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +149,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.198.tgz",
-      "integrity": "sha512-y3HLuCCz1kDwUrhd6OnqO+d5BUpTFSzNUsPT9kf3r1vk9HYKF+eMC9eIlcOhiW2kX491kxEvuEOfqgIkGx15cg==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.207.tgz",
+      "integrity": "sha512-YPjVT0q6aXEM2MgN4CI6/9fqiTXwETji+4NoPOzCYuqAkhXZqp30Jsk7/NHqYGNNSfURKrsuAoliKB0rsbpbjg==",
       "cpu": [
         "x64"
       ],

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -20,7 +20,7 @@
     "node": ">=24"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.198"
+    "@anthropic-ai/claude-agent-sdk": "0.3.207"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.3",

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -1399,6 +1399,26 @@ test("buildQueryOptions forwards settings and maps startup model and permission 
   assert.equal("effort" in options, false);
 });
 
+test("buildQueryOptions normalizes manual startup permission mode to default", () => {
+  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const options = buildQueryOptions({
+    cwd: "C:/work",
+    launchSettings: {
+      settings: {
+        permissions: { defaultMode: "manual" },
+      },
+    },
+    provisionalSessionId: "session-manual",
+    input,
+    canUseTool: async () => ({ behavior: "deny", message: "not used" }),
+    enableSdkDebug: false,
+    enableSpawnDebug: false,
+    sessionIdForLogs: () => "session-manual",
+  });
+
+  assert.equal(options.permissionMode, "default");
+});
+
 test("buildQueryOptions trims startup model before passing sdk option", () => {
   const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
   const options = buildQueryOptions({
@@ -1490,6 +1510,7 @@ test("buildQueryOptions omits optional startup overrides but keeps bridge guard 
 
 test("dispatchCancelTurnCommand interrupts the matching session query", async () => {
   let interruptCount = 0;
+  let receiptReturned = false;
   const slashErrors: Array<{ sessionId: string; message: string; requestId?: string }> = [];
 
   await dispatchCancelTurnCommand(
@@ -1502,6 +1523,8 @@ test("dispatchCancelTurnCommand interrupts the matching session query", async ()
               query: {
                 interrupt: async () => {
                   interruptCount += 1;
+                  receiptReturned = true;
+                  return { still_queued: ["user-message-1"] };
                 },
               },
             }
@@ -1513,6 +1536,7 @@ test("dispatchCancelTurnCommand interrupts the matching session query", async ()
   );
 
   assert.equal(interruptCount, 1);
+  assert.equal(receiptReturned, true);
   assert.deepEqual(slashErrors, []);
 });
 
@@ -1762,6 +1786,44 @@ test("handleTaskSystemMessage falls back to description and last tool when progr
             content: { type: "text", text: "Inspecting auth code (last tool: Read)" },
           },
         ],
+      },
+    },
+  });
+});
+
+test("handleTaskSystemMessage preserves blocked and parent agent metadata", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleTaskSystemMessage(session, "task_started", {
+      task_id: "task-1",
+      tool_use_id: "tool-1",
+      description: "Investigate release blocker",
+      blocked: true,
+      parent_agent_id: "agent-parent",
+    });
+  });
+
+  const lastEvent = events.at(-1);
+  assert.ok(lastEvent);
+  assert.equal(lastEvent.event, "session_update");
+  assert.deepEqual(lastEvent.update, {
+    type: "tool_call_update",
+    tool_call_update: {
+      tool_call_id: "tool-1",
+      fields: {
+        status: "in_progress",
+        raw_output: "Investigate release blocker",
+        content: [
+          {
+            type: "content",
+            content: { type: "text", text: "Investigate release blocker" },
+          },
+        ],
+        task_metadata: {
+          blocked: true,
+          parent_agent_id: "agent-parent",
+        },
       },
     },
   });
@@ -6144,7 +6206,7 @@ test("looksLikeAuthRequired detects login hints", () => {
 });
 
 test("agent sdk version compatibility check matches pinned version", () => {
-  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.198");
+  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.207");
   assert.equal(agentSdkVersionCompatibilityError(), undefined);
 });
 
@@ -6155,6 +6217,7 @@ test("mapSessionMessagesToUpdates maps message content blocks", () => {
       uuid: "u1",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         role: "user",
         content: [{ type: "text", text: "Top-level user prompt" }],
@@ -6165,6 +6228,7 @@ test("mapSessionMessagesToUpdates maps message content blocks", () => {
       uuid: "a1",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         id: "msg-1",
         role: "assistant",
@@ -6185,6 +6249,7 @@ test("mapSessionMessagesToUpdates maps message content blocks", () => {
       uuid: "u2",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         role: "user",
         content: [
@@ -6246,6 +6311,7 @@ test("mapSessionMessagesToUpdates suppresses ToolSearch history blocks", () => {
       uuid: "a1",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         role: "assistant",
         content: [
@@ -6264,6 +6330,7 @@ test("mapSessionMessagesToUpdates suppresses ToolSearch history blocks", () => {
       uuid: "u1",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         role: "user",
         content: [
@@ -6304,6 +6371,7 @@ test("mapSessionMessagesToUpdates preserves parallel tool results", () => {
       uuid: "a1",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         role: "assistant",
         content: [
@@ -6317,6 +6385,7 @@ test("mapSessionMessagesToUpdates preserves parallel tool results", () => {
       uuid: "u1",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         role: "user",
         content: [
@@ -6361,6 +6430,7 @@ test("mapSessionMessagesToUpdates maps task system records from resume history",
       uuid: "assistant-agent",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         role: "assistant",
         content: [
@@ -6378,6 +6448,7 @@ test("mapSessionMessagesToUpdates maps task system records from resume history",
       uuid: "system-bg-start",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         type: "system",
         subtype: "task_started",
@@ -6392,6 +6463,7 @@ test("mapSessionMessagesToUpdates maps task system records from resume history",
       uuid: "system-bg-update",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         type: "system",
         subtype: "task_updated",
@@ -6408,6 +6480,7 @@ test("mapSessionMessagesToUpdates maps task system records from resume history",
       uuid: "system-remote-start",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         type: "system",
         subtype: "task_started",
@@ -6423,6 +6496,7 @@ test("mapSessionMessagesToUpdates maps task system records from resume history",
       uuid: "system-mcp-start",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         type: "system",
         subtype: "task_started",
@@ -6502,6 +6576,68 @@ test("mapSessionMessagesToUpdates maps task system records from resume history",
   });
 });
 
+test("handleSdkMessage maps background_tasks_changed with background-only replacement semantics", () => {
+  const session = makeSessionState();
+  session.tasksById.set("task-list", {
+    task_id: "task-list",
+    subject: "From task list",
+    status: "pending",
+    blocks: [],
+    blocked_by: [],
+  });
+  session.tasksById.set("bg-old", {
+    task_id: "bg-old",
+    subject: "Old background task",
+    status: "in_progress",
+    blocks: [],
+    blocked_by: [],
+    metadata: { sdk_background_task: true },
+  });
+  session.taskOrder.push("task-list", "bg-old");
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [
+        {
+          task_id: "bg-new",
+          task_type: "workflow_agent",
+          description: "Run release checks",
+        },
+      ],
+    } as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events.at(-1), {
+    event: "session_update",
+    session_id: "session-1",
+    update: {
+      type: "task_state_update",
+      source: "background_tasks",
+      tasks: [
+        {
+          task_id: "bg-new",
+          subject: "Run release checks",
+          description: "Run release checks",
+          status: "in_progress",
+          blocks: [],
+          blocked_by: [],
+          metadata: {
+            sdk_background_task: true,
+            task_type: "workflow_agent",
+          },
+        },
+      ],
+      removed_task_ids: ["bg-old"],
+      is_complete_snapshot: true,
+    },
+  });
+  assert.equal(session.tasksById.has("task-list"), true);
+  assert.equal(session.tasksById.has("bg-old"), false);
+  assert.equal(session.tasksById.has("bg-new"), true);
+});
+
 test("handleResultMessage emits terminal reason on successful turn completion", () => {
   const session = makeSessionState();
 
@@ -6519,6 +6655,34 @@ test("handleResultMessage emits terminal reason on successful turn completion", 
     session_id: "session-1",
     terminal_reason: "completed",
   });
+});
+
+test("handleResultMessage preserves new SDK terminal reasons", () => {
+  const terminalReasons = [
+    "api_error",
+    "malformed_tool_use_exhausted",
+    "budget_exhausted",
+    "structured_output_retry_exhausted",
+    "tool_deferred_unavailable",
+    "turn_setup_failed",
+  ] as const;
+
+  for (const terminalReason of terminalReasons) {
+    const session = makeSessionState();
+    const events = captureBridgeEvents(() => {
+      handleResultMessage(session, {
+        type: "result",
+        subtype: "success",
+        terminal_reason: terminalReason,
+      });
+    });
+
+    assert.equal(events.at(-1)?.event, "turn_complete");
+    assert.equal(
+      (events.at(-1) as { terminal_reason?: string } | undefined)?.terminal_reason,
+      terminalReason,
+    );
+  }
 });
 
 test("handleResultMessage ignores success result telemetry fields", () => {
@@ -6671,6 +6835,7 @@ test("mapSessionMessagesToUpdates ignores unsupported records", () => {
       uuid: "u1",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         role: "assistant",
         content: [{ type: "thinking", thinking: "h" }],
@@ -6681,6 +6846,7 @@ test("mapSessionMessagesToUpdates ignores unsupported records", () => {
       uuid: "system-unsupported",
       session_id: "s1",
       parent_tool_use_id: null,
+      parent_agent_id: null,
       message: {
         type: "system",
         subtype: "compact_boundary",

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -271,7 +271,7 @@ export function emitAgentConfigOptionUpdate(sessionId: string, agent: string | n
   });
 }
 
-const EXPECTED_AGENT_SDK_VERSION = "0.3.198";
+const EXPECTED_AGENT_SDK_VERSION = "0.3.207";
 const require = createRequire(import.meta.url);
 
 export function resolveInstalledAgentSdkVersion(): string | undefined {

--- a/agent-sdk/src/bridge/command_dispatch.ts
+++ b/agent-sdk/src/bridge/command_dispatch.ts
@@ -1,10 +1,11 @@
 import type { BridgeCommand } from "../types.js";
+import { bridgeLogger, LOG_TARGETS } from "./logger.js";
 
 type CancelTurnCommand = Extract<BridgeCommand, { command: "cancel_turn" }>;
 
 export type InterruptibleSession = {
   query: {
-    interrupt: () => Promise<void>;
+    interrupt: () => Promise<{ still_queued?: string[] } | undefined>;
   };
 };
 
@@ -23,5 +24,22 @@ export async function dispatchCancelTurnCommand(
     deps.slashError(command.session_id, `unknown session: ${command.session_id}`, deps.requestId);
     return;
   }
-  await session.query.interrupt();
+  const receipt = await session.query.interrupt();
+  const stillQueued = Array.isArray(receipt?.still_queued)
+    ? receipt.still_queued.filter((entry): entry is string => typeof entry === "string")
+    : [];
+  if (stillQueued.length > 0) {
+    bridgeLogger.info({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "interrupt_receipt_still_queued",
+      message: "interrupt receipt reported queued async messages",
+      outcome: "success",
+      sessionId: command.session_id,
+      ...(deps.requestId ? { requestId: deps.requestId } : {}),
+      fields: {
+        still_queued_count: stillQueued.length,
+        still_queued: stillQueued,
+      },
+    });
+  }
 }

--- a/agent-sdk/src/bridge/commands.ts
+++ b/agent-sdk/src/bridge/commands.ts
@@ -583,6 +583,9 @@ function parseQuestionAnnotation(value: unknown): { preview?: string; notes?: st
 }
 
 export function toPermissionMode(mode: string): PermissionMode | null {
+  if (mode === "manual") {
+    return "default";
+  }
   if (
     mode === "default" ||
     mode === "auto" ||
@@ -603,4 +606,3 @@ export function buildModeState(session: SessionState, mode: PermissionMode): Mod
     available_modes: availableModesForSession(session),
   };
 }
-

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -36,7 +36,7 @@ import {
   taskUpdatedFields,
   type ToolCorrelationMetadata,
 } from "./tool_calls.js";
-import { applyTaskLifecycleState } from "./tasks.js";
+import { applyBackgroundTasksChanged, applyTaskLifecycleState } from "./tasks.js";
 import { linkTaskToolUse, unlinkTaskToolUse } from "./task_links.js";
 import { emitAuthRequired, classifyTurnErrorKind, emitFastModeUpdateIfChanged } from "./error_classification.js";
 import { mapAvailableAgentsFromNames, emitAvailableAgentsIfChanged, refreshAvailableAgents } from "./agents.js";
@@ -100,6 +100,7 @@ function sdkCorrelationMetadata(msg: Record<string, unknown>): ToolCorrelationMe
     requestId: typeof msg.request_id === "string" ? msg.request_id : undefined,
     subagentType: typeof msg.subagent_type === "string" ? msg.subagent_type : undefined,
     taskDescription: typeof msg.task_description === "string" ? msg.task_description : undefined,
+    parentAgentId: typeof msg.parent_agent_id === "string" ? msg.parent_agent_id : undefined,
   };
 }
 
@@ -117,12 +118,14 @@ function sdkTaskMetadata(msg: Record<string, unknown>): TaskMetadata | undefined
     ...(metadata.requestId ? { request_id: metadata.requestId } : {}),
     ...(metadata.subagentType ? { subagent_type: metadata.subagentType } : {}),
     ...(metadata.taskDescription ? { task_description: metadata.taskDescription } : {}),
+    ...(metadata.parentAgentId ? { parent_agent_id: metadata.parentAgentId } : {}),
     ...(taskType ? { task_type: taskType } : {}),
     ...(workflowName ? { workflow_name: workflowName } : {}),
     ...(prompt ? { prompt } : {}),
     ...(outputFile ? { output_file: outputFile } : {}),
     ...(summary ? { summary } : {}),
     ...(status ? { terminal_status: status } : {}),
+    ...(typeof msg.blocked === "boolean" ? { blocked: msg.blocked } : {}),
   };
   return Object.keys(taskMetadata).length > 0 ? taskMetadata : undefined;
 }
@@ -1026,6 +1029,13 @@ function terminalReasonFromValue(value: unknown): TerminalReason | undefined {
     case "hook_stopped":
     case "tool_deferred":
     case "max_turns":
+    case "background_requested":
+    case "api_error":
+    case "malformed_tool_use_exhausted":
+    case "budget_exhausted":
+    case "structured_output_retry_exhausted":
+    case "tool_deferred_unavailable":
+    case "turn_setup_failed":
     case "completed":
       return value;
     default:
@@ -1054,6 +1064,11 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
 
     if (subtype === "commands_changed") {
       updateAvailableCommands(session, "commands_changed", mapSdkSlashCommands(msg.commands));
+      return;
+    }
+
+    if (subtype === "background_tasks_changed") {
+      applyBackgroundTasksChanged(session, msg);
       return;
     }
 

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -803,6 +803,8 @@ function permissionModeFromSettingsValue(rawMode: unknown): PermissionMode | und
     return undefined;
   }
   switch (rawMode) {
+    case "manual":
+      return "default";
     case "default":
     case "auto":
     case "acceptEdits":

--- a/agent-sdk/src/bridge/tasks.ts
+++ b/agent-sdk/src/bridge/tasks.ts
@@ -30,6 +30,8 @@ export type TaskTitleContext = {
   taskSubject?: string;
 };
 
+const BACKGROUND_TASK_METADATA_KEY = "sdk_background_task";
+
 export function isTaskToolName(name: string): boolean {
   return TASK_TOOL_NAMES.has(name);
 }
@@ -944,6 +946,8 @@ function lifecycleMetadata(msg: Record<string, unknown>): Record<string, Json> |
     "summary",
     "end_time",
     "total_paused_ms",
+    "blocked",
+    "parent_agent_id",
   ]) {
     copyValue(msg, key);
     copyValue(patch, key);
@@ -1006,6 +1010,48 @@ export function applyTaskLifecycleState(
       source_tool_call_id: sourceToolCallId,
     }),
   ]);
+}
+
+export function applyBackgroundTasksChanged(
+  session: SessionState,
+  msg: Record<string, unknown>,
+): void {
+  const rawTasks = Array.isArray(msg.tasks) ? msg.tasks : [];
+  const nextTasks = rawTasks
+    .map((entry): TaskPatch | undefined => {
+      const task = asRecordOrNull(entry);
+      const taskId = nonEmptyString(task?.task_id);
+      if (!task || !taskId) {
+        return undefined;
+      }
+      const taskType = nonEmptyString(task.task_type);
+      const description = nonEmptyString(task.description);
+      return {
+        task_id: taskId,
+        subject: description ?? taskType ?? taskId,
+        description,
+        status: "in_progress",
+        blocks: [],
+        blocked_by: [],
+        metadata: {
+          [BACKGROUND_TASK_METADATA_KEY]: true,
+          ...(taskType ? { task_type: taskType } : {}),
+        },
+      };
+    })
+    .filter((task): task is TaskPatch => Boolean(task));
+
+  const nextIds = new Set(nextTasks.map((task) => task.task_id));
+  const removedTaskIds = session.taskOrder.filter((taskId) => {
+    if (nextIds.has(taskId)) {
+      return false;
+    }
+    const metadata = asRecordOrNull(session.tasksById.get(taskId)?.metadata);
+    return metadata?.[BACKGROUND_TASK_METADATA_KEY] === true;
+  });
+  const tasks = nextTasks.map((task) => upsertTask(session, task));
+  const removed = removeTasks(session, removedTaskIds);
+  emitTaskStateUpdate(session, "background_tasks", tasks, removed, true);
 }
 
 export function currentTaskSnapshot(session: SessionState): TaskItem[] {

--- a/agent-sdk/src/bridge/tool_calls.ts
+++ b/agent-sdk/src/bridge/tool_calls.ts
@@ -28,6 +28,7 @@ export type ToolCorrelationMetadata = {
   requestId?: string;
   subagentType?: string;
   taskDescription?: string;
+  parentAgentId?: string;
 };
 
 const TOOL_SUMMARY_TOOL_NAMES = new Set(["Agent", "Task", "WebSearch", "WebFetch", "ExitPlanMode"]);
@@ -573,6 +574,12 @@ function buildTaskMetadata(patch: Record<string, unknown>): TaskMetadata | undef
   }
   if (typeof patch.status === "string" && ["completed", "failed", "killed"].includes(patch.status)) {
     taskMetadata.terminal_status = patch.status;
+  }
+  if (typeof patch.blocked === "boolean") {
+    taskMetadata.blocked = patch.blocked;
+  }
+  if (typeof patch.parent_agent_id === "string" && patch.parent_agent_id.length > 0) {
+    taskMetadata.parent_agent_id = patch.parent_agent_id;
   }
   return Object.keys(taskMetadata).length > 0 ? taskMetadata : undefined;
 }

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -72,12 +72,19 @@ export type TerminalReason =
   | "prompt_too_long"
   | "image_error"
   | "model_error"
+  | "api_error"
+  | "malformed_tool_use_exhausted"
   | "aborted_streaming"
   | "aborted_tools"
   | "stop_hook_prevented"
   | "hook_stopped"
   | "tool_deferred"
   | "max_turns"
+  | "background_requested"
+  | "budget_exhausted"
+  | "structured_output_retry_exhausted"
+  | "tool_deferred_unavailable"
+  | "turn_setup_failed"
   | "completed";
 
 export interface RateLimitUpdate {
@@ -175,6 +182,8 @@ export interface TaskMetadata {
   output_file?: string;
   summary?: string;
   terminal_status?: string;
+  blocked?: boolean;
+  parent_agent_id?: string;
 }
 
 export interface ToolLocation {
@@ -240,7 +249,8 @@ export type TaskUpdateSource =
   | "task_update"
   | "task_get"
   | "task_list"
-  | "task_lifecycle";
+  | "task_lifecycle"
+  | "background_tasks";
 
 export interface TaskItem {
   task_id: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.13.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.198"
+        "@anthropic-ai/claude-agent-sdk": "0.3.207"
       },
       "bin": {
         "claude-rs": "bin/claude-rs.js"
@@ -22,22 +22,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.198.tgz",
-      "integrity": "sha512-xt469sSCyclTPtzpLAg0Aschy665GiRMgZKabSmESbGUA5/H56HcILVOiFxclXswkeMUk2fQxfHJUY9UZfiTnA==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.207.tgz",
+      "integrity": "sha512-y0PkQRmQBi96MHiN5Xzfq+GaddxCZCqI/cXEQBLYBLXGa4i1nDSlulQqkMBj2RorrrSGQJ6Wdw+uhu6OfHNPzA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.198"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.207",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.207"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.198.tgz",
-      "integrity": "sha512-ZmiAybQKIKcP1qEAE/vfXvfxtKxG9CnJn98QTXC5Zxiwuy7Mllx2ALXh9dfmsf0V87CGEodlZQmMgUJotNIsUw==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.207.tgz",
+      "integrity": "sha512-08xSo1FDx8h0aLhL5tvcRxa2SMmcUV3aDWeZiEJVTclyiDAs61BgTjAxCg+SZcu1CndjJO8cfO0yM5dhamxz3g==",
       "cpu": [
         "arm64"
       ],
@@ -59,9 +59,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.198.tgz",
-      "integrity": "sha512-XwH5vgN46WSwg8aC1OagNofnJpV/G1ciEu118GEKer8ZhVkq/dvK/DqShxMkb6r1jV7u5IJ7zPXu9uKliyNJAw==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.207.tgz",
+      "integrity": "sha512-1o7K4EYqyCixZ/oeOZSh7AzSy6TM86xoOuf4VuORjPSS31hBnoqY0NGZd27+2VDs9LGtsdksmsTqcNGx9xd1hA==",
       "cpu": [
         "x64"
       ],
@@ -72,9 +72,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.198.tgz",
-      "integrity": "sha512-qmz8dxEtDIlKntU5qYe0R4aWTxTue5S7zIQknatLX7aJ6HN/nq1aCNXWn5smTH2FViBkUPPR+sCIsNwSk6AT6Q==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.207.tgz",
+      "integrity": "sha512-X4uezYOifDiNTTmmugfRCdg3nNamrr1LFRY9hg30vWYTShL+bbN+nfC3KaFfSYCl4GTtsEEUbYdOTC2F3bBpcA==",
       "cpu": [
         "arm64"
       ],
@@ -88,9 +88,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.198.tgz",
-      "integrity": "sha512-Q7lKVNjIrUQ2B/AR77OvRf0zeOdEjonFVaR9FYrrwtzGeEqum69WSht5nM7Y7el3wjbNi0/eV0QTUM0DlsTEfw==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.207.tgz",
+      "integrity": "sha512-oPj+g2DslhH4Y9nCTs7al4t9wZv78FZwLFQwOCg99BXuz1o0ZOpKmxyvR7J9eBR+GPszeMMS8gYplQTiZC9o2w==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.198.tgz",
-      "integrity": "sha512-Zqxyz2AT1UM5WlOOoLJhLssZDgZo8rBK5ku6daveK12zp+UTJGZhGsjFghz1/ASxH08KqOTbUePNTORnPhHAEQ==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.207.tgz",
+      "integrity": "sha512-Kg6BPH8Ee0ny/oEUWJmvT1jCRBne4jVpRSOMsJcYp1Fav1rMEgpU219oJJs+LWwx4ifuuLtNWedqJNnVw7mnKg==",
       "cpu": [
         "x64"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.198.tgz",
-      "integrity": "sha512-h1SrWVIMjLInYNPlf+TxXuKTOdoiOfJLBSoQG97315Z2Nh0IpBfqWExlqYTtPCgKE7q2iga31U283QfHpIDlSQ==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.207.tgz",
+      "integrity": "sha512-uRv+D5oG/7EYr41FAJ9IPo2pZYBe2ZMaA6nSHCeizsgPxCSMtl5bNppmU21+jZJvo4hivObEgkGFERAhdGqygg==",
       "cpu": [
         "x64"
       ],
@@ -136,9 +136,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.198.tgz",
-      "integrity": "sha512-mjIHf1HFiRuXefewWTaNZFlTZlCaEt/xsRjc1nSTCEEpFolZayVhrDKz+O2QFVcDtPl8x8GeYSL0kiikg1DZjQ==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.207.tgz",
+      "integrity": "sha512-9fWpUzfkXlPAg2tf8JpQe7w9avFaomAUbfAwyAmykQgSIf66LwaJjvI5hNqhNqczRKyfsXPn3ei2S5HKlmFP+Q==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +149,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.198.tgz",
-      "integrity": "sha512-y3HLuCCz1kDwUrhd6OnqO+d5BUpTFSzNUsPT9kf3r1vk9HYKF+eMC9eIlcOhiW2kX491kxEvuEOfqgIkGx15cg==",
+      "version": "0.3.207",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.207.tgz",
+      "integrity": "sha512-YPjVT0q6aXEM2MgN4CI6/9fqiTXwETji+4NoPOzCYuqAkhXZqp30Jsk7/NHqYGNNSfURKrsuAoliKB0rsbpbjg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.198"
+    "@anthropic-ai/claude-agent-sdk": "0.3.207"
   },
   "scripts": {
     "prepack": "npm --prefix agent-sdk run build",

--- a/src/agent/model/tasks.rs
+++ b/src/agent/model/tasks.rs
@@ -17,6 +17,8 @@ pub struct TaskMetadata {
     pub output_file: Option<String>,
     pub summary: Option<String>,
     pub terminal_status: Option<String>,
+    pub blocked: Option<bool>,
+    pub parent_agent_id: Option<String>,
 }
 
 impl TaskMetadata {
@@ -102,6 +104,18 @@ impl TaskMetadata {
         self.terminal_status = terminal_status;
         self
     }
+
+    #[must_use]
+    pub fn blocked(mut self, blocked: Option<bool>) -> Self {
+        self.blocked = blocked;
+        self
+    }
+
+    #[must_use]
+    pub fn parent_agent_id(mut self, parent_agent_id: Option<String>) -> Self {
+        self.parent_agent_id = parent_agent_id;
+        self
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -124,6 +138,8 @@ pub enum TaskUpdateSource {
     List,
     #[serde(rename = "task_lifecycle")]
     Lifecycle,
+    #[serde(rename = "background_tasks")]
+    BackgroundTasks,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -331,6 +331,8 @@ pub struct TaskMetadata {
     pub output_file: Option<String>,
     pub summary: Option<String>,
     pub terminal_status: Option<String>,
+    pub blocked: Option<bool>,
+    pub parent_agent_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -374,6 +376,8 @@ pub enum TaskUpdateSource {
     List,
     #[serde(rename = "task_lifecycle")]
     Lifecycle,
+    #[serde(rename = "background_tasks")]
+    BackgroundTasks,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -668,12 +672,19 @@ pub enum TerminalReason {
     PromptTooLong,
     ImageError,
     ModelError,
+    ApiError,
+    MalformedToolUseExhausted,
     AbortedStreaming,
     AbortedTools,
     StopHookPrevented,
     HookStopped,
     ToolDeferred,
     MaxTurns,
+    BackgroundRequested,
+    BudgetExhausted,
+    StructuredOutputRetryExhausted,
+    ToolDeferredUnavailable,
+    TurnSetupFailed,
     Completed,
 }
 
@@ -686,12 +697,19 @@ impl TerminalReason {
             Self::PromptTooLong => "prompt_too_long",
             Self::ImageError => "image_error",
             Self::ModelError => "model_error",
+            Self::ApiError => "api_error",
+            Self::MalformedToolUseExhausted => "malformed_tool_use_exhausted",
             Self::AbortedStreaming => "aborted_streaming",
             Self::AbortedTools => "aborted_tools",
             Self::StopHookPrevented => "stop_hook_prevented",
             Self::HookStopped => "hook_stopped",
             Self::ToolDeferred => "tool_deferred",
             Self::MaxTurns => "max_turns",
+            Self::BackgroundRequested => "background_requested",
+            Self::BudgetExhausted => "budget_exhausted",
+            Self::StructuredOutputRetryExhausted => "structured_output_retry_exhausted",
+            Self::ToolDeferredUnavailable => "tool_deferred_unavailable",
+            Self::TurnSetupFailed => "turn_setup_failed",
             Self::Completed => "completed",
         }
     }
@@ -941,7 +959,8 @@ mod tests {
     use super::{
         AccountInfo, ApiRetryError, AvailableModel, EffortLevel, McpServerOrgMaxPermission,
         McpServerStatus, McpServerStatusConfig, McpServerToolPermissionPolicy, RateLimitStatus,
-        SessionStatus, SessionUpdate, SystemNoticeSeverity, TranscriptRetractionReason,
+        SessionStatus, SessionUpdate, SystemNoticeSeverity, TaskUpdateSource, TerminalReason,
+        TranscriptRetractionReason,
     };
 
     #[test]
@@ -1176,7 +1195,9 @@ mod tests {
                         "prompt": "Validate everything",
                         "output_file": "C:/tmp/output.md",
                         "summary": "Validation complete",
-                        "terminal_status": "completed"
+                        "terminal_status": "completed",
+                        "blocked": true,
+                        "parent_agent_id": "agent-parent"
                     }
                 }
             }
@@ -1196,6 +1217,47 @@ mod tests {
         assert_eq!(metadata.output_file.as_deref(), Some("C:/tmp/output.md"));
         assert_eq!(metadata.summary.as_deref(), Some("Validation complete"));
         assert_eq!(metadata.terminal_status.as_deref(), Some("completed"));
+        assert_eq!(metadata.blocked, Some(true));
+        assert_eq!(metadata.parent_agent_id.as_deref(), Some("agent-parent"));
+    }
+
+    #[test]
+    fn new_terminal_reasons_deserialize_and_preserve_stored_names() {
+        let cases = [
+            ("api_error", TerminalReason::ApiError),
+            ("malformed_tool_use_exhausted", TerminalReason::MalformedToolUseExhausted),
+            ("background_requested", TerminalReason::BackgroundRequested),
+            ("budget_exhausted", TerminalReason::BudgetExhausted),
+            ("structured_output_retry_exhausted", TerminalReason::StructuredOutputRetryExhausted),
+            ("tool_deferred_unavailable", TerminalReason::ToolDeferredUnavailable),
+            ("turn_setup_failed", TerminalReason::TurnSetupFailed),
+        ];
+
+        for (stored, expected) in cases {
+            let reason: TerminalReason =
+                serde_json::from_value(serde_json::json!(stored)).expect("terminal reason");
+            assert_eq!(reason, expected);
+            assert_eq!(reason.as_stored(), stored);
+        }
+    }
+
+    #[test]
+    fn background_tasks_source_deserializes() {
+        let update: SessionUpdate = serde_json::from_value(serde_json::json!({
+            "type": "task_state_update",
+            "source": "background_tasks",
+            "tasks": [],
+            "removed_task_ids": ["bg-old"],
+            "is_complete_snapshot": true
+        }))
+        .expect("deserialize background task update");
+
+        let SessionUpdate::TaskStateUpdate { update: task_update } = update else {
+            panic!("expected task state update");
+        };
+        assert_eq!(task_update.source, TaskUpdateSource::BackgroundTasks);
+        assert_eq!(task_update.removed_task_ids, vec!["bg-old"]);
+        assert!(task_update.is_complete_snapshot);
     }
 
     #[test]

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -879,6 +879,8 @@ fn convert_task_metadata(task_metadata: types::TaskMetadata) -> model::TaskMetad
         .output_file(task_metadata.output_file)
         .summary(task_metadata.summary)
         .terminal_status(task_metadata.terminal_status)
+        .blocked(task_metadata.blocked)
+        .parent_agent_id(task_metadata.parent_agent_id)
 }
 
 fn convert_tool_call_content(
@@ -945,6 +947,7 @@ fn convert_task_update_source(source: types::TaskUpdateSource) -> model::TaskUpd
         types::TaskUpdateSource::Get => model::TaskUpdateSource::Get,
         types::TaskUpdateSource::List => model::TaskUpdateSource::List,
         types::TaskUpdateSource::Lifecycle => model::TaskUpdateSource::Lifecycle,
+        types::TaskUpdateSource::BackgroundTasks => model::TaskUpdateSource::BackgroundTasks,
     }
 }
 
@@ -1500,6 +1503,8 @@ mod tests {
                 output_file: Some("C:/tmp/output.md".to_owned()),
                 summary: Some("Validation complete".to_owned()),
                 terminal_status: Some("completed".to_owned()),
+                blocked: Some(true),
+                parent_agent_id: Some("agent-parent".to_owned()),
             }),
             ..types::ToolCallUpdateFields::default()
         });
@@ -1520,7 +1525,9 @@ mod tests {
                     .prompt(Some("Run validation".to_owned()))
                     .output_file(Some("C:/tmp/output.md".to_owned()))
                     .summary(Some("Validation complete".to_owned()))
-                    .terminal_status(Some("completed".to_owned())),
+                    .terminal_status(Some("completed".to_owned()))
+                    .blocked(Some(true))
+                    .parent_agent_id(Some("agent-parent".to_owned())),
             )
         );
     }
@@ -1551,6 +1558,8 @@ mod tests {
                 output_file: Some("C:/tmp/review.md".to_owned()),
                 summary: Some("Review stopped".to_owned()),
                 terminal_status: Some("killed".to_owned()),
+                blocked: Some(false),
+                parent_agent_id: Some("agent-root".to_owned()),
             }),
             locations: Vec::new(),
             meta: None,
@@ -1574,7 +1583,9 @@ mod tests {
                     .prompt(Some("Review changes".to_owned()))
                     .output_file(Some("C:/tmp/review.md".to_owned()))
                     .summary(Some("Review stopped".to_owned()))
-                    .terminal_status(Some("killed".to_owned())),
+                    .terminal_status(Some("killed".to_owned()))
+                    .blocked(Some(false))
+                    .parent_agent_id(Some("agent-root".to_owned())),
             )
         );
     }

--- a/src/app/events/tool_updates.rs
+++ b/src/app/events/tool_updates.rs
@@ -286,6 +286,12 @@ fn apply_tool_call_task_metadata_update(
     if task_metadata.terminal_status.is_some() {
         merged.terminal_status.clone_from(&task_metadata.terminal_status);
     }
+    if task_metadata.blocked.is_some() {
+        merged.blocked = task_metadata.blocked;
+    }
+    if task_metadata.parent_agent_id.is_some() {
+        merged.parent_agent_id.clone_from(&task_metadata.parent_agent_id);
+    }
     if tc.task_metadata.as_ref() == Some(&merged) {
         return false;
     }
@@ -939,6 +945,8 @@ mod tests {
             tool_id,
             model::ToolCallUpdateFields::new().task_metadata(
                 model::TaskMetadata::new()
+                    .blocked(Some(true))
+                    .parent_agent_id(Some("parent-agent-1".to_owned()))
                     .summary(Some("Stopped after validation".to_owned()))
                     .terminal_status(Some("killed".to_owned())),
             ),
@@ -963,6 +971,8 @@ mod tests {
                     .workflow_name(Some("review-flow".to_owned()))
                     .prompt(Some("Review the branch".to_owned()))
                     .output_file(Some("C:/tmp/review.md".to_owned()))
+                    .blocked(Some(true))
+                    .parent_agent_id(Some("parent-agent-1".to_owned()))
                     .summary(Some("Stopped after validation".to_owned()))
                     .terminal_status(Some("killed".to_owned())),
             )

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -11,6 +11,18 @@ pub(super) fn apply_task_state_update(app: &mut App, update: model::TaskStateUpd
         update.removed_task_ids.iter().map(std::string::String::as_str).collect();
 
     if update.is_complete_snapshot {
+        if update.source == model::TaskUpdateSource::BackgroundTasks {
+            app.sdk_inventory.tasks.retain(|task| {
+                !is_sdk_background_task(task) && !removed.contains(task.task_id.as_str())
+            });
+            for task in update.tasks {
+                if !removed.contains(task.task_id.as_str()) {
+                    app.sdk_inventory.tasks.push(task);
+                }
+            }
+            refresh_task_tool_displays_with_previous(app, &previous_tasks);
+            return;
+        }
         app.sdk_inventory.tasks = update
             .tasks
             .into_iter()
@@ -37,6 +49,15 @@ pub(super) fn apply_task_state_update(app: &mut App, update: model::TaskStateUpd
         }
     }
     refresh_task_tool_displays_with_previous(app, &previous_tasks);
+}
+
+fn is_sdk_background_task(task: &model::TaskItem) -> bool {
+    task.metadata
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+        .and_then(|metadata| metadata.get("sdk_background_task"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
 }
 
 pub(super) fn refresh_task_tool_displays(app: &mut App) -> bool {
@@ -218,6 +239,12 @@ mod tests {
         model::TaskItem::new(id, subject, status)
     }
 
+    fn background_task(id: &str, subject: &str) -> model::TaskItem {
+        let mut task = model::TaskItem::new(id, subject, model::TaskStatus::InProgress);
+        task.metadata = Some(json!({ "sdk_background_task": true }));
+        task
+    }
+
     fn task_tool_call(
         id: &str,
         sdk_tool_name: &str,
@@ -335,6 +362,30 @@ mod tests {
         assert_eq!(app.sdk_inventory.tasks.len(), 1);
         assert_eq!(app.sdk_inventory.tasks[0].task_id, "task-2");
         assert_eq!(app.sdk_inventory.tasks[0].subject, "two updated");
+    }
+
+    #[test]
+    fn background_task_snapshot_replaces_only_background_membership() {
+        let mut app = App::test_default();
+        app.sdk_inventory.tasks.push(task(
+            "task-list",
+            "from task list",
+            model::TaskStatus::Pending,
+        ));
+        app.sdk_inventory.tasks.push(background_task("bg-old", "old background"));
+
+        apply_task_state_update(
+            &mut app,
+            model::TaskStateUpdate::new(model::TaskUpdateSource::BackgroundTasks)
+                .tasks(vec![background_task("bg-new", "new background")])
+                .removed_task_ids(vec!["bg-old".to_owned()])
+                .complete_snapshot(true),
+        );
+
+        assert_eq!(app.sdk_inventory.tasks.len(), 2);
+        assert!(app.sdk_inventory.tasks.iter().any(|task| task.task_id == "task-list"));
+        assert!(app.sdk_inventory.tasks.iter().any(|task| task.task_id == "bg-new"));
+        assert!(!app.sdk_inventory.tasks.iter().any(|task| task.task_id == "bg-old"));
     }
 
     #[test]

--- a/src/app/terminal_runtime/modes.rs
+++ b/src/app/terminal_runtime/modes.rs
@@ -2,7 +2,7 @@
 // Copyright 2025 Simon Peter Rothgang
 
 use crossterm::cursor::{Hide, SetCursorStyle, Show};
-use crossterm::event::{DisableFocusChange, DisableMouseCapture, EnableFocusChange};
+use crossterm::event::{DisableFocusChange, EnableFocusChange};
 #[cfg(target_os = "macos")]
 use crossterm::event::{
     KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
@@ -19,7 +19,6 @@ pub(super) enum TerminalModeAction {
     DisableRawMode,
     EnterAlternateScreen,
     LeaveAlternateScreen,
-    DisableMouseCapture,
     EnableFocusChange,
     DisableFocusChange,
     HideCursor,
@@ -62,7 +61,6 @@ const SHUTDOWN_RESTORE_ACTIONS: &[TerminalModeAction] = &[
     TerminalModeAction::RestoreDefaultCursorShape,
     TerminalModeAction::ShowCursor,
     TerminalModeAction::EnableLineWrap,
-    TerminalModeAction::DisableMouseCapture,
     TerminalModeAction::DisableFocusChange,
     #[cfg(target_os = "macos")]
     TerminalModeAction::PopKeyboardEnhancement,
@@ -117,7 +115,6 @@ pub(super) fn apply_actions(
             TerminalModeAction::DisableRawMode => disable_raw_mode(),
             TerminalModeAction::EnterAlternateScreen => execute!(stdout, EnterAlternateScreen),
             TerminalModeAction::LeaveAlternateScreen => execute!(stdout, LeaveAlternateScreen),
-            TerminalModeAction::DisableMouseCapture => execute!(stdout, DisableMouseCapture),
             TerminalModeAction::EnableFocusChange => execute!(stdout, EnableFocusChange),
             TerminalModeAction::DisableFocusChange => execute!(stdout, DisableFocusChange),
             TerminalModeAction::HideCursor => execute!(stdout, Hide),
@@ -214,7 +211,6 @@ mod tests {
                 TerminalModeAction::RestoreDefaultCursorShape,
                 TerminalModeAction::ShowCursor,
                 TerminalModeAction::EnableLineWrap,
-                TerminalModeAction::DisableMouseCapture,
                 TerminalModeAction::DisableFocusChange,
                 #[cfg(target_os = "macos")]
                 TerminalModeAction::PopKeyboardEnhancement,


### PR DESCRIPTION
## Summary

- Update the bundled Claude Agent SDK dependencies to `0.3.207`.
- Normalize the new SDK permission-mode alias into the existing default mode.
- Preserve new task metadata, task source updates, and terminal reason values across the bridge.
- Handle background task snapshots without clearing unrelated task state.
- Remove the unmatched `DisableMouseCapture` shutdown restore action now that the app never enables mouse capture.

## Why

The SDK update introduces new bridge payload fields and enum values that need to round-trip without dropping state or misclassifying task updates. The terminal restore cleanup prevents Windows shutdown warnings caused by disabling mouse capture that was never enabled.

Closes #256 

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo check --offline`
  - `cargo test`
  - `cargo clippy --all-targets --all-features -- -D warnings`
- Manual:
  - Rebased `chore/migrate-sdk-0.3.207` onto latest `origin/main` after `f0d710c`.
  - Verified `DisableMouseCapture` no longer appears in `src/app/terminal_runtime`.
  - Verified the tracked cursor backend changes from latest `origin/main` remain present after rebase.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: Updates bundled SDK package locks and compatibility handling; no crate version change in this branch.
