### PR TITLE
chore(release): remove bundled runtime provenance from release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -542,14 +542,6 @@ jobs:
               echo "Automated npm platform-package release for claude-code-rust $VERSION."
             } > release-notes.md
           fi
-          {
-            echo
-            echo "Bundled runtime provenance:"
-            echo
-            echo "- npm platform packages include private Bun runtime files."
-            echo "- Bun source asset names, source archive SHA256 checksums, runtime SHA256 checksums, and source URLs are recorded in dist-npm/manifests/*.json."
-            echo "- Install archives, install manifests, and release bundle metadata are recorded in dist-install/manifests/*.json and release-manifest.json."
-          } >> release-notes.md
 
       - name: Create annotated tag
         run: |


### PR DESCRIPTION
## Summary

Remove the hard-coded "Bundled runtime provenance" block that the release workflow appended to every GitHub Release's notes.

## Why

The `Create release notes` step in `.github/workflows/release.yml` unconditionally stapled a three-bullet provenance blurb onto the notes for every release, regardless of the `CHANGELOG.md` content. It cluttered the release notes and was not tied to actual runtime rebundling.

Closes #

## Validation

- Automated: N/A (workflow-only change)
- Manual: Reviewed the `Create release notes` step; changelog extraction and empty-notes fallback are unaffected.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: Release notes no longer include the bundled runtime provenance section; provenance is still recorded in the manifest files under `dist-npm/` and `dist-install/`.