### PR TITLE
feat(keymap): make Ctrl+A/Ctrl+E step across lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **Readline line-stepping** (#305, @srothgan): Make `Ctrl+A`/`Ctrl+E` move to the line start/end, then step to the previous/next logical line on repeat, keep `Home`/`End` as plain line-boundary jumps, and add rebindable catalog actions.
+
 ## [0.14.1] - 2026-07-18 [Changes][v0.14.1]
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- **Readline line-stepping** (#305, @srothgan): Make `Ctrl+A`/`Ctrl+E` move to the line start/end, then step to the previous/next logical line on repeat, keep `Home`/`End` as plain line-boundary jumps, and add rebindable catalog actions.
+- **Readline line-stepping** (#305, @srothgan): Make `Ctrl+A`/`Ctrl+E` move to the line start/end, then step to the previous/next logical line on repeat.
 
 ## [0.14.1] - 2026-07-18 [Changes][v0.14.1]
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -279,6 +279,21 @@ impl InputState {
         })
     }
 
+    pub fn textarea_move_line_start_or_up(&mut self) -> bool {
+        let (row, col) = self.cursor();
+        let target_row = if col == 0 { row.saturating_sub(1) } else { row };
+        self.set_cursor(target_row, 0)
+    }
+
+    pub fn textarea_move_line_end_or_down(&mut self) -> bool {
+        let (row, col) = self.cursor();
+        let current_line_end = self.lines()[row].chars().count();
+        let target_row =
+            if col == current_line_end && row + 1 < self.lines().len() { row + 1 } else { row };
+        let target_col = self.lines()[target_row].chars().count();
+        self.set_cursor(target_row, target_col)
+    }
+
     pub fn textarea_undo(&mut self) -> bool {
         let changed = self.editor.undo();
         if changed {
@@ -1049,6 +1064,64 @@ mod tests {
         let v = input.version;
         input.move_home(); // col already 0, but still bumps
         assert!(input.version > v);
+    }
+
+    #[test]
+    fn move_line_start_or_up_stops_at_each_logical_line_start() {
+        let mut input = InputState::new();
+        input.set_text("alpha\nbeta\ngamma");
+        let _ = input.set_cursor(1, 2);
+
+        let version = input.version;
+        assert!(input.textarea_move_line_start_or_up());
+        assert_eq!(input.cursor(), (1, 0));
+        assert_eq!(input.version, version + 1);
+
+        assert!(input.textarea_move_line_start_or_up());
+        assert_eq!(input.cursor(), (0, 0));
+
+        let version = input.version;
+        assert!(!input.textarea_move_line_start_or_up());
+        assert_eq!(input.cursor(), (0, 0));
+        assert_eq!(input.version, version);
+    }
+
+    #[test]
+    fn move_line_end_or_down_stops_at_each_logical_line_end() {
+        let mut input = InputState::new();
+        input.set_text("alpha\nbeta\ngamma");
+        let _ = input.set_cursor(1, 2);
+
+        let version = input.version;
+        assert!(input.textarea_move_line_end_or_down());
+        assert_eq!(input.cursor(), (1, 4));
+        assert_eq!(input.version, version + 1);
+
+        assert!(input.textarea_move_line_end_or_down());
+        assert_eq!(input.cursor(), (2, 5));
+
+        let version = input.version;
+        assert!(!input.textarea_move_line_end_or_down());
+        assert_eq!(input.cursor(), (2, 5));
+        assert_eq!(input.version, version);
+    }
+
+    #[test]
+    fn line_boundary_navigation_handles_empty_and_unicode_lines() {
+        let mut input = InputState::new();
+        input.set_text("α\n\n猫犬");
+
+        let _ = input.set_cursor(2, 0);
+        assert!(input.textarea_move_line_start_or_up());
+        assert_eq!(input.cursor(), (1, 0));
+        assert!(input.textarea_move_line_start_or_up());
+        assert_eq!(input.cursor(), (0, 0));
+
+        let _ = input.set_cursor(0, 1);
+        assert!(input.textarea_move_line_end_or_down());
+        assert_eq!(input.cursor(), (1, 0));
+        assert!(input.textarea_move_line_end_or_down());
+        assert_eq!(input.cursor(), (2, 2));
     }
 
     // line_count

--- a/src/app/keymap/action.rs
+++ b/src/app/keymap/action.rs
@@ -30,6 +30,8 @@ pub enum InputAction {
     MoveWordRight,
     MoveLineStart,
     MoveLineEnd,
+    MoveLineStartOrUp,
+    MoveLineEndOrDown,
     MoveUp,
     MoveDown,
     DeleteCharBefore,

--- a/src/app/keymap/catalog.rs
+++ b/src/app/keymap/catalog.rs
@@ -115,6 +115,20 @@ const ACTION_CATALOG: &[KeyActionDescriptor] = &[
         default_contexts: &[KeyContext::ChatInput],
     },
     KeyActionDescriptor {
+        action: KeyAction::Input(InputAction::MoveLineStartOrUp),
+        id: "input.move_line_start_or_up",
+        label: "Move line start, then up",
+        description: "Move to the current line start, or the previous line start when already there.",
+        default_contexts: &[KeyContext::ChatInput],
+    },
+    KeyActionDescriptor {
+        action: KeyAction::Input(InputAction::MoveLineEndOrDown),
+        id: "input.move_line_end_or_down",
+        label: "Move line end, then down",
+        description: "Move to the current line end, or the next line end when already there.",
+        default_contexts: &[KeyContext::ChatInput],
+    },
+    KeyActionDescriptor {
         action: KeyAction::Input(InputAction::MoveUp),
         id: "input.move_up",
         label: "Move up",

--- a/src/app/keymap/defaults.rs
+++ b/src/app/keymap/defaults.rs
@@ -121,8 +121,8 @@ fn chat_navigation_default_bindings() -> [KeyBinding; 16] {
 
 fn chat_readline_default_bindings() -> [KeyBinding; 13] {
     [
-        chat_input('a', KeyModifiers::CONTROL, InputAction::MoveLineStart),
-        chat_input('e', KeyModifiers::CONTROL, InputAction::MoveLineEnd),
+        chat_input('a', KeyModifiers::CONTROL, InputAction::MoveLineStartOrUp),
+        chat_input('e', KeyModifiers::CONTROL, InputAction::MoveLineEndOrDown),
         chat_input('b', KeyModifiers::CONTROL, InputAction::MoveCharLeft),
         chat_input('f', KeyModifiers::CONTROL, InputAction::MoveCharRight),
         chat_input('d', KeyModifiers::CONTROL, InputAction::DeleteCharAfter),

--- a/src/app/keymap/tests.rs
+++ b/src/app/keymap/tests.rs
@@ -265,7 +265,28 @@ fn default_keymap_contains_chat_input_readline_bindings() {
             KeyContext::ChatInput,
             KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL),
         ),
+        Some(KeyAction::Input(InputAction::MoveLineStartOrUp))
+    );
+    assert_eq!(
+        keymap.action_for_event(
+            KeyContext::ChatInput,
+            KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL),
+        ),
+        Some(KeyAction::Input(InputAction::MoveLineEndOrDown))
+    );
+    assert_eq!(
+        keymap.action_for_event(
+            KeyContext::ChatInput,
+            KeyEvent::new(KeyCode::Home, KeyModifiers::NONE),
+        ),
         Some(KeyAction::Input(InputAction::MoveLineStart))
+    );
+    assert_eq!(
+        keymap.action_for_event(
+            KeyContext::ChatInput,
+            KeyEvent::new(KeyCode::End, KeyModifiers::NONE),
+        ),
+        Some(KeyAction::Input(InputAction::MoveLineEnd))
     );
 }
 

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -293,6 +293,8 @@ fn execute_input_action(app: &mut App, action: InputAction) -> KeyOutcome {
         InputAction::MoveWordRight => app.input.textarea_move_word_right(),
         InputAction::MoveLineStart => app.input.textarea_move_home(),
         InputAction::MoveLineEnd => app.input.textarea_move_end(),
+        InputAction::MoveLineStartOrUp => app.input.textarea_move_line_start_or_up(),
+        InputAction::MoveLineEndOrDown => app.input.textarea_move_line_end_or_down(),
         InputAction::MoveUp => {
             let _ = try_move_input_cursor_up(app);
             true
@@ -956,6 +958,36 @@ mod tests {
 
         assert_eq!(outcome, KeyOutcome::Handled(true));
         assert_eq!(app.input.cursor_col(), 1);
+    }
+
+    #[test]
+    fn ctrl_a_moves_to_line_start_then_previous_line_start() {
+        let mut app = App::test_default();
+        app.input.set_text("alpha\nbeta\ngamma");
+        let _ = app.input.set_cursor(1, 2);
+        let key = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
+
+        assert_eq!(handle_normal_key(&mut app, key), KeyOutcome::Handled(true));
+        assert_eq!(app.input.cursor(), (1, 0));
+        assert_eq!(handle_normal_key(&mut app, key), KeyOutcome::Handled(true));
+        assert_eq!(app.input.cursor(), (0, 0));
+        assert_eq!(handle_normal_key(&mut app, key), KeyOutcome::Handled(false));
+        assert_eq!(app.input.cursor(), (0, 0));
+    }
+
+    #[test]
+    fn ctrl_e_moves_to_line_end_then_next_line_end() {
+        let mut app = App::test_default();
+        app.input.set_text("alpha\nbeta\ngamma");
+        let _ = app.input.set_cursor(1, 2);
+        let key = KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL);
+
+        assert_eq!(handle_normal_key(&mut app, key), KeyOutcome::Handled(true));
+        assert_eq!(app.input.cursor(), (1, 4));
+        assert_eq!(handle_normal_key(&mut app, key), KeyOutcome::Handled(true));
+        assert_eq!(app.input.cursor(), (2, 5));
+        assert_eq!(handle_normal_key(&mut app, key), KeyOutcome::Handled(false));
+        assert_eq!(app.input.cursor(), (2, 5));
     }
 
     #[test]

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -309,8 +309,10 @@ mod tests {
 
         assert!(has_row(&rows, "Enter", "Send message"));
         assert!(has_row(&rows, "Shift+Enter, Ctrl+Enter", "Insert newline"));
-        assert!(has_row(&rows, "Home, Ctrl+A", "Move line start"));
-        assert!(has_row(&rows, "End, Ctrl+E", "Move line end"));
+        assert!(has_row(&rows, "Home", "Move line start"));
+        assert!(has_row(&rows, "End", "Move line end"));
+        assert!(has_row(&rows, "Ctrl+A", "Move line start, then up"));
+        assert!(has_row(&rows, "Ctrl+E", "Move line end, then down"));
         assert!(has_row(&rows, "Ctrl+Y", "Yank"));
         assert!(!rows.iter().any(|(left, right)| left == "Ctrl+z/y" || right == "Undo/redo"));
     }


### PR DESCRIPTION
## Summary

Make `Ctrl+A` / `Ctrl+E` do "smart" readline navigation in the chat input: they move to the current line boundary, then walk to the previous/next logical line's boundary on repeat. `Home` / `End` keep their plain line-start / line-end behavior.

- Add `MoveLineStartOrUp` / `MoveLineEndOrDown` input actions and their `InputState` implementations.
- Rebind `Ctrl+A` → `MoveLineStartOrUp` and `Ctrl+E` → `MoveLineEndOrDown` in the default keymap.
- Register both actions in the keymap catalog (`input.move_line_start_or_up` / `input.move_line_end_or_down`) so they can be rebound.
- Split the `Home/End` and `Ctrl+A/Ctrl+E` rows in the help view.

## Why

Previously `Ctrl+A` / `Ctrl+E` were aliases for `Home` / `End`. Aligning them with common readline behavior lets users step across a multi-line input by repeatedly pressing the shortcut, while still keeping a plain single-line boundary jump available on `Home` / `End`.

Closes #

## Validation

- Automated: added unit tests for `InputState` (boundary, multi-line, and Unicode/empty-line cases), keymap binding tests, key-dispatch integration tests, and updated help-view row assertions.
- Manual: N/A
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: `Ctrl+A` / `Ctrl+E` default behavior changes; users who want the old behavior can rebind to `MoveLineStart` / `MoveLineEnd`.
- Docs updated: N/A
- Governance/release impact: N/A
