### PR TITLE
feat(install): improve installer UX and idempotency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,8 @@
 *.js text eol=lf
 *.cjs text eol=lf
 *.mjs text eol=lf
+*.ps1 text eol=lf
+*.sh text eol=lf
 *.ts text eol=lf
 *.tsx text eol=lf
 *.mts text eol=lf

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -170,6 +170,7 @@ jobs:
             }
           '
           pwsh -NoLogo -NoProfile -File scripts/install/install.ps1 -Help
+          pwsh -NoLogo -NoProfile -File scripts/install/test-install-progress.ps1
 
       - name: Stage bundled Bun runtimes
         run: node scripts/runtime/stage-bun-runtime.mjs --download
@@ -188,6 +189,9 @@ jobs:
 
       - name: Verify install archives
         run: node scripts/install/verify-install-archives.mjs
+
+      - name: Test redirected Unix installer progress
+        run: node --test scripts/install/install-progress.test.mjs
 
       - name: Smoke-test install archive
         run: node scripts/install/smoke-install-archive.mjs --platform linux-x64-gnu

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -171,6 +171,7 @@ jobs:
           '
           pwsh -NoLogo -NoProfile -File scripts/install/install.ps1 -Help
           pwsh -NoLogo -NoProfile -File scripts/install/test-install-progress.ps1
+          pwsh -NoLogo -NoProfile -File scripts/install/test-install-version-guard.ps1
 
       - name: Stage bundled Bun runtimes
         run: node scripts/runtime/stage-bun-runtime.mjs --download
@@ -190,8 +191,8 @@ jobs:
       - name: Verify install archives
         run: node scripts/install/verify-install-archives.mjs
 
-      - name: Test redirected Unix installer progress
-        run: node --test scripts/install/install-progress.test.mjs
+      - name: Test Unix installer behavior
+        run: node --test scripts/install/install-progress.test.mjs scripts/install/install-version-guard.test.mjs
 
       - name: Smoke-test install archive
         run: node scripts/install/smoke-install-archive.mjs --platform linux-x64-gnu

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Claude Code Rust replaces the stock Claude Code terminal interface with a native
 
 ### Install script (recommended, v0.14.0+)
 
-The install script downloads a complete GitHub Release archive. It does not require Rust, Node.js, npm, or Bun on the user's machine.
+The install script downloads a complete GitHub Release archive. It does not require Rust, Node.js, npm, or Bun on the user's machine. If the selected release is already present in the script-owned install directory, the installer asks before downloading the release payload; pass `--yes` or `-Yes` to reinstall it intentionally.
 
 **macOS/Linux:**
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -12,6 +12,8 @@ Install scripts are available in GitHub Releases starting with `v0.14.0` and are
 
 The scripts download a complete release archive from GitHub, verify the release archive integrity, install the native binary with the bundled private Bun runtime, Agent SDK bridge, and production `node_modules`, then run a quiet `claude-rs --version` check. Strict runtime diagnostics are available with the opt-in verify flag.
 
+Interactive terminals display live progress for longer installation steps. Redirected output and CI remain plain and log-friendly, and `NO_COLOR` disables colored status output.
+
 **macOS/Linux:**
 
 ```bash

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -72,6 +72,24 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "irm 'https://raw.githubu
 
 The version can include or omit the `v` prefix.
 
+### Reinstalling the Same Version
+
+Before downloading release checksums or an archive, the installer compares the selected release with the version recorded in an existing script-owned install at the configured install directory. It does not compare with an npm install or another `claude-rs` found on `PATH`, because those may represent a different installation method or location.
+
+When the selected version is already installed, an interactive installation asks whether to reinstall it and defaults to no. Declining is a successful no-op and leaves the existing files unchanged. In CI or another non-interactive environment, the same-version check also exits successfully without reinstalling.
+
+Use `--yes` or `-Yes` to approve an intentional same-version reinstall, for example to repair an installation:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/srothgan/claude-code-rust/main/scripts/install/install.sh | sh -s -- --release v0.14.0 --yes
+```
+
+```powershell
+.\install.ps1 -Release v0.14.0 -Yes
+```
+
+Update mode always treats an already-installed selected version as a successful no-op, even though update mode otherwise runs non-interactively. With the default `latest` selection, the installer must first request GitHub Release metadata to resolve the release tag; the same-version guard still runs before downloading `SHA256SUMS` or the release archive.
+
 ### Custom Install Locations
 
 On macOS/Linux, pass installer flags after `sh -s --`:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,8 +40,12 @@ active release tooling and are validated by PR, release, or nightly workflows.
   for archive extraction and startup smoke tests.
 - `install/install-progress.test.mjs` executes the Unix installer with redirected
   output and local release fixtures to verify progress suppression and cleanup.
+- `install/install-version-guard.test.mjs` verifies Unix same-version no-op,
+  explicit reinstall, update, exact-version, and `latest` metadata behavior.
 - `install/test-install-progress.ps1` validates the PowerShell progress and
   output-helper behavior without executing the installer body.
+- `install/test-install-version-guard.ps1` validates PowerShell version metadata,
+  decision precedence, and release-download boundaries under Windows PowerShell.
 - `install/install.sh` and `install/install.ps1` are maintained public installer
   assets. Keep syntax checks and help text current before publishing them.
 
@@ -95,13 +99,14 @@ node --test scripts/npm/npm-resolver.test.cjs scripts/npm/smoke-npm-package-inst
 shellcheck -s sh scripts/install/install.sh
 pwsh -NoLogo -NoProfile -File scripts/install/install.ps1 -Help
 pwsh -NoLogo -NoProfile -File scripts/install/test-install-progress.ps1
+pwsh -NoLogo -NoProfile -File scripts/install/test-install-version-guard.ps1
 node scripts/runtime/stage-bun-runtime.mjs --download
 node scripts/npm/generate-npm-packages.mjs --mock-native-binary
 node scripts/npm/verify-npm-packages.mjs
 node scripts/npm/smoke-npm-package-install.mjs
 node scripts/install/generate-install-archives.mjs --mock-binaries
 node scripts/install/verify-install-archives.mjs
-node --test scripts/install/install-progress.test.mjs
+node --test scripts/install/install-progress.test.mjs scripts/install/install-version-guard.test.mjs
 node scripts/install/smoke-install-archive.mjs --platform linux-x64-gnu
 ```
 
@@ -109,6 +114,7 @@ On Windows, also run the progress-helper test under Windows PowerShell 5.1:
 
 ```powershell
 powershell -NoLogo -NoProfile -File scripts/install/test-install-progress.ps1
+powershell -NoLogo -NoProfile -File scripts/install/test-install-version-guard.ps1
 ```
 
 Repository-wide validation after script changes:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,6 +38,10 @@ active release tooling and are validated by PR, release, or nightly workflows.
   for verifying install archive contents and manifests.
 - `install/smoke-install-archive.mjs` is a maintainer and workflow entry point
   for archive extraction and startup smoke tests.
+- `install/install-progress.test.mjs` executes the Unix installer with redirected
+  output and local release fixtures to verify progress suppression and cleanup.
+- `install/test-install-progress.ps1` validates the PowerShell progress and
+  output-helper behavior without executing the installer body.
 - `install/install.sh` and `install/install.ps1` are maintained public installer
   assets. Keep syntax checks and help text current before publishing them.
 
@@ -90,13 +94,21 @@ node scripts/shared/verify-third-party-notices.mjs
 node --test scripts/npm/npm-resolver.test.cjs scripts/npm/smoke-npm-package-install.test.mjs scripts/runtime/verify-staged-bun-runtimes.test.mjs scripts/npm/dry-run-npm-publish.test.mjs scripts/npm/publish-npm-platform-packages.test.mjs
 shellcheck -s sh scripts/install/install.sh
 pwsh -NoLogo -NoProfile -File scripts/install/install.ps1 -Help
+pwsh -NoLogo -NoProfile -File scripts/install/test-install-progress.ps1
 node scripts/runtime/stage-bun-runtime.mjs --download
 node scripts/npm/generate-npm-packages.mjs --mock-native-binary
 node scripts/npm/verify-npm-packages.mjs
 node scripts/npm/smoke-npm-package-install.mjs
 node scripts/install/generate-install-archives.mjs --mock-binaries
 node scripts/install/verify-install-archives.mjs
+node --test scripts/install/install-progress.test.mjs
 node scripts/install/smoke-install-archive.mjs --platform linux-x64-gnu
+```
+
+On Windows, also run the progress-helper test under Windows PowerShell 5.1:
+
+```powershell
+powershell -NoLogo -NoProfile -File scripts/install/test-install-progress.ps1
 ```
 
 Repository-wide validation after script changes:

--- a/scripts/install/install-progress.test.mjs
+++ b/scripts/install/install-progress.test.mjs
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { resolveRepoRoot } from "../shared/repo-root.mjs";
+import {
+  PLATFORM_PACKAGES,
+  installArchiveName,
+  readCargoPackageMetadata,
+} from "../shared/npm-package-config.mjs";
+
+const repoRoot = resolveRepoRoot(import.meta.url);
+const installerPath = path.join(repoRoot, "scripts", "install", "install.sh");
+const cargoPackage = readCargoPackageMetadata(path.join(repoRoot, "Cargo.toml"));
+const releaseTag = `v${cargoPackage.version}`;
+const platformPackage = unixPlatformPackage();
+const skipReason = platformPackage ? false : `unsupported test host ${process.platform}:${process.arch}`;
+
+const runningMessages = [
+  "Resolving release",
+  "Downloading release archive",
+  "Verifying release archive",
+  "Installing files",
+  "Verifying installed command",
+  "Running runtime diagnostics",
+];
+
+const successfulMessages = [
+  `Release ${releaseTag} selected`,
+  "Downloaded release archive",
+  "Verified release archive integrity",
+  "Installed files",
+  "Verified claude-rs 0.0.0-mock",
+];
+
+test("Unix installer keeps successful redirected output completed-step-only", { skip: skipReason }, () => {
+  const result = runInstallerScenario("success");
+  assertScenarioResult(result, 0, successfulMessages);
+  assert.equal(result.installed, true, "successful install did not create the installed command");
+  assert.equal(result.launcherInstalled, true, "successful install did not create the launcher");
+});
+
+test("Unix installer preserves checksum-download failures without progress noise", { skip: skipReason }, () => {
+  const result = runInstallerScenario("checksum-download-failure");
+  assertScenarioResult(result, 1, [
+    `Release ${releaseTag} selected`,
+    `could not download SHA256SUMS for ${releaseTag}`,
+  ]);
+});
+
+test("Unix installer preserves archive-unavailable failures without progress noise", { skip: skipReason }, () => {
+  const result = runInstallerScenario("archive-unavailable");
+  assertScenarioResult(result, 1, [
+    `Release ${releaseTag} selected`,
+    "install script is currently not available for this release",
+  ]);
+});
+
+test("Unix installer preserves checksum-mismatch failures without progress noise", { skip: skipReason }, () => {
+  const result = runInstallerScenario("checksum-mismatch");
+  assertScenarioResult(result, 1, [
+    `Release ${releaseTag} selected`,
+    "Downloaded release archive",
+    `checksum mismatch for ${result.archiveName}`,
+  ]);
+});
+
+test("Unix installer keeps CI output completed-step-only", { skip: skipReason }, () => {
+  const result = runInstallerScenario("ci");
+  assertScenarioResult(result, 0, successfulMessages);
+});
+
+test("Unix installer keeps NO_COLOR output plain and completed-step-only", { skip: skipReason }, () => {
+  const result = runInstallerScenario("no-color");
+  assertScenarioResult(result, 0, successfulMessages);
+});
+
+function runInstallerScenario(scenario) {
+  const archiveName = installArchiveName(platformPackage, cargoPackage.version);
+  const archivePath = path.join(repoRoot, "dist-install", archiveName);
+  assert.ok(
+    fs.existsSync(archivePath),
+    `missing mock install archive ${archivePath}; run generate-install-archives.mjs --mock-binaries first`,
+  );
+
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-installer-progress-"));
+  const homeDir = path.join(sandbox, "home");
+  const tempDir = path.join(sandbox, "tmp");
+  const installDir = path.join(sandbox, "app", "claude-rs");
+  const binDir = path.join(sandbox, "bin");
+  const shimDir = path.join(sandbox, "shims");
+  const checksumsPath = path.join(sandbox, "SHA256SUMS");
+  for (const directory of [homeDir, tempDir, binDir, shimDir]) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+
+  const archiveSha256 = crypto.createHash("sha256").update(fs.readFileSync(archivePath)).digest("hex");
+  const expectedSha256 = scenario === "checksum-mismatch" ? "0".repeat(64) : archiveSha256;
+  fs.writeFileSync(checksumsPath, `${expectedSha256}  dist-install/${archiveName}\n`, "utf8");
+  writeCommandShims(shimDir);
+
+  const env = { ...process.env };
+  for (const name of Object.keys(env)) {
+    if (name.startsWith("CLAUDE_RS_")) {
+      delete env[name];
+    }
+  }
+  delete env.CI;
+  delete env.NO_COLOR;
+  Object.assign(env, {
+    HOME: homeDir,
+    TMPDIR: tempDir,
+    PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    TERM: "xterm",
+    MOCK_ARCHIVE_FILE: archivePath,
+    MOCK_CHECKSUM_FILE: checksumsPath,
+    MOCK_DOWNLOAD_MODE: scenario,
+  });
+  if (scenario === "ci") {
+    env.CI = "1";
+  }
+  if (scenario === "no-color") {
+    env.NO_COLOR = "1";
+  }
+
+  let commandResult;
+  try {
+    commandResult = spawnSync(
+      "sh",
+      [
+        installerPath,
+        "--release",
+        releaseTag,
+        "--install-dir",
+        installDir,
+        "--bin-dir",
+        binDir,
+        "--yes",
+        "--non-interactive",
+        "--no-modify-path",
+        "--keep-npm",
+      ],
+      {
+        encoding: "utf8",
+        env,
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 120_000,
+      },
+    );
+    if (commandResult.error) {
+      throw commandResult.error;
+    }
+
+    const lockPath = path.join(path.dirname(installDir), ".claude-rs-install.lock");
+    assert.equal(fs.existsSync(lockPath), false, `${scenario} left the install lock behind`);
+    assert.deepEqual(fs.readdirSync(tempDir), [], `${scenario} left temporary installer files behind`);
+
+    return {
+      archiveName,
+      installed: fs.existsSync(path.join(installDir, platformPackage.binaryName)),
+      launcherInstalled: fs.existsSync(path.join(binDir, "claude-rs")),
+      status: commandResult.status,
+      signal: commandResult.signal,
+      stderr: commandResult.stderr,
+      stdout: commandResult.stdout,
+    };
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+function assertScenarioResult(result, expectedStatus, expectedMessages) {
+  assert.equal(result.signal, null, "installer was terminated by a signal");
+  assert.equal(result.status, expectedStatus, `unexpected installer exit status\n${result.stderr}`);
+  const output = `${result.stdout}${result.stderr}`;
+  for (const message of expectedMessages) {
+    assert.match(output, new RegExp(escapeRegex(message)), `missing installer message: ${message}`);
+  }
+  assert.doesNotMatch(output, /\u001b/, "redirected installer output contains ANSI escape bytes");
+  assert.doesNotMatch(output, /\r/, "redirected installer output contains carriage returns");
+  assert.doesNotMatch(output, /[\u2800-\u28ff]/u, "redirected installer output contains Braille spinner frames");
+  for (const message of runningMessages) {
+    assert.doesNotMatch(
+      output,
+      new RegExp(`(?:^|\\n)${escapeRegex(message)}(?:\\n|$)`),
+      `redirected installer output contains a step-start line: ${message}`,
+    );
+  }
+}
+
+function writeCommandShims(shimDir) {
+  const curlPath = path.join(shimDir, "curl");
+  fs.writeFileSync(
+    curlPath,
+    `#!/bin/sh
+url=""
+destination=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      shift
+      destination="$1"
+      ;;
+    http://* | https://*)
+      url="$1"
+      ;;
+  esac
+  shift
+done
+case "$url" in
+  */SHA256SUMS)
+    if [ "$MOCK_DOWNLOAD_MODE" = "checksum-download-failure" ]; then
+      printf '%s\\n' 'mock checksum download failed' >&2
+      exit 22
+    fi
+    cp "$MOCK_CHECKSUM_FILE" "$destination"
+    ;;
+  *)
+    if [ "$MOCK_DOWNLOAD_MODE" = "archive-unavailable" ]; then
+      printf '%s\\n' 'mock archive download failed' >&2
+      exit 22
+    fi
+    cp "$MOCK_ARCHIVE_FILE" "$destination"
+    ;;
+esac
+`,
+    "utf8",
+  );
+  fs.chmodSync(curlPath, 0o755);
+
+  const npmPath = path.join(shimDir, "npm");
+  fs.writeFileSync(npmPath, "#!/bin/sh\nexit 1\n", "utf8");
+  fs.chmodSync(npmPath, 0o755);
+}
+
+function unixPlatformPackage() {
+  if (process.platform === "win32") {
+    return undefined;
+  }
+  const expectedDir =
+    process.platform === "darwin"
+      ? `darwin-${process.arch === "arm64" ? "arm64" : "x64"}`
+      : process.platform === "linux"
+        ? `linux-${process.arch === "arm64" ? "arm64" : "x64"}-gnu`
+        : undefined;
+  return PLATFORM_PACKAGES.find((entry) => entry.dir === expectedDir);
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/install/install-version-guard.test.mjs
+++ b/scripts/install/install-version-guard.test.mjs
@@ -1,0 +1,289 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { resolveRepoRoot } from "../shared/repo-root.mjs";
+
+const repoRoot = resolveRepoRoot(import.meta.url);
+const installerPath = path.join(repoRoot, "scripts", "install", "install.sh");
+const selectedVersion = "9.8.7-preview.1+build.5";
+const selectedTag = `v${selectedVersion}`;
+const platformDir = unixPlatformDir();
+const skipReason = platformDir ? false : `Unix installer test is not supported on ${process.platform}:${process.arch}`;
+
+test("Unix installer skips a pinned same-version install before release downloads", { skip: skipReason }, () => {
+  const result = runInstallerScenario();
+
+  assert.equal(result.status, 0, result.output);
+  assert.match(result.output, /already installed; no changes made/);
+  assert.deepEqual(result.downloads, []);
+  assert.equal(result.installedVersion, selectedVersion);
+});
+
+test("Unix installer treats a same-version update as a no-op even though update mode accepts prompts", { skip: skipReason }, () => {
+  const result = runInstallerScenario({ extraArgs: ["--update"] });
+
+  assert.equal(result.status, 0, result.output);
+  assert.match(result.output, /already installed; no changes made/);
+  assert.doesNotMatch(result.output, /Reinstalling claude-rs/);
+  assert.deepEqual(result.downloads, []);
+});
+
+test("Unix installer --yes explicitly proceeds with a same-version reinstall", { skip: skipReason }, () => {
+  const result = runInstallerScenario({ extraArgs: ["--yes"], allowReleasePayload: true });
+
+  assert.equal(result.status, 0, result.output);
+  assert.match(result.output, new RegExp(`Reinstalling claude-rs ${escapeRegex(selectedVersion)}`));
+  assert.match(result.output, new RegExp(`Verified claude-rs ${escapeRegex(selectedVersion)}`));
+  assert.deepEqual(result.downloads, [
+    `https://github.com/srothgan/claude-code-rust/releases/download/${selectedTag}/SHA256SUMS`,
+    `https://github.com/srothgan/claude-code-rust/releases/download/${selectedTag}/claude-code-rust-${selectedVersion}-${platformDir}.tar.gz`,
+  ]);
+  assert.equal(result.replacementMarker, true, "approved reinstall did not replace the existing app");
+});
+
+test("Unix installer resolves latest metadata but skips same-version release payloads", { skip: skipReason }, () => {
+  const result = runInstallerScenario({ requestedRelease: "latest" });
+
+  assert.equal(result.status, 0, result.output);
+  assert.match(result.output, new RegExp(`Release ${escapeRegex(selectedTag)} selected`));
+  assert.match(result.output, /already installed; no changes made/);
+  assert.deepEqual(result.downloads, [
+    "https://api.github.com/repos/srothgan/claude-code-rust/releases/latest",
+  ]);
+});
+
+test("Unix installer compares release identity exactly", { skip: skipReason }, () => {
+  const differentlyCasedTag = "v9.8.7-Preview.1+build.5";
+  const result = runInstallerScenario({ requestedRelease: differentlyCasedTag });
+
+  assert.equal(result.status, 1, "mock checksum failure should prove the different release proceeded");
+  assert.doesNotMatch(result.output, /already installed; no changes made/);
+  assert.deepEqual(result.downloads, [
+    `https://github.com/srothgan/claude-code-rust/releases/download/${differentlyCasedTag}/SHA256SUMS`,
+  ]);
+});
+
+function runInstallerScenario({ requestedRelease = selectedTag, extraArgs = [], allowReleasePayload = false } = {}) {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "claude-rs-version-guard-"));
+  const homeDir = path.join(sandbox, "home");
+  const tempDir = path.join(sandbox, "tmp");
+  const installDir = path.join(sandbox, "app", "claude-rs");
+  const binDir = path.join(sandbox, "bin");
+  const shimDir = path.join(sandbox, "shims");
+  const downloadLog = path.join(sandbox, "downloads.log");
+  for (const directory of [homeDir, tempDir, installDir, binDir, shimDir]) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+
+  writeOwnedInstall(installDir, selectedVersion);
+  const releaseFixture = createReleaseFixture(sandbox, selectedVersion);
+  writeCommandShims(shimDir);
+
+  const env = { ...process.env };
+  for (const name of Object.keys(env)) {
+    if (name.startsWith("CLAUDE_RS_")) {
+      delete env[name];
+    }
+  }
+  delete env.CI;
+  Object.assign(env, {
+    HOME: homeDir,
+    TMPDIR: tempDir,
+    PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    MOCK_DOWNLOAD_LOG: downloadLog,
+    MOCK_LATEST_TAG: selectedTag,
+    MOCK_ALLOW_RELEASE_PAYLOAD: allowReleasePayload ? "1" : "0",
+    MOCK_ARCHIVE_FILE: releaseFixture.archivePath,
+    MOCK_CHECKSUM_FILE: releaseFixture.checksumsPath,
+  });
+
+  try {
+    const commandResult = spawnSync(
+      "sh",
+      [
+        installerPath,
+        "--release",
+        requestedRelease,
+        "--install-dir",
+        installDir,
+        "--bin-dir",
+        binDir,
+        "--non-interactive",
+        "--no-modify-path",
+        "--keep-npm",
+        ...extraArgs,
+      ],
+      {
+        encoding: "utf8",
+        env,
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 30_000,
+      },
+    );
+    if (commandResult.error) {
+      throw commandResult.error;
+    }
+
+    assert.deepEqual(fs.readdirSync(tempDir), [], "installer left temporary files behind");
+    assert.equal(
+      fs.existsSync(path.join(path.dirname(installDir), ".claude-rs-install.lock")),
+      false,
+      "installer left its install lock behind",
+    );
+
+    const downloads = fs.existsSync(downloadLog)
+      ? fs.readFileSync(downloadLog, "utf8").split(/\r?\n/u).filter(Boolean)
+      : [];
+    const installedPackage = JSON.parse(fs.readFileSync(path.join(installDir, "package.json"), "utf8"));
+    return {
+      status: commandResult.status,
+      signal: commandResult.signal,
+      output: `${commandResult.stdout}${commandResult.stderr}`,
+      downloads,
+      installedVersion: installedPackage.version,
+      replacementMarker: installedPackage.versionGuardReplacement === true,
+    };
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+function writeOwnedInstall(installDir, version) {
+  fs.writeFileSync(
+    path.join(installDir, "package.json"),
+    `${JSON.stringify({ name: "claude-code-rust", version }, null, 2)}\n`,
+    "utf8",
+  );
+  fs.writeFileSync(path.join(installDir, "claude-rs"), "existing binary\n", "utf8");
+  fs.writeFileSync(path.join(installDir, "claude-rs-bridge-bun"), "existing runtime\n", "utf8");
+}
+
+function createReleaseFixture(sandbox, version) {
+  const fixtureParent = path.join(sandbox, "release-fixture");
+  const appRootName = `claude-code-rust-${version}-${platformDir}`;
+  const appRoot = path.join(fixtureParent, appRootName);
+  const archiveName = `${appRootName}.tar.gz`;
+  const archivePath = path.join(sandbox, archiveName);
+  const checksumsPath = path.join(sandbox, "SHA256SUMS");
+  for (const directory of [
+    appRoot,
+    path.join(appRoot, "agent-sdk", "dist"),
+    path.join(appRoot, "node_modules", "@anthropic-ai", "claude-agent-sdk"),
+  ]) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+
+  fs.writeFileSync(
+    path.join(appRoot, "package.json"),
+    `${JSON.stringify(
+      { name: "claude-code-rust", version, private: true, versionGuardReplacement: true },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  fs.writeFileSync(path.join(appRoot, "THIRD-PARTY-NOTICES.md"), "test notices\n", "utf8");
+  fs.writeFileSync(path.join(appRoot, "agent-sdk", "package.json"), '{"private":true}\n', "utf8");
+  fs.writeFileSync(path.join(appRoot, "agent-sdk", "dist", "bridge.js"), "export {};\n", "utf8");
+  fs.writeFileSync(path.join(appRoot, "agent-sdk", "dist", "types.js"), "export {};\n", "utf8");
+  fs.writeFileSync(
+    path.join(appRoot, "node_modules", "@anthropic-ai", "claude-agent-sdk", "package.json"),
+    '{"name":"@anthropic-ai/claude-agent-sdk"}\n',
+    "utf8",
+  );
+
+  const binaryPath = path.join(appRoot, "claude-rs");
+  fs.writeFileSync(
+    binaryPath,
+    `#!/bin/sh
+case "\${1:-}" in
+  --version) printf '%s\\n' 'claude-rs ${version}' ;;
+  --help) printf '%s\\n' 'mock help' ;;
+  *) exit 0 ;;
+esac
+`,
+    "utf8",
+  );
+  const runtimePath = path.join(appRoot, "claude-rs-bridge-bun");
+  fs.writeFileSync(runtimePath, "#!/bin/sh\nexit 0\n", "utf8");
+  fs.chmodSync(binaryPath, 0o755);
+  fs.chmodSync(runtimePath, 0o755);
+
+  const tarResult = spawnSync("tar", ["-czf", archivePath, "-C", fixtureParent, appRootName], {
+    encoding: "utf8",
+  });
+  if (tarResult.error) {
+    throw tarResult.error;
+  }
+  assert.equal(tarResult.status, 0, `${tarResult.stdout}${tarResult.stderr}`);
+
+  const archiveSha256 = crypto.createHash("sha256").update(fs.readFileSync(archivePath)).digest("hex");
+  fs.writeFileSync(checksumsPath, `${archiveSha256}  dist-install/${archiveName}\n`, "utf8");
+  return { archivePath, checksumsPath };
+}
+
+function writeCommandShims(shimDir) {
+  const curlPath = path.join(shimDir, "curl");
+  fs.writeFileSync(
+    curlPath,
+    `#!/bin/sh
+url=""
+destination=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      shift
+      destination="$1"
+      ;;
+    http://* | https://*)
+      url="$1"
+      ;;
+  esac
+  shift
+done
+printf '%s\\n' "$url" >> "$MOCK_DOWNLOAD_LOG"
+case "$url" in
+  */releases/latest)
+    printf '{"tag_name":"%s"}\\n' "$MOCK_LATEST_TAG" > "$destination"
+    exit 0
+    ;;
+esac
+if [ "$MOCK_ALLOW_RELEASE_PAYLOAD" != "1" ]; then
+    printf '%s\\n' 'mock release payload download blocked' >&2
+    exit 22
+fi
+case "$url" in
+  */SHA256SUMS)
+    cp "$MOCK_CHECKSUM_FILE" "$destination"
+    ;;
+  *)
+    cp "$MOCK_ARCHIVE_FILE" "$destination"
+    ;;
+esac
+`,
+    "utf8",
+  );
+  fs.chmodSync(curlPath, 0o755);
+
+  const npmPath = path.join(shimDir, "npm");
+  fs.writeFileSync(npmPath, "#!/bin/sh\nexit 1\n", "utf8");
+  fs.chmodSync(npmPath, 0o755);
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function unixPlatformDir() {
+  if (process.platform === "darwin" && ["arm64", "x64"].includes(process.arch)) {
+    return `darwin-${process.arch}`;
+  }
+  if (process.platform === "linux" && ["arm64", "x64"].includes(process.arch)) {
+    return `linux-${process.arch}-gnu`;
+  }
+  return undefined;
+}

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -126,6 +126,161 @@ if ($RemoveNpm -and $KeepNpm) {
 $UseColor = -not $env:NO_COLOR
 $OkMark = [char]0x2713
 $FailMark = [char]0x2717
+$script:InstallerProgressSupported = $false
+$script:InstallerProgressActive = $false
+$script:InstallerProgressWorker = $null
+
+if (-not $env:CI -and $env:TERM -ne "dumb") {
+    try {
+        if (-not [Console]::IsOutputRedirected) {
+            # Accessing cursor state throws in hosts without a real console.
+            $null = [Console]::CursorLeft
+            $script:InstallerProgressSupported = $true
+        }
+    } catch {
+        $script:InstallerProgressSupported = $false
+    }
+}
+
+function New-InstallerProgressWorker {
+    param([string]$Message)
+
+    $stopEvent = $null
+    $renderedEvent = $null
+    $runspace = $null
+    $powerShell = $null
+    try {
+        $stopEvent = New-Object System.Threading.ManualResetEvent($false)
+        $renderedEvent = New-Object System.Threading.ManualResetEvent($false)
+        $runspace = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace()
+        $runspace.Open()
+
+        $renderer = {
+            param(
+                [string]$Message,
+                [System.Threading.ManualResetEvent]$StopEvent,
+                [System.Threading.ManualResetEvent]$RenderedEvent,
+                [bool]$UseColor
+            )
+
+            $frames = @("|", "/", "-", "\")
+            $frameIndex = 0
+            if ($StopEvent.WaitOne(200)) {
+                return
+            }
+            while (-not $StopEvent.WaitOne(0)) {
+                [Console]::Write("`r")
+                if ($UseColor) {
+                    $previousColor = [Console]::ForegroundColor
+                    try {
+                        [Console]::ForegroundColor = [ConsoleColor]::Cyan
+                        [Console]::Write($frames[$frameIndex])
+                    } finally {
+                        [Console]::ForegroundColor = $previousColor
+                    }
+                } else {
+                    [Console]::Write($frames[$frameIndex])
+                }
+                [Console]::Write(" $Message")
+                $null = $RenderedEvent.Set()
+
+                $frameIndex = ($frameIndex + 1) % $frames.Count
+                if ($StopEvent.WaitOne(150)) {
+                    break
+                }
+            }
+        }
+
+        $powerShell = [System.Management.Automation.PowerShell]::Create()
+        $powerShell.Runspace = $runspace
+        $null = $powerShell.AddScript($renderer.ToString())
+        $null = $powerShell.AddArgument($Message)
+        $null = $powerShell.AddArgument($stopEvent)
+        $null = $powerShell.AddArgument($renderedEvent)
+        $null = $powerShell.AddArgument($UseColor)
+        $asyncResult = $powerShell.BeginInvoke()
+
+        return [pscustomobject]@{
+            PowerShell = $powerShell
+            AsyncResult = $asyncResult
+            Runspace = $runspace
+            StopEvent = $stopEvent
+            RenderedEvent = $renderedEvent
+            Width = $Message.Length + 2
+        }
+    } catch {
+        if ($powerShell) {
+            $powerShell.Dispose()
+        }
+        if ($runspace) {
+            $runspace.Dispose()
+        }
+        if ($stopEvent) {
+            $stopEvent.Dispose()
+        }
+        if ($renderedEvent) {
+            $renderedEvent.Dispose()
+        }
+        throw
+    }
+}
+
+function Close-InstallerProgressWorker {
+    param($Worker)
+
+    $rendered = $false
+    try {
+        $null = $Worker.StopEvent.Set()
+        $null = $Worker.PowerShell.EndInvoke($Worker.AsyncResult)
+    } finally {
+        $rendered = $Worker.RenderedEvent.WaitOne(0)
+        $Worker.PowerShell.Dispose()
+        $Worker.Runspace.Dispose()
+        $Worker.StopEvent.Dispose()
+        $Worker.RenderedEvent.Dispose()
+        if ($rendered) {
+            [Console]::Write("`r" + (" " * $Worker.Width) + "`r")
+        }
+    }
+}
+
+function Stop-InstallerProgress {
+    $worker = $script:InstallerProgressWorker
+    $script:InstallerProgressWorker = $null
+    $script:InstallerProgressActive = $false
+    if (-not $worker) {
+        return
+    }
+
+    try {
+        Close-InstallerProgressWorker $worker
+    } catch {
+        $script:InstallerProgressSupported = $false
+    }
+}
+
+function Start-InstallerProgress {
+    param([string]$Message)
+    Stop-InstallerProgress
+    if (-not $script:InstallerProgressSupported) {
+        return
+    }
+
+    try {
+        $script:InstallerProgressWorker = New-InstallerProgressWorker $Message
+        $script:InstallerProgressActive = $true
+    } catch {
+        $script:InstallerProgressWorker = $null
+        $script:InstallerProgressActive = $false
+        $script:InstallerProgressSupported = $false
+    }
+}
+
+function Complete-InstallerProgress {
+    param([string]$Message)
+    Stop-InstallerProgress
+    Write-Ok $Message
+}
 
 function Write-InstallerLine {
     param(
@@ -133,6 +288,7 @@ function Write-InstallerLine {
         [string]$Message,
         [ConsoleColor]$Color
     )
+    Stop-InstallerProgress
     if ($UseColor) {
         Write-Host "$Mark $Message" -ForegroundColor $Color
     } else {
@@ -147,6 +303,7 @@ function Write-Ok {
 
 function Write-WarnLine {
     param([string]$Message)
+    Stop-InstallerProgress
     if ($UseColor) {
         $previousColor = [Console]::ForegroundColor
         [Console]::ForegroundColor = [ConsoleColor]::Yellow
@@ -159,11 +316,13 @@ function Write-WarnLine {
 
 function Write-WarnDetail {
     param([string]$Message)
+    Stop-InstallerProgress
     [Console]::Error.WriteLine($Message)
 }
 
 function Write-FailLine {
     param([string]$Message)
+    Stop-InstallerProgress
     if ($UseColor) {
         $previousColor = [Console]::ForegroundColor
         [Console]::ForegroundColor = [ConsoleColor]::Red
@@ -174,12 +333,19 @@ function Write-FailLine {
     }
 }
 
+function Write-InstallerDiagnostic {
+    param([string]$Message)
+    Stop-InstallerProgress
+    Write-Host $Message
+}
+
 function Test-CanPrompt {
     return (-not $NonInteractive) -and (-not [Console]::IsInputRedirected)
 }
 
 function Confirm-DefaultNo {
     param([string]$Prompt)
+    Stop-InstallerProgress
     if (-not (Test-CanPrompt)) {
         return $false
     }
@@ -195,6 +361,7 @@ function Fail {
 }
 
 function Fail-Unavailable {
+    Stop-InstallerProgress
     [Console]::Error.WriteLine("install script is currently not available for this release")
     exit 1
 }
@@ -582,7 +749,7 @@ function Assert-InstalledCommand {
     if ($LASTEXITCODE -ne 0) {
         Fail "installed claude-rs help check failed"
     }
-    Write-Ok "Verified $versionOutput"
+    Complete-InstallerProgress "Verified $versionOutput"
 }
 
 function Invoke-InstallDoctor {
@@ -598,11 +765,11 @@ function Invoke-InstallDoctor {
     $doctorOutput = ($doctorLines -join [Environment]::NewLine).Trim()
     if ($LASTEXITCODE -ne 0) {
         if (-not [string]::IsNullOrWhiteSpace($doctorOutput)) {
-            Write-Host $doctorOutput
+            Write-InstallerDiagnostic $doctorOutput
         }
         Fail "runtime diagnostics failed"
     }
-    Write-Ok "Runtime diagnostics passed"
+    Complete-InstallerProgress "Runtime diagnostics passed"
 }
 
 function Warn-OtherClaudeRsCommands {
@@ -667,29 +834,33 @@ try {
     Write-Ok "$targetLabel detected"
     Write-Ok "Install location: $InstallDir"
 
+    Start-InstallerProgress "Resolving release"
     $tag = Resolve-ReleaseTag -RequestedRelease $Release -TempDir $tempDir
     $archiveName = Get-ArchiveName -Target $target -Tag $tag
     $baseUrl = "https://github.com/$RepoSlug/releases/download/$tag"
     $checksumsPath = Join-Path $tempDir "SHA256SUMS"
     $archivePath = Join-Path $tempDir $archiveName
 
-    Write-Ok "Release $tag selected"
+    Complete-InstallerProgress "Release $tag selected"
 
+    Start-InstallerProgress "Downloading release archive"
     Invoke-WebRequest -Uri "$baseUrl/SHA256SUMS" -OutFile $checksumsPath
     try {
         Invoke-WebRequest -Uri "$baseUrl/$archiveName" -OutFile $archivePath
     } catch {
         Fail-Unavailable
     }
-    Write-Ok "Downloaded release archive"
+    Complete-InstallerProgress "Downloaded release archive"
 
+    Start-InstallerProgress "Verifying release archive"
     $expectedSha = Get-ExpectedSha256 -ChecksumsPath $checksumsPath -ArchiveName $archiveName
     $actualSha = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
     if ($actualSha -ne $expectedSha) {
         Fail "checksum mismatch for $archiveName"
     }
-    Write-Ok "Verified release archive integrity"
+    Complete-InstallerProgress "Verified release archive integrity"
 
+    Start-InstallerProgress "Installing files"
     $extractDir = Join-Path $tempDir "extract"
     Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir -Force
     $topLevelDirs = @(Get-ChildItem -LiteralPath $extractDir -Directory)
@@ -705,7 +876,7 @@ try {
     $installParent = Split-Path -Parent $InstallDir
     $lockStream = Acquire-InstallLock -InstallParent $installParent
     Replace-AppDirectory -SourceApp $extractedApp -FinalApp $InstallDir
-    Write-Ok "Installed files"
+    Complete-InstallerProgress "Installed files"
 
     Prepend-ProcessPath -Directory $InstallDir
     if ($Update) {
@@ -721,8 +892,10 @@ try {
         }
     }
 
+    Start-InstallerProgress "Verifying installed command"
     Assert-InstalledCommand
     if ($Verify) {
+        Start-InstallerProgress "Running runtime diagnostics"
         Invoke-InstallDoctor
     }
 
@@ -750,6 +923,7 @@ try {
             Write-Host "PATH is updated for new shells."
         }
         if ($Run -or ((-not $Yes) -and (Confirm-DefaultNo "Start claude-rs now?"))) {
+            Stop-InstallerProgress
             Invoke-InstalledClaudeRs @()
         } elseif ($NoModifyPath) {
             Write-Host "Run directly: $(Join-Path $InstallDir "claude-rs.exe")"
@@ -758,6 +932,7 @@ try {
         }
     }
 } finally {
+    Stop-InstallerProgress
     if ($lockStream) {
         $lockStream.Dispose()
     }

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -29,7 +29,8 @@ Usage: install.ps1 [options]
 Options:
   -Release <version>      Release tag or version. Defaults to latest.
   -InstallDir <dir>      App install directory.
-  -Yes                   Skip optional installer prompts.
+  -Yes                   Reinstall the selected version when already installed;
+                         skip optional installer prompts.
   -NoModifyPath          Do not update the user PATH.
   -Verify                Run strict runtime diagnostics after install.
   -Run                   Start claude-rs after a successful install.
@@ -394,8 +395,16 @@ function Get-Target {
 
 function Get-ArchiveName {
     param([string]$Target, [string]$Tag)
-    $version = $Tag.TrimStart("v")
+    $version = Get-ReleaseVersion -Tag $Tag
     return "$RootPackage-$version-$Target.zip"
+}
+
+function Get-ReleaseVersion {
+    param([string]$Tag)
+    if ($Tag.StartsWith("v", [StringComparison]::Ordinal)) {
+        return $Tag.Substring(1)
+    }
+    return $Tag
 }
 
 function Get-ExpectedSha256 {
@@ -520,29 +529,57 @@ for ($attempt = 0; $attempt -lt 20; $attempt++) {
     $worker.Dispose()
 }
 
-function Test-ScriptInstallDirectory {
+function Get-ScriptInstallInfo {
     param([string]$Path)
     if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
-        return $false
+        return $null
     }
 
     $packageJsonPath = Join-Path $Path "package.json"
     if (-not (Test-Path -LiteralPath $packageJsonPath -PathType Leaf)) {
-        return $false
+        return $null
     }
     if (-not (Test-Path -LiteralPath (Join-Path $Path "claude-rs.exe") -PathType Leaf)) {
-        return $false
+        return $null
     }
     if (-not (Test-Path -LiteralPath (Join-Path $Path "claude-rs-bridge-bun.exe") -PathType Leaf)) {
-        return $false
+        return $null
     }
 
     try {
         $packageJson = Get-Content -LiteralPath $packageJsonPath -Raw | ConvertFrom-Json
-        return ($packageJson.PSObject.Properties.Name -contains "name") -and $packageJson.name -eq $RootPackage
+        if (-not ($packageJson.PSObject.Properties.Name -contains "name") -or $packageJson.name -cne $RootPackage) {
+            return $null
+        }
+        $version = if ($packageJson.PSObject.Properties.Name -contains "version") {
+            [string]$packageJson.version
+        } else {
+            $null
+        }
+        return [pscustomobject]@{
+            Path = $Path
+            PackageJson = $packageJsonPath
+            Version = $version
+        }
     } catch {
+        return $null
+    }
+}
+
+function Test-ScriptInstallDirectory {
+    param([string]$Path)
+    return $null -ne (Get-ScriptInstallInfo -Path $Path)
+}
+
+function Confirm-SameVersionReinstall {
+    param([string]$Version)
+    if ($Update) {
         return $false
     }
+    if ($Yes) {
+        return $true
+    }
+    return Confirm-DefaultNo "claude-rs $Version is already installed at $InstallDir. Reinstall the same version?"
 }
 
 function Get-NpmCommand {
@@ -822,6 +859,7 @@ if ($Update -and -not (Test-ScriptInstallDirectory -Path $InstallDir)) {
 $tempDir = Join-Path ([IO.Path]::GetTempPath()) "claude-rs-install-$PID"
 $lockStream = $null
 $pathChanged = $false
+$sameVersionReinstallApproved = $false
 
 try {
     Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
@@ -836,12 +874,28 @@ try {
 
     Start-InstallerProgress "Resolving release"
     $tag = Resolve-ReleaseTag -RequestedRelease $Release -TempDir $tempDir
+    $selectedVersion = Get-ReleaseVersion -Tag $tag
     $archiveName = Get-ArchiveName -Target $target -Tag $tag
     $baseUrl = "https://github.com/$RepoSlug/releases/download/$tag"
     $checksumsPath = Join-Path $tempDir "SHA256SUMS"
     $archivePath = Join-Path $tempDir $archiveName
 
     Complete-InstallerProgress "Release $tag selected"
+
+    $existingInstall = Get-ScriptInstallInfo -Path $InstallDir
+    if ($existingInstall) {
+        if ([string]::IsNullOrWhiteSpace($existingInstall.Version)) {
+            Write-WarnLine "Could not determine the version of the existing script install; continuing with installation"
+        } elseif ([string]::Equals($existingInstall.Version, $selectedVersion, [StringComparison]::Ordinal)) {
+            if (Confirm-SameVersionReinstall -Version $selectedVersion) {
+                $sameVersionReinstallApproved = $true
+                Write-Ok "Reinstalling claude-rs $selectedVersion"
+            } else {
+                Write-Ok "claude-rs $selectedVersion is already installed; no changes made"
+                exit 0
+            }
+        }
+    }
 
     Start-InstallerProgress "Downloading release archive"
     Invoke-WebRequest -Uri "$baseUrl/SHA256SUMS" -OutFile $checksumsPath
@@ -875,6 +929,16 @@ try {
 
     $installParent = Split-Path -Parent $InstallDir
     $lockStream = Acquire-InstallLock -InstallParent $installParent
+    if (-not $sameVersionReinstallApproved) {
+        $lockedInstall = Get-ScriptInstallInfo -Path $InstallDir
+        if ($lockedInstall -and
+            -not [string]::IsNullOrWhiteSpace($lockedInstall.Version) -and
+            [string]::Equals($lockedInstall.Version, $selectedVersion, [StringComparison]::Ordinal)) {
+            Stop-InstallerProgress
+            Write-Ok "claude-rs $selectedVersion was installed by another installer; no changes made"
+            exit 0
+        }
+    }
     Replace-AppDirectory -SourceApp $extractedApp -FinalApp $InstallDir
     Complete-InstallerProgress "Installed files"
 
@@ -916,7 +980,7 @@ try {
 
     Write-Host
     if ($Update) {
-        Write-Host "claude-rs is updated. Start claude-rs again to use v$($tag.TrimStart('v'))."
+        Write-Host "claude-rs is updated. Start claude-rs again to use v$selectedVersion."
     } else {
         Write-Host "claude-rs is installed."
         if ($pathChanged) {

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -56,7 +56,8 @@ Options:
   --release <version>       Release tag or version. Defaults to latest.
   --install-dir <dir>       App install directory.
   --bin-dir <dir>           Directory for the claude-rs launcher.
-  --yes, -y                 Accept safe installer prompts; optional prompts are skipped.
+  --yes, -y                 Reinstall the selected version when already installed;
+                            accept safe prompts; optional prompts are skipped.
   --non-interactive         Do not prompt.
   --no-modify-path          Do not update shell profile PATH.
   --verify                  Run strict runtime diagnostics after install.
@@ -575,6 +576,63 @@ is_script_install_dir() {
   grep -q '"name"[ 	]*:[ 	]*"claude-code-rust"' "$app/package.json" 2>/dev/null
 }
 
+script_install_version() {
+  app="$1"
+  is_script_install_dir "$app" || return 1
+  sed -n 's/.*"version"[ 	]*:[ 	]*"\([^"]*\)".*/\1/p' "$app/package.json" | sed -n '1p'
+}
+
+release_version() {
+  selected_tag="$1"
+  printf '%s\n' "${selected_tag#v}"
+}
+
+approve_same_version_reinstall() {
+  selected_version="$1"
+  if [ "$update" -eq 1 ]; then
+    return 1
+  fi
+  if [ "$yes" -eq 1 ]; then
+    return 0
+  fi
+  confirm_default_no "claude-rs $selected_version is already installed at $install_dir. Reinstall the same version?"
+}
+
+guard_same_version_before_download() {
+  selected_version="$1"
+  is_script_install_dir "$install_dir" || return 0
+
+  installed_version="$(script_install_version "$install_dir" || true)"
+  if [ -z "$installed_version" ]; then
+    warn "could not determine the version of the existing script install; continuing with installation"
+    return 0
+  fi
+  [ "$installed_version" = "$selected_version" ] || return 0
+
+  if approve_same_version_reinstall "$selected_version"; then
+    same_version_reinstall_approved=1
+    ok "Reinstalling claude-rs $selected_version"
+    return 0
+  fi
+
+  ok "claude-rs $selected_version is already installed; no changes made"
+  exit 0
+}
+
+stop_if_selected_version_became_installed() {
+  selected_version="$1"
+  [ "$same_version_reinstall_approved" -eq 0 ] || return 0
+  is_script_install_dir "$install_dir" || return 0
+
+  installed_version="$(script_install_version "$install_dir" || true)"
+  [ -n "$installed_version" ] || return 0
+  [ "$installed_version" = "$selected_version" ] || return 0
+
+  progress_stop
+  ok "claude-rs $selected_version was installed by another installer; no changes made"
+  exit 0
+}
+
 remove_launcher_if_owned() {
   launcher="$bin_dir/claude-rs"
   app_binary="$install_dir/claude-rs"
@@ -777,6 +835,7 @@ need_cmd grep
 need_cmd awk
 
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/claude-rs-install.XXXXXX")"
+same_version_reinstall_approved=0
 cleanup() {
   progress_stop
   [ -z "${lock_dir:-}" ] || rm -rf "$lock_dir"
@@ -818,12 +877,15 @@ ok "Install location: $install_dir"
 
 progress_start "Resolving release"
 tag="$(resolve_tag "$release")"
+selected_version="$(release_version "$tag")"
 archive_name="$(archive_name_for_target "$target")"
 base_url="https://github.com/$repo_slug/releases/download/$tag"
 checksum_file="$tmpdir/SHA256SUMS"
 archive_file="$tmpdir/$archive_name"
 
 progress_done "Release $tag selected"
+
+guard_same_version_before_download "$selected_version"
 
 progress_start "Downloading release archive"
 download "$base_url/SHA256SUMS" "$checksum_file" || die "could not download SHA256SUMS for $tag"
@@ -854,6 +916,7 @@ validate_extracted_app "$extracted_app"
 install_parent="$(dirname "$install_dir")"
 mkdir -p "$install_parent"
 lock_dir="$(acquire_lock "$install_parent")"
+stop_if_selected_version_became_installed "$selected_version"
 replace_app_dir "$extracted_app" "$install_dir"
 if [ "$update" -eq 0 ]; then
   write_launcher

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -157,11 +157,13 @@ fi
 green=""
 yellow=""
 red=""
+cyan=""
 reset=""
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
   green="$(printf '\033[32m')"
   yellow="$(printf '\033[33m')"
   red="$(printf '\033[31m')"
+  cyan="$(printf '\033[36m')"
   reset="$(printf '\033[0m')"
 fi
 
@@ -177,24 +179,81 @@ case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
     fail_mark="$(printf '\342\234\227')"
     ;;
 esac
+progress_frames="$(printf '| / - \134')"
+
+progress_enabled=0
+progress_pid=""
+progress_rendered_file=""
+if [ -t 1 ] && [ -z "${CI:-}" ] && [ "${TERM:-}" != "dumb" ] && [ -w /dev/tty ]; then
+  progress_enabled=1
+fi
+
+progress_render() {
+  progress_message="$1"
+  sleep 0.2
+  while :; do
+    # shellcheck disable=SC2086 # Frames are intentionally split on spaces.
+    for progress_frame in $progress_frames; do
+      : > "$progress_rendered_file"
+      printf '\r\033[2K%s%s%s %s' "$cyan" "$progress_frame" "$reset" "$progress_message" > /dev/tty
+      sleep 0.15
+    done
+  done
+}
+
+progress_stop() {
+  saved_progress_pid="${progress_pid:-}"
+  saved_progress_rendered_file="${progress_rendered_file:-}"
+  progress_pid=""
+  progress_rendered_file=""
+
+  if [ -n "$saved_progress_pid" ]; then
+    kill "$saved_progress_pid" 2>/dev/null || :
+    wait "$saved_progress_pid" 2>/dev/null || :
+  fi
+  if [ "$progress_enabled" -eq 1 ] && [ -n "$saved_progress_rendered_file" ] && [ -f "$saved_progress_rendered_file" ]; then
+    printf '\r\033[2K' > /dev/tty 2>/dev/null || :
+  fi
+  [ -z "$saved_progress_rendered_file" ] || rm -f "$saved_progress_rendered_file"
+}
+
+progress_start() {
+  progress_stop
+  [ "$progress_enabled" -eq 1 ] || return 0
+
+  progress_rendered_file="$tmpdir/.progress-rendered"
+  rm -f "$progress_rendered_file"
+  progress_render "$1" &
+  progress_pid=$!
+}
+
+progress_done() {
+  progress_stop
+  ok "$1"
+}
 
 info() {
+  progress_stop
   printf '%s\n' "$*"
 }
 
 ok() {
+  progress_stop
   printf '%s%s%s %s\n' "$green" "$ok_mark" "$reset" "$*"
 }
 
 warn() {
+  progress_stop
   printf '%s%s%s %s\n' "$yellow" "$warn_mark" "$reset" "$*" >&2
 }
 
 warn_detail() {
+  progress_stop
   printf '%s\n' "$*" >&2
 }
 
 die() {
+  progress_stop
   printf '%s%s%s %s\n' "$red" "$fail_mark" "$reset" "$*" >&2
   exit 1
 }
@@ -204,6 +263,7 @@ can_prompt() {
 }
 
 launch_installed() {
+  progress_stop
   if [ -r /dev/tty ]; then
     "$install_dir/$binary_name" < /dev/tty
   else
@@ -213,6 +273,7 @@ launch_installed() {
 
 confirm_default_no() {
   prompt="$1"
+  progress_stop
   can_prompt || return 1
   printf '%s [y/N] ' "$prompt" > /dev/tty
   IFS= read -r answer < /dev/tty || answer=
@@ -223,6 +284,7 @@ confirm_default_no() {
 }
 
 die_unavailable() {
+  progress_stop
   printf '%s\n' "install script is currently not available for this release" >&2
   exit 1
 }
@@ -235,12 +297,36 @@ download() {
   url="$1"
   destination="$2"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$url" -o "$destination"
-    return $?
+    if [ "$progress_enabled" -eq 0 ]; then
+      curl -fsSL "$url" -o "$destination"
+      return $?
+    fi
+    if curl -fsSL "$url" -o "$destination" 2>"$tmpdir/download.stderr"; then
+      return 0
+    else
+      download_status=$?
+    fi
+    progress_stop
+    while IFS= read -r download_detail || [ -n "$download_detail" ]; do
+      warn_detail "$download_detail"
+    done < "$tmpdir/download.stderr"
+    return "$download_status"
   fi
   if command -v wget >/dev/null 2>&1; then
-    wget -q -O "$destination" "$url"
-    return $?
+    if [ "$progress_enabled" -eq 0 ]; then
+      wget -q -O "$destination" "$url"
+      return $?
+    fi
+    if wget -q -O "$destination" "$url" 2>"$tmpdir/download.stderr"; then
+      return 0
+    else
+      download_status=$?
+    fi
+    progress_stop
+    while IFS= read -r download_detail || [ -n "$download_detail" ]; do
+      warn_detail "$download_detail"
+    done < "$tmpdir/download.stderr"
+    return "$download_status"
   fi
   die "required command not found: curl or wget"
 }
@@ -361,7 +447,7 @@ validate_tar_listing() {
   tar -tzf "$archive" | while IFS= read -r entry; do
     case "$entry" in
       "" | /* | ../* | */../* | */..)
-        echo "unsafe archive path: $entry" >&2
+        warn_detail "unsafe archive path: $entry"
         exit 1
         ;;
     esac
@@ -631,12 +717,8 @@ maybe_update_path() {
   should_modify=0
   if [ "$yes" -eq 1 ]; then
     should_modify=1
-  elif [ "$non_interactive" -eq 0 ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
-    printf 'Add %s to PATH in your shell profile? [y/N] ' "$bin_dir" > /dev/tty
-    IFS= read -r answer < /dev/tty || answer=
-    case "$answer" in
-      y | Y | yes | YES) should_modify=1 ;;
-    esac
+  elif confirm_default_no "Add $bin_dir to PATH in your shell profile?"; then
+    should_modify=1
   fi
 
   if [ "$should_modify" -eq 1 ]; then
@@ -696,6 +778,7 @@ need_cmd awk
 
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/claude-rs-install.XXXXXX")"
 cleanup() {
+  progress_stop
   [ -z "${lock_dir:-}" ] || rm -rf "$lock_dir"
   rm -rf "$tmpdir"
 }
@@ -733,26 +816,30 @@ info ""
 ok "$target_label detected"
 ok "Install location: $install_dir"
 
+progress_start "Resolving release"
 tag="$(resolve_tag "$release")"
 archive_name="$(archive_name_for_target "$target")"
 base_url="https://github.com/$repo_slug/releases/download/$tag"
 checksum_file="$tmpdir/SHA256SUMS"
 archive_file="$tmpdir/$archive_name"
 
-ok "Release $tag selected"
+progress_done "Release $tag selected"
 
+progress_start "Downloading release archive"
 download "$base_url/SHA256SUMS" "$checksum_file" || die "could not download SHA256SUMS for $tag"
 if ! download "$base_url/$archive_name" "$archive_file"; then
   die_unavailable
 fi
-ok "Downloaded release archive"
+progress_done "Downloaded release archive"
 
+progress_start "Verifying release archive"
 expected_sha="$(checksum_for_archive "$checksum_file" "$archive_name")"
 [ -n "$expected_sha" ] || die "SHA256SUMS does not contain dist-install/$archive_name"
 actual_sha="$(sha256_file "$archive_file")"
 [ "$actual_sha" = "$expected_sha" ] || die "checksum mismatch for $archive_name"
-ok "Verified release archive integrity"
+progress_done "Verified release archive integrity"
 
+progress_start "Installing files"
 validate_tar_listing "$archive_file"
 extract_dir="$tmpdir/extract"
 mkdir -p "$extract_dir"
@@ -771,7 +858,7 @@ replace_app_dir "$extracted_app" "$install_dir"
 if [ "$update" -eq 0 ]; then
   write_launcher
 fi
-ok "Installed files"
+progress_done "Installed files"
 
 if [ "$update" -eq 0 ]; then
   maybe_update_path
@@ -782,19 +869,21 @@ fi
 PATH="$bin_dir:$PATH"
 export PATH
 
+progress_start "Verifying installed command"
 version_output="$("$install_dir/$binary_name" --version)" ||
   die "installed claude-rs did not run successfully"
 [ -n "$version_output" ] || die "installed claude-rs did not print a version"
 "$install_dir/$binary_name" --help >/dev/null ||
   die "installed claude-rs help check failed"
-ok "Verified $version_output"
+progress_done "Verified $version_output"
 
 if [ "$verify" -eq 1 ]; then
+  progress_start "Running runtime diagnostics"
   doctor_output="$("$install_dir/$binary_name" doctor --strict 2>&1)" || {
-    [ -z "$doctor_output" ] || printf '%s\n' "$doctor_output"
+    [ -z "$doctor_output" ] || info "$doctor_output"
     die "runtime diagnostics failed"
   }
-  ok "Runtime diagnostics passed"
+  progress_done "Runtime diagnostics passed"
 fi
 
 # Only offer to remove an existing npm install after the script install has

--- a/scripts/install/test-install-progress.ps1
+++ b/scripts/install/test-install-progress.ps1
@@ -1,0 +1,218 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$installerPath = Join-Path $PSScriptRoot "install.ps1"
+$tokens = $null
+$parseErrors = $null
+$installerAst = [System.Management.Automation.Language.Parser]::ParseFile(
+    $installerPath,
+    [ref]$tokens,
+    [ref]$parseErrors
+)
+if ($parseErrors) {
+    throw "install.ps1 contains parser errors: $($parseErrors -join '; ')"
+}
+
+$progressCommands = @($installerAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -eq "Write-Progress"
+}, $true))
+if ($progressCommands.Count -ne 0) {
+    throw "install.ps1 must use the inline spinner instead of Write-Progress"
+}
+
+$helperNames = @(
+    "New-InstallerProgressWorker",
+    "Close-InstallerProgressWorker",
+    "Stop-InstallerProgress",
+    "Start-InstallerProgress",
+    "Complete-InstallerProgress",
+    "Write-InstallerLine",
+    "Write-Ok",
+    "Write-WarnLine",
+    "Write-WarnDetail",
+    "Write-FailLine",
+    "Write-InstallerDiagnostic",
+    "Test-CanPrompt",
+    "Confirm-DefaultNo"
+)
+$helperDefinitions = @($installerAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $helperNames -contains $node.Name
+}, $true))
+if ($helperDefinitions.Count -ne $helperNames.Count) {
+    $loadedNames = @($helperDefinitions | ForEach-Object { $_.Name })
+    $missingNames = @($helperNames | Where-Object { $loadedNames -notcontains $_ })
+    throw "Could not load installer helper definitions: $($missingNames -join ', ')"
+}
+Invoke-Expression (($helperDefinitions | ForEach-Object { $_.Extent.Text }) -join [Environment]::NewLine)
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -ne $Actual) {
+        throw "$Message (expected '$Expected', got '$Actual')"
+    }
+}
+
+$UseColor = $false
+$OkMark = [char]0x2713
+$FailMark = [char]0x2717
+$NonInteractive = $true
+$script:InstallerProgressSupported = $true
+$script:InstallerProgressActive = $false
+$script:InstallerProgressWorker = $null
+
+# Exercise the real background runspace with Console.Out captured. This verifies
+# that the renderer emits an inline animated line and that stopping it erases
+# the line without relying on the host-native progress area.
+$originalConsoleOut = [Console]::Out
+$spinnerOutputWriter = New-Object System.IO.StringWriter
+$spinnerOutput = ""
+[Console]::SetOut($spinnerOutputWriter)
+try {
+    Start-InstallerProgress "Downloading release archive"
+    Start-Sleep -Milliseconds 1000
+    Assert-True $script:InstallerProgressActive "Real inline spinner did not become active"
+    Assert-True ($null -ne $script:InstallerProgressWorker) "Real inline spinner did not retain its worker"
+    Stop-InstallerProgress
+} finally {
+    Stop-InstallerProgress
+    [Console]::SetOut($originalConsoleOut)
+    $spinnerOutput = $spinnerOutputWriter.ToString()
+    $spinnerOutputWriter.Dispose()
+}
+Assert-True $spinnerOutput.Contains("`r| Downloading release archive") "Inline spinner did not render its vertical frame"
+Assert-True $spinnerOutput.Contains("`r/ Downloading release archive") "Inline spinner did not render its slash frame"
+Assert-True $spinnerOutput.Contains("`r- Downloading release archive") "Inline spinner did not render its dash frame"
+Assert-True $spinnerOutput.Contains("`r\ Downloading release archive") "Inline spinner did not render its backslash frame"
+Assert-True (-not $spinnerOutput.Contains("Installing claude-rs")) "Inline spinner rendered a host-style progress banner"
+Assert-True (-not $script:InstallerProgressActive) "Real inline spinner remained active after stop"
+Assert-True ($null -eq $script:InstallerProgressWorker) "Real inline spinner retained its worker after stop"
+Assert-Equal "SilentlyContinue" $ProgressPreference "Real inline spinner changed the outer progress preference"
+
+$fastOutputWriter = New-Object System.IO.StringWriter
+$fastOutput = ""
+[Console]::SetOut($fastOutputWriter)
+try {
+    $script:InstallerProgressSupported = $true
+    Start-InstallerProgress "Resolving release"
+    Start-Sleep -Milliseconds 50
+    Stop-InstallerProgress
+} finally {
+    Stop-InstallerProgress
+    [Console]::SetOut($originalConsoleOut)
+    $fastOutput = $fastOutputWriter.ToString()
+    $fastOutputWriter.Dispose()
+}
+Assert-Equal "" $fastOutput "A fast operation rendered or cleared a spinner before the delay elapsed"
+Assert-True (-not $script:InstallerProgressActive) "Delayed spinner remained active after an early stop"
+Assert-True ($null -eq $script:InstallerProgressWorker) "Delayed spinner retained its worker after an early stop"
+
+$script:RecordedEvents = New-Object System.Collections.ArrayList
+function New-InstallerProgressWorker {
+    param([string]$Message)
+    [void]$script:RecordedEvents.Add([pscustomobject]@{
+        Kind = "SpinnerStart"
+        Message = $Message
+    })
+    return [pscustomobject]@{
+        Message = $Message
+        Width = $Message.Length + 2
+    }
+}
+
+function Close-InstallerProgressWorker {
+    param($Worker)
+    [void]$script:RecordedEvents.Add([pscustomobject]@{
+        Kind = "SpinnerStop"
+        Message = $Worker.Message
+    })
+}
+
+function Write-Host {
+    param(
+        [Parameter(Position = 0)]
+        [object]$Object,
+        [ConsoleColor]$ForegroundColor,
+        [switch]$NoNewline
+    )
+    [void]$script:RecordedEvents.Add([pscustomobject]@{
+        Kind = "Host"
+        Text = [string]$Object
+        ForegroundColor = $ForegroundColor
+        NoNewline = [bool]$NoNewline
+    })
+}
+
+function Reset-RecordedEvents {
+    $script:RecordedEvents.Clear()
+}
+
+function Assert-OutputBoundaryClearsProgress {
+    param([string]$Name, [scriptblock]$Action)
+    $script:InstallerProgressSupported = $true
+    Start-InstallerProgress "active $Name"
+    Reset-RecordedEvents
+    & $Action
+    Assert-True ($script:RecordedEvents.Count -ge 1) "$Name did not clear the active spinner"
+    Assert-Equal "SpinnerStop" $script:RecordedEvents[0].Kind "$Name did not stop progress before output"
+    Assert-True (-not $script:InstallerProgressActive) "$Name left progress active"
+    Assert-True ($null -eq $script:InstallerProgressWorker) "$Name retained the progress worker"
+    Assert-Equal "SilentlyContinue" $ProgressPreference "$Name changed the outer progress preference"
+}
+
+Reset-RecordedEvents
+$script:InstallerProgressSupported = $false
+$script:InstallerProgressActive = $false
+$script:InstallerProgressWorker = $null
+Start-InstallerProgress "disabled"
+Assert-Equal 0 $script:RecordedEvents.Count "Disabled progress started a spinner"
+Assert-True (-not $script:InstallerProgressActive) "Disabled progress became active"
+Assert-True ($null -eq $script:InstallerProgressWorker) "Disabled progress created a worker"
+
+$script:InstallerProgressSupported = $true
+Start-InstallerProgress "Downloading release archive"
+Assert-Equal 1 $script:RecordedEvents.Count "Progress start emitted an unexpected event sequence"
+Assert-Equal "SpinnerStart" $script:RecordedEvents[0].Kind "Progress start emitted the wrong event"
+Assert-Equal "Downloading release archive" $script:RecordedEvents[0].Message "Progress start used the wrong message"
+Assert-True $script:InstallerProgressActive "Progress start did not become active"
+Assert-True ($null -ne $script:InstallerProgressWorker) "Progress start did not retain its worker"
+
+Complete-InstallerProgress "Downloaded release archive"
+Assert-Equal 3 $script:RecordedEvents.Count "Progress completion emitted an unexpected event sequence"
+Assert-Equal "SpinnerStop" $script:RecordedEvents[1].Kind "Progress completion did not stop the spinner"
+Assert-Equal "Host" $script:RecordedEvents[2].Kind "Progress completion did not print the success line last"
+Assert-Equal "$OkMark Downloaded release archive" $script:RecordedEvents[2].Text "Progress completion changed the success line"
+Assert-True (-not $script:InstallerProgressActive) "Progress completion left the spinner active"
+Assert-True ($null -eq $script:InstallerProgressWorker) "Progress completion retained the worker"
+
+Reset-RecordedEvents
+$script:InstallerProgressSupported = $true
+Start-InstallerProgress "repeated stop"
+Reset-RecordedEvents
+Stop-InstallerProgress
+Stop-InstallerProgress
+Assert-Equal 1 $script:RecordedEvents.Count "Repeated progress stop emitted extra events"
+Assert-Equal "SpinnerStop" $script:RecordedEvents[0].Kind "Progress stop emitted the wrong event"
+
+Assert-OutputBoundaryClearsProgress "normal status" {
+    Write-InstallerLine -Mark $OkMark -Message "normal status" -Color Green
+}
+Assert-OutputBoundaryClearsProgress "warning" { Write-WarnLine "warning" }
+Assert-OutputBoundaryClearsProgress "warning detail" { Write-WarnDetail "warning detail" }
+Assert-OutputBoundaryClearsProgress "failure" { Write-FailLine "failure" }
+Assert-OutputBoundaryClearsProgress "prompt" { [void](Confirm-DefaultNo "prompt") }
+Assert-OutputBoundaryClearsProgress "diagnostic" { Write-InstallerDiagnostic "diagnostic" }
+
+Assert-Equal "SilentlyContinue" $ProgressPreference "Installer helpers changed the script-wide progress preference"
+Write-Output "PowerShell installer inline progress helper tests passed"

--- a/scripts/install/test-install-version-guard.ps1
+++ b/scripts/install/test-install-version-guard.ps1
@@ -1,0 +1,216 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$installerPath = Join-Path $PSScriptRoot "install.ps1"
+$tokens = $null
+$parseErrors = $null
+$installerAst = [System.Management.Automation.Language.Parser]::ParseFile(
+    $installerPath,
+    [ref]$tokens,
+    [ref]$parseErrors
+)
+if ($parseErrors) {
+    throw "install.ps1 contains parser errors: $($parseErrors -join '; ')"
+}
+
+$helperNames = @(
+    "Test-CanPrompt",
+    "Confirm-DefaultNo",
+    "Get-ReleaseVersion",
+    "Get-ScriptInstallInfo",
+    "Test-ScriptInstallDirectory",
+    "Confirm-SameVersionReinstall"
+)
+$helperDefinitions = @($installerAst.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $helperNames -contains $node.Name
+}, $true))
+if ($helperDefinitions.Count -ne $helperNames.Count) {
+    $loadedNames = @($helperDefinitions | ForEach-Object { $_.Name })
+    $missingNames = @($helperNames | Where-Object { $loadedNames -notcontains $_ })
+    throw "Could not load installer version-guard helpers: $($missingNames -join ', ')"
+}
+Invoke-Expression (($helperDefinitions | ForEach-Object { $_.Extent.Text }) -join [Environment]::NewLine)
+
+# The decision helper only needs the prompt result. Progress lifecycle behavior
+# is covered independently by test-install-progress.ps1.
+function Stop-InstallerProgress {}
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -cne $Actual) {
+        throw "$Message (expected '$Expected', got '$Actual')"
+    }
+}
+
+function New-OwnedInstall {
+    param([string]$Path, [string]$Version)
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    $packageJson = [pscustomobject]@{
+        name = "claude-code-rust"
+        version = $Version
+    } | ConvertTo-Json
+    [IO.File]::WriteAllText((Join-Path $Path "package.json"), "$packageJson$([Environment]::NewLine)")
+    [IO.File]::WriteAllText((Join-Path $Path "claude-rs.exe"), "existing binary")
+    [IO.File]::WriteAllText((Join-Path $Path "claude-rs-bridge-bun.exe"), "existing runtime")
+}
+
+function Invoke-InstallerScenario {
+    param(
+        [string]$RequestedRelease,
+        [ValidateSet("Default", "Update", "Yes", "Latest")]
+        [string]$Mode = "Default"
+    )
+
+    $sandbox = Join-Path ([IO.Path]::GetTempPath()) "claude-rs-version-guard-test-$PID-$([Guid]::NewGuid().ToString('N'))"
+    $installDir = Join-Path $sandbox "install"
+    $wrapperPath = Join-Path $sandbox "invoke-installer.ps1"
+    $downloadLog = Join-Path $sandbox "downloads.log"
+    $selectedVersion = "9.8.7-preview.1+build.5"
+    New-OwnedInstall -Path $installDir -Version $selectedVersion
+
+    $wrapper = @'
+param(
+    [string]$InstallerPath,
+    [string]$InstallDir,
+    [string]$RequestedRelease,
+    [string]$Mode,
+    [string]$DownloadLog,
+    [string]$LatestTag
+)
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+Get-ChildItem Env:CLAUDE_RS_* -ErrorAction SilentlyContinue | Remove-Item -ErrorAction SilentlyContinue
+$env:CLAUDE_RS_NON_INTERACTIVE = "1"
+
+function Invoke-WebRequest {
+    param([string]$Uri, [string]$OutFile)
+    Add-Content -LiteralPath $DownloadLog -Value $Uri
+    if ($Mode -eq "Latest" -and $Uri.EndsWith("/releases/latest", [StringComparison]::Ordinal)) {
+        [IO.File]::WriteAllText($OutFile, "{`"tag_name`":`"$LatestTag`"}")
+        return
+    }
+    throw "mock release payload download blocked: $Uri"
+}
+
+$installerArgs = @{
+    Release = $RequestedRelease
+    InstallDir = $InstallDir
+    NoModifyPath = $true
+    KeepNpm = $true
+}
+if ($Mode -eq "Update") {
+    $installerArgs["Update"] = $true
+}
+if ($Mode -eq "Yes") {
+    $installerArgs["Yes"] = $true
+}
+& $InstallerPath @installerArgs
+'@
+    [IO.File]::WriteAllText($wrapperPath, $wrapper)
+
+    $engine = (Get-Process -Id $PID).Path
+    try {
+        $previousErrorActionPreference = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        try {
+            $outputLines = @(& $engine -NoLogo -NoProfile -File $wrapperPath `
+                -InstallerPath $installerPath `
+                -InstallDir $installDir `
+                -RequestedRelease $RequestedRelease `
+                -Mode $Mode `
+                -DownloadLog $downloadLog `
+                -LatestTag "v$selectedVersion" 2>&1)
+            $status = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
+        $downloads = @()
+        if (Test-Path -LiteralPath $downloadLog -PathType Leaf) {
+            $downloads = @(Get-Content -LiteralPath $downloadLog)
+        }
+        $installedPackage = Get-Content -LiteralPath (Join-Path $installDir "package.json") -Raw | ConvertFrom-Json
+        return [pscustomobject]@{
+            Status = $status
+            Output = ($outputLines | Out-String)
+            Downloads = $downloads
+            InstalledVersion = [string]$installedPackage.version
+        }
+    } finally {
+        Remove-Item -LiteralPath $sandbox -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$RootPackage = "claude-code-rust"
+$NonInteractive = $true
+$InstallDir = "C:\test\claude-rs"
+
+Assert-Equal "1.2.3-preview.1+build.5" (Get-ReleaseVersion -Tag "v1.2.3-preview.1+build.5") "Release normalization did not remove exactly one v prefix"
+Assert-Equal "Version1" (Get-ReleaseVersion -Tag "Version1") "Release normalization removed non-prefix version characters"
+
+$metadataSandbox = Join-Path ([IO.Path]::GetTempPath()) "claude-rs-version-metadata-test-$PID"
+try {
+    Remove-Item -LiteralPath $metadataSandbox -Recurse -Force -ErrorAction SilentlyContinue
+    New-OwnedInstall -Path $metadataSandbox -Version "1.2.3-preview.1+build.5"
+    $installInfo = Get-ScriptInstallInfo -Path $metadataSandbox
+    Assert-True ($null -ne $installInfo) "Installer-owned metadata was not recognized"
+    Assert-Equal "1.2.3-preview.1+build.5" $installInfo.Version "Installer-owned version was not read exactly"
+    Assert-True (Test-ScriptInstallDirectory -Path $metadataSandbox) "Installer-owned directory check rejected valid metadata"
+} finally {
+    Remove-Item -LiteralPath $metadataSandbox -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$Update = $true
+$Yes = $true
+Assert-True (-not (Confirm-SameVersionReinstall -Version "1.2.3")) "Update mode allowed a same-version reinstall"
+$Update = $false
+$Yes = $true
+Assert-True (Confirm-SameVersionReinstall -Version "1.2.3") "-Yes did not approve a same-version reinstall"
+$Yes = $false
+Assert-True (-not (Confirm-SameVersionReinstall -Version "1.2.3")) "Non-interactive mode approved a same-version reinstall"
+
+$selectedVersion = "9.8.7-preview.1+build.5"
+$selectedTag = "v$selectedVersion"
+
+$defaultResult = Invoke-InstallerScenario -RequestedRelease $selectedTag
+Assert-Equal 0 $defaultResult.Status "Pinned same-version install did not exit successfully: $($defaultResult.Output)"
+Assert-True $defaultResult.Output.Contains("already installed; no changes made") "Pinned same-version install did not report its no-op"
+Assert-Equal 0 $defaultResult.Downloads.Count "Pinned same-version install attempted a release download"
+Assert-Equal $selectedVersion $defaultResult.InstalledVersion "Pinned same-version no-op changed installed metadata"
+
+$updateResult = Invoke-InstallerScenario -RequestedRelease $selectedTag -Mode "Update"
+Assert-Equal 0 $updateResult.Status "Same-version update did not exit successfully"
+Assert-True $updateResult.Output.Contains("already installed; no changes made") "Same-version update did not report its no-op"
+Assert-True (-not $updateResult.Output.Contains("Reinstalling claude-rs")) "Same-version update attempted a reinstall"
+Assert-Equal 0 $updateResult.Downloads.Count "Same-version update attempted a release download"
+
+$yesResult = Invoke-InstallerScenario -RequestedRelease $selectedTag -Mode "Yes"
+Assert-True ($yesResult.Status -ne 0) "Mock release payload failure did not stop the -Yes reinstall"
+Assert-True $yesResult.Output.Contains("Reinstalling claude-rs $selectedVersion") "-Yes did not report a same-version reinstall"
+Assert-Equal 1 $yesResult.Downloads.Count "-Yes reinstall made an unexpected number of download attempts"
+Assert-True $yesResult.Downloads[0].EndsWith("/$selectedTag/SHA256SUMS", [StringComparison]::Ordinal) "-Yes reinstall did not reach the checksum download"
+
+$latestResult = Invoke-InstallerScenario -RequestedRelease "latest" -Mode "Latest"
+Assert-Equal 0 $latestResult.Status "Latest same-version install did not exit successfully"
+Assert-True $latestResult.Output.Contains("Release $selectedTag selected") "Latest same-version install did not resolve the expected release"
+Assert-True $latestResult.Output.Contains("already installed; no changes made") "Latest same-version install did not report its no-op"
+Assert-Equal 1 $latestResult.Downloads.Count "Latest same-version install requested release payloads"
+Assert-True $latestResult.Downloads[0].EndsWith("/releases/latest", [StringComparison]::Ordinal) "Latest same-version install did not limit network access to metadata"
+
+$differentlyCasedTag = "v9.8.7-Preview.1+build.5"
+$differentResult = Invoke-InstallerScenario -RequestedRelease $differentlyCasedTag
+Assert-True ($differentResult.Status -ne 0) "Mock release payload failure did not stop the distinct release install"
+Assert-True (-not $differentResult.Output.Contains("already installed; no changes made")) "Release comparison ignored prerelease identifier casing"
+Assert-Equal 1 $differentResult.Downloads.Count "Distinct release install made an unexpected number of download attempts"
+Assert-True $differentResult.Downloads[0].EndsWith("/$differentlyCasedTag/SHA256SUMS", [StringComparison]::Ordinal) "Distinct release install did not reach the checksum download"
+
+Write-Output "PowerShell installer version guard tests passed"


### PR DESCRIPTION
## Summary

- Add consistent inline installer progress for Windows PowerShell, macOS, and Linux.
- Preserve clean, script-friendly output for CI, redirected streams, and `NO_COLOR` environments, including safe spinner cleanup around prompts, errors, and completion.
- Add same-version installation guards using the installer-owned version metadata, with an interactive default-no prompt, explicit `--yes`/`-Yes` reinstall overrides, and an idempotent `--update` path.
- Add cross-platform regression coverage, CI validation, documentation, and normalized LF endings for installer scripts.

## Why

Installer runs can take long enough that users need clear feedback, while repeated runs for the version already installed should not download and replace the same release unnecessarily. This change improves interactive progress without compromising automation and makes repeat installs safer and predictable across Windows and Unix-like systems.

Closes #

## Validation

- Automated:
  - `cargo fmt --all -- --check`
  - `cargo check --offline`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test` (all tests passed)
  - ShellCheck for `scripts/install/install.sh`
  - Windows PowerShell 5.1 progress and version-guard tests
  - Linux-container Unix progress and version-guard tests, including the full archive installation flow
- Manual:
  - Verified spinner rendering and cleanup across PowerShell, macOS, and Linux, with plain output for CI and redirected streams.
  - Verified pinned and `latest` same-version installs stop before checksum/archive downloads; `--yes`/`-Yes` reinstalls; and `--update` exits successfully without reinstalling an up-to-date version.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: README, installation guide, scripts README, and CI validation instructions.
- Governance/release impact: N/A
