### PR TITLE
ci: correct the MSRV pin label and group codeql-action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,13 @@ updates:
       - "area: ci"
     commit-message:
       prefix: "ci"
+    groups:
+      # codeql-action/init and codeql-action/analyze must run the same version:
+      # analyze rejects a config file written by a different init version. Split
+      # across two PRs, each one fails on its own and only passes once both land.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   # npm dependencies (root package)
   - package-ecosystem: "npm"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # master
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: "1.88.0"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2


### PR DESCRIPTION
## Summary

<!-- What changed -->

Two pieces of CI pin hygiene, both fallout from this week's Dependabot batch:

1. **`.github/workflows/nightly.yml`** — corrects the trailing ref comment on the MSRV job's `dtolnay/rust-toolchain` pin from `# master` to `# stable`. One word; no SHA, job, or behaviour change.
2. **`.github/dependabot.yml`** — adds a `codeql-action` group so `github/codeql-action/init` and `github/codeql-action/analyze` are bumped in a single PR instead of two.

## Why

<!-- Why this change is needed -->

**The pin label.** #275 bumped that pin's SHA to `4be7066`, the head of the action's `stable` branch, but Dependabot left the existing `# master` comment in place. The repo has ten `dtolnay/rust-toolchain` pins across `_release-build.yml`, `docs.yml`, `nightly.yml`, and `pr.yml`; all ten now carry the identical SHA, and nine already read `# stable`. The MSRV job was the lone holdout, so the file claimed two different refs for the same commit. That is misleading rather than broken — the SHA is what actually gets resolved — but a wrong ref label is exactly what misreads during a pin audit.

**The grouping.** `codeql-action/init` and `codeql-action/analyze` must run the same version: `analyze` rejects a config file written by a different `init` version, failing with `Loaded a configuration file for version 'X', but running version 'Y'`. Dependabot tracks the two as separate dependencies, so the 4.37.0 bump arrived as #274 and #276 — each red on its own, green only once both landed. Without a group this recurs on every CodeQL release, and each time it looks like a broken update rather than a split one. Grouping them makes the pair atomic.

Closes #

## Validation

- Automated: CI on this PR. The MSRV job passes `toolchain: "1.88.0"` explicitly, so the only difference between the action's `master` and `stable` branches (the `stable` branch defaults the `toolchain` input) is inert here.
- Manual: `git grep "# master" -- .github` returns no matches; `git grep "rust-toolchain@"` shows all ten pins on one SHA with a consistent `# stable` label. The new `groups:` block mirrors the existing `npm-minor-patch` groups already in this file; it takes effect on Dependabot's next run and cannot be exercised before merge.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: N/A
- Changelog: intentionally omitted; CI-config only, no user-facing effect.
- Supersedes #283, which was closed automatically when this branch was renamed.
