### PR TITLE
ci: group Dependabot minor/patch updates and fix stale CI metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      # Batch non-breaking Rust bumps into one PR. Major bumps stay
+      # ungrouped so each breaking change gets its own reviewable PR.
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -29,9 +36,17 @@ updates:
       # codeql-action/init and codeql-action/analyze must run the same version:
       # analyze rejects a config file written by a different init version. Split
       # across two PRs, each one fails on its own and only passes once both land.
+      # Listed first and matching all update types so the pair always travels
+      # together, even on a major bump that actions-minor-patch would not catch.
       codeql-action:
         patterns:
           - "github/codeql-action*"
+      # Batch non-breaking action bumps. Major bumps stay ungrouped so a
+      # breaking change (e.g. setup-node v6 -> v7) gets its own PR.
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # npm dependencies (root package)
   - package-ecosystem: "npm"

--- a/.github/workflows/_agent-sdk.yml
+++ b/.github/workflows/_agent-sdk.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/dependency-monitor.yml
+++ b/.github/workflows/dependency-monitor.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
 
@@ -43,11 +43,12 @@ jobs:
           set -euo pipefail
 
           package='@anthropic-ai/claude-agent-sdk'
+          # Only @anthropic-ai/claude-agent-sdk is a declared direct pin now.
+          # @anthropic-ai/sdk, @modelcontextprotocol/sdk, and zod are pulled in
+          # transitively by the Agent SDK and move with it, so tracking them
+          # here just reported bumps for deps the project no longer pins.
           bridge_stack=(
             '@anthropic-ai/claude-agent-sdk'
-            '@anthropic-ai/sdk'
-            '@modelcontextprotocol/sdk'
-            'zod'
           )
 
           package_version() {

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           cache: npm
@@ -128,7 +128,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           package-manager-cache: false
@@ -206,7 +206,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           package-manager-cache: false
@@ -228,7 +228,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           cache: npm
@@ -349,7 +349,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -133,7 +133,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           cache: npm
@@ -220,7 +220,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -172,7 +172,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           package-manager-cache: false
@@ -199,7 +199,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -326,7 +326,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
 
@@ -429,7 +429,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -468,7 +468,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary

- Group Dependabot `cargo` and `github-actions` minor/patch updates so non-breaking bumps land in one PR each, while major bumps stay ungrouped for individual review (the `npm` ecosystems were already grouped).
- Keep the existing `codeql-action` group first and matching all update types so `init`/`analyze` always travel together, even on a major bump.
- Trim the Agent SDK update monitor's `bridge_stack` to the only dependency still pinned directly (`@anthropic-ai/claude-agent-sdk`); `@anthropic-ai/sdk`, `@modelcontextprotocol/sdk`, and `zod` are now transitive and were reporting bumps for pins that no longer exist.
- Correct every `setup-node` pin comment from `# v6` to `# v7` to match the SHA that merged as the 7.0.0 major bump in #289 (Dependabot bumped the SHA but left the major-only comment stale).

## Why

The last Dependabot run produced 14 separate PRs — 10 of them individual Rust crate bumps — because `cargo` and most of `github-actions` had no grouping. Grouping non-breaking updates cuts that to a handful of batched PRs while still surfacing majors on their own. Separately, the update monitor was flagging three dependencies the project no longer pins directly, and the `setup-node` pins were annotated `# v6` while actually running v7, which is misleading during review.

Closes #

## Validation

- Automated: `actionlint` (built from source with Go 1.26.4) passes clean across all workflows.
- Manual: Verified via the lockfiles that `@anthropic-ai/sdk`, `@modelcontextprotocol/sdk`, and `zod` appear only as transitive deps of the Agent SDK; confirmed the `820762786026740c76f36085b0efc47a31fe5020` SHA corresponds to setup-node 7.0.0 from the #289 merge metadata.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A — config/metadata only; no runtime behavior changes.
- Docs updated: N/A
- Governance/release impact: N/A