### PR TITLE
chore(release): publish 0.14.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: Questions & Discussion
     url: https://github.com/srothgan/claude-code-rust/discussions
     about: Use GitHub Discussions for questions, help, and general conversation
+  - name: Code of Conduct Report
+    url: mailto:simonrothgang@icloud.com
+    about: Report code of conduct concerns privately to the project maintainer
   - name: Security Vulnerability
     url: https://github.com/srothgan/claude-code-rust/security/advisories/new
     about: Report security vulnerabilities privately via GitHub Security Advisories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [0.14.0] - 2026-07-12 [Changes][v0.14.0]
 
 ### Features
 
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Documentation
 
 - **Governance and source install docs** (#262, @srothgan): Document repository release controls and clarify source-build auth/runtime setup.
+- **Private conduct reporting** (@srothgan): Add a dedicated private contact for code of conduct reports and keep security advisories focused on vulnerability disclosure.
 
 ### Maintenance
 
@@ -758,6 +759,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.14.0]: https://github.com/srothgan/claude-code-rust/compare/v0.13.4...v0.14.0
 [v0.13.4]: https://github.com/srothgan/claude-code-rust/compare/v0.13.3...v0.13.4
 [v0.13.3]: https://github.com/srothgan/claude-code-rust/compare/v0.13.2...v0.13.3
 [v0.13.2]: https://github.com/srothgan/claude-code-rust/compare/v0.13.0...v0.13.2

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -47,7 +47,7 @@ We agree to restrict the following behaviors in our community. Instances, threat
 
 Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
-When an incident does occur, it is important to report it promptly. To report a possible violation, **use [GitHub Security Advisories](https://github.com/srothgan/claude-code-rust/security/advisories/new) or contact the project maintainer, Simon Rothgang, at simonrothgang@icloud.com.**
+When an incident does occur, it is important to report it promptly. To report a possible violation, **contact the project maintainer, Simon Rothgang, at simonrothgang@icloud.com. Please do not use public GitHub issues for code of conduct reports.**
 
 Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.13.4"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/docs/src/about.md
+++ b/docs/src/about.md
@@ -6,7 +6,7 @@ The goal is a faster, lower-memory terminal experience with reliable scrollback,
 
 ## Project Status
 
-The project is pre-1.0. The current release line is `0.13.x`, and the crate version is tracked in the root `Cargo.toml`.
+The project is pre-1.0. The current release line is `0.14.x`, and the crate version is tracked in the root `Cargo.toml`.
 
 The project is useful today, but the runtime still depends on the upstream Claude Agent SDK bridge. Startup readiness, authentication behavior, billing, model availability, and service limits are controlled by Anthropic.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rust",
-  "version": "0.13.4",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rust",
-      "version": "0.13.4",
+      "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.207"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-rust",
-  "version": "0.13.4",
+  "version": "0.14.0",
   "description": "Claude Code Rust - native Rust terminal interface for Claude Code",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary

- Publish the project metadata for `0.14.0` across Cargo and npm, including the root lockfile entries used by the release workflow.
- Finalize the `0.14.0` changelog section with the release date, comparison link, and the complete set of changes accumulated since `0.13.4`.
- Update the documented current release line from `0.13.x` to `0.14.x`.
- Add a dedicated private code-of-conduct reporting contact to the issue chooser, direct conduct reports away from public issues, and keep Security Advisories focused on vulnerability disclosure.

## Why

The `0.14.0` release introduces public script installation as the recommended installation method, installer-aware in-app updates, and the accumulated UI, diagnostics, packaging, governance, and dependency work currently recorded under `Unreleased`.

Cargo and npm package versions must agree before the release workflow can build and publish the native binaries, platform packages, install archives, checksums, attestations, and GitHub release. Finalizing the changelog also provides the release notes extracted by the workflow.

The community-reporting changes provide a clearly private route for conduct concerns without conflating them with security vulnerabilities or encouraging disclosure through public issues.

Closes: N/A

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test --all-features` (1,699 tests across library, binary, integration, and documentation targets)
  - `npm ci`
  - `npm ci --prefix agent-sdk`
  - `npm run build --prefix agent-sdk`
  - runtime manifest, third-party notice, npm resolver, packaging, publication, and smoke-test suites
  - generated and verified all seven npm package layouts at `0.14.0`
  - completed the Windows x64 global npm installation smoke without a system Bun runtime
  - generated and verified all six script-install archives and manifests at `0.14.0`
  - shell syntax and PowerShell parser/help checks for the public installers
  - `mdbook build docs`
  - `cargo metadata --offline --no-deps --format-version 1`
  - release metadata agreement, changelog extraction, comparison-link, tag-availability, and `git diff --check` checks
- Manual:
  - confirmed `claude-code-rust@0.14.0` is not currently published on npm
  - reviewed the final diff to ensure dependency versions, historical changelog entries, and update-test fixtures were not changed by the release bump
  - confirmed the private conduct-reporting stash remains retained until this PR merges
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: `CHANGELOG.md`, `docs/src/about.md`, `CODE_OF_CONDUCT.md`, and `.github/ISSUE_TEMPLATE/config.yml`
- Governance/release impact: Merging this PR changes `Cargo.toml` on `main` and automatically triggers the `0.14.0` release workflow. Publication requires approval through the protected `npm-release` environment and includes npm packages, native binaries, script-install archives, checksums, attestations, and the GitHub release.
- Release scope: Product metadata moves to `0.14.0`; unrelated dependency versions and intentional `0.13.4` update-test fixtures remain unchanged.
