### PR TITLE
feat(agent-sdk): migrate to 0.3.214

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 
 - **Installer progress and idempotency** (#281, @srothgan): Add inline installer progress across PowerShell, macOS, and Linux while keeping CI output plain, and make same-version reinstalls a prompted opt-in with `--yes`/`-Yes` approval.
 
+### CI and Dependencies
+
+- **Claude Agent SDK update** (#285, @srothgan): Bump the bundled bridge to Agent SDK `0.3.214`, preserve subagent model routes, retry and Bash timeout state, keep Grep and Artifact output accurate, and disable new review-dependent tools until the TUI can present them safely.
+
 ## [0.14.0] - 2026-07-12 [Changes][v0.14.0]
 
 ### Features

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.207"
+        "@anthropic-ai/claude-agent-sdk": "0.3.214"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.3",
@@ -22,22 +22,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.207.tgz",
-      "integrity": "sha512-y0PkQRmQBi96MHiN5Xzfq+GaddxCZCqI/cXEQBLYBLXGa4i1nDSlulQqkMBj2RorrrSGQJ6Wdw+uhu6OfHNPzA==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.214.tgz",
+      "integrity": "sha512-wt5ImwhU+p259Zt4K/Q9v5xVi6ruxYO5+KFICyJxnjs/QFEClAeSRqhcXx1J8jgGfatPW1faw09hkm66680UjA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.207"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.214"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.207.tgz",
-      "integrity": "sha512-08xSo1FDx8h0aLhL5tvcRxa2SMmcUV3aDWeZiEJVTclyiDAs61BgTjAxCg+SZcu1CndjJO8cfO0yM5dhamxz3g==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.214.tgz",
+      "integrity": "sha512-vAAOeVtlXs3p7MpFVfvfu9ja32eaKtB+MDZnPxCbdzxJk5nofCHlNsHa1UJwXHOsP9lOnFYNIccYztsZ4DNaJA==",
       "cpu": [
         "arm64"
       ],
@@ -59,9 +59,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.207.tgz",
-      "integrity": "sha512-1o7K4EYqyCixZ/oeOZSh7AzSy6TM86xoOuf4VuORjPSS31hBnoqY0NGZd27+2VDs9LGtsdksmsTqcNGx9xd1hA==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.214.tgz",
+      "integrity": "sha512-NTbV8U2yucxCWqEiDC7L0MUehNmd8x3Op8OGzLZRhMF3xmQBy2DxpXiNZgSwwKWNDC3HdgKmJM5ZBbT7XrF/0g==",
       "cpu": [
         "x64"
       ],
@@ -72,9 +72,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.207.tgz",
-      "integrity": "sha512-X4uezYOifDiNTTmmugfRCdg3nNamrr1LFRY9hg30vWYTShL+bbN+nfC3KaFfSYCl4GTtsEEUbYdOTC2F3bBpcA==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.214.tgz",
+      "integrity": "sha512-KBCf+BlusG0ZcgvpjjHwv1kh+6WiR8vJbPjpR2udwkrtcQgKLN+24l+FeaQEzO2TL+ExCmM1KC4tNPvnPpy+tw==",
       "cpu": [
         "arm64"
       ],
@@ -88,9 +88,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.207.tgz",
-      "integrity": "sha512-oPj+g2DslhH4Y9nCTs7al4t9wZv78FZwLFQwOCg99BXuz1o0ZOpKmxyvR7J9eBR+GPszeMMS8gYplQTiZC9o2w==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.214.tgz",
+      "integrity": "sha512-i06wQRsmevE7spY1ryYfs+NP+xdZ1FwAyTjDaF0k/xG+cgtzZYghTFUemdYF3GVwgWgpcava9GiCFDT3DoHI6w==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.207.tgz",
-      "integrity": "sha512-Kg6BPH8Ee0ny/oEUWJmvT1jCRBne4jVpRSOMsJcYp1Fav1rMEgpU219oJJs+LWwx4ifuuLtNWedqJNnVw7mnKg==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.214.tgz",
+      "integrity": "sha512-vqadSceJkBKHaTUszxI35uTuECGWtsHWK/mOwIJ4b9DUtYYySz6EJEk4gHg4ccutisJ/oRVCpFXHIKFb+osrKw==",
       "cpu": [
         "x64"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.207.tgz",
-      "integrity": "sha512-uRv+D5oG/7EYr41FAJ9IPo2pZYBe2ZMaA6nSHCeizsgPxCSMtl5bNppmU21+jZJvo4hivObEgkGFERAhdGqygg==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.214.tgz",
+      "integrity": "sha512-948RstHDhs0E69h+2dKYWIAL1kcwEme4zvtgNUwP8XpKXzWOhrTKmd6MAokHn25zwfuSx5d+HE0XHfFH6R4hLg==",
       "cpu": [
         "x64"
       ],
@@ -136,9 +136,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.207.tgz",
-      "integrity": "sha512-9fWpUzfkXlPAg2tf8JpQe7w9avFaomAUbfAwyAmykQgSIf66LwaJjvI5hNqhNqczRKyfsXPn3ei2S5HKlmFP+Q==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.214.tgz",
+      "integrity": "sha512-CEKlPFCPv+ee79utQMEDSsgeo2f27ulhNHpjrKIt1jXz5G04J7lAWN/QwvPDv9XaLBkWpyfqZWiPXlRcwuaO/w==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +149,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.207.tgz",
-      "integrity": "sha512-YPjVT0q6aXEM2MgN4CI6/9fqiTXwETji+4NoPOzCYuqAkhXZqp30Jsk7/NHqYGNNSfURKrsuAoliKB0rsbpbjg==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.214.tgz",
+      "integrity": "sha512-cJMJfFoR9IWBZWnTtt9PnEm89hGOsZjoDNjOCEOF3+x+g/ANIXAjMJTcaQYv2HKh6MylWZ0AkxBASI+twkukaQ==",
       "cpu": [
         "x64"
       ],

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -20,7 +20,7 @@
     "node": ">=24"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.207"
+    "@anthropic-ai/claude-agent-sdk": "0.3.214"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.3",

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -7,6 +7,7 @@ import {
   buildRateLimitUpdate,
   buildRewindConversationPlan,
   buildQueryOptions,
+  buildPromptUserMessage,
   resolveClaudeCodeSpawnCommand,
   canGenerateSessionTitle,
   generatePersistedSessionTitle,
@@ -1316,6 +1317,7 @@ test("buildQueryOptions maps launch settings into sdk query options", () => {
     outputStyle: "Default",
     spinnerTipsEnabled: true,
     terminalProgressBarEnabled: true,
+    feedbackDrafts: "off",
   });
   assert.deepEqual(options.systemPrompt, {
     type: "preset",
@@ -1332,6 +1334,7 @@ test("buildQueryOptions maps launch settings into sdk query options", () => {
   assert.equal(options.agentProgressSummaries, true);
   assert.equal(options.promptSuggestions, true);
   assert.equal(options.enableFileCheckpointing, true);
+  assert.deepEqual(options.disallowedTools, ["ProposeSkills"]);
   assert.equal(options.executable, "bun");
   assert.equal(options.sessionId, "session-1");
   assert.deepEqual(options.settingSources, ["user", "project", "local"]);
@@ -1391,6 +1394,7 @@ test("buildQueryOptions forwards settings and maps startup model and permission 
     outputStyle: "Learning",
     spinnerTipsEnabled: false,
     terminalProgressBarEnabled: false,
+    feedbackDrafts: "off",
   });
   assert.equal("model" in options, false);
   assert.equal(options.permissionMode, "default");
@@ -1506,6 +1510,34 @@ test("buildQueryOptions omits optional startup overrides but keeps bridge guard 
     append: BRIDGE_RUNTIME_GUARD_PROMPT,
   });
   assert.equal("agentProgressSummaries" in options, false);
+  assert.deepEqual(options.settings, { feedbackDrafts: "off" });
+});
+
+test("buildQueryOptions disables feedback drafts without mutating launch settings", () => {
+  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const settings = {
+    feedbackDrafts: "notify",
+    spinnerTipsEnabled: true,
+  };
+  const options = buildQueryOptions({
+    cwd: "C:/work",
+    launchSettings: { settings },
+    provisionalSessionId: "session-feedback",
+    input,
+    canUseTool: async () => ({ behavior: "deny", message: "not used" }),
+    enableSdkDebug: false,
+    enableSpawnDebug: false,
+    sessionIdForLogs: () => "session-feedback",
+  });
+
+  assert.deepEqual(options.settings, {
+    feedbackDrafts: "off",
+    spinnerTipsEnabled: true,
+  });
+  assert.deepEqual(settings, {
+    feedbackDrafts: "notify",
+    spinnerTipsEnabled: true,
+  });
 });
 
 test("dispatchCancelTurnCommand interrupts the matching session query", async () => {
@@ -1681,6 +1713,7 @@ test("buildQueryOptions makes sandbox fallback explicit when enabled", () => {
   });
 
   assert.deepEqual(options.settings, {
+    feedbackDrafts: "off",
     sandbox: {
       enabled: true,
       failIfUnavailable: false,
@@ -1709,6 +1742,7 @@ test("buildQueryOptions preserves explicit sandbox failIfUnavailable setting", (
   });
 
   assert.deepEqual(options.settings, {
+    feedbackDrafts: "off",
     sandbox: {
       enabled: true,
       failIfUnavailable: true,
@@ -3635,6 +3669,165 @@ test("emitToolProgressUpdate does not reopen completed tools", () => {
   assert.equal(session.toolCalls.get("tool-1")?.status, "completed");
 });
 
+test("handleSdkMessage updates and clears subagent retry progress in place", () => {
+  const session = makeSessionState();
+  const toolCall = createToolCall("tool-agent-retry", "Agent", {
+    description: "Review changes",
+    prompt: "Review the branch",
+  });
+  toolCall.status = "in_progress";
+  session.toolCalls.set(toolCall.tool_call_id, toolCall);
+
+  const waitingEvents = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "tool_progress",
+      tool_use_id: toolCall.tool_call_id,
+      tool_name: "Agent",
+      parent_tool_use_id: null,
+      elapsed_time_seconds: 5,
+      heartbeat: true,
+      subagent_type: "reviewer",
+      subagent_retry: {
+        agent_id: "agent-1",
+        attempt: 2,
+        max_retries: 4,
+        retry_delay_ms: 1_500,
+        error_status: 429,
+        error_category: "rate_limit",
+      },
+      uuid: "message-retry-waiting",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(waitingEvents.at(-1), {
+    event: "session_update",
+    session_id: "session-1",
+    update: {
+      type: "tool_call_update",
+      tool_call_update: {
+        tool_call_id: "tool-agent-retry",
+        fields: {
+          task_metadata: {
+            subagent_retry: {
+              state: "waiting",
+              agent_id: "agent-1",
+              attempt: 2,
+              max_retries: 4,
+              retry_delay_ms: 1_500,
+              error_status: 429,
+              error_category: "rate_limit",
+            },
+            subagent_type: "reviewer",
+          },
+        },
+      },
+    },
+  });
+  assert.equal(session.toolCalls.get(toolCall.tool_call_id)?.status, "in_progress");
+  assert.equal(
+    session.toolCalls.get(toolCall.tool_call_id)?.task_metadata?.subagent_retry?.state,
+    "waiting",
+  );
+
+  const clearEvents = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "tool_progress",
+      tool_use_id: toolCall.tool_call_id,
+      tool_name: "Agent",
+      parent_tool_use_id: null,
+      elapsed_time_seconds: 7,
+      heartbeat: true,
+      subagent_type: "reviewer",
+      uuid: "message-retry-cleared",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(clearEvents.at(-1), {
+    event: "session_update",
+    session_id: "session-1",
+    update: {
+      type: "tool_call_update",
+      tool_call_update: {
+        tool_call_id: "tool-agent-retry",
+        fields: {
+          task_metadata: { subagent_retry: { state: "clear" } },
+        },
+      },
+    },
+  });
+  assert.equal(
+    session.toolCalls.get(toolCall.tool_call_id)?.task_metadata?.subagent_retry,
+    undefined,
+  );
+});
+
+test("handleSdkMessage ignores malformed subagent retry progress", () => {
+  const session = makeSessionState();
+  const toolCall = createToolCall("tool-agent-invalid-retry", "Agent", {
+    prompt: "Review the branch",
+  });
+  toolCall.status = "in_progress";
+  session.toolCalls.set(toolCall.tool_call_id, toolCall);
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "tool_progress",
+      tool_use_id: toolCall.tool_call_id,
+      tool_name: "Agent",
+      parent_tool_use_id: null,
+      elapsed_time_seconds: 5,
+      subagent_retry: {
+        agent_id: "agent-1",
+        attempt: 1.5,
+        max_retries: 4,
+        retry_delay_ms: -1,
+        error_status: null,
+        error_category: "rate_limit",
+      },
+      uuid: "message-invalid-retry",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events, []);
+  assert.equal(session.toolCalls.get(toolCall.tool_call_id)?.task_metadata, undefined);
+});
+
+test("emitToolResultUpdate clears active subagent retry metadata", () => {
+  const session = makeSessionState();
+  const toolCall = createToolCall("tool-agent-retry-result", "Agent", {
+    prompt: "Review the branch",
+  });
+  toolCall.status = "in_progress";
+  toolCall.task_metadata = {
+    subagent_retry: {
+      state: "waiting",
+      agent_id: "agent-1",
+      attempt: 2,
+      max_retries: 4,
+      retry_delay_ms: 1_500,
+    },
+  };
+  session.toolCalls.set(toolCall.tool_call_id, toolCall);
+
+  const events = captureBridgeEvents(() => {
+    emitToolResultUpdate(session, toolCall.tool_call_id, false, {
+      agentId: "agent-1",
+      content: [{ type: "text", text: "Done" }],
+      status: "completed",
+      prompt: "Review the branch",
+    });
+  });
+
+  const update = events.at(-1)?.update as Record<string, unknown>;
+  const toolCallUpdate = update.tool_call_update as Record<string, unknown>;
+  const fields = toolCallUpdate.fields as Record<string, unknown>;
+  assert.deepEqual(fields.task_metadata, { subagent_retry: { state: "clear" } });
+  assert.equal(session.toolCalls.get(toolCall.tool_call_id)?.task_metadata?.subagent_retry, undefined);
+});
+
 test("buildQueryOptions trims language before appending system prompt", () => {
   const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
   const options = buildQueryOptions({
@@ -4967,6 +5160,50 @@ test("applySessionEffort uses live flag settings for xhigh and max", async () =>
   assert.deepEqual(calls, [{ effortLevel: "xhigh" }, { effortLevel: "max" }]);
 });
 
+test("buildPromptUserMessage attributes keyboard text input to a human", () => {
+  assert.deepEqual(
+    buildPromptUserMessage(
+      {
+        command: "prompt",
+        session_id: "session-1",
+        chunks: [{ kind: "text", value: "hello" }],
+      },
+      "session-1",
+    ),
+    {
+      type: "user",
+      session_id: "session-1",
+      parent_tool_use_id: null,
+      origin: { kind: "human" },
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      },
+    },
+  );
+});
+
+test("buildPromptUserMessage attributes structured keyboard input to a human", () => {
+  const message = buildPromptUserMessage(
+    {
+      command: "prompt",
+      session_id: "session-1",
+      chunks: [
+        { kind: "text", value: "inspect this" },
+        {
+          kind: "image",
+          value: { mime_type: "image/png", data: "aGVsbG8=" },
+        },
+      ],
+    },
+    "session-1",
+  );
+
+  assert.equal(message?.origin?.kind, "human");
+  assert.equal(Array.isArray(message?.message.content), true);
+  assert.equal(message?.message.content.length, 2);
+});
+
 test("applySessionAgent uses live flag settings for agent switch and reset", async () => {
   const calls: unknown[] = [];
   const query = {
@@ -5042,6 +5279,7 @@ test("shouldEmitStartupAuthRequiredForAccount skips Claude OAuth hint for extern
     "foundry",
     "gateway",
     "anthropicAws",
+    "anthropicGoogleCloud",
     "mantle",
   ] as const) {
     assert.equal(shouldEmitStartupAuthRequiredForAccount({ apiProvider }), false);
@@ -5373,6 +5611,78 @@ test("buildToolResultFields extracts plain-text output", () => {
   ]);
 });
 
+test("new SDK tools retain generic inputs and structured outputs losslessly", () => {
+  const feedbackInput = {
+    type: "bug",
+    title: "Feedback draft",
+    details: "Reproduction details",
+    area: "/feedback",
+  };
+  const feedback = createToolCall("tc-feedback", "SendFeedback", feedbackInput);
+  const feedbackOutput = { success: true, message: "Feedback queued for review." };
+  const feedbackFields = buildToolResultFields(false, feedbackOutput, feedback, feedbackOutput);
+
+  assert.deepEqual(feedback.raw_input, feedbackInput);
+  assert.equal(feedbackFields.raw_output, JSON.stringify(feedbackOutput));
+  assert.deepEqual(feedbackFields.content, [
+    {
+      type: "content",
+      content: { type: "text", text: JSON.stringify(feedbackOutput) },
+    },
+  ]);
+
+  const refreshInput = { server: "docs" };
+  const refresh = createToolCall("tc-refresh", "RefreshMcpTools", refreshInput);
+  const refreshOutput = [
+    {
+      server: "docs",
+      status: "refreshed",
+      toolCount: 3,
+      added: ["lookup"],
+      removed: ["legacy_lookup"],
+    },
+    {
+      server: "offline",
+      status: "not_connected",
+      error: "No live connection",
+    },
+  ];
+  const refreshFields = buildToolResultFields(false, refreshOutput, refresh, refreshOutput);
+
+  assert.deepEqual(refresh.raw_input, refreshInput);
+  assert.equal(refreshFields.raw_output, JSON.stringify(refreshOutput));
+  assert.deepEqual(refreshFields.content, [
+    {
+      type: "content",
+      content: { type: "text", text: JSON.stringify(refreshOutput) },
+    },
+  ]);
+
+  const proposalInput = {
+    proposals: [
+      {
+        name: "diagnose-bridge",
+        kind: "new",
+        description: "Diagnose the bridge",
+        evidence: ["memory/bridge.md"],
+        skillMd: "---\nname: diagnose-bridge\n---\n",
+      },
+    ],
+  };
+  const proposal = createToolCall("tc-propose", "ProposeSkills", proposalInput);
+  const proposalOutput = { proposalCount: 1 };
+  const proposalFields = buildToolResultFields(false, proposalOutput, proposal, proposalOutput);
+
+  assert.deepEqual(proposal.raw_input, proposalInput);
+  assert.equal(proposalFields.raw_output, JSON.stringify(proposalOutput));
+  assert.deepEqual(proposalFields.content, [
+    {
+      type: "content",
+      content: { type: "text", text: JSON.stringify(proposalOutput) },
+    },
+  ]);
+});
+
 test("buildToolResultFields renders structured Grep output", () => {
   const base = createToolCall("tc-grep", "Grep", {
     pattern: "TODO",
@@ -5396,6 +5706,71 @@ test("buildToolResultFields renders structured Grep output", () => {
   assert.deepEqual(fields.content, [
     { type: "content", content: { type: "text", text: expected } },
   ]);
+});
+
+test("buildToolResultFields prefers target Grep totals over legacy counts", () => {
+  const base = createToolCall("tc-grep-totals", "Grep", {
+    pattern: "TODO",
+    path: "src",
+    output_mode: "content",
+  });
+  const fields = buildToolResultFields(false, "raw SDK text", base, {
+    mode: "content",
+    numFiles: 2,
+    totalFiles: 5,
+    filenames: ["src/a.rs", "src/b.rs"],
+    content: "src/a.rs:1:TODO\nsrc/b.rs:2:TODO",
+    numLines: 2,
+    totalLines: 9,
+    numMatches: 2,
+  });
+
+  assert.equal(
+    fields.raw_output,
+    "src/a.rs:1:TODO\nsrc/b.rs:2:TODO\nSummary: 5 files, 2 matches, 9 lines, mode content",
+  );
+});
+
+test("buildToolResultFields omits a contradictory legacy zero Grep file count", () => {
+  const base = createToolCall("tc-grep-unreported-files", "Grep", {
+    pattern: "ToolCallInfo",
+    path: "src",
+    output_mode: "content",
+  });
+  const fields = buildToolResultFields(false, "raw SDK text", base, {
+    mode: "content",
+    numFiles: 0,
+    filenames: [],
+    content: "src/app/mod.rs:1:ToolCallInfo\nsrc/ui/mod.rs:2:ToolCallInfo",
+    numLines: 239,
+    totalLines: 239,
+  });
+
+  assert.equal(
+    fields.raw_output,
+    "src/app/mod.rs:1:ToolCallInfo\nsrc/ui/mod.rs:2:ToolCallInfo\nSummary: 239 lines, mode content",
+  );
+});
+
+test("buildToolResultFields ignores malformed Grep totals without losing output", () => {
+  const base = createToolCall("tc-grep-invalid-totals", "Grep", {
+    pattern: "TODO",
+    output_mode: "content",
+  });
+  const fields = buildToolResultFields(false, "raw SDK text", base, {
+    mode: "content",
+    numFiles: 2,
+    totalFiles: -5,
+    filenames: ["src/a.rs", "src/b.rs"],
+    content: "src/a.rs:1:TODO",
+    numLines: 1,
+    totalLines: "many",
+  });
+
+  assert.equal(
+    fields.raw_output,
+    "src/a.rs:1:TODO\nSummary: 2 files, 1 line, mode content",
+  );
 });
 
 test("buildToolResultFields renders structured empty Grep output", () => {
@@ -5664,6 +6039,52 @@ test("buildToolResultFields adds Bash auto-backgrounded metadata and message", (
       assistant_auto_backgrounded: true,
     },
   });
+});
+
+test("buildToolResultFields preserves Bash timeout and cwd metadata", () => {
+  const base = createToolCall("tc-bash-timeout", "Bash", { command: "npm run watch" });
+  const fields = buildToolResultFields(
+    false,
+    {
+      stdout: "watching",
+      stderr: "",
+      interrupted: false,
+      backgroundTaskId: "task-43",
+      timedOutAfterMs: 10_000.9,
+      backgroundCwdHint: " session cwd unchanged ",
+    },
+    base,
+  );
+
+  assert.equal(
+    fields.raw_output,
+    "watching\nCommand was auto-backgrounded after 10,000 ms with ID: task-43.",
+  );
+  assert.deepEqual(fields.output_metadata, {
+    bash: {
+      timed_out_after_ms: 10_000,
+      background_cwd_hint: "session cwd unchanged",
+    },
+  });
+});
+
+test("buildToolResultFields rejects malformed Bash timeout metadata", () => {
+  const base = createToolCall("tc-bash-invalid-timeout", "Bash", { command: "npm run watch" });
+  const fields = buildToolResultFields(
+    false,
+    {
+      stdout: "",
+      stderr: "",
+      interrupted: false,
+      backgroundTaskId: "task-44",
+      timedOutAfterMs: -1,
+      backgroundCwdHint: " ",
+    },
+    base,
+  );
+
+  assert.equal(fields.raw_output, "Command is running in background with ID: task-44.");
+  assert.equal(fields.output_metadata, undefined);
 });
 
 test("buildToolResultFields maps structured ReadMcpResource output to typed resource content", () => {
@@ -5987,6 +6408,65 @@ test("buildToolResultFields preserves Agent resolvedModel metadata", () => {
   });
 });
 
+test("buildToolResultFields preserves ordered Agent modelsUsed metadata", () => {
+  const base = createToolCall("tc-agent-model-route", "Agent", {
+    description: "review changes",
+    prompt: "Review the branch",
+    model: "opus",
+  });
+  const fields = buildToolResultFields(
+    false,
+    {
+      agentId: "agent-1",
+      resolvedModel: " claude-sonnet-4-7 ",
+      modelsUsed: [
+        " claude-opus-4-8 ",
+        "",
+        "claude-opus-4-8",
+        42,
+        "claude-sonnet-4-7",
+      ],
+      content: [{ type: "text", text: "Done" }],
+      status: "completed",
+      prompt: "Review the branch",
+      futureField: true,
+    },
+    base,
+  );
+
+  assert.deepEqual(fields.output_metadata, {
+    agent: {
+      resolved_model: "claude-sonnet-4-7",
+      models_used: ["claude-opus-4-8", "claude-sonnet-4-7"],
+    },
+  });
+});
+
+test("buildToolResultFields preserves Agent modelsUsed independently of resolvedModel", () => {
+  const base = createToolCall("tc-agent-background-route", "Agent", {
+    description: "review changes",
+    prompt: "Review the branch",
+  });
+  const fields = buildToolResultFields(
+    false,
+    {
+      status: "async_launched",
+      agentId: "agent-1",
+      description: "Review changes",
+      modelsUsed: ["claude-opus-4-8", "claude-sonnet-4-7"],
+      prompt: "Review the branch",
+      outputFile: "C:/tmp/agent.output",
+    },
+    base,
+  );
+
+  assert.deepEqual(fields.output_metadata, {
+    agent: {
+      models_used: ["claude-opus-4-8", "claude-sonnet-4-7"],
+    },
+  });
+});
+
 test("buildToolResultFields keeps Agent input name while preserving resolvedModel metadata", () => {
   const base = createToolCall("tc-agent-named-model", "Agent", {
     description: "review changes",
@@ -6206,7 +6686,7 @@ test("looksLikeAuthRequired detects login hints", () => {
 });
 
 test("agent sdk version compatibility check matches pinned version", () => {
-  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.207");
+  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.214");
   assert.equal(agentSdkVersionCompatibilityError(), undefined);
 });
 

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -242,9 +242,27 @@ export async function applySessionEffort(
   query: import("@anthropic-ai/claude-agent-sdk").Query,
   effort: EffortLevel,
 ): Promise<void> {
-  const settings = { effortLevel: effort } as Parameters<typeof query.applyFlagSettings>[0];
-  // applyFlagSettings controls live session settings; SDK Settings typings model persisted effort levels.
-  await query.applyFlagSettings(settings);
+  await query.applyFlagSettings({ effortLevel: effort });
+}
+
+export function buildPromptUserMessage(
+  command: Extract<BridgeCommand, { command: "prompt" }>,
+  sessionId: string,
+): import("@anthropic-ai/claude-agent-sdk").SDKUserMessage | undefined {
+  const content = contentFromPrompt(command);
+  if (content.length === 0) {
+    return undefined;
+  }
+  return {
+    type: "user",
+    session_id: sessionId,
+    parent_tool_use_id: null,
+    origin: { kind: "human" },
+    message: {
+      role: "user",
+      content,
+    },
+  };
 }
 
 export async function applySessionAgent(
@@ -271,7 +289,7 @@ export function emitAgentConfigOptionUpdate(sessionId: string, agent: string | n
   });
 }
 
-const EXPECTED_AGENT_SDK_VERSION = "0.3.207";
+const EXPECTED_AGENT_SDK_VERSION = "0.3.214";
 const require = createRequire(import.meta.url);
 
 export function resolveInstalledAgentSdkVersion(): string | undefined {
@@ -899,19 +917,10 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
         slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
         return;
       }
-      const content = contentFromPrompt(command);
-      if (content.length === 0) {
+      const message = buildPromptUserMessage(command, session.sessionId);
+      if (!message) {
         return;
       }
-      const message: import("@anthropic-ai/claude-agent-sdk").SDKUserMessage = {
-        type: "user",
-        session_id: session.sessionId,
-        parent_tool_use_id: null,
-        message: {
-          role: "user",
-          content,
-        },
-      };
       session.input.enqueue(message);
       return;
     }

--- a/agent-sdk/src/bridge/account_metadata.ts
+++ b/agent-sdk/src/bridge/account_metadata.ts
@@ -7,6 +7,7 @@ export type KnownApiProvider =
   | "vertex"
   | "foundry"
   | "anthropicAws"
+  | "anthropicGoogleCloud"
   | "mantle"
   | "gateway";
 
@@ -16,6 +17,7 @@ const KNOWN_API_PROVIDERS = new Set<string>([
   "vertex",
   "foundry",
   "anthropicAws",
+  "anthropicGoogleCloud",
   "mantle",
   "gateway",
 ]);

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -48,6 +48,7 @@ import {
 import {
   buildApiRetryUpdate,
   buildRateLimitUpdate,
+  buildSubagentRetryUpdate,
   normalizeSettingsParseErrors,
   numberField,
   parseApiRetryError,
@@ -1410,7 +1411,30 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
       },
     });
     if (resolvedToolUseId) {
-      emitToolProgressUpdate(session, resolvedToolUseId, toolName);
+      const hasSubagentRetry = Object.hasOwn(msg, "subagent_retry");
+      const subagentRetry = hasSubagentRetry ? buildSubagentRetryUpdate(msg) : null;
+      if (hasSubagentRetry && !subagentRetry) {
+        bridgeLogger.warn({
+          target: LOG_TARGETS.APP_TOOL,
+          eventName: "sdk_subagent_retry_rejected",
+          message: "ignored malformed SDK subagent retry progress",
+          outcome: "invalid_payload",
+          sessionId: session.sessionId,
+          toolCallId: resolvedToolUseId,
+        });
+      }
+      const subagentType =
+        typeof msg.subagent_type === "string" && msg.subagent_type.trim()
+          ? msg.subagent_type.trim()
+          : undefined;
+      emitToolProgressUpdate(session, resolvedToolUseId, toolName, {
+        ...(subagentRetry
+          ? { subagentRetry }
+          : hasSubagentRetry
+            ? {}
+            : { subagentRetry: { state: "clear" } }),
+        ...(subagentType ? { subagentType } : {}),
+      });
     }
     return;
   }

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -271,11 +271,16 @@ function settingsObjectFromLaunchSettings(
 
 function normalizedSettingsFromLaunchSettings(
   launchSettings: SessionLaunchSettings,
-): Record<string, unknown> | undefined {
-  const settings = settingsObjectFromLaunchSettings(launchSettings);
-  if (!settings) {
-    return undefined;
-  }
+): Record<string, unknown> {
+  const settings = settingsObjectFromLaunchSettings(launchSettings) ?? {};
+  // SendFeedback queues a local draft that can only be reviewed, edited, and
+  // discarded through the native /feedback surface. Agent SDK command
+  // snapshots do not expose that command to this host, so enabling drafts
+  // would create content that claude-rs cannot safely let the user approve.
+  const hostSettings = {
+    ...settings,
+    feedbackDrafts: "off" as const,
+  };
 
   const sandbox =
     settings.sandbox && typeof settings.sandbox === "object" && !Array.isArray(settings.sandbox)
@@ -283,7 +288,7 @@ function normalizedSettingsFromLaunchSettings(
       : undefined;
   if (sandbox?.enabled === true && sandbox.failIfUnavailable === undefined) {
     return {
-      ...settings,
+      ...hostSettings,
       sandbox: {
         ...sandbox,
         failIfUnavailable: false,
@@ -291,7 +296,7 @@ function normalizedSettingsFromLaunchSettings(
     };
   }
 
-  return settings;
+  return hostSettings;
 }
 
 export function sessionById(sessionId: string): SessionState | null {
@@ -896,9 +901,13 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
     includePartialMessages: true,
     promptSuggestions: true,
     enableFileCheckpointing: true,
+    // ProposeSkills reports only a proposal count and expects a native review
+    // surface. Keep it out of this host until claude-rs can display the actual
+    // proposal input and accept/reject it without losing content.
+    disallowedTools: ["ProposeSkills"],
     executable: "bun" as const,
     ...(params.resume ? {} : { sessionId: params.provisionalSessionId }),
-    ...(settings ? { settings } : {}),
+    settings,
     ...modelOption,
     ...permissionModeOptions,
     toolConfig: { askUserQuestion: { previewFormat: "markdown" as const } },

--- a/agent-sdk/src/bridge/state_parsing.ts
+++ b/agent-sdk/src/bridge/state_parsing.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeSessionState,
   SessionUpdate,
   SettingsParseErrorUpdate,
+  SubagentRetryUpdate,
 } from "../types.js";
 import { asRecordOrNull } from "./shared.js";
 
@@ -24,6 +25,41 @@ function nonNegativeNumberField(record: Record<string, unknown>, ...keys: string
     return undefined;
   }
   return value;
+}
+
+function nonNegativeIntegerField(
+  record: Record<string, unknown>,
+  ...keys: string[]
+): number | undefined {
+  const value = numberField(record, ...keys);
+  return value !== undefined && value >= 0 && Number.isInteger(value) ? value : undefined;
+}
+
+export function buildSubagentRetryUpdate(message: Record<string, unknown>): SubagentRetryUpdate | null {
+  const retry = asRecordOrNull(message.subagent_retry);
+  if (!retry) {
+    return null;
+  }
+  const attempt = nonNegativeIntegerField(retry, "attempt");
+  const maxRetries = nonNegativeIntegerField(retry, "max_retries", "maxRetries");
+  const retryDelayMs = nonNegativeIntegerField(retry, "retry_delay_ms", "retryDelayMs");
+  if (attempt === undefined || maxRetries === undefined || retryDelayMs === undefined) {
+    return null;
+  }
+
+  const agentId = typeof retry.agent_id === "string" ? retry.agent_id.trim() : "";
+  const errorCategory =
+    typeof retry.error_category === "string" ? retry.error_category.trim() : "";
+  const errorStatus = nonNegativeIntegerField(retry, "error_status", "errorStatus");
+  return {
+    state: "waiting",
+    ...(agentId ? { agent_id: agentId } : {}),
+    attempt,
+    max_retries: maxRetries,
+    retry_delay_ms: retryDelayMs,
+    ...(errorStatus !== undefined ? { error_status: errorStatus } : {}),
+    ...(errorCategory ? { error_category: errorCategory } : {}),
+  };
 }
 
 export function parseFastModeState(value: unknown): FastModeState | null {

--- a/agent-sdk/src/bridge/tool_calls.ts
+++ b/agent-sdk/src/bridge/tool_calls.ts
@@ -163,10 +163,14 @@ function mergeTaskMetadata(
   if (update === undefined) {
     return current;
   }
-  return {
+  const merged = {
     ...(current ?? {}),
     ...update,
   };
+  if (update.subagent_retry?.state === "clear") {
+    delete merged.subagent_retry;
+  }
+  return merged;
 }
 
 function applyFieldsToBase(base: ToolCall, fields: ToolCallUpdateFields): void {
@@ -320,6 +324,17 @@ export function emitToolCallUpdate(
   sourceMessageUuid?: string,
 ): void {
   const base = session.toolCalls.get(toolUseId);
+  const nextStatus = fields.status ?? base?.status;
+  const terminal = nextStatus === "completed" || nextStatus === "failed" || nextStatus === "killed";
+  const hasActiveRetry =
+    base?.task_metadata?.subagent_retry?.state === "waiting" ||
+    fields.task_metadata?.subagent_retry?.state === "waiting";
+  if (terminal && hasActiveRetry) {
+    fields.task_metadata = {
+      ...(fields.task_metadata ?? {}),
+      subagent_retry: { state: "clear" },
+    };
+  }
   logToolCallUpdateEmitted(session.sessionId, toolUseId, fields, base, updateKind);
   emitSessionUpdate(session.sessionId, {
     type: "tool_call_update",
@@ -459,14 +474,21 @@ export function finalizeOpenToolCalls(session: SessionState, status: "completed"
   }
 }
 
-export function emitToolProgressUpdate(session: SessionState, toolUseId: string, toolName: string): void {
-  const existing = session.toolCalls.get(toolUseId);
+export function emitToolProgressUpdate(
+  session: SessionState,
+  toolUseId: string,
+  toolName: string,
+  progress: {
+    subagentRetry?: import("../types.js").SubagentRetryUpdate;
+    subagentType?: string;
+  } = {},
+): void {
+  let existing = session.toolCalls.get(toolUseId);
   if (!existing) {
     emitToolCall(session, toolUseId, toolName, {});
-    return;
+    existing = session.toolCalls.get(toolUseId);
   }
-  if (
-    existing.status === "in_progress" ||
+  if (!existing ||
     existing.status === "completed" ||
     existing.status === "failed" ||
     existing.status === "killed"
@@ -474,7 +496,29 @@ export function emitToolProgressUpdate(session: SessionState, toolUseId: string,
     return;
   }
 
-  emitToolCallUpdate(session, toolUseId, { status: "in_progress" }, "progress");
+  const taskMetadata: import("../types.js").TaskMetadata = {};
+  if (progress.subagentRetry?.state === "waiting") {
+    taskMetadata.subagent_retry = progress.subagentRetry;
+  } else if (
+    progress.subagentRetry?.state === "clear" &&
+    existing.task_metadata?.subagent_retry?.state === "waiting"
+  ) {
+    taskMetadata.subagent_retry = progress.subagentRetry;
+  }
+  if (progress.subagentType && progress.subagentType !== existing.task_metadata?.subagent_type) {
+    taskMetadata.subagent_type = progress.subagentType;
+  }
+
+  const fields: ToolCallUpdateFields = {};
+  if (existing.status !== "in_progress") {
+    fields.status = "in_progress";
+  }
+  if (Object.keys(taskMetadata).length > 0) {
+    fields.task_metadata = taskMetadata;
+  }
+  if (Object.keys(fields).length > 0) {
+    emitToolCallUpdate(session, toolUseId, fields, "progress");
+  }
 }
 
 export function emitToolSummaryUpdate(session: SessionState, toolUseId: string, summary: string): void {

--- a/agent-sdk/src/bridge/tooling.ts
+++ b/agent-sdk/src/bridge/tooling.ts
@@ -563,9 +563,19 @@ function extractToolOutputMetadata(
   if (toolName === "Bash") {
     for (const candidate of candidates) {
       const hasAssistantAutoBackgrounded = typeof candidate.assistantAutoBackgrounded === "boolean";
-      if (hasAssistantAutoBackgrounded) {
+      const timedOutAfterMs = nonNegativeInteger(candidate.timedOutAfterMs);
+      const backgroundCwdHint = nonEmptyString(candidate.backgroundCwdHint);
+      if (hasAssistantAutoBackgrounded || timedOutAfterMs !== undefined || backgroundCwdHint) {
         const bashMetadata: import("../types.js").BashOutputMetadata = {};
-        bashMetadata.assistant_auto_backgrounded = candidate.assistantAutoBackgrounded as boolean;
+        if (hasAssistantAutoBackgrounded) {
+          bashMetadata.assistant_auto_backgrounded = candidate.assistantAutoBackgrounded as boolean;
+        }
+        if (timedOutAfterMs !== undefined) {
+          bashMetadata.timed_out_after_ms = timedOutAfterMs;
+        }
+        if (backgroundCwdHint) {
+          bashMetadata.background_cwd_hint = backgroundCwdHint;
+        }
         metadata.bash = bashMetadata;
         break;
       }
@@ -575,9 +585,11 @@ function extractToolOutputMetadata(
   if (toolName === "Agent" || toolName === "Task") {
     for (const candidate of candidates) {
       const resolvedModel = nonEmptyString(candidate.resolvedModel);
-      if (resolvedModel) {
+      const modelsUsed = orderedNonEmptyStrings(candidate.modelsUsed);
+      if (resolvedModel || modelsUsed) {
         const agentMetadata: import("../types.js").AgentOutputMetadata = {
-          resolved_model: resolvedModel,
+          ...(resolvedModel ? { resolved_model: resolvedModel } : {}),
+          ...(modelsUsed ? { models_used: modelsUsed } : {}),
         };
         metadata.agent = agentMetadata;
         break;
@@ -861,6 +873,10 @@ function shellBackgroundMessage(record: Record<string, unknown>): string {
   if (!backgroundTaskId) {
     return "";
   }
+  const timedOutAfterMs = nonNegativeInteger(record.timedOutAfterMs);
+  if (timedOutAfterMs !== undefined) {
+    return `Command was auto-backgrounded after ${timedOutAfterMs.toLocaleString("en-US")} ms with ID: ${backgroundTaskId}.`;
+  }
   if (record.assistantAutoBackgrounded === true) {
     return `Command was auto-backgrounded by assistant mode with ID: ${backgroundTaskId}.`;
   }
@@ -947,6 +963,10 @@ function recordNumber(record: Record<string, unknown>, key: string): number | un
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
+function recordNonNegativeInteger(record: Record<string, unknown>, key: string): number | undefined {
+  return nonNegativeInteger(record[key]);
+}
+
 function recordString(record: Record<string, unknown>, key: string): string | undefined {
   const value = record[key];
   return typeof value === "string" ? value : undefined;
@@ -1000,8 +1020,15 @@ function globResultText(record: Record<string, unknown>): string | undefined {
 function grepResultText(record: Record<string, unknown>): string | undefined {
   const filenames = searchFilenames(record);
   const content = recordString(record, "content") ?? "";
-  const numFiles = recordNumber(record, "numFiles") ?? filenames.length;
-  const numLines = recordNumber(record, "numLines");
+  const hasVisibleMatches = content.trim().length > 0 || filenames.length > 0;
+  const totalFiles = recordNonNegativeInteger(record, "totalFiles");
+  const legacyNumFiles = recordNonNegativeInteger(record, "numFiles");
+  const numFiles =
+    totalFiles ??
+    (legacyNumFiles !== 0 || !hasVisibleMatches ? legacyNumFiles : undefined) ??
+    (filenames.length > 0 ? filenames.length : undefined);
+  const numLines =
+    recordNonNegativeInteger(record, "totalLines") ?? recordNonNegativeInteger(record, "numLines");
   const numMatches = recordNumber(record, "numMatches");
   const appliedLimit = recordNumber(record, "appliedLimit");
   const appliedOffset = recordNumber(record, "appliedOffset");
@@ -1021,7 +1048,9 @@ function grepResultText(record: Record<string, unknown>): string | undefined {
   }
 
   const summaryParts: string[] = [];
-  summaryParts.push(`${numFiles} ${pluralize(numFiles, "file")}`);
+  if (numFiles !== undefined) {
+    summaryParts.push(`${numFiles} ${pluralize(numFiles, "file")}`);
+  }
   if (numMatches !== undefined) {
     summaryParts.push(`${numMatches} ${pluralize(numMatches, "match", "matches")}`);
   }
@@ -1095,6 +1124,28 @@ function pushBooleanField(lines: string[], label: string, value: unknown): void 
 
 function nonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function nonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.trunc(value)
+    : undefined;
+}
+
+function orderedNonEmptyStrings(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const seen = new Set<string>();
+  const values: string[] = [];
+  for (const item of value) {
+    const normalized = nonEmptyString(item);
+    if (normalized && !seen.has(normalized)) {
+      seen.add(normalized);
+      values.push(normalized);
+    }
+  }
+  return values.length > 0 ? values : undefined;
 }
 
 const CRON_MONTH_NAMES = [
@@ -2272,4 +2323,3 @@ export function unwrapToolUseResult(rawResult: unknown): { isError: boolean; con
   }
   return { isError: Boolean(isError), content: rawResult };
 }
-

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -147,10 +147,13 @@ export type ToolCallContent =
 
 export interface BashOutputMetadata {
   assistant_auto_backgrounded?: boolean;
+  timed_out_after_ms?: number;
+  background_cwd_hint?: string;
 }
 
 export interface AgentOutputMetadata {
   resolved_model?: string;
+  models_used?: string[];
 }
 
 export interface WebFetchArtifactReadMetadata {
@@ -168,6 +171,18 @@ export interface ToolOutputMetadata {
   web_fetch?: WebFetchOutputMetadata;
 }
 
+export type SubagentRetryUpdate =
+  | {
+      state: "waiting";
+      agent_id?: string;
+      attempt: number;
+      max_retries: number;
+      retry_delay_ms: number;
+      error_status?: number;
+      error_category?: string;
+    }
+  | { state: "clear" };
+
 export interface TaskMetadata {
   end_time?: number;
   total_paused_ms?: number;
@@ -184,6 +199,7 @@ export interface TaskMetadata {
   terminal_status?: string;
   blocked?: boolean;
   parent_agent_id?: string;
+  subagent_retry?: SubagentRetryUpdate;
 }
 
 export interface ToolLocation {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.207"
+        "@anthropic-ai/claude-agent-sdk": "0.3.214"
       },
       "bin": {
         "claude-rs": "bin/claude-rs.js"
@@ -22,22 +22,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.207.tgz",
-      "integrity": "sha512-y0PkQRmQBi96MHiN5Xzfq+GaddxCZCqI/cXEQBLYBLXGa4i1nDSlulQqkMBj2RorrrSGQJ6Wdw+uhu6OfHNPzA==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.214.tgz",
+      "integrity": "sha512-wt5ImwhU+p259Zt4K/Q9v5xVi6ruxYO5+KFICyJxnjs/QFEClAeSRqhcXx1J8jgGfatPW1faw09hkm66680UjA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.207",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.207"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.214"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.207.tgz",
-      "integrity": "sha512-08xSo1FDx8h0aLhL5tvcRxa2SMmcUV3aDWeZiEJVTclyiDAs61BgTjAxCg+SZcu1CndjJO8cfO0yM5dhamxz3g==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.214.tgz",
+      "integrity": "sha512-vAAOeVtlXs3p7MpFVfvfu9ja32eaKtB+MDZnPxCbdzxJk5nofCHlNsHa1UJwXHOsP9lOnFYNIccYztsZ4DNaJA==",
       "cpu": [
         "arm64"
       ],
@@ -59,9 +59,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.207.tgz",
-      "integrity": "sha512-1o7K4EYqyCixZ/oeOZSh7AzSy6TM86xoOuf4VuORjPSS31hBnoqY0NGZd27+2VDs9LGtsdksmsTqcNGx9xd1hA==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.214.tgz",
+      "integrity": "sha512-NTbV8U2yucxCWqEiDC7L0MUehNmd8x3Op8OGzLZRhMF3xmQBy2DxpXiNZgSwwKWNDC3HdgKmJM5ZBbT7XrF/0g==",
       "cpu": [
         "x64"
       ],
@@ -72,9 +72,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.207.tgz",
-      "integrity": "sha512-X4uezYOifDiNTTmmugfRCdg3nNamrr1LFRY9hg30vWYTShL+bbN+nfC3KaFfSYCl4GTtsEEUbYdOTC2F3bBpcA==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.214.tgz",
+      "integrity": "sha512-KBCf+BlusG0ZcgvpjjHwv1kh+6WiR8vJbPjpR2udwkrtcQgKLN+24l+FeaQEzO2TL+ExCmM1KC4tNPvnPpy+tw==",
       "cpu": [
         "arm64"
       ],
@@ -88,9 +88,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.207.tgz",
-      "integrity": "sha512-oPj+g2DslhH4Y9nCTs7al4t9wZv78FZwLFQwOCg99BXuz1o0ZOpKmxyvR7J9eBR+GPszeMMS8gYplQTiZC9o2w==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.214.tgz",
+      "integrity": "sha512-i06wQRsmevE7spY1ryYfs+NP+xdZ1FwAyTjDaF0k/xG+cgtzZYghTFUemdYF3GVwgWgpcava9GiCFDT3DoHI6w==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.207.tgz",
-      "integrity": "sha512-Kg6BPH8Ee0ny/oEUWJmvT1jCRBne4jVpRSOMsJcYp1Fav1rMEgpU219oJJs+LWwx4ifuuLtNWedqJNnVw7mnKg==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.214.tgz",
+      "integrity": "sha512-vqadSceJkBKHaTUszxI35uTuECGWtsHWK/mOwIJ4b9DUtYYySz6EJEk4gHg4ccutisJ/oRVCpFXHIKFb+osrKw==",
       "cpu": [
         "x64"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.207.tgz",
-      "integrity": "sha512-uRv+D5oG/7EYr41FAJ9IPo2pZYBe2ZMaA6nSHCeizsgPxCSMtl5bNppmU21+jZJvo4hivObEgkGFERAhdGqygg==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.214.tgz",
+      "integrity": "sha512-948RstHDhs0E69h+2dKYWIAL1kcwEme4zvtgNUwP8XpKXzWOhrTKmd6MAokHn25zwfuSx5d+HE0XHfFH6R4hLg==",
       "cpu": [
         "x64"
       ],
@@ -136,9 +136,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.207.tgz",
-      "integrity": "sha512-9fWpUzfkXlPAg2tf8JpQe7w9avFaomAUbfAwyAmykQgSIf66LwaJjvI5hNqhNqczRKyfsXPn3ei2S5HKlmFP+Q==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.214.tgz",
+      "integrity": "sha512-CEKlPFCPv+ee79utQMEDSsgeo2f27ulhNHpjrKIt1jXz5G04J7lAWN/QwvPDv9XaLBkWpyfqZWiPXlRcwuaO/w==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +149,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.207",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.207.tgz",
-      "integrity": "sha512-YPjVT0q6aXEM2MgN4CI6/9fqiTXwETji+4NoPOzCYuqAkhXZqp30Jsk7/NHqYGNNSfURKrsuAoliKB0rsbpbjg==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.214.tgz",
+      "integrity": "sha512-cJMJfFoR9IWBZWnTtt9PnEm89hGOsZjoDNjOCEOF3+x+g/ANIXAjMJTcaQYv2HKh6MylWZ0AkxBASI+twkukaQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.207"
+    "@anthropic-ai/claude-agent-sdk": "0.3.214"
   },
   "scripts": {
     "prepack": "npm --prefix agent-sdk run build",

--- a/src/agent/model/tasks.rs
+++ b/src/agent/model/tasks.rs
@@ -19,6 +19,21 @@ pub struct TaskMetadata {
     pub terminal_status: Option<String>,
     pub blocked: Option<bool>,
     pub parent_agent_id: Option<String>,
+    pub subagent_retry: Option<SubagentRetryUpdate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum SubagentRetryUpdate {
+    Waiting {
+        agent_id: Option<String>,
+        attempt: u64,
+        max_retries: u64,
+        retry_delay_ms: u64,
+        error_status: Option<u64>,
+        error_category: Option<String>,
+    },
+    Clear,
 }
 
 impl TaskMetadata {
@@ -114,6 +129,12 @@ impl TaskMetadata {
     #[must_use]
     pub fn parent_agent_id(mut self, parent_agent_id: Option<String>) -> Self {
         self.parent_agent_id = parent_agent_id;
+        self
+    }
+
+    #[must_use]
+    pub fn subagent_retry(mut self, subagent_retry: Option<SubagentRetryUpdate>) -> Self {
+        self.subagent_retry = subagent_retry;
         self
     }
 }

--- a/src/agent/model/tools.rs
+++ b/src/agent/model/tools.rs
@@ -312,12 +312,14 @@ impl ToolCallUpdate {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct BashOutputMetadata {
     pub assistant_auto_backgrounded: Option<bool>,
+    pub timed_out_after_ms: Option<u64>,
+    pub background_cwd_hint: Option<String>,
 }
 
 impl BashOutputMetadata {
     #[must_use]
     pub fn new() -> Self {
-        Self { assistant_auto_backgrounded: None }
+        Self::default()
     }
 
     #[must_use]
@@ -326,6 +328,18 @@ impl BashOutputMetadata {
         assistant_auto_backgrounded: Option<bool>,
     ) -> Self {
         self.assistant_auto_backgrounded = assistant_auto_backgrounded;
+        self
+    }
+
+    #[must_use]
+    pub fn timed_out_after_ms(mut self, timed_out_after_ms: Option<u64>) -> Self {
+        self.timed_out_after_ms = timed_out_after_ms;
+        self
+    }
+
+    #[must_use]
+    pub fn background_cwd_hint(mut self, background_cwd_hint: Option<String>) -> Self {
+        self.background_cwd_hint = background_cwd_hint;
         self
     }
 }
@@ -340,6 +354,7 @@ pub struct ToolOutputMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct AgentOutputMetadata {
     pub resolved_model: Option<String>,
+    pub models_used: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -387,6 +402,12 @@ impl AgentOutputMetadata {
     #[must_use]
     pub fn resolved_model(mut self, resolved_model: Option<String>) -> Self {
         self.resolved_model = resolved_model;
+        self
+    }
+
+    #[must_use]
+    pub fn models_used(mut self, models_used: Option<Vec<String>>) -> Self {
+        self.models_used = models_used;
         self
     }
 }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -291,6 +291,8 @@ pub struct ToolLocation {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct BashOutputMetadata {
     pub assistant_auto_backgrounded: Option<bool>,
+    pub timed_out_after_ms: Option<u64>,
+    pub background_cwd_hint: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -303,6 +305,7 @@ pub struct ToolOutputMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct AgentOutputMetadata {
     pub resolved_model: Option<String>,
+    pub models_used: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -333,6 +336,21 @@ pub struct TaskMetadata {
     pub terminal_status: Option<String>,
     pub blocked: Option<bool>,
     pub parent_agent_id: Option<String>,
+    pub subagent_retry: Option<SubagentRetryUpdate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum SubagentRetryUpdate {
+    Waiting {
+        agent_id: Option<String>,
+        attempt: u64,
+        max_retries: u64,
+        retry_delay_ms: u64,
+        error_status: Option<u64>,
+        error_category: Option<String>,
+    },
+    Clear,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -959,8 +977,8 @@ mod tests {
     use super::{
         AccountInfo, ApiRetryError, AvailableModel, EffortLevel, McpServerOrgMaxPermission,
         McpServerStatus, McpServerStatusConfig, McpServerToolPermissionPolicy, RateLimitStatus,
-        SessionStatus, SessionUpdate, SystemNoticeSeverity, TaskUpdateSource, TerminalReason,
-        TranscriptRetractionReason,
+        SessionStatus, SessionUpdate, SubagentRetryUpdate, SystemNoticeSeverity, TaskMetadata,
+        TaskUpdateSource, TerminalReason, TranscriptRetractionReason,
     };
 
     #[test]
@@ -1269,7 +1287,8 @@ mod tests {
                 "fields": {
                     "output_metadata": {
                         "agent": {
-                            "resolved_model": "claude-sonnet-4-7"
+                            "resolved_model": "claude-sonnet-4-7",
+                            "models_used": ["claude-opus-4-8", "claude-sonnet-4-7"]
                         },
                         "web_fetch": {
                             "artifact_read": {
@@ -1287,14 +1306,50 @@ mod tests {
             panic!("expected tool call update");
         };
         let metadata = tool_call_update.fields.output_metadata.expect("output metadata");
-        let resolved_model = metadata.agent.and_then(|agent| agent.resolved_model);
+        let agent = metadata.agent.expect("agent metadata");
+        let resolved_model = agent.resolved_model;
         assert_eq!(resolved_model.as_deref(), Some("claude-sonnet-4-7"));
+        assert_eq!(
+            agent.models_used,
+            Some(vec!["claude-opus-4-8".to_owned(), "claude-sonnet-4-7".to_owned()])
+        );
         let artifact_read = metadata
             .web_fetch
             .and_then(|web_fetch| web_fetch.artifact_read)
             .expect("artifact read metadata");
         assert_eq!(artifact_read.slug, "dashboard");
         assert_eq!(artifact_read.ver, "v3");
+    }
+
+    #[test]
+    fn task_metadata_deserializes_subagent_retry_waiting_and_clear_updates() {
+        let waiting: TaskMetadata = serde_json::from_value(serde_json::json!({
+            "subagent_retry": {
+                "state": "waiting",
+                "agent_id": "agent-1",
+                "attempt": 2,
+                "max_retries": 4,
+                "retry_delay_ms": 1500,
+                "error_status": 429,
+                "error_category": "rate_limit"
+            }
+        }))
+        .expect("deserialize waiting retry");
+        assert!(matches!(
+            waiting.subagent_retry,
+            Some(SubagentRetryUpdate::Waiting {
+                attempt: 2,
+                max_retries: 4,
+                retry_delay_ms: 1500,
+                ..
+            })
+        ));
+
+        let clear: TaskMetadata = serde_json::from_value(serde_json::json!({
+            "subagent_retry": { "state": "clear" }
+        }))
+        .expect("deserialize retry clear");
+        assert_eq!(clear.subagent_retry, Some(SubagentRetryUpdate::Clear));
     }
 
     #[test]

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -840,12 +840,14 @@ fn convert_tool_output_metadata(
         .bash(output_metadata.bash.map(|bash| {
             model::BashOutputMetadata::new()
                 .assistant_auto_backgrounded(bash.assistant_auto_backgrounded)
+                .timed_out_after_ms(bash.timed_out_after_ms)
+                .background_cwd_hint(bash.background_cwd_hint)
         }))
-        .agent(
-            output_metadata.agent.map(|agent| {
-                model::AgentOutputMetadata::new().resolved_model(agent.resolved_model)
-            }),
-        )
+        .agent(output_metadata.agent.map(|agent| {
+            model::AgentOutputMetadata::new()
+                .resolved_model(agent.resolved_model)
+                .models_used(agent.models_used)
+        }))
         .web_fetch(output_metadata.web_fetch.map(|web_fetch| {
             model::WebFetchOutputMetadata::new().artifact_read(web_fetch.artifact_read.map(
                 |artifact| model::WebFetchArtifactReadMetadata::new(artifact.slug, artifact.ver),
@@ -881,6 +883,28 @@ fn convert_task_metadata(task_metadata: types::TaskMetadata) -> model::TaskMetad
         .terminal_status(task_metadata.terminal_status)
         .blocked(task_metadata.blocked)
         .parent_agent_id(task_metadata.parent_agent_id)
+        .subagent_retry(task_metadata.subagent_retry.map(convert_subagent_retry_update))
+}
+
+fn convert_subagent_retry_update(retry: types::SubagentRetryUpdate) -> model::SubagentRetryUpdate {
+    match retry {
+        types::SubagentRetryUpdate::Waiting {
+            agent_id,
+            attempt,
+            max_retries,
+            retry_delay_ms,
+            error_status,
+            error_category,
+        } => model::SubagentRetryUpdate::Waiting {
+            agent_id,
+            attempt,
+            max_retries,
+            retry_delay_ms,
+            error_status,
+            error_category,
+        },
+        types::SubagentRetryUpdate::Clear => model::SubagentRetryUpdate::Clear,
+    }
 }
 
 fn convert_tool_call_content(
@@ -1415,9 +1439,17 @@ mod tests {
         let fields = convert_tool_call_update_fields(types::ToolCallUpdateFields {
             status: Some("completed".to_owned()),
             output_metadata: Some(types::ToolOutputMetadata {
-                bash: Some(types::BashOutputMetadata { assistant_auto_backgrounded: Some(true) }),
+                bash: Some(types::BashOutputMetadata {
+                    assistant_auto_backgrounded: Some(true),
+                    timed_out_after_ms: Some(10_000),
+                    background_cwd_hint: Some("session cwd unchanged".to_owned()),
+                }),
                 agent: Some(types::AgentOutputMetadata {
                     resolved_model: Some("claude-sonnet-4-7".to_owned()),
+                    models_used: Some(vec![
+                        "claude-opus-4-8".to_owned(),
+                        "claude-sonnet-4-7".to_owned(),
+                    ]),
                 }),
                 web_fetch: Some(types::WebFetchOutputMetadata {
                     artifact_read: Some(types::WebFetchArtifactReadMetadata {
@@ -1434,11 +1466,18 @@ mod tests {
             Some(
                 model::ToolOutputMetadata::new()
                     .bash(Some(
-                        model::BashOutputMetadata::new().assistant_auto_backgrounded(Some(true)),
+                        model::BashOutputMetadata::new()
+                            .assistant_auto_backgrounded(Some(true))
+                            .timed_out_after_ms(Some(10_000))
+                            .background_cwd_hint(Some("session cwd unchanged".to_owned())),
                     ))
                     .agent(Some(
                         model::AgentOutputMetadata::new()
-                            .resolved_model(Some("claude-sonnet-4-7".to_owned())),
+                            .resolved_model(Some("claude-sonnet-4-7".to_owned()))
+                            .models_used(Some(vec![
+                                "claude-opus-4-8".to_owned(),
+                                "claude-sonnet-4-7".to_owned(),
+                            ])),
                     ))
                     .web_fetch(Some(model::WebFetchOutputMetadata::new().artifact_read(Some(
                         model::WebFetchArtifactReadMetadata::new("dashboard", "v2"),
@@ -1505,6 +1544,7 @@ mod tests {
                 terminal_status: Some("completed".to_owned()),
                 blocked: Some(true),
                 parent_agent_id: Some("agent-parent".to_owned()),
+                subagent_retry: None,
             }),
             ..types::ToolCallUpdateFields::default()
         });
@@ -1560,6 +1600,7 @@ mod tests {
                 terminal_status: Some("killed".to_owned()),
                 blocked: Some(false),
                 parent_agent_id: Some("agent-root".to_owned()),
+                subagent_retry: None,
             }),
             locations: Vec::new(),
             meta: None,

--- a/src/app/events/tool_updates.rs
+++ b/src/app/events/tool_updates.rs
@@ -123,6 +123,7 @@ fn apply_tool_call_update_to_indexed_block(
         changed |= apply_tool_call_locations_update(tc, tcu.fields.locations.as_ref());
         changed |= apply_tool_call_output_metadata_update(tc, tcu.fields.output_metadata.as_ref());
         changed |= apply_tool_call_task_metadata_update(tc, tcu.fields.task_metadata.as_ref());
+        changed |= clear_subagent_retry_if_terminal(tc);
         changed |= apply_tool_call_raw_output_update(tc, tcu.fields.raw_output.as_ref());
         changed |= apply_tool_call_name_update(tc, tcu.meta.as_ref());
         changed |= apply_tool_call_hidden_update(tc, tcu.meta.as_ref());
@@ -292,11 +293,33 @@ fn apply_tool_call_task_metadata_update(
     if task_metadata.parent_agent_id.is_some() {
         merged.parent_agent_id.clone_from(&task_metadata.parent_agent_id);
     }
+    match &task_metadata.subagent_retry {
+        Some(model::SubagentRetryUpdate::Waiting { .. }) => {
+            merged.subagent_retry.clone_from(&task_metadata.subagent_retry);
+        }
+        Some(model::SubagentRetryUpdate::Clear) => merged.subagent_retry = None,
+        None => {}
+    }
     if tc.task_metadata.as_ref() == Some(&merged) {
         return false;
     }
     tc.task_metadata = Some(merged);
     true
+}
+
+fn clear_subagent_retry_if_terminal(tc: &mut ToolCallInfo) -> bool {
+    if !matches!(
+        tc.status,
+        model::ToolCallStatus::Completed
+            | model::ToolCallStatus::Failed
+            | model::ToolCallStatus::Killed
+    ) {
+        return false;
+    }
+    let Some(task_metadata) = tc.task_metadata.as_mut() else {
+        return false;
+    };
+    task_metadata.subagent_retry.take().is_some()
 }
 
 fn apply_tool_call_raw_output_update(
@@ -977,6 +1000,99 @@ mod tests {
                     .terminal_status(Some("killed".to_owned())),
             )
         );
+    }
+
+    #[test]
+    fn task_metadata_update_applies_and_clears_subagent_retry() {
+        let mut app = App::test_default();
+        let tool_id = "task-retry";
+        app.transcript.messages.push(ChatMessage::new(
+            MessageRole::Assistant,
+            vec![MessageBlock::ToolCall(Box::new(make_task_tool_call(
+                tool_id,
+                model::ToolCallStatus::InProgress,
+            )))],
+            None,
+        ));
+        app.index_tool_call(tool_id.to_owned(), 0, 0);
+
+        let waiting = model::SubagentRetryUpdate::Waiting {
+            agent_id: Some("agent-1".to_owned()),
+            attempt: 2,
+            max_retries: 4,
+            retry_delay_ms: 1_500,
+            error_status: Some(429),
+            error_category: Some("rate_limit".to_owned()),
+        };
+        handle_tool_call_update_session(
+            &mut app,
+            &model::ToolCallUpdate::new(
+                tool_id,
+                model::ToolCallUpdateFields::new().task_metadata(
+                    model::TaskMetadata::new().subagent_retry(Some(waiting.clone())),
+                ),
+            ),
+        );
+
+        let MessageBlock::ToolCall(tc) = &app.transcript.messages[0].blocks[0] else {
+            panic!("expected tool call block");
+        };
+        assert_eq!(
+            tc.task_metadata.as_ref().and_then(|meta| meta.subagent_retry.clone()),
+            Some(waiting)
+        );
+
+        handle_tool_call_update_session(
+            &mut app,
+            &model::ToolCallUpdate::new(
+                tool_id,
+                model::ToolCallUpdateFields::new().task_metadata(
+                    model::TaskMetadata::new()
+                        .subagent_retry(Some(model::SubagentRetryUpdate::Clear)),
+                ),
+            ),
+        );
+
+        let MessageBlock::ToolCall(tc) = &app.transcript.messages[0].blocks[0] else {
+            panic!("expected tool call block");
+        };
+        assert_eq!(tc.task_metadata.as_ref().and_then(|meta| meta.subagent_retry.as_ref()), None);
+    }
+
+    #[test]
+    fn terminal_tool_update_clears_subagent_retry_without_explicit_clear() {
+        let mut app = App::test_default();
+        let tool_id = "task-retry-terminal";
+        let mut tool_call = make_task_tool_call(tool_id, model::ToolCallStatus::InProgress);
+        tool_call.task_metadata = Some(model::TaskMetadata::new().subagent_retry(Some(
+            model::SubagentRetryUpdate::Waiting {
+                agent_id: None,
+                attempt: 1,
+                max_retries: 3,
+                retry_delay_ms: 500,
+                error_status: None,
+                error_category: None,
+            },
+        )));
+        app.transcript.messages.push(ChatMessage::new(
+            MessageRole::Assistant,
+            vec![MessageBlock::ToolCall(Box::new(tool_call))],
+            None,
+        ));
+        app.index_tool_call(tool_id.to_owned(), 0, 0);
+
+        handle_tool_call_update_session(
+            &mut app,
+            &model::ToolCallUpdate::new(
+                tool_id,
+                model::ToolCallUpdateFields::new().status(model::ToolCallStatus::Completed),
+            ),
+        );
+
+        let MessageBlock::ToolCall(tc) = &app.transcript.messages[0].blocks[0] else {
+            panic!("expected tool call block");
+        };
+        assert_eq!(tc.task_metadata.as_ref().and_then(|meta| meta.subagent_retry.as_ref()), None);
     }
 
     #[test]

--- a/src/app/state/tool_call_info.rs
+++ b/src/app/state/tool_call_info.rs
@@ -106,6 +106,14 @@ impl ToolCallInfo {
     }
 
     #[must_use]
+    pub fn timed_out_after_ms(&self) -> Option<u64> {
+        self.output_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.bash.as_ref())
+            .and_then(|metadata| metadata.timed_out_after_ms)
+    }
+
+    #[must_use]
     pub fn task_is_backgrounded(&self) -> bool {
         self.task_metadata.as_ref().and_then(|metadata| metadata.is_backgrounded).unwrap_or(false)
     }

--- a/src/ui/tool_call/artifact.rs
+++ b/src/ui/tool_call/artifact.rs
@@ -3,7 +3,9 @@
 //! Rendering helpers for SDK `Artifact` tool calls.
 
 use crate::app::ToolCallInfo;
-use ratatui::text::Line;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use serde_json::{Map, Value};
 
 use super::fields::{self, ToolField};
 use super::typed;
@@ -27,6 +29,18 @@ fn render_input_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
     let mut artifact_fields = Vec::new();
 
     if let Some(input) = input {
+        if let Some(action) = typed::json_string(input, "action") {
+            artifact_fields.push(ToolField::new("Action", action));
+        }
+        if let Some(scope) = typed::json_string(input, "scope") {
+            artifact_fields.push(ToolField::new("Scope", scope));
+        }
+        if let Some(limit) = typed::json_i64(input, "limit") {
+            artifact_fields.push(ToolField::new("Limit", limit.to_string()));
+        }
+        if let Some(title) = typed::json_string(input, "title") {
+            artifact_fields.push(ToolField::new("Title", title));
+        }
         if let Some(label) = typed::json_string(input, "label") {
             artifact_fields.push(ToolField::new("Label", label));
         }
@@ -36,16 +50,57 @@ fn render_input_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
         if let Some(file_path) = typed::json_string(input, "file_path") {
             artifact_fields.push(ToolField::new("File path", file_path));
         }
+        if let Some(favicon) = typed::json_string(input, "favicon") {
+            artifact_fields.push(ToolField::new("Favicon", favicon));
+        }
         if let Some(url) = typed::json_string(input, "url") {
             artifact_fields.push(ToolField::new("URL", url));
         }
+        if let Some(additional) = additional_json(
+            input,
+            &[
+                "action",
+                "scope",
+                "limit",
+                "title",
+                "label",
+                "description",
+                "file_path",
+                "favicon",
+                "url",
+                "force",
+            ],
+        ) {
+            artifact_fields.push(ToolField::new("Additional input", additional));
+        }
     }
 
-    fields::render_fields(artifact_fields)
+    let mut lines = fields::render_fields(artifact_fields);
+    if let Some(force) = input.and_then(|input| typed::json_bool(input, "force")) {
+        let style = if force {
+            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::from(vec![
+            Span::styled("Overwrite conflicts: ", Style::default().fg(crate::ui::theme::DIM)),
+            Span::styled(typed::bool_label(force), style),
+        ]));
+    }
+    lines
 }
 
-fn render_output_object(object: &serde_json::Map<String, serde_json::Value>) -> Vec<Line<'static>> {
+fn render_output_object(object: &Map<String, Value>) -> Vec<Line<'static>> {
     let mut artifact_fields = Vec::new();
+    if let Some(scope) = typed::json_string(object, "scope") {
+        artifact_fields.push(ToolField::new("Scope", scope));
+    }
+    if let Some(truncated) = typed::json_bool(object, "truncated") {
+        artifact_fields.push(ToolField::new("Truncated", typed::bool_label(truncated)));
+    }
+    if let Some(artifacts) = object.get("artifacts").and_then(Value::as_array) {
+        artifact_fields.push(ToolField::new("Artifacts", artifacts.len().to_string()));
+    }
     if let Some(title) = typed::json_string(object, "title") {
         artifact_fields.push(ToolField::new("Title", title));
     }
@@ -61,7 +116,83 @@ fn render_output_object(object: &serde_json::Map<String, serde_json::Value>) -> 
     if let Some(mcp_dropped) = typed::json_string(object, "mcpDropped") {
         artifact_fields.push(ToolField::new("MCP dropped", mcp_dropped));
     }
-    fields::render_fields(artifact_fields)
+    if let Some(capabilities) = object.get("capabilities").and_then(typed::non_empty_compact_json) {
+        artifact_fields.push(ToolField::new("Capabilities", capabilities));
+    }
+    if let Some(stored) = object.get("stored").and_then(Value::as_object) {
+        if let Some(contract) = typed::json_string(stored, "contract") {
+            artifact_fields.push(ToolField::new("Stored contract", contract));
+        }
+        if let Some(capabilities) =
+            stored.get("capabilities").and_then(typed::non_empty_compact_json)
+        {
+            artifact_fields.push(ToolField::new("Stored capabilities", capabilities));
+        }
+    }
+    if let Some(warnings) = typed::json_string_array(object.get("warnings")) {
+        artifact_fields.push(ToolField::new("Warnings", warnings.join("; ")));
+    }
+    if let Some(contract) = typed::json_string(object, "contract") {
+        artifact_fields.push(ToolField::new("Contract", contract));
+    }
+    if let Some(updated) = typed::json_bool(object, "updated") {
+        artifact_fields.push(ToolField::new("Updated", typed::bool_label(updated)));
+    }
+    if let Some(additional) = additional_json(
+        object,
+        &[
+            "artifacts",
+            "truncated",
+            "scope",
+            "title",
+            "url",
+            "path",
+            "version",
+            "mcpDropped",
+            "capabilities",
+            "stored",
+            "warnings",
+            "contract",
+            "updated",
+        ],
+    ) {
+        artifact_fields.push(ToolField::new("Additional output", additional));
+    }
+
+    let mut lines = fields::render_fields(artifact_fields);
+    if let Some(artifacts) = object.get("artifacts").and_then(Value::as_array) {
+        for (index, artifact) in artifacts.iter().enumerate() {
+            let Some(artifact) = artifact.as_object() else {
+                if let Some(value) = typed::non_empty_compact_json(artifact) {
+                    lines.push(fields::render_dynamic_field(
+                        format!("Artifact {}", index + 1),
+                        value,
+                    ));
+                }
+                continue;
+            };
+            let title = typed::json_string(artifact, "title").unwrap_or("<untitled>");
+            let url = typed::json_string(artifact, "url").unwrap_or("<no URL>");
+            let relation = typed::json_string(artifact, "rel").map(|rel| format!("({rel}) "));
+            let updated = typed::json_string(artifact, "updatedAt")
+                .map(|timestamp| format!(" — updated {timestamp}"))
+                .unwrap_or_default();
+            lines.push(fields::render_dynamic_field(
+                format!("Artifact {}", index + 1),
+                format!("{}{title} — {url}{updated}", relation.unwrap_or_default()),
+            ));
+        }
+    }
+    lines
+}
+
+fn additional_json(object: &Map<String, Value>, handled: &[&str]) -> Option<String> {
+    let additional = object
+        .iter()
+        .filter(|(key, _)| !handled.contains(&key.as_str()))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<Map<_, _>>();
+    (!additional.is_empty()).then(|| typed::compact_json(&Value::Object(additional))).flatten()
 }
 
 #[cfg(test)]
@@ -110,6 +241,94 @@ mod tests {
                 "URL: https://artifact.local/new",
                 "Path: C:/work/dashboard.html",
                 "Version: v2",
+            ]
+        );
+    }
+
+    #[test]
+    fn renders_publish_contract_without_dropping_unknown_fields() {
+        let tc = artifact_tool_call(
+            json!({
+                "action": "publish",
+                "title": "Dashboard page",
+                "favicon": "chart",
+                "force": true,
+                "futureInput": {"enabled": true}
+            }),
+            Some(
+                r#"{"title":"Dashboard","url":"https://artifact.local/dashboard","path":"C:/work/dashboard.html","version":"v3","capabilities":{"storage":true},"stored":{"contract":"artifact-v1","capabilities":{"persist":true}},"warnings":["legacy contract"],"contract":"artifact-v2","updated":true,"futureOutput":{"revision":4}}"#,
+            ),
+        );
+
+        let lines = render_tool_content(&tc);
+
+        assert_eq!(
+            rendered_line_texts(&lines),
+            vec![
+                "Action: publish",
+                "Title: Dashboard page",
+                "Favicon: chart",
+                "Additional input: {\"futureInput\":{\"enabled\":true}}",
+                "Overwrite conflicts: yes",
+                "Title: Dashboard",
+                "URL: https://artifact.local/dashboard",
+                "Path: C:/work/dashboard.html",
+                "Version: v3",
+                "Capabilities: {\"storage\":true}",
+                "Stored contract: artifact-v1",
+                "Stored capabilities: {\"persist\":true}",
+                "Warnings: legacy contract",
+                "Contract: artifact-v2",
+                "Updated: yes",
+                "Additional output: {\"futureOutput\":{\"revision\":4}}",
+            ]
+        );
+    }
+
+    #[test]
+    fn renders_list_scope_and_each_artifact() {
+        let tc = artifact_tool_call(
+            json!({"action": "list", "scope": "all", "limit": 10}),
+            Some(
+                r#"{"scope":"all","truncated":false,"artifacts":[{"rel":"mine","title":"Dashboard","url":"https://artifact.local/dashboard","updatedAt":"2026-07-18T10:00:00Z"},{"rel":"shared","title":"Roadmap","url":"https://artifact.local/roadmap"}]}"#,
+            ),
+        );
+
+        let lines = render_tool_content(&tc);
+
+        assert_eq!(
+            rendered_line_texts(&lines),
+            vec![
+                "Action: list",
+                "Scope: all",
+                "Limit: 10",
+                "Scope: all",
+                "Truncated: no",
+                "Artifacts: 2",
+                "Artifact 1: (mine) Dashboard — https://artifact.local/dashboard — updated 2026-07-18T10:00:00Z",
+                "Artifact 2: (shared) Roadmap — https://artifact.local/roadmap",
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_native_human_readable_output() {
+        let tc = artifact_tool_call(
+            json!({"action": "list", "scope": "all"}),
+            Some(
+                "Found 1 artifact(s) (scope: all):\n- (mine) Dashboard — https://artifact.local/dashboard",
+            ),
+        );
+
+        let lines = render_tool_content(&tc);
+
+        assert_eq!(
+            rendered_line_texts(&lines),
+            vec![
+                "Action: list",
+                "Scope: all",
+                "Found 1 artifact(s) (scope: all):",
+                "- (mine) Dashboard — https://artifact.local/dashboard",
             ]
         );
     }

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -173,7 +173,12 @@ fn truncate_spans_to_width(spans: Vec<Span<'static>>, max_width: usize) -> Vec<S
 fn tool_output_badge_spans(tc: &ToolCallInfo) -> Vec<Span<'static>> {
     let mut badges = Vec::new();
 
-    if tc.assistant_auto_backgrounded() {
+    if let Some(timeout_ms) = tc.timed_out_after_ms() {
+        badges.push(Span::styled(
+            format!("  [auto-backgrounded after {} ms]", format_u64_grouped(timeout_ms)),
+            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        ));
+    } else if tc.assistant_auto_backgrounded() {
         badges.push(Span::styled(
             "  [assistant backgrounded]",
             Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
@@ -181,13 +186,24 @@ fn tool_output_badge_spans(tc: &ToolCallInfo) -> Vec<Span<'static>> {
     }
 
     if matches!(tc.sdk_tool_name.as_str(), "Agent" | "Task") {
+        if let Some(retry) = subagent_retry_badge(tc) {
+            badges.push(Span::styled(
+                format!("  [{retry}]"),
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            ));
+        }
         if let Some(agent_type) = agent_requested_type_badge(tc) {
             badges.push(Span::styled(
                 format!("  [type: {agent_type}]"),
                 Style::default().fg(Color::LightBlue).add_modifier(Modifier::BOLD),
             ));
         }
-        if let Some(model) = agent_display_model_badge(tc) {
+        if let Some(models) = agent_model_route_badge(tc) {
+            badges.push(Span::styled(
+                format!("  [models: {}]", models.join(" -> ")),
+                Style::default().fg(Color::LightBlue).add_modifier(Modifier::BOLD),
+            ));
+        } else if let Some(model) = agent_display_model_badge(tc) {
             badges.push(Span::styled(
                 format!("  [model: {model}]"),
                 Style::default().fg(Color::LightBlue).add_modifier(Modifier::BOLD),
@@ -203,6 +219,43 @@ fn tool_output_badge_spans(tc: &ToolCallInfo) -> Vec<Span<'static>> {
     }
 
     badges
+}
+
+fn subagent_retry_badge(tc: &ToolCallInfo) -> Option<String> {
+    if !matches!(tc.status, model::ToolCallStatus::InProgress) {
+        return None;
+    }
+    let model::SubagentRetryUpdate::Waiting { attempt, max_retries, retry_delay_ms, .. } =
+        tc.task_metadata.as_ref()?.subagent_retry.as_ref()?
+    else {
+        return None;
+    };
+    Some(format!("retry {attempt}/{max_retries} in {}", format_retry_delay(*retry_delay_ms)))
+}
+
+fn format_retry_delay(delay_ms: u64) -> String {
+    if delay_ms < 1_000 {
+        return format!("{delay_ms}ms");
+    }
+    let seconds = delay_ms / 1_000;
+    let milliseconds = delay_ms % 1_000;
+    if milliseconds == 0 {
+        return format!("{seconds}s");
+    }
+    let fractional = format!("{milliseconds:03}").trim_end_matches('0').to_owned();
+    format!("{seconds}.{fractional}s")
+}
+
+fn format_u64_grouped(value: u64) -> String {
+    let digits = value.to_string();
+    let mut grouped = String::with_capacity(digits.len() + digits.len() / 3);
+    for (index, ch) in digits.chars().enumerate() {
+        if index > 0 && (digits.len() - index).is_multiple_of(3) {
+            grouped.push(',');
+        }
+        grouped.push(ch);
+    }
+    grouped
 }
 
 fn tool_raw_input_string<'a>(tc: &'a ToolCallInfo, key: &str) -> Option<&'a str> {
@@ -223,6 +276,14 @@ fn agent_requested_type_badge(tc: &ToolCallInfo) -> Option<String> {
         return None;
     }
     Some(subagent_type.to_owned())
+}
+
+fn agent_model_route_badge(tc: &ToolCallInfo) -> Option<&[String]> {
+    tc.output_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.agent.as_ref())
+        .and_then(|agent| agent.models_used.as_deref())
+        .filter(|models| models.len() >= 2)
 }
 
 fn agent_display_model_badge(tc: &ToolCallInfo) -> Option<String> {

--- a/src/ui/tool_call/tests.rs
+++ b/src/ui/tool_call/tests.rs
@@ -180,6 +180,52 @@ fn render_tool_call_title_shows_resolved_model_badge_for_subagents() {
 }
 
 #[test]
+fn render_tool_call_title_shows_ordered_model_route_after_subagent_swap() {
+    let mut tc = test_tool_call("reviewer", "Agent", model::ToolCallStatus::Completed);
+    tc.raw_input = Some(serde_json::json!({ "model": "opus" }));
+    tc.output_metadata = Some(
+        model::ToolOutputMetadata::new().agent(Some(
+            model::AgentOutputMetadata::new()
+                .resolved_model(Some("claude-sonnet-4-7".to_owned()))
+                .models_used(Some(vec![
+                    "claude-opus-4-8".to_owned(),
+                    "claude-sonnet-4-7".to_owned(),
+                ])),
+        )),
+    );
+
+    let line = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 160, 0);
+    let rendered: String = line.spans.iter().map(|span| span.content.as_ref()).collect();
+
+    assert!(rendered.contains("[models: claude-opus-4-8 -> claude-sonnet-4-7]"));
+    assert!(!rendered.contains("[model:"));
+}
+
+#[test]
+fn render_tool_call_title_shows_transient_subagent_retry() {
+    let mut tc = test_tool_call("reviewer", "Agent", model::ToolCallStatus::InProgress);
+    tc.task_metadata = Some(model::TaskMetadata::new().subagent_retry(Some(
+        model::SubagentRetryUpdate::Waiting {
+            agent_id: Some("agent-1".to_owned()),
+            attempt: 2,
+            max_retries: 4,
+            retry_delay_ms: 1_500,
+            error_status: Some(429),
+            error_category: Some("rate_limit".to_owned()),
+        },
+    )));
+
+    let line = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 100, 0);
+    let rendered: String = line.spans.iter().map(|span| span.content.as_ref()).collect();
+    assert!(rendered.contains("[retry 2/4 in 1.5s]"));
+
+    tc.status = model::ToolCallStatus::Completed;
+    let line = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 100, 0);
+    let rendered: String = line.spans.iter().map(|span| span.content.as_ref()).collect();
+    assert!(!rendered.contains("[retry"));
+}
+
+#[test]
 fn render_tool_call_title_shows_running_agent_type_and_requested_model_from_input() {
     let mut tc = test_tool_call("Agent: review-worker", "Agent", model::ToolCallStatus::InProgress);
     tc.raw_input = Some(serde_json::json!({
@@ -334,6 +380,19 @@ fn standard_title_uses_generic_icon_for_unknown_tools() {
     let rendered = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 80, 0);
 
     assert_eq!(rendered.spans.get(1).map(|span| span.content.as_ref()), Some("\u{25cb} "));
+}
+
+#[test]
+fn generic_renderer_preserves_refresh_mcp_tools_json_output() {
+    let mut tc =
+        test_tool_call("RefreshMcpTools", "RefreshMcpTools", model::ToolCallStatus::Completed);
+    let payload = r#"[{"server":"docs","status":"refreshed","toolCount":3,"added":["lookup"],"removed":["legacy_lookup"]}]"#;
+    tc.content = vec![model::ToolCallContent::from(payload.to_owned())];
+
+    let body = standard::render_tool_call_body(&tc, 300);
+    let rendered = rendered_line_texts_trimmed(&body).join("\n");
+
+    assert!(rendered.contains(payload));
 }
 
 #[test]
@@ -810,6 +869,23 @@ fn bash_title_renders_assistant_backgrounded_badge() {
     let rendered = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 100, 0);
     let text: String = rendered.spans.iter().map(|span| span.content.as_ref()).collect();
     assert!(text.contains("[assistant backgrounded]"));
+}
+
+#[test]
+fn bash_title_distinguishes_timeout_auto_backgrounding() {
+    let mut tc = test_tool_call("tc-bash-timeout", "Bash", model::ToolCallStatus::Completed);
+    tc.output_metadata = Some(
+        model::ToolOutputMetadata::new().bash(Some(
+            model::BashOutputMetadata::new()
+                .assistant_auto_backgrounded(Some(true))
+                .timed_out_after_ms(Some(10_000)),
+        )),
+    );
+
+    let rendered = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 100, 0);
+    let text: String = rendered.spans.iter().map(|span| span.content.as_ref()).collect();
+    assert!(text.contains("[auto-backgrounded after 10,000 ms]"));
+    assert!(!text.contains("[assistant backgrounded]"));
 }
 
 #[test]

--- a/src/ui/tool_call/typed.rs
+++ b/src/ui/tool_call/typed.rs
@@ -212,8 +212,11 @@ pub(super) fn render_json_or_text_blocks(
         if let Ok(value) = serde_json::from_str::<Value>(&stripped)
             && let Some(object) = value.as_object()
         {
-            lines.extend(render_object(object));
-            continue;
+            let rendered = render_object(object);
+            if !rendered.is_empty() {
+                lines.extend(rendered);
+                continue;
+            }
         }
         lines.extend(non_empty_trimmed_lines(&stripped).map(|line| Line::from(line.to_owned())));
     }
@@ -267,4 +270,27 @@ pub(super) fn format_duration_seconds(seconds: i64) -> String {
     }
 
     parts.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::tool_call::test_support::{rendered_line_texts, tool_call};
+    use serde_json::json;
+
+    #[test]
+    fn json_object_falls_back_to_raw_text_when_typed_renderer_is_empty() {
+        let tc = tool_call(
+            "tc-future-shape",
+            "Future typed tool",
+            "FutureTool",
+            json!({}),
+            Some(r#"{"futureShape":{"value":1}}"#),
+            model::ToolCallStatus::Completed,
+        );
+
+        let lines = render_json_or_text_blocks(&tc, |_| Vec::new());
+
+        assert_eq!(rendered_line_texts(&lines), vec![r#"{"futureShape":{"value":1}}"#]);
+    }
 }


### PR DESCRIPTION
## Summary

- Upgrade the root package and bridge from Claude Agent SDK `0.3.207` to `0.3.214`.
- Preserve new SDK contracts across the TypeScript bridge and Rust models, including human prompt origin, Google Cloud provider metadata, terminal reasons, subagent retry state, resolved model routes, and Bash timeout metadata.
- Improve tool output fidelity by preferring trustworthy Grep totals, omitting unavailable file counts, expanding Artifact rendering, and falling back to raw structured output when a typed renderer produces no rows.
- Keep review-dependent SDK workflows safe by disabling feedback drafts and `ProposeSkills` until claude-rs provides the required review UI.

## Why

SDK releases `0.3.208` through `0.3.214` add and change fields that cross the bridge boundary. Without explicit mapping, the TUI can lose useful metadata, misrepresent tool results, or expose workflows that require review interactions claude-rs does not yet implement.

This migration covers the published release changes and additional schema differences found by comparing the installed SDK versions. It keeps new output losslessly visible, gives mid-turn subagent model changes and retries a stable UI representation, and avoids displaying a misleading `0 files` Grep summary when the SDK did not provide a trustworthy file total.

Closes #

## Validation

- Automated:
  - `npm test` in `agent-sdk` — 284 tests passed
  - `npm run lint` in `agent-sdk`
  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test`
  - `cargo check --offline`
  - `git diff --check`
- Manual:
  - Verified a foreground Bash command with a 5-second timeout renders `[auto-backgrounded after 5,000 ms]`, remains alive in the background, and later returns its output.
  - Verified an Agent subagent displays its SDK-resolved model (`claude-opus-4-8`) in the tool title.
  - Captured a real content-mode Grep payload with `totalLines` but no trustworthy file total and added matching regression coverage for the summary fallback.
  - Confirmed the authoritative command snapshot does not expose `/feedback` in the current SDK session.
- Screenshot/video (if UI changed): N/A — verified interactively in the TUI; no capture attached.

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: Updates the pinned Agent SDK and lockfiles; no Rust MSRV, CLI argument, or packaging-layout change.
