### PR TITLE
ci(workflows): label the MSRV toolchain pin as stable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # master
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: "1.88.0"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2


### PR DESCRIPTION
## Summary

<!-- What changed -->

Corrects the trailing ref comment on the `dtolnay/rust-toolchain` pin in the MSRV job (`.github/workflows/nightly.yml:65`) from `# master` to `# stable`. One word; no SHA, job, or behaviour change.

## Why

<!-- Why this change is needed -->

#275 bumped that pin's SHA to `4be7066`, which is the head of the action's `stable` branch, but Dependabot left the existing `# master` comment in place. The repo has ten `dtolnay/rust-toolchain` pins across `_release-build.yml`, `docs.yml`, `nightly.yml`, and `pr.yml`; all ten now carry the identical SHA, and nine already read `# stable`. The MSRV job was the lone holdout, so the file claimed two different refs for the same commit.

That is misleading rather than broken — the SHA is what actually gets resolved — but a wrong ref label is exactly the kind of thing that misreads during a pin audit.

Closes #

## Validation

- Automated: CI on this PR. The MSRV job passes `toolchain: "1.88.0"` explicitly, so the only difference between the `master` and `stable` branches of the action (the `stable` branch defaults the `toolchain` input) is inert here.
- Manual: `git grep "# master" -- .github` returns no matches; `git grep "rust-toolchain@"` shows all ten pins on the same SHA with a consistent `# stable` label.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: N/A
- Changelog: intentionally omitted; comment-only change with no user-facing effect.
