### PR TITLE
chore(release): publish 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-07-18 [Changes][v0.14.1]
+
 ### Documentation
 
 - **Manual restructure** (#282, @srothgan): Split installation into end-user install, development, and troubleshooting pages, document `/agent`, restore the conduct report contact in the issue chooser, and add tests keeping the slash command and CLI tables in sync with the code.
@@ -773,6 +775,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.14.1]: https://github.com/srothgan/claude-code-rust/compare/v0.14.0...v0.14.1
 [v0.14.0]: https://github.com/srothgan/claude-code-rust/compare/v0.13.4...v0.14.0
 [v0.13.4]: https://github.com/srothgan/claude-code-rust/compare/v0.13.3...v0.13.4
 [v0.13.3]: https://github.com/srothgan/claude-code-rust/compare/v0.13.2...v0.13.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Claude Code Rust - native Rust terminal interface for Claude Code",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary

Prepares the 0.14.1 release. Bumps the crate version to `0.14.1` in `Cargo.toml` and `Cargo.lock`, syncs `package.json`, and promotes the Unreleased changelog entries into a dated `[0.14.1]` section with its compare link.

## Why

Landing a `Cargo.toml` version change on `main` is the trigger for the Release workflow, which reads the version, tags `v0.14.1`, builds/attests artifacts, and publishes the npm packages and GitHub Release. The changelog section is required because the release job extracts its notes from `## [0.14.1]`.

Closes #

## Validation

- Automated: `cargo update -p claude-code-rust --precise 0.14.1` refreshed `Cargo.lock`; CI to run on this PR.
- Manual: Reviewed the full diff — versions consistent across `Cargo.toml`, `Cargo.lock`, `package.json`; changelog section dated 2026-07-18 with `v0.14.0...v0.14.1` compare link added.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A (changelog only)
- Governance/release impact: Merging to `main` triggers the Release workflow; publishing pauses at the `npm-release` environment approval gate and the workflow creates/pushes the `v0.14.1` tag automatically (do not tag manually).