### PR TITLE
feat(sdk): add Opus 5 with Agent SDK 0.3.220

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - **Readline line-stepping** (#305, @srothgan): Make `Ctrl+A`/`Ctrl+E` move to the line start/end, then step to the previous/next logical line on repeat.
+- **Opus 5 and Claude Agent SDK 0.3.220 migration** (#310, @srothgan): Add Opus 5 support, preserve rejected and cancelled tool outcomes, warn on partial rewinds, and surface detached Skills, fast-mode failures, and Artifact live subscriptions.
 
 ### Fixes
 

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.214"
+        "@anthropic-ai/claude-agent-sdk": "0.3.220"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.4",
@@ -22,22 +22,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.214.tgz",
-      "integrity": "sha512-wt5ImwhU+p259Zt4K/Q9v5xVi6ruxYO5+KFICyJxnjs/QFEClAeSRqhcXx1J8jgGfatPW1faw09hkm66680UjA==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.214"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.214.tgz",
-      "integrity": "sha512-vAAOeVtlXs3p7MpFVfvfu9ja32eaKtB+MDZnPxCbdzxJk5nofCHlNsHa1UJwXHOsP9lOnFYNIccYztsZ4DNaJA==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
       "cpu": [
         "arm64"
       ],
@@ -59,9 +59,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.214.tgz",
-      "integrity": "sha512-NTbV8U2yucxCWqEiDC7L0MUehNmd8x3Op8OGzLZRhMF3xmQBy2DxpXiNZgSwwKWNDC3HdgKmJM5ZBbT7XrF/0g==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
       "cpu": [
         "x64"
       ],
@@ -72,9 +72,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.214.tgz",
-      "integrity": "sha512-KBCf+BlusG0ZcgvpjjHwv1kh+6WiR8vJbPjpR2udwkrtcQgKLN+24l+FeaQEzO2TL+ExCmM1KC4tNPvnPpy+tw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
       "cpu": [
         "arm64"
       ],
@@ -88,9 +88,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.214.tgz",
-      "integrity": "sha512-i06wQRsmevE7spY1ryYfs+NP+xdZ1FwAyTjDaF0k/xG+cgtzZYghTFUemdYF3GVwgWgpcava9GiCFDT3DoHI6w==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.214.tgz",
-      "integrity": "sha512-vqadSceJkBKHaTUszxI35uTuECGWtsHWK/mOwIJ4b9DUtYYySz6EJEk4gHg4ccutisJ/oRVCpFXHIKFb+osrKw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
       "cpu": [
         "x64"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.214.tgz",
-      "integrity": "sha512-948RstHDhs0E69h+2dKYWIAL1kcwEme4zvtgNUwP8XpKXzWOhrTKmd6MAokHn25zwfuSx5d+HE0XHfFH6R4hLg==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
       "cpu": [
         "x64"
       ],
@@ -136,9 +136,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.214.tgz",
-      "integrity": "sha512-CEKlPFCPv+ee79utQMEDSsgeo2f27ulhNHpjrKIt1jXz5G04J7lAWN/QwvPDv9XaLBkWpyfqZWiPXlRcwuaO/w==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +149,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.214.tgz",
-      "integrity": "sha512-cJMJfFoR9IWBZWnTtt9PnEm89hGOsZjoDNjOCEOF3+x+g/ANIXAjMJTcaQYv2HKh6MylWZ0AkxBASI+twkukaQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
       "cpu": [
         "x64"
       ],

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -20,7 +20,7 @@
     "node": ">=24"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.214"
+    "@anthropic-ai/claude-agent-sdk": "0.3.220"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.4",

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -22,6 +22,7 @@ import {
   handleSdkMessage,
   isShellToolName,
   mapSdkAccountInfo,
+  mapRewindFilesResult,
   mapAvailableAgents,
   mapAvailableModels,
   mapSessionMessagesToUpdates,
@@ -77,7 +78,7 @@ import {
 } from "./bridge/session_lifecycle.js";
 import {
   classifyTurnErrorKind,
-  setFastModeStateIfChanged,
+  setFastModeSnapshotIfChanged,
 } from "./bridge/error_classification.js";
 import {
   buildConnectBridgeEvent,
@@ -1224,6 +1225,30 @@ test("parseCommandEnvelope validates get_rewind_targets command", () => {
   });
 });
 
+test("mapRewindFilesResult preserves valid skipped link counts", () => {
+  const base = {
+    canRewind: true,
+    filesChanged: ["src/main.rs"],
+  };
+
+  assert.deepEqual(mapRewindFilesResult(base), {
+    can_rewind: true,
+    files_changed: ["src/main.rs"],
+  });
+  assert.equal(mapRewindFilesResult({ ...base, skippedLinks: 0 }).skipped_links, 0);
+  assert.equal(mapRewindFilesResult({ ...base, skippedLinks: 2 }).skipped_links, 2);
+});
+
+test("mapRewindFilesResult drops malformed skipped link counts", () => {
+  const base = {
+    canRewind: true,
+    filesChanged: [],
+  };
+  for (const skippedLinks of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.equal(mapRewindFilesResult({ ...base, skippedLinks }).skipped_links, undefined);
+  }
+});
+
 test("parseCommandEnvelope validates rewind command modes", () => {
   for (const restoreMode of ["both", "conversation", "code"] as const) {
     const parsed = parseCommandEnvelope(
@@ -1964,6 +1989,32 @@ test("buildQueryOptions preserves explicit sandbox failIfUnavailable setting", (
       enabled: true,
       failIfUnavailable: true,
     },
+  });
+});
+
+test("buildQueryOptions preserves target sandbox network and filesystem fields", () => {
+  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const options = buildQueryOptions({
+    cwd: "C:/work",
+    launchSettings: {
+      settings: {
+        sandbox: {
+          network: { strictAllowlist: true },
+          filesystem: { disabled: true },
+        },
+      },
+    },
+    provisionalSessionId: "session-sandbox-target-fields",
+    input,
+    canUseTool: async () => ({ behavior: "deny", message: "not used" }),
+    enableSdkDebug: false,
+    enableSpawnDebug: false,
+    sessionIdForLogs: () => "session-sandbox-target-fields",
+  });
+
+  assert.deepEqual(options.settings?.sandbox, {
+    network: { strictAllowlist: true },
+    filesystem: { disabled: true },
   });
 });
 
@@ -3873,13 +3924,14 @@ test("handleSdkMessage emits MCP snapshot from init status payload", () => {
 
 test("authority snapshots publish fast mode set during initialization", () => {
   const session = makeSessionState();
-  assert.equal(setFastModeStateIfChanged(session, "on"), true);
+  assert.equal(setFastModeSnapshotIfChanged(session, "on", "model_not_allowed"), true);
 
   for (const connectEvent of ["connected", "session_replaced"] as const) {
     session.connectEvent = connectEvent;
     const authorityEvent = buildConnectBridgeEvent(session, connectEvent);
     assert.equal(authorityEvent.event, connectEvent);
     assert.equal(authorityEvent.fast_mode_state, "on");
+    assert.equal(authorityEvent.fast_mode_disabled_reason, "model_not_allowed");
   }
 });
 
@@ -3914,6 +3966,65 @@ test("handleSdkMessage emits fast mode as a delta after authority exists", () =>
       },
     },
   ]);
+});
+
+test("fast mode snapshots deduplicate state and reason together and clear stale reasons", () => {
+  const session = makeSessionState();
+  const reasons = [
+    "free",
+    "preference",
+    "extra_usage_disabled",
+    "network_error",
+    "unknown",
+    "not_first_party",
+    "disabled_by_env",
+    "model_not_allowed",
+    "sdk_opt_in_required",
+    "pending",
+    "future-reason",
+  ];
+
+  const events = captureBridgeEvents(() => {
+    for (const reason of reasons) {
+      handleSdkMessage(session, {
+        type: "system",
+        subtype: "status",
+        fast_mode_state: "off",
+        fast_mode_disabled_reason: reason,
+      } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+      handleSdkMessage(session, {
+        type: "system",
+        subtype: "status",
+        fast_mode_state: "off",
+        fast_mode_disabled_reason: reason,
+      } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    }
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "status",
+      fast_mode_state: "off",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  const updates = events
+    .filter((event) => event.event === "session_update")
+    .map((event) => event.update as import("./types.js").SessionUpdate)
+    .filter(
+      (update): update is Extract<import("./types.js").SessionUpdate, { type: "fast_mode_update" }> =>
+        update.type === "fast_mode_update",
+    );
+  assert.deepEqual(updates, [
+    ...reasons.map((reason) => ({
+      type: "fast_mode_update" as const,
+      fast_mode_state: "off" as const,
+      fast_mode_disabled_reason: reason,
+    })),
+    {
+      type: "fast_mode_update",
+      fast_mode_state: "off",
+    },
+  ]);
+  assert.equal(session.fastModeDisabledReason, undefined);
 });
 
 test("emitToolProgressUpdate does not reopen completed tools", () => {
@@ -4866,6 +4977,46 @@ test("available command registry blocks stale supportedCommands after dynamic up
   );
 });
 
+test("commands_changed wins an actual supportedCommands bootstrap race", async () => {
+  const session = makeSessionState();
+  let resolveSupportedCommands:
+    | ((commands: import("@anthropic-ai/claude-agent-sdk").SlashCommand[]) => void)
+    | undefined;
+  session.query = {
+    supportedCommands: () =>
+      new Promise<import("@anthropic-ai/claude-agent-sdk").SlashCommand[]>((resolve) => {
+        resolveSupportedCommands = resolve;
+      }),
+  } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
+
+  captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "init",
+      session_id: "session-1",
+      model: "haiku",
+      slash_commands: ["/bootstrap"],
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "commands_changed",
+      session_id: "session-1",
+      commands: [{ name: "/dynamic", description: "Dynamic command" }],
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.ok(resolveSupportedCommands);
+  resolveSupportedCommands([
+    { name: "/stale", description: "Stale bootstrap", argumentHint: "" },
+  ]);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(session.availableCommands?.source, "commands_changed");
+  assert.deepEqual(session.availableCommands?.commands, [
+    { name: "/dynamic", description: "Dynamic command", input_hint: undefined },
+  ]);
+});
+
 test("available command registry lets authoritative snapshots remove commands", () => {
   const session = makeSessionState();
   const events = captureBridgeEvents(() => {
@@ -5467,7 +5618,7 @@ test("applySessionEffort uses live flag settings for xhigh and max", async () =>
 test("applySessionFastMode applies live settings and decodes the SDK's sparse off state", async () => {
   const calls: unknown[] = [];
   const responses = [
-    { fast_mode_state: "on" },
+    { fast_mode_state: "on", fast_mode_disabled_reason: "pending" },
     { fast_mode_state: "cooldown" },
     {},
     { fast_mode_state: "off" },
@@ -5481,10 +5632,13 @@ test("applySessionFastMode applies live settings and decodes the SDK's sparse of
     },
   } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
 
-  assert.equal(await applySessionFastMode(query, true), "on");
-  assert.equal(await applySessionFastMode(query, true), "cooldown");
-  assert.equal(await applySessionFastMode(query, false), "off");
-  assert.equal(await applySessionFastMode(query, false), "off");
+  assert.deepEqual(await applySessionFastMode(query, true), {
+    state: "on",
+    disabled_reason: "pending",
+  });
+  assert.deepEqual(await applySessionFastMode(query, true), { state: "cooldown" });
+  assert.deepEqual(await applySessionFastMode(query, false), { state: "off" });
+  assert.deepEqual(await applySessionFastMode(query, false), { state: "off" });
   assert.deepEqual(calls, [
     { fastMode: true },
     { fastMode: true },
@@ -5894,7 +6048,7 @@ test("looksLikeAuthRequired detects login hints", () => {
 });
 
 test("agent sdk version compatibility check matches pinned version", () => {
-  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.214");
+  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.220");
   assert.equal(agentSdkVersionCompatibilityError(), undefined);
 });
 
@@ -6109,6 +6263,174 @@ test("mapSessionMessagesToUpdates preserves parallel tool results", () => {
     toolUpdates.map((update) => update.tool_call_update.fields.raw_output),
     ["result b", "result a"],
   );
+});
+
+test("handleSdkMessage correlates tool non-execution metadata by tool ID", () => {
+  const session = makeSessionState();
+  const cases = [
+    ["tool-user-rejected", "user-rejected", "failed"],
+    ["tool-permission-rule", "permission-rule", "failed"],
+    ["tool-automode-unavailable", "automode-unavailable", "failed"],
+    ["tool-automode-parsing-error", "automode-parsing-error", "failed"],
+    ["tool-automode-blocked", "automode-blocked", "failed"],
+    ["tool-cancelled", "cancelled", "killed"],
+    ["tool-interrupted", "interrupted", "killed"],
+    ["tool-future", "future-reason", "completed"],
+  ] as const;
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "assistant",
+      uuid: "assistant-tools",
+      session_id: "session-1",
+      message: {
+        role: "assistant",
+        content: cases.map(([id]) => ({
+          type: "tool_use",
+          id,
+          name: "Bash",
+          input: { command: `echo ${id}` },
+        })),
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "user",
+      uuid: "user-results",
+      session_id: "session-1",
+      message: {
+        role: "user",
+        content: [...cases].reverse().map(([id]) => ({
+          type: "tool_result",
+          tool_use_id: id,
+          content: `raw output for ${id}`,
+          is_error: false,
+        })),
+      },
+      tool_result_meta: [
+        ...cases.map(([id, kind]) => ({
+          id,
+          non_execution_kind: kind,
+          ...(id === "tool-user-rejected" ? { user_feedback: "Please use a safer command." } : {}),
+        })),
+      ].reverse(),
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  const updates = events
+    .map((event) => event.update as import("./types.js").SessionUpdate | undefined)
+    .filter(
+      (update): update is Extract<import("./types.js").SessionUpdate, { type: "tool_call_update" }> =>
+        update?.type === "tool_call_update",
+    );
+  assert.equal(updates.length, cases.length);
+  for (const [id, kind, status] of cases) {
+    const fields = updates.find((update) => update.tool_call_update.tool_call_id === id)
+      ?.tool_call_update.fields;
+    assert.equal(fields?.status, status);
+    assert.equal(fields?.raw_output, `raw output for ${id}`);
+    assert.equal(fields?.output_metadata?.non_execution?.kind, kind);
+  }
+  assert.equal(
+    updates.find(
+      (update) => update.tool_call_update.tool_call_id === "tool-user-rejected",
+    )?.tool_call_update.fields.output_metadata?.non_execution?.user_feedback,
+    "Please use a safer command.",
+  );
+});
+
+test("handleSdkMessage ignores malformed and mismatched tool non-execution metadata", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "assistant",
+      uuid: "assistant-tool",
+      session_id: "session-1",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tool-ok", name: "Bash", input: { command: "echo ok" } }],
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "user",
+      uuid: "user-result",
+      session_id: "session-1",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "tool-ok", content: "ok", is_error: false }],
+      },
+      tool_result_meta: [
+        null,
+        {},
+        { id: "", non_execution_kind: "cancelled" },
+        { id: "tool-ok", non_execution_kind: "" },
+        { id: "other-tool", non_execution_kind: "cancelled" },
+      ],
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  const update = events
+    .map((event) => event.update as import("./types.js").SessionUpdate | undefined)
+    .find((candidate) => candidate?.type === "tool_call_update");
+  assert.equal(update?.type, "tool_call_update");
+  if (update?.type !== "tool_call_update") {
+    throw new Error("expected tool update");
+  }
+  assert.equal(update.tool_call_update.fields.status, "completed");
+  assert.equal(update.tool_call_update.fields.output_metadata, undefined);
+});
+
+test("mapSessionMessagesToUpdates carries tool non-execution metadata from history", () => {
+  const updates = mapSessionMessagesToUpdates([
+    {
+      type: "assistant",
+      uuid: "a1",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "echo ok" } },
+        ],
+      },
+    },
+    {
+      type: "user",
+      uuid: "u1",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      tool_result_meta: [
+        {
+          id: "tool-1",
+          non_execution_kind: "interrupted",
+          user_feedback: "Stopped intentionally.",
+        },
+      ],
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool-1",
+            content: "partial output",
+            is_error: false,
+          },
+        ],
+      },
+    },
+  ] as unknown as SessionMessage[]);
+
+  const update = updates.find((candidate) => candidate.type === "tool_call_update");
+  assert.equal(update?.type, "tool_call_update");
+  if (update?.type !== "tool_call_update") {
+    throw new Error("expected tool update");
+  }
+  assert.equal(update.tool_call_update.fields.status, "killed");
+  assert.deepEqual(update.tool_call_update.fields.output_metadata?.non_execution, {
+    kind: "interrupted",
+    user_feedback: "Stopped intentionally.",
+  });
 });
 
 test("mapSessionMessagesToUpdates maps task system records from resume history", () => {
@@ -6492,28 +6814,30 @@ test("handleResultMessage emits typed turn error classifications for SDK assista
   }
 });
 
-test("handleResultMessage preserves result api error status", () => {
-  const session = makeSessionState();
-  session.lastAssistantError = "overloaded";
+test("handleResultMessage preserves target api error status shapes", () => {
+  for (const apiErrorStatus of [429, 529, null, undefined]) {
+    const session = makeSessionState();
+    session.lastAssistantError = "overloaded";
 
-  const events = captureBridgeEvents(() => {
-    handleResultMessage(session, {
-      type: "result",
-      subtype: "error_during_execution",
-      errors: ["service overloaded"],
-      api_error_status: 529,
+    const events = captureBridgeEvents(() => {
+      handleResultMessage(session, {
+        type: "result",
+        subtype: "error_during_execution",
+        errors: ["service overloaded"],
+        ...(apiErrorStatus !== undefined ? { api_error_status: apiErrorStatus } : {}),
+      });
     });
-  });
 
-  assert.deepEqual(events.at(-1), {
-    event: "turn_error",
-    session_id: "session-1",
-    message: "service overloaded",
-    error_kind: "transient_service",
-    sdk_result_subtype: "error_during_execution",
-    assistant_error: "overloaded",
-    api_error_status: 529,
-  });
+    assert.deepEqual(events.at(-1), {
+      event: "turn_error",
+      session_id: "session-1",
+      message: "service overloaded",
+      error_kind: "transient_service",
+      sdk_result_subtype: "error_during_execution",
+      assistant_error: "overloaded",
+      ...(typeof apiErrorStatus === "number" ? { api_error_status: apiErrorStatus } : {}),
+    });
+  }
 });
 
 test("mapSessionMessagesToUpdates ignores unsupported records", () => {

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -11,14 +11,16 @@ import type {
 import type {
   BridgeCommand,
   BridgeEvent,
-  FastModeState,
   RewindFilesResult,
   RewindRestoreMode,
   RewindTarget,
 } from "./types.js";
 import type { EffortLevel } from "./types.js";
 import { parseCommandEnvelope } from "./bridge/commands.js";
-import { parseFastModeState } from "./bridge/state_parsing.js";
+import {
+  parseFastModeDisabledReason,
+  parseFastModeState,
+} from "./bridge/state_parsing.js";
 import {
   writeEvent,
   failConnection,
@@ -227,7 +229,7 @@ export async function applySessionEffort(
 export async function applySessionFastMode(
   query: import("@anthropic-ai/claude-agent-sdk").Query,
   enabled: boolean,
-): Promise<FastModeState> {
+): Promise<import("./types.js").FastModeSnapshot> {
   try {
     await query.applyFlagSettings({ fastMode: enabled });
   } catch (error) {
@@ -245,10 +247,14 @@ export async function applySessionFastMode(
 
   const state = parseFastModeState(result.fast_mode_state);
   if (state) {
-    return state;
+    const disabledReason = parseFastModeDisabledReason(result.fast_mode_disabled_reason);
+    return {
+      state,
+      ...(disabledReason ? { disabled_reason: disabledReason } : {}),
+    };
   }
   if (!enabled && result.fast_mode_state === undefined) {
-    return "off";
+    return { state: "off" };
   }
   throw new Error("SDK accepted the fast-mode change but did not report its resulting state");
 }
@@ -297,7 +303,7 @@ export function emitAgentConfigOptionUpdate(sessionId: string, agent: string | n
   });
 }
 
-const EXPECTED_AGENT_SDK_VERSION = "0.3.214";
+const EXPECTED_AGENT_SDK_VERSION = "0.3.220";
 const require = createRequire(import.meta.url);
 
 export function resolveInstalledAgentSdkVersion(): string | undefined {
@@ -436,13 +442,20 @@ export function buildRewindConversationPlan(
   };
 }
 
-function mapRewindFilesResult(result: SdkRewindFilesResult): RewindFilesResult {
+export function mapRewindFilesResult(result: SdkRewindFilesResult): RewindFilesResult {
+  const skippedLinks =
+    Number.isFinite(result.skippedLinks) &&
+    Number.isInteger(result.skippedLinks) &&
+    (result.skippedLinks ?? -1) >= 0
+      ? result.skippedLinks
+      : undefined;
   return {
     can_rewind: result.canRewind,
     ...(result.error ? { error: result.error } : {}),
     files_changed: result.filesChanged ?? [],
     ...(result.insertions !== undefined ? { insertions: result.insertions } : {}),
     ...(result.deletions !== undefined ? { deletions: result.deletions } : {}),
+    ...(skippedLinks !== undefined ? { skipped_links: skippedLinks } : {}),
   };
 }
 

--- a/agent-sdk/src/bridge/available_commands.ts
+++ b/agent-sdk/src/bridge/available_commands.ts
@@ -85,7 +85,7 @@ function shouldAcceptAvailableCommandsSnapshot(
   if (source === "supportedCommands" && current.commands.length > 0) {
     return {
       accept: false,
-      reason: "supportedCommands is an initialize-time fallback and current snapshot already exists",
+      reason: "supportedCommands bootstrap cannot replace an existing snapshot",
     };
   }
   if (commands.length === 0) {

--- a/agent-sdk/src/bridge/command_session_control.ts
+++ b/agent-sdk/src/bridge/command_session_control.ts
@@ -2,7 +2,7 @@ import type { Query, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 import type {
   BridgeCommand,
   EffortLevel,
-  FastModeState,
+  FastModeSnapshot,
 } from "../types.js";
 import {
   buildModeState,
@@ -45,7 +45,7 @@ export type SessionControlCommandDeps = {
   ) => SDKUserMessage | undefined;
   applySessionEffort: (query: Query, effort: EffortLevel) => Promise<void>;
   applySessionAgent: (query: Query, agent: string | null) => Promise<void>;
-  applySessionFastMode: (query: Query, enabled: boolean) => Promise<FastModeState>;
+  applySessionFastMode: (query: Query, enabled: boolean) => Promise<FastModeSnapshot>;
   emitEffortConfigOptionUpdate: (sessionId: string, effort: EffortLevel) => void;
   emitAgentConfigOptionUpdate: (sessionId: string, agent: string | null) => void;
   handleReloadPluginsCommand: (
@@ -282,8 +282,10 @@ async function setFastMode(
     },
   });
   try {
-    const state = await deps.applySessionFastMode(session.query, command.enabled);
+    const snapshot = await deps.applySessionFastMode(session.query, command.enabled);
+    const state = snapshot.state;
     session.fastModeState = state;
+    session.fastModeDisabledReason = snapshot.disabled_reason;
     emitFastModeUpdate(session);
     const reportedEnabled = state !== "off";
     if (reportedEnabled !== command.enabled) {

--- a/agent-sdk/src/bridge/error_classification.ts
+++ b/agent-sdk/src/bridge/error_classification.ts
@@ -3,7 +3,7 @@ import { looksLikeAuthRequired } from "./auth.js";
 import { writeEvent } from "./events.js";
 import { emitSessionUpdate } from "./events.js";
 import type { SessionState } from "./session_lifecycle.js";
-import { parseFastModeState } from "./state_parsing.js";
+import { parseFastModeDisabledReason, parseFastModeState } from "./state_parsing.js";
 
 export function emitAuthRequired(session: SessionState, detail?: string): void {
   if (session.authHintSent) {
@@ -77,12 +77,21 @@ export function classifyTurnErrorKind(
   return "other";
 }
 
-export function setFastModeStateIfChanged(session: SessionState, value: unknown): boolean {
-  const next = parseFastModeState(value);
-  if (!next || next === session.fastModeState) {
+export function setFastModeSnapshotIfChanged(
+  session: SessionState,
+  stateValue: unknown,
+  disabledReasonValue: unknown,
+): boolean {
+  const nextState = parseFastModeState(stateValue) ?? session.fastModeState;
+  const nextDisabledReason = parseFastModeDisabledReason(disabledReasonValue);
+  if (
+    nextState === session.fastModeState &&
+    nextDisabledReason === session.fastModeDisabledReason
+  ) {
     return false;
   }
-  session.fastModeState = next;
+  session.fastModeState = nextState;
+  session.fastModeDisabledReason = nextDisabledReason;
   return true;
 }
 
@@ -90,11 +99,18 @@ export function emitFastModeUpdate(session: SessionState): void {
   emitSessionUpdate(session.sessionId, {
     type: "fast_mode_update",
     fast_mode_state: session.fastModeState,
+    ...(session.fastModeDisabledReason
+      ? { fast_mode_disabled_reason: session.fastModeDisabledReason }
+      : {}),
   });
 }
 
-export function emitFastModeUpdateIfChanged(session: SessionState, value: unknown): void {
-  if (setFastModeStateIfChanged(session, value)) {
+export function emitFastModeUpdateIfChanged(
+  session: SessionState,
+  stateValue: unknown,
+  disabledReasonValue: unknown,
+): void {
+  if (setFastModeSnapshotIfChanged(session, stateValue, disabledReasonValue)) {
     emitFastModeUpdate(session);
   }
 }

--- a/agent-sdk/src/bridge/events.ts
+++ b/agent-sdk/src/bridge/events.ts
@@ -200,6 +200,9 @@ export function buildConnectBridgeEvent(
         available_models: session.availableModels,
         mode: session.mode ? buildModeState(session, session.mode) : null,
         fast_mode_state: session.fastModeState,
+        ...(session.fastModeDisabledReason
+          ? { fast_mode_disabled_reason: session.fastModeDisabledReason }
+          : {}),
         ...(historyUpdates && historyUpdates.length > 0 ? { history_updates: historyUpdates } : {}),
         ...(session.restoredInput !== undefined ? { restored_input: session.restoredInput } : {}),
       }
@@ -211,6 +214,9 @@ export function buildConnectBridgeEvent(
         available_models: session.availableModels,
         mode: session.mode ? buildModeState(session, session.mode) : null,
         fast_mode_state: session.fastModeState,
+        ...(session.fastModeDisabledReason
+          ? { fast_mode_disabled_reason: session.fastModeDisabledReason }
+          : {}),
         ...(historyUpdates && historyUpdates.length > 0 ? { history_updates: historyUpdates } : {}),
       };
 }

--- a/agent-sdk/src/bridge/history.ts
+++ b/agent-sdk/src/bridge/history.ts
@@ -2,12 +2,14 @@ import type { SDKSessionInfo, SessionMessage } from "@anthropic-ai/claude-agent-
 import type { Json, SessionListEntry, SessionUpdate, TaskItem, TaskStatus, ToolCall } from "../types.js";
 import { asRecordOrNull } from "./shared.js";
 import {
+  applyToolNonExecutionMetadata,
   TOOL_RESULT_TYPES,
   buildToolResultFields,
   createToolCall,
   isToolSearchToolName,
   isToolSearchToolResultType,
   isToolUseBlockType,
+  parseToolNonExecutionMetadata,
 } from "./tooling.js";
 
 function nonEmptyTrimmed(value: unknown): string | undefined {
@@ -256,6 +258,7 @@ function pushResumeToolResult(
   toolCalls: Map<string, ToolCall>,
   hiddenToolUseIds: Set<string>,
   block: Record<string, unknown>,
+  nonExecutionByToolUseId: Map<string, import("../types.js").ToolNonExecutionMetadata>,
   sourceMessageUuid?: string,
 ): void {
   const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
@@ -270,6 +273,7 @@ function pushResumeToolResult(
   const isError = Boolean(block.is_error);
   const base = toolCalls.get(toolUseId);
   const fields = buildToolResultFields(isError, block.content, base, block);
+  applyToolNonExecutionMetadata(fields, nonExecutionByToolUseId.get(toolUseId));
   updates.push({
     type: "tool_call_update",
     tool_call_update: {
@@ -365,6 +369,11 @@ export function mapSessionMessagesToUpdates(messages: SessionMessage[]): Session
             : null;
 
       const content = Array.isArray(message.content) ? message.content : [];
+      const nonExecutionByToolUseId = parseToolNonExecutionMetadata(
+        Object.hasOwn(entry, "tool_result_meta")
+          ? (entry as unknown as Record<string, unknown>).tool_result_meta
+          : message.tool_result_meta,
+      );
       for (const item of content) {
         const block = asRecordOrNull(item);
         if (!block) {
@@ -390,7 +399,14 @@ export function mapSessionMessagesToUpdates(messages: SessionMessage[]): Session
           continue;
         }
         if (TOOL_RESULT_TYPES.has(blockType)) {
-          pushResumeToolResult(updates, toolCalls, hiddenToolUseIds, block, sourceMessageUuid);
+          pushResumeToolResult(
+            updates,
+            toolCalls,
+            hiddenToolUseIds,
+            block,
+            nonExecutionByToolUseId,
+            sourceMessageUuid,
+          );
           continue;
         }
         if (blockType === "image") {

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -20,6 +20,7 @@ import {
   isToolSearchToolName,
   isToolSearchToolResultType,
   unwrapToolUseResult,
+  parseToolNonExecutionMetadata,
 } from "./tooling.js";
 import {
   emitToolCall,
@@ -43,7 +44,7 @@ import {
   classifyTurnErrorKind,
   emitFastModeUpdate,
   emitFastModeUpdateIfChanged,
-  setFastModeStateIfChanged,
+  setFastModeSnapshotIfChanged,
 } from "./error_classification.js";
 import { mapAvailableAgentsFromNames, emitAvailableAgentsIfChanged, refreshAvailableAgents } from "./agents.js";
 import {
@@ -942,6 +943,7 @@ export function handleUserToolResultBlocks(session: SessionState, message: Recor
     return false;
   }
   const content = Array.isArray(messageObject.content) ? messageObject.content : [];
+  const nonExecutionByToolUseId = parseToolNonExecutionMetadata(message.tool_result_meta);
   let handled = false;
   for (const block of content) {
     if (!block || typeof block !== "object") {
@@ -972,6 +974,7 @@ export function handleUserToolResultBlocks(session: SessionState, message: Recor
         blockRecord.content,
         messageToolUseResult(message) ?? blockRecord,
         sourceMessageUuid(message),
+        nonExecutionByToolUseId.get(toolUseId),
       );
     }
   }
@@ -979,7 +982,11 @@ export function handleUserToolResultBlocks(session: SessionState, message: Recor
 }
 
 export function handleResultMessage(session: SessionState, message: Record<string, unknown>): void {
-  emitFastModeUpdateIfChanged(session, message.fast_mode_state);
+  emitFastModeUpdateIfChanged(
+    session,
+    message.fast_mode_state,
+    message.fast_mode_disabled_reason,
+  );
   const terminalReason = terminalReasonFromValue(message.terminal_reason);
 
   const subtype = typeof message.subtype === "string" ? message.subtype : "";
@@ -1208,7 +1215,11 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         session.mode = incomingMode;
       }
       refreshSupportedModesForSession(session);
-      const fastModeChanged = setFastModeStateIfChanged(session, msg.fast_mode_state);
+      const fastModeChanged = setFastModeSnapshotIfChanged(
+        session,
+        msg.fast_mode_state,
+        msg.fast_mode_disabled_reason,
+      );
 
       if (!session.connected) {
         emitConnectEvent(session);
@@ -1285,7 +1296,11 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
       } else if (msg.status === null) {
         emitSessionUpdate(session.sessionId, { type: "session_status_update", status: "idle" });
       }
-      emitFastModeUpdateIfChanged(session, msg.fast_mode_state);
+      emitFastModeUpdateIfChanged(
+        session,
+        msg.fast_mode_state,
+        msg.fast_mode_disabled_reason,
+      );
       return;
     }
 
@@ -1549,6 +1564,7 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         parsed.content,
         rawToolUseResult,
         sourceMessageUuid(msg),
+        parseToolNonExecutionMetadata(msg.tool_result_meta).get(toolUseId),
       );
     }
     return;

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -70,7 +70,7 @@ import {
 import {
   emitAuthRequired,
   emitFastModeUpdate,
-  setFastModeStateIfChanged,
+  setFastModeSnapshotIfChanged,
 } from "./error_classification.js";
 import {
   mapAvailableModels,
@@ -157,6 +157,7 @@ export type SessionState = {
   runtimeUnavailableModeIds: PermissionMode[];
   supportsBypassPermissionsMode: boolean;
   fastModeState: FastModeState;
+  fastModeDisabledReason?: string;
   query: Query;
   initializationTask?: Promise<void>;
   queryConsumerTask?: Promise<void>;
@@ -700,7 +701,11 @@ export async function createSession(params: {
       const currentModelChanged = refreshCurrentModel(session);
       const { buildModeState, refreshSupportedModesForSession } = await import("./commands.js");
       refreshSupportedModesForSession(session);
-      const fastModeChanged = setFastModeStateIfChanged(session, result.fast_mode_state);
+      const fastModeChanged = setFastModeSnapshotIfChanged(
+        session,
+        result.fast_mode_state,
+        result.fast_mode_disabled_reason,
+      );
       if (!session.connected) {
         emitConnectEvent(session);
       } else {

--- a/agent-sdk/src/bridge/state_parsing.ts
+++ b/agent-sdk/src/bridge/state_parsing.ts
@@ -69,6 +69,14 @@ export function parseFastModeState(value: unknown): FastModeState | null {
   return null;
 }
 
+export function parseFastModeDisabledReason(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const reason = value.trim();
+  return reason.length > 0 ? reason : undefined;
+}
+
 export function parseRateLimitStatus(value: unknown): RateLimitStatus | null {
   if (value === "allowed" || value === "allowed_warning" || value === "rejected") {
     return value;

--- a/agent-sdk/src/bridge/tool_calls.ts
+++ b/agent-sdk/src/bridge/tool_calls.ts
@@ -6,6 +6,7 @@ import { asRecordOrNull } from "./shared.js";
 import { applyTaskToolResult } from "./tasks.js";
 import { activeTaskIdForToolUse, linkTaskToolUse, unlinkTaskToolUse } from "./task_links.js";
 import {
+  applyToolNonExecutionMetadata,
   backgroundToolLaunchTaskIdFromResult,
   buildToolResultFields,
   createToolCall,
@@ -436,6 +437,7 @@ export function emitToolResultUpdate(
   rawContent: unknown,
   rawResult: unknown = rawContent,
   sourceMessageUuid?: string,
+  nonExecutionMetadata?: import("../types.js").ToolNonExecutionMetadata,
 ): void {
   const base = session.toolCalls.get(toolUseId);
   const baseToolName = toolNameFromMeta(base?.meta) ?? "";
@@ -446,14 +448,21 @@ export function emitToolResultUpdate(
     rawResult,
     taskTitleContext(session, baseToolName, asRecordOrNull(base?.raw_input) ?? {}),
   );
-  if (!isError) {
+  applyToolNonExecutionMetadata(fields, nonExecutionMetadata);
+  if (!isError && !nonExecutionMetadata) {
     const taskId = backgroundToolLaunchTaskIdFromResult(baseToolName, rawResult, rawContent);
     if (taskId) {
       linkTaskToolUse(session, taskId, toolUseId);
     }
   }
   emitToolCallUpdate(session, toolUseId, fields, "result", sourceMessageUuid);
-  applyTaskToolResult(session, toolUseId, isError, rawContent, rawResult);
+  applyTaskToolResult(
+    session,
+    toolUseId,
+    isError || nonExecutionMetadata !== undefined,
+    rawContent,
+    rawResult,
+  );
   if (baseToolName === "Agent" || baseToolName === "Task") {
     const taskId = activeTaskIdForToolUse(session, toolUseId);
     if (taskId) {

--- a/agent-sdk/src/bridge/tooling.test.ts
+++ b/agent-sdk/src/bridge/tooling.test.ts
@@ -1033,6 +1033,34 @@ test("buildToolResultFields preserves WebFetch artifactRead only as metadata", (
   });
 });
 
+test("buildToolResultFields marks only structured Skill background launches", () => {
+  const skill = createToolCall("tc-skill-background", "Skill", {
+    skill: "review",
+  });
+  assert.deepEqual(
+    buildToolResultFields(false, "launched", skill, { background: true }).output_metadata,
+    {
+      skill: { background: true },
+    },
+  );
+  assert.equal(
+    buildToolResultFields(false, "complete", skill, { background: false }).output_metadata,
+    undefined,
+  );
+  assert.equal(
+    buildToolResultFields(false, "complete", skill, { background: "true" }).output_metadata,
+    undefined,
+  );
+
+  const bash = createToolCall("tc-bash-coincidental-background", "Bash", {
+    command: "echo ok",
+  });
+  assert.equal(
+    buildToolResultFields(false, "ok", bash, { background: true }).output_metadata,
+    undefined,
+  );
+});
+
 test("buildToolResultFields preserves Agent resolvedModel metadata", () => {
   const base = createToolCall("tc-agent-model", "Agent", {
     description: "review changes",
@@ -1886,4 +1914,3 @@ test("buildToolResultFields ignores removed TodoWrite verification metadata", ()
 
   assert.equal(fields.output_metadata, undefined);
 });
-

--- a/agent-sdk/src/bridge/tooling.ts
+++ b/agent-sdk/src/bridge/tooling.ts
@@ -612,7 +612,67 @@ function extractToolOutputMetadata(
     }
   }
 
-  return metadata.bash || metadata.agent || metadata.web_fetch ? metadata : undefined;
+  if (toolName === "Skill") {
+    for (const candidate of candidates) {
+      if (candidate.background === true) {
+        metadata.skill = { background: true };
+        break;
+      }
+    }
+  }
+
+  return metadata.bash || metadata.agent || metadata.web_fetch || metadata.skill
+    ? metadata
+    : undefined;
+}
+
+export function parseToolNonExecutionMetadata(
+  value: unknown,
+): Map<string, import("../types.js").ToolNonExecutionMetadata> {
+  const byToolUseId = new Map<string, import("../types.js").ToolNonExecutionMetadata>();
+  if (!Array.isArray(value)) {
+    return byToolUseId;
+  }
+  for (const entry of value) {
+    const record = asRecordOrNull(entry);
+    const id = nonEmptyString(record?.id);
+    const kind = nonEmptyString(record?.non_execution_kind);
+    if (!id || !kind || byToolUseId.has(id)) {
+      continue;
+    }
+    const userFeedback = nonEmptyString(record?.user_feedback);
+    byToolUseId.set(id, {
+      kind,
+      ...(userFeedback ? { user_feedback: userFeedback } : {}),
+    });
+  }
+  return byToolUseId;
+}
+
+export function applyToolNonExecutionMetadata(
+  fields: ToolCallUpdateFields,
+  metadata: import("../types.js").ToolNonExecutionMetadata | undefined,
+): void {
+  if (!metadata) {
+    return;
+  }
+  fields.output_metadata = {
+    ...(fields.output_metadata ?? {}),
+    non_execution: metadata,
+  };
+  switch (metadata.kind) {
+    case "user-rejected":
+    case "permission-rule":
+    case "automode-unavailable":
+    case "automode-parsing-error":
+    case "automode-blocked":
+      fields.status = "failed";
+      break;
+    case "cancelled":
+    case "interrupted":
+      fields.status = "killed";
+      break;
+  }
 }
 
 export function extractText(value: unknown): string {

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -65,6 +65,10 @@ export interface CurrentModel {
 }
 
 export type FastModeState = "off" | "cooldown" | "on";
+export interface FastModeSnapshot {
+  state: FastModeState;
+  disabled_reason?: string;
+}
 export type RateLimitStatus = "allowed" | "allowed_warning" | "rejected";
 export type TerminalReason =
   | "blocking_limit"
@@ -165,10 +169,21 @@ export interface WebFetchOutputMetadata {
   artifact_read?: WebFetchArtifactReadMetadata;
 }
 
+export interface SkillOutputMetadata {
+  background?: boolean;
+}
+
+export interface ToolNonExecutionMetadata {
+  kind: string;
+  user_feedback?: string;
+}
+
 export interface ToolOutputMetadata {
   bash?: BashOutputMetadata;
   agent?: AgentOutputMetadata;
   web_fetch?: WebFetchOutputMetadata;
+  skill?: SkillOutputMetadata;
+  non_execution?: ToolNonExecutionMetadata;
 }
 
 export type SubagentRetryUpdate =
@@ -307,7 +322,11 @@ export type SessionUpdate =
   | { type: "current_mode_update"; current_mode_id: string }
   | { type: "current_model_update"; current_model: CurrentModel }
   | { type: "config_option_update"; option_id: string; value: Json }
-  | { type: "fast_mode_update"; fast_mode_state: FastModeState }
+  | {
+      type: "fast_mode_update";
+      fast_mode_state: FastModeState;
+      fast_mode_disabled_reason?: string;
+    }
   | ({ type: "rate_limit_update" } & RateLimitUpdate)
   | {
       type: "api_retry_update";
@@ -606,6 +625,7 @@ export interface RewindFilesResult {
   files_changed: string[];
   insertions?: number;
   deletions?: number;
+  skipped_links?: number;
 }
 
 export interface BridgeCommandEnvelope {
@@ -806,6 +826,7 @@ export type BridgeEvent =
       available_models: AvailableModel[];
       mode: ModeState | null;
       fast_mode_state: FastModeState;
+      fast_mode_disabled_reason?: string;
       history_updates?: SessionUpdate[];
     }
   | { event: "auth_required"; method_name: string; method_description: string }
@@ -841,6 +862,7 @@ export type BridgeEvent =
       available_models: AvailableModel[];
       mode: ModeState | null;
       fast_mode_state: FastModeState;
+      fast_mode_disabled_reason?: string;
       history_updates?: SessionUpdate[];
       restored_input?: string;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rust",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.214"
+        "@anthropic-ai/claude-agent-sdk": "0.3.220"
       },
       "bin": {
         "claude-rs": "bin/claude-rs.js"
@@ -22,22 +22,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.214.tgz",
-      "integrity": "sha512-wt5ImwhU+p259Zt4K/Q9v5xVi6ruxYO5+KFICyJxnjs/QFEClAeSRqhcXx1J8jgGfatPW1faw09hkm66680UjA==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.214",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.214"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.214.tgz",
-      "integrity": "sha512-vAAOeVtlXs3p7MpFVfvfu9ja32eaKtB+MDZnPxCbdzxJk5nofCHlNsHa1UJwXHOsP9lOnFYNIccYztsZ4DNaJA==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
       "cpu": [
         "arm64"
       ],
@@ -59,9 +59,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.214.tgz",
-      "integrity": "sha512-NTbV8U2yucxCWqEiDC7L0MUehNmd8x3Op8OGzLZRhMF3xmQBy2DxpXiNZgSwwKWNDC3HdgKmJM5ZBbT7XrF/0g==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
       "cpu": [
         "x64"
       ],
@@ -72,9 +72,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.214.tgz",
-      "integrity": "sha512-KBCf+BlusG0ZcgvpjjHwv1kh+6WiR8vJbPjpR2udwkrtcQgKLN+24l+FeaQEzO2TL+ExCmM1KC4tNPvnPpy+tw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
       "cpu": [
         "arm64"
       ],
@@ -88,9 +88,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.214.tgz",
-      "integrity": "sha512-i06wQRsmevE7spY1ryYfs+NP+xdZ1FwAyTjDaF0k/xG+cgtzZYghTFUemdYF3GVwgWgpcava9GiCFDT3DoHI6w==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.214.tgz",
-      "integrity": "sha512-vqadSceJkBKHaTUszxI35uTuECGWtsHWK/mOwIJ4b9DUtYYySz6EJEk4gHg4ccutisJ/oRVCpFXHIKFb+osrKw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
       "cpu": [
         "x64"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.214.tgz",
-      "integrity": "sha512-948RstHDhs0E69h+2dKYWIAL1kcwEme4zvtgNUwP8XpKXzWOhrTKmd6MAokHn25zwfuSx5d+HE0XHfFH6R4hLg==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
       "cpu": [
         "x64"
       ],
@@ -136,9 +136,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.214.tgz",
-      "integrity": "sha512-CEKlPFCPv+ee79utQMEDSsgeo2f27ulhNHpjrKIt1jXz5G04J7lAWN/QwvPDv9XaLBkWpyfqZWiPXlRcwuaO/w==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +149,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.214.tgz",
-      "integrity": "sha512-cJMJfFoR9IWBZWnTtt9PnEm89hGOsZjoDNjOCEOF3+x+g/ANIXAjMJTcaQYv2HKh6MylWZ0AkxBASI+twkukaQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.214"
+    "@anthropic-ai/claude-agent-sdk": "0.3.220"
   },
   "scripts": {
     "prepack": "npm --prefix agent-sdk run build",

--- a/src/agent/events.rs
+++ b/src/agent/events.rs
@@ -85,6 +85,7 @@ pub enum ClientEvent {
         available_models: Vec<model::AvailableModel>,
         mode: Option<crate::app::ModeState>,
         fast_mode_state: model::FastModeState,
+        fast_mode_disabled_reason: Option<String>,
         history_updates: Vec<model::SessionUpdate>,
     },
     /// Background connection failed.
@@ -109,6 +110,7 @@ pub enum ClientEvent {
         available_models: Vec<model::AvailableModel>,
         mode: Option<crate::app::ModeState>,
         fast_mode_state: model::FastModeState,
+        fast_mode_disabled_reason: Option<String>,
         history_updates: Vec<model::SessionUpdate>,
         restored_input: Option<String>,
     },

--- a/src/agent/model/rewind.rs
+++ b/src/agent/model/rewind.rs
@@ -54,6 +54,7 @@ pub struct RewindFilesResult {
     pub files_changed: Vec<String>,
     pub insertions: Option<u64>,
     pub deletions: Option<u64>,
+    pub skipped_links: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/agent/model/session.rs
+++ b/src/agent/model/session.rs
@@ -58,6 +58,19 @@ pub enum FastModeState {
     On,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FastModeSnapshot {
+    pub state: FastModeState,
+    pub disabled_reason: Option<String>,
+}
+
+impl FastModeSnapshot {
+    #[must_use]
+    pub fn new(state: FastModeState, disabled_reason: Option<String>) -> Self {
+        Self { state, disabled_reason }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RateLimitStatus {
@@ -168,7 +181,10 @@ pub enum SessionUpdate {
     CurrentModeUpdate(CurrentModeUpdate),
     CurrentModelUpdate(CurrentModelUpdate),
     ConfigOptionUpdate(ConfigOptionUpdate),
-    FastModeUpdate(FastModeState),
+    FastModeUpdate {
+        state: FastModeState,
+        disabled_reason: Option<String>,
+    },
     RateLimitUpdate(RateLimitUpdate),
     ApiRetryUpdate {
         attempt: u64,

--- a/src/agent/model/tools.rs
+++ b/src/agent/model/tools.rs
@@ -349,6 +349,8 @@ pub struct ToolOutputMetadata {
     pub bash: Option<BashOutputMetadata>,
     pub agent: Option<AgentOutputMetadata>,
     pub web_fetch: Option<WebFetchOutputMetadata>,
+    pub skill: Option<SkillOutputMetadata>,
+    pub non_execution: Option<ToolNonExecutionMetadata>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -366,6 +368,17 @@ pub struct WebFetchOutputMetadata {
 pub struct WebFetchArtifactReadMetadata {
     pub slug: String,
     pub ver: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SkillOutputMetadata {
+    pub background: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolNonExecutionMetadata {
+    pub kind: String,
+    pub user_feedback: Option<String>,
 }
 
 impl ToolOutputMetadata {
@@ -389,6 +402,44 @@ impl ToolOutputMetadata {
     #[must_use]
     pub fn web_fetch(mut self, web_fetch: Option<WebFetchOutputMetadata>) -> Self {
         self.web_fetch = web_fetch;
+        self
+    }
+
+    #[must_use]
+    pub fn skill(mut self, skill: Option<SkillOutputMetadata>) -> Self {
+        self.skill = skill;
+        self
+    }
+
+    #[must_use]
+    pub fn non_execution(mut self, non_execution: Option<ToolNonExecutionMetadata>) -> Self {
+        self.non_execution = non_execution;
+        self
+    }
+}
+
+impl SkillOutputMetadata {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn background(mut self, background: Option<bool>) -> Self {
+        self.background = background;
+        self
+    }
+}
+
+impl ToolNonExecutionMetadata {
+    #[must_use]
+    pub fn new(kind: impl Into<String>) -> Self {
+        Self { kind: kind.into(), user_feedback: None }
+    }
+
+    #[must_use]
+    pub fn user_feedback(mut self, user_feedback: Option<String>) -> Self {
+        self.user_feedback = user_feedback;
         self
     }
 }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -79,6 +79,7 @@ pub struct RewindFilesResult {
     pub files_changed: Vec<String>,
     pub insertions: Option<u64>,
     pub deletions: Option<u64>,
+    pub skipped_links: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -300,6 +301,8 @@ pub struct ToolOutputMetadata {
     pub bash: Option<BashOutputMetadata>,
     pub agent: Option<AgentOutputMetadata>,
     pub web_fetch: Option<WebFetchOutputMetadata>,
+    pub skill: Option<SkillOutputMetadata>,
+    pub non_execution: Option<ToolNonExecutionMetadata>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -317,6 +320,17 @@ pub struct WebFetchOutputMetadata {
 pub struct WebFetchArtifactReadMetadata {
     pub slug: String,
     pub ver: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SkillOutputMetadata {
+    pub background: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolNonExecutionMetadata {
+    pub kind: String,
+    pub user_feedback: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -472,6 +486,7 @@ pub enum SessionUpdate {
     },
     FastModeUpdate {
         fast_mode_state: FastModeState,
+        fast_mode_disabled_reason: Option<String>,
     },
     RateLimitUpdate {
         status: RateLimitStatus,
@@ -1302,6 +1317,13 @@ mod tests {
                                 "slug": "dashboard",
                                 "ver": "v3"
                             }
+                        },
+                        "skill": {
+                            "background": true
+                        },
+                        "non_execution": {
+                            "kind": "user-rejected",
+                            "user_feedback": "Use a safer command."
                         }
                     }
                 }
@@ -1326,6 +1348,10 @@ mod tests {
             .expect("artifact read metadata");
         assert_eq!(artifact_read.slug, "dashboard");
         assert_eq!(artifact_read.ver, "v3");
+        assert_eq!(metadata.skill.and_then(|skill| skill.background), Some(true));
+        let non_execution = metadata.non_execution.expect("non-execution metadata");
+        assert_eq!(non_execution.kind, "user-rejected");
+        assert_eq!(non_execution.user_feedback.as_deref(), Some("Use a safer command."));
     }
 
     #[test]

--- a/src/agent/wire.rs
+++ b/src/agent/wire.rs
@@ -296,6 +296,7 @@ pub enum BridgeEvent {
         available_models: Vec<types::AvailableModel>,
         mode: Option<types::ModeState>,
         fast_mode_state: types::FastModeState,
+        fast_mode_disabled_reason: Option<String>,
         history_updates: Option<Vec<types::SessionUpdate>>,
     },
     AuthRequired {
@@ -377,6 +378,7 @@ pub enum BridgeEvent {
         available_models: Vec<types::AvailableModel>,
         mode: Option<types::ModeState>,
         fast_mode_state: types::FastModeState,
+        fast_mode_disabled_reason: Option<String>,
         history_updates: Option<Vec<types::SessionUpdate>>,
         restored_input: Option<String>,
     },
@@ -698,7 +700,8 @@ mod tests {
                 "can_rewind": true,
                 "files_changed": ["src/main.rs"],
                 "insertions": 2,
-                "deletions": 1
+                "deletions": 1,
+                "skipped_links": 3
             }
         }))
         .expect("deserialize rewind result");
@@ -715,6 +718,7 @@ mod tests {
                     files_changed: vec!["src/main.rs".to_owned()],
                     insertions: Some(2),
                     deletions: Some(1),
+                    skipped_links: Some(3),
                 }),
                 message: None,
             }
@@ -1058,22 +1062,57 @@ mod tests {
     }
 
     #[test]
-    fn turn_error_deserializes_api_error_status() {
+    fn turn_error_deserializes_target_api_error_status_shapes() {
+        for (raw_status, expected) in [
+            (Some(serde_json::json!(429)), Some(429)),
+            (Some(serde_json::json!(529)), Some(529)),
+            (Some(serde_json::Value::Null), None),
+            (None, None),
+        ] {
+            let mut event = serde_json::json!({
+                "event": "turn_error",
+                "session_id": "session-1",
+                "message": "service overloaded",
+                "error_kind": "transient_service"
+            });
+            if let Some(raw_status) = raw_status {
+                event["api_error_status"] = raw_status;
+            }
+            let decoded: EventEnvelope =
+                serde_json::from_value(event).expect("deserialize turn error");
+
+            let BridgeEvent::TurnError { api_error_status, error_kind, .. } = decoded.event else {
+                panic!("expected turn_error event");
+            };
+
+            assert_eq!(api_error_status, expected);
+            assert_eq!(error_kind.as_deref(), Some("transient_service"));
+        }
+    }
+
+    #[test]
+    fn fast_mode_update_deserializes_open_disabled_reason() {
         let decoded: EventEnvelope = serde_json::from_value(serde_json::json!({
-            "event": "turn_error",
+            "event": "session_update",
             "session_id": "session-1",
-            "message": "service overloaded",
-            "error_kind": "transient_service",
-            "api_error_status": 529
+            "update": {
+                "type": "fast_mode_update",
+                "fast_mode_state": "off",
+                "fast_mode_disabled_reason": "future-reason"
+            }
         }))
-        .expect("deserialize turn error");
+        .expect("deserialize fast mode update");
 
-        let BridgeEvent::TurnError { api_error_status, error_kind, .. } = decoded.event else {
-            panic!("expected turn_error event");
+        let BridgeEvent::SessionUpdate {
+            update:
+                types::SessionUpdate::FastModeUpdate { fast_mode_state, fast_mode_disabled_reason },
+            ..
+        } = decoded.event
+        else {
+            panic!("expected fast mode update");
         };
-
-        assert_eq!(api_error_status, Some(529));
-        assert_eq!(error_kind.as_deref(), Some("transient_service"));
+        assert_eq!(fast_mode_state, types::FastModeState::Off);
+        assert_eq!(fast_mode_disabled_reason.as_deref(), Some("future-reason"));
     }
 
     #[test]

--- a/src/app/connect/event_dispatch.rs
+++ b/src/app/connect/event_dispatch.rs
@@ -28,6 +28,7 @@ struct ConnectedEventData {
     available_models: Vec<types::AvailableModel>,
     mode: Option<types::ModeState>,
     fast_mode_state: types::FastModeState,
+    fast_mode_disabled_reason: Option<String>,
     history_updates: Option<Vec<types::SessionUpdate>>,
 }
 
@@ -47,6 +48,7 @@ pub(super) async fn handle_bridge_event(
             available_models,
             mode,
             fast_mode_state,
+            fast_mode_disabled_reason,
             history_updates,
         } => {
             handle_connected_event(
@@ -59,6 +61,7 @@ pub(super) async fn handle_bridge_event(
                     available_models,
                     mode,
                     fast_mode_state,
+                    fast_mode_disabled_reason,
                     history_updates,
                 },
             )
@@ -167,6 +170,7 @@ pub(super) async fn handle_bridge_event(
             available_models,
             mode,
             fast_mode_state,
+            fast_mode_disabled_reason,
             history_updates,
             restored_input,
         } => {
@@ -183,6 +187,7 @@ pub(super) async fn handle_bridge_event(
                     available_models: map_available_models(available_models),
                     mode: mode.map(convert_mode_state),
                     fast_mode_state: convert_fast_mode_state(fast_mode_state),
+                    fast_mode_disabled_reason,
                     history_updates,
                     restored_input,
                 })
@@ -272,6 +277,7 @@ async fn handle_connected_event(
                 available_models: map_available_models(event.available_models),
                 mode,
                 fast_mode_state: convert_fast_mode_state(event.fast_mode_state),
+                fast_mode_disabled_reason: event.fast_mode_disabled_reason,
                 history_updates,
                 restored_input: None,
             })
@@ -286,6 +292,7 @@ async fn handle_connected_event(
                 available_models: map_available_models(event.available_models),
                 mode,
                 fast_mode_state: convert_fast_mode_state(event.fast_mode_state),
+                fast_mode_disabled_reason: event.fast_mode_disabled_reason,
                 history_updates,
             })
             .await;

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -283,6 +283,7 @@ fn map_rewind_files_result(result: types::RewindFilesResult) -> model::RewindFil
         files_changed: result.files_changed,
         insertions: result.insertions,
         deletions: result.deletions,
+        skipped_links: result.skipped_links,
     }
 }
 
@@ -430,8 +431,11 @@ pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::
                 value,
             }))
         }
-        types::SessionUpdate::FastModeUpdate { fast_mode_state } => {
-            Some(model::SessionUpdate::FastModeUpdate(convert_fast_mode_state(fast_mode_state)))
+        types::SessionUpdate::FastModeUpdate { fast_mode_state, fast_mode_disabled_reason } => {
+            Some(model::SessionUpdate::FastModeUpdate {
+                state: convert_fast_mode_state(fast_mode_state),
+                disabled_reason: fast_mode_disabled_reason,
+            })
         }
         types::SessionUpdate::RateLimitUpdate {
             status,
@@ -858,6 +862,15 @@ fn convert_tool_output_metadata(
             model::WebFetchOutputMetadata::new().artifact_read(web_fetch.artifact_read.map(
                 |artifact| model::WebFetchArtifactReadMetadata::new(artifact.slug, artifact.ver),
             ))
+        }))
+        .skill(
+            output_metadata
+                .skill
+                .map(|skill| model::SkillOutputMetadata::new().background(skill.background)),
+        )
+        .non_execution(output_metadata.non_execution.map(|metadata| {
+            model::ToolNonExecutionMetadata::new(metadata.kind)
+                .user_feedback(metadata.user_feedback)
         }))
 }
 
@@ -1471,6 +1484,11 @@ mod tests {
                         ver: "v2".to_owned(),
                     }),
                 }),
+                skill: Some(types::SkillOutputMetadata { background: Some(true) }),
+                non_execution: Some(types::ToolNonExecutionMetadata {
+                    kind: "interrupted".to_owned(),
+                    user_feedback: Some("Stopped intentionally.".to_owned()),
+                }),
             }),
             ..types::ToolCallUpdateFields::default()
         });
@@ -1496,6 +1514,11 @@ mod tests {
                     .web_fetch(Some(model::WebFetchOutputMetadata::new().artifact_read(Some(
                         model::WebFetchArtifactReadMetadata::new("dashboard", "v2"),
                     ))))
+                    .skill(Some(model::SkillOutputMetadata::new().background(Some(true))))
+                    .non_execution(Some(
+                        model::ToolNonExecutionMetadata::new("interrupted")
+                            .user_feedback(Some("Stopped intentionally.".to_owned())),
+                    ))
             )
         );
     }

--- a/src/app/events/client/session.rs
+++ b/src/app/events/client/session.rs
@@ -12,6 +12,7 @@ pub(super) fn handle(app: &mut App, event: ClientEvent) {
             available_models,
             mode,
             fast_mode_state,
+            fast_mode_disabled_reason,
             history_updates,
         } => {
             session::handle_connected_client_event(
@@ -23,6 +24,7 @@ pub(super) fn handle(app: &mut App, event: ClientEvent) {
                     available_models,
                     mode,
                     fast_mode_state,
+                    fast_mode_disabled_reason,
                     history_updates,
                 },
             );
@@ -35,6 +37,7 @@ pub(super) fn handle(app: &mut App, event: ClientEvent) {
             available_models,
             mode,
             fast_mode_state,
+            fast_mode_disabled_reason,
             history_updates,
             restored_input,
         } => {
@@ -47,6 +50,7 @@ pub(super) fn handle(app: &mut App, event: ClientEvent) {
                     available_models,
                     mode,
                     fast_mode_state,
+                    fast_mode_disabled_reason,
                     history_updates,
                     restored_input,
                 },

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -394,8 +394,11 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
         model::SessionUpdate::ConfigOptionUpdate(config) => {
             handle_config_option_update(app, config);
         }
-        model::SessionUpdate::FastModeUpdate(state) => {
+        model::SessionUpdate::FastModeUpdate { state, disabled_reason } => {
+            let previous_reason = app.session_runtime.fast_mode_disabled_reason.clone();
             app.session_runtime.fast_mode_state = state;
+            app.session_runtime.fast_mode_disabled_reason.clone_from(&disabled_reason);
+            session::maybe_emit_fast_mode_disabled_notice(app, previous_reason.as_deref());
             if matches!(app.turn.pending_command_ack, Some(PendingCommandAck::FastMode)) {
                 session::clear_pending_command(app);
             }

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -23,6 +23,7 @@ pub(super) struct SessionReplacedEventData {
     pub available_models: Vec<model::AvailableModel>,
     pub mode: Option<super::super::ModeState>,
     pub fast_mode_state: model::FastModeState,
+    pub fast_mode_disabled_reason: Option<String>,
     pub history_updates: Vec<model::SessionUpdate>,
     pub restored_input: Option<String>,
 }
@@ -34,6 +35,7 @@ pub(super) struct ConnectedEventData {
     pub available_models: Vec<model::AvailableModel>,
     pub mode: Option<super::super::ModeState>,
     pub fast_mode_state: model::FastModeState,
+    pub fast_mode_disabled_reason: Option<String>,
     pub history_updates: Vec<model::SessionUpdate>,
 }
 
@@ -45,6 +47,7 @@ pub(super) fn handle_connected_client_event(app: &mut App, event: ConnectedEvent
         available_models,
         mode,
         fast_mode_state,
+        fast_mode_disabled_reason,
         history_updates,
     } = event;
     let session_id_for_log = session_id.to_string();
@@ -59,7 +62,7 @@ pub(super) fn handle_connected_client_event(app: &mut App, event: ConnectedEvent
         session_id,
         current_model,
         mode,
-        fast_mode_state,
+        model::FastModeSnapshot::new(fast_mode_state, fast_mode_disabled_reason),
         true,
         ChatResetRenderMode::PreserveInlineViewport,
     );
@@ -68,6 +71,7 @@ pub(super) fn handle_connected_client_event(app: &mut App, event: ConnectedEvent
     if !history_updates.is_empty() {
         load_resume_history(app, &history_updates);
     }
+    maybe_emit_fast_mode_disabled_notice(app, None);
     clear_pending_command(app);
     app.resuming_session_id = None;
     crate::app::file_index::restart(app);
@@ -311,6 +315,7 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
         available_models,
         mode,
         fast_mode_state,
+        fast_mode_disabled_reason,
         history_updates,
         restored_input,
     } = event;
@@ -325,7 +330,7 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
         session_id,
         current_model,
         mode,
-        fast_mode_state,
+        model::FastModeSnapshot::new(fast_mode_state, fast_mode_disabled_reason),
         false,
         ChatResetRenderMode::DeferTranscriptRender,
     );
@@ -333,6 +338,7 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
     if !history_updates.is_empty() {
         load_resume_history(app, &history_updates);
     }
+    maybe_emit_fast_mode_disabled_notice(app, None);
     clear_pending_command(app);
     if let Some(restored_input) = restored_input.as_deref() {
         app.input.set_text(restored_input);
@@ -357,6 +363,45 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
     );
 }
 
+pub(super) fn maybe_emit_fast_mode_disabled_notice(app: &mut App, previous_reason: Option<&str>) {
+    if !app.config.fast_mode_effective()
+        || !matches!(app.session_runtime.fast_mode_state, model::FastModeState::Off)
+    {
+        return;
+    }
+    let Some(reason) = app.session_runtime.fast_mode_disabled_reason.as_deref() else {
+        return;
+    };
+    if previous_reason == Some(reason) {
+        return;
+    }
+
+    let message = fast_mode_disabled_message(reason);
+    tracing::info!(
+        target: crate::logging::targets::APP_SESSION,
+        event_name = "fast_mode_disabled_reason_observed",
+        message = "fast mode disabled reason observed",
+        outcome = "unavailable",
+        reason,
+    );
+    super::notices::emit_system_notice(app, SystemSeverity::Warning, message);
+}
+
+fn fast_mode_disabled_message(reason: &str) -> &'static str {
+    match reason {
+        "free" => "Fast mode is unavailable on the free plan.",
+        "preference" => "Fast mode is disabled by an account preference.",
+        "extra_usage_disabled" => "Fast mode requires extra usage to be enabled.",
+        "network_error" => "Fast mode is unavailable because its availability check failed.",
+        "not_first_party" => "Fast mode is unavailable through the current API provider.",
+        "disabled_by_env" => "Fast mode is disabled by the runtime environment.",
+        "model_not_allowed" => "Fast mode is unavailable for the current model.",
+        "sdk_opt_in_required" => "Fast mode requires SDK opt-in before it can activate.",
+        "pending" => "Fast mode availability is still being determined.",
+        _ => "Fast mode is currently unavailable.",
+    }
+}
+
 pub(super) fn handle_rewind_result_event(app: &mut App, result: &model::RewindResult) {
     if app.session_runtime.session_id.as_ref().map(ToString::to_string).as_deref()
         != Some(result.session_id.as_str())
@@ -372,7 +417,12 @@ pub(super) fn handle_rewind_result_event(app: &mut App, result: &model::RewindRe
         return;
     }
 
+    let skipped_links =
+        result.file_result.as_ref().and_then(|file_result| file_result.skipped_links);
     let severity = match result.status {
+        model::RewindResultStatus::Success if skipped_links.is_some_and(|count| count > 0) => {
+            SystemSeverity::Warning
+        }
         model::RewindResultStatus::Success => SystemSeverity::Info,
         model::RewindResultStatus::Failure | model::RewindResultStatus::PartialFailure => {
             SystemSeverity::Error
@@ -402,6 +452,15 @@ fn rewind_result_message(result: &model::RewindResult) -> String {
     let deletions = file_result.deletions.unwrap_or(0);
     let file_word = if file_count == 1 { "file" } else { "files" };
     match result.status {
+        model::RewindResultStatus::Success
+            if file_result.skipped_links.is_some_and(|count| count > 0) =>
+        {
+            let skipped_links = file_result.skipped_links.unwrap_or_default();
+            let path_word = if skipped_links == 1 { "path was" } else { "paths were" };
+            format!(
+                "Restored tracked code for {file_count} {file_word} ({insertions} insertions, {deletions} deletions), but {skipped_links} unsafe linked {path_word} skipped."
+            )
+        }
         model::RewindResultStatus::Success => format!(
             "Restored code for {file_count} {file_word} ({insertions} insertions, {deletions} deletions)."
         ),
@@ -577,8 +636,8 @@ fn maybe_open_startup_session_picker(app: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::App;
     use crate::app::file_index::FileCandidate;
+    use crate::app::{App, MessageRole};
     use std::time::{Duration, Instant};
 
     fn wait_for(app: &mut App, timeout: Duration, mut predicate: impl FnMut(&App) -> bool) {
@@ -603,6 +662,69 @@ mod tests {
         }
     }
 
+    fn successful_rewind(skipped_links: Option<u64>) -> model::RewindResult {
+        model::RewindResult {
+            session_id: "session-1".to_owned(),
+            restore_mode: model::RewindRestoreMode::Code,
+            status: model::RewindResultStatus::Success,
+            file_result: Some(model::RewindFilesResult {
+                can_rewind: true,
+                error: None,
+                files_changed: vec!["src/main.rs".to_owned()],
+                insertions: Some(2),
+                deletions: Some(1),
+                skipped_links,
+            }),
+            message: None,
+        }
+    }
+
+    #[test]
+    fn successful_rewind_reports_skipped_unsafe_paths_without_inflating_file_count() {
+        assert_eq!(
+            rewind_result_message(&successful_rewind(None)),
+            "Restored code for 1 file (2 insertions, 1 deletions)."
+        );
+        assert_eq!(
+            rewind_result_message(&successful_rewind(Some(0))),
+            "Restored code for 1 file (2 insertions, 1 deletions)."
+        );
+        assert_eq!(
+            rewind_result_message(&successful_rewind(Some(2))),
+            "Restored tracked code for 1 file (2 insertions, 1 deletions), but 2 unsafe linked paths were skipped."
+        );
+    }
+
+    #[test]
+    fn successful_rewind_with_skips_emits_warning() {
+        let mut app = App::test_default();
+        app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
+
+        handle_rewind_result_event(&mut app, &successful_rewind(Some(1)));
+
+        let message = app.transcript.messages.last().expect("rewind notice");
+        assert!(matches!(message.role, MessageRole::System(Some(SystemSeverity::Warning))));
+    }
+
+    #[test]
+    fn fast_mode_disabled_reason_wording_covers_target_values() {
+        for reason in [
+            "free",
+            "preference",
+            "extra_usage_disabled",
+            "network_error",
+            "unknown",
+            "not_first_party",
+            "disabled_by_env",
+            "model_not_allowed",
+            "sdk_opt_in_required",
+            "pending",
+            "future-reason",
+        ] {
+            assert!(!fast_mode_disabled_message(reason).is_empty());
+        }
+    }
+
     #[test]
     fn connected_refreshes_file_index_candidates_for_new_cwd() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -622,6 +744,7 @@ mod tests {
                 available_models: Vec::new(),
                 mode: None,
                 fast_mode_state: model::FastModeState::Off,
+                fast_mode_disabled_reason: None,
                 history_updates: Vec::new(),
             },
         );
@@ -660,6 +783,7 @@ mod tests {
                 available_models: Vec::new(),
                 mode: None,
                 fast_mode_state: model::FastModeState::Off,
+                fast_mode_disabled_reason: None,
                 history_updates: Vec::new(),
                 restored_input: None,
             },

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -15,11 +15,11 @@ pub(super) fn reset_for_new_session(
     session_id: model::SessionId,
     current_model: model::CurrentModel,
     mode: Option<super::super::ModeState>,
-    fast_mode_state: model::FastModeState,
+    fast_mode: model::FastModeSnapshot,
     preserve_current_welcome_tip: bool,
     render_mode: ChatResetRenderMode,
 ) {
-    reset_session_identity_state(app, session_id, current_model, mode, fast_mode_state);
+    reset_session_identity_state(app, session_id, current_model, mode, fast_mode);
     reset_messages_for_new_session(app, preserve_current_welcome_tip);
     reset_input_state_for_new_session(app);
     reset_interaction_state_for_new_session(app);
@@ -33,7 +33,7 @@ fn reset_session_identity_state(
     session_id: model::SessionId,
     current_model: model::CurrentModel,
     mode: Option<super::super::ModeState>,
-    fast_mode_state: model::FastModeState,
+    fast_mode: model::FastModeSnapshot,
 ) {
     app.bump_session_scope_epoch();
     app.session_runtime.session_id = Some(session_id);
@@ -50,7 +50,8 @@ fn reset_session_identity_state(
     app.session_runtime.session_usage = super::super::SessionUsageState::default();
     app.sdk_inventory.clear_rewind_targets();
     app.status = super::super::AppStatus::Ready;
-    app.session_runtime.fast_mode_state = fast_mode_state;
+    app.session_runtime.fast_mode_state = fast_mode.state;
+    app.session_runtime.fast_mode_disabled_reason = fast_mode.disabled_reason;
     app.session_runtime.runtime_session_state = None;
     app.session_runtime.prompt_suggestion = None;
     app.session_runtime.last_rate_limit_update = None;
@@ -201,7 +202,7 @@ mod tests {
             model::SessionId::new("session-2"),
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
-            model::FastModeState::Off,
+            model::FastModeSnapshot::new(model::FastModeState::Off, None),
             false,
             ChatResetRenderMode::DeferTranscriptRender,
         );
@@ -225,7 +226,7 @@ mod tests {
             model::SessionId::new("session-2"),
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
-            model::FastModeState::Off,
+            model::FastModeSnapshot::new(model::FastModeState::Off, None),
             true,
             ChatResetRenderMode::PreserveInlineViewport,
         );
@@ -251,7 +252,7 @@ mod tests {
             model::SessionId::new("session-2"),
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
-            model::FastModeState::Off,
+            model::FastModeSnapshot::new(model::FastModeState::Off, None),
             false,
             ChatResetRenderMode::DeferTranscriptRender,
         );
@@ -277,7 +278,7 @@ mod tests {
             model::SessionId::new("session-2"),
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
-            model::FastModeState::Off,
+            model::FastModeSnapshot::new(model::FastModeState::Off, None),
             false,
             ChatResetRenderMode::DeferTranscriptRender,
         );

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -736,6 +736,7 @@ fn connected_event(model_name: &str) -> ClientEvent {
         available_models: Vec::new(),
         mode: None,
         fast_mode_state: model::FastModeState::Off,
+        fast_mode_disabled_reason: None,
         history_updates: Vec::new(),
     }
 }
@@ -1277,6 +1278,7 @@ fn startup_resume_history_renders_from_canonical_messages() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates,
         },
     );
@@ -1329,6 +1331,7 @@ fn startup_resume_history_allows_immediate_prompt_submit() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates,
         },
     );
@@ -1376,6 +1379,7 @@ fn resume_history_preserves_turn_order_between_user_and_assistant_messages() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates,
             restored_input: None,
         },
@@ -1421,6 +1425,7 @@ fn resume_history_forces_open_tool_calls_to_failed() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates: vec![model::SessionUpdate::ToolCall(open_tool)],
             restored_input: None,
         },
@@ -1450,6 +1455,7 @@ fn resume_history_clears_active_turn_owner_after_loading() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates: vec![model::SessionUpdate::AgentMessageChunk(
                 model::ContentChunk::new(model::ContentBlock::Text(model::TextContent::new(
                     "assistant reply",
@@ -1479,6 +1485,7 @@ fn resume_history_clears_tool_scope_tracking_after_loading() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates: vec![model::SessionUpdate::ToolCall(task_tool)],
             restored_input: None,
         },
@@ -1995,10 +2002,73 @@ fn fast_mode_update_sets_state() {
 
     handle_client_event(
         &mut app,
-        session_update(model::SessionUpdate::FastModeUpdate(model::FastModeState::Cooldown)),
+        session_update(model::SessionUpdate::FastModeUpdate {
+            state: model::FastModeState::Cooldown,
+            disabled_reason: None,
+        }),
     );
 
     assert_eq!(app.session_runtime.fast_mode_state, model::FastModeState::Cooldown);
+}
+
+#[test]
+fn fast_mode_disabled_reason_updates_clears_and_notifies_once_when_requested() {
+    let mut app = make_test_app();
+    app.config.committed_settings_document = serde_json::json!({ "fastMode": true });
+
+    let update = model::SessionUpdate::FastModeUpdate {
+        state: model::FastModeState::Off,
+        disabled_reason: Some("model_not_allowed".to_owned()),
+    };
+    handle_client_event(&mut app, session_update(update.clone()));
+
+    assert_eq!(app.session_runtime.fast_mode_disabled_reason.as_deref(), Some("model_not_allowed"));
+    assert_eq!(
+        first_block_text(app.transcript.messages.last().expect("fast mode notice")),
+        "Fast mode is unavailable for the current model."
+    );
+    assert!(matches!(
+        app.transcript.messages.last().map(|message| &message.role),
+        Some(MessageRole::System(Some(SystemSeverity::Warning)))
+    ));
+
+    let notice_count = app.transcript.messages.len();
+    handle_client_event(&mut app, session_update(update));
+    assert_eq!(app.transcript.messages.len(), notice_count);
+
+    handle_client_event(
+        &mut app,
+        session_update(model::SessionUpdate::FastModeUpdate {
+            state: model::FastModeState::Off,
+            disabled_reason: None,
+        }),
+    );
+    assert!(app.session_runtime.fast_mode_disabled_reason.is_none());
+    assert_eq!(app.transcript.messages.len(), notice_count);
+}
+
+#[test]
+fn fast_mode_disabled_reason_does_not_warn_when_unrequested_or_cooling_down() {
+    let mut unrequested = make_test_app();
+    handle_client_event(
+        &mut unrequested,
+        session_update(model::SessionUpdate::FastModeUpdate {
+            state: model::FastModeState::Off,
+            disabled_reason: Some("free".to_owned()),
+        }),
+    );
+    assert!(unrequested.transcript.messages.is_empty());
+
+    let mut cooling_down = make_test_app();
+    cooling_down.config.committed_settings_document = serde_json::json!({ "fastMode": true });
+    handle_client_event(
+        &mut cooling_down,
+        session_update(model::SessionUpdate::FastModeUpdate {
+            state: model::FastModeState::Cooldown,
+            disabled_reason: Some("network_error".to_owned()),
+        }),
+    );
+    assert!(cooling_down.transcript.messages.is_empty());
 }
 
 #[test]
@@ -2246,6 +2316,7 @@ fn turn_notice_tracking_clears_on_turn_complete_and_session_reset() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates: Vec::new(),
         },
     );
@@ -2816,6 +2887,7 @@ fn update_result_persists_across_session_replaced_reset_without_notice() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates: Vec::new(),
             restored_input: None,
         },

--- a/src/app/events/tests/client_events.rs
+++ b/src/app/events/tests/client_events.rs
@@ -121,6 +121,7 @@ fn connected_updates_cwd_and_clears_resuming_marker() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates: Vec::new(),
         },
     );
@@ -154,6 +155,7 @@ fn connected_reconciles_trust_for_new_cwd() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates: Vec::new(),
         },
     );
@@ -477,6 +479,7 @@ fn session_replaced_resets_chat_and_transient_state() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates: Vec::new(),
             restored_input: None,
         },
@@ -535,6 +538,7 @@ fn session_replaced_requests_mcp_snapshot_even_outside_mcp_tab() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates: Vec::new(),
             restored_input: None,
         },
@@ -616,7 +620,10 @@ fn stale_session_update_is_rejected_before_dispatch() {
         &mut app,
         ClientEvent::SessionUpdate {
             session_id: "old-session".to_owned(),
-            update: model::SessionUpdate::FastModeUpdate(model::FastModeState::Cooldown),
+            update: model::SessionUpdate::FastModeUpdate {
+                state: model::FastModeState::Cooldown,
+                disabled_reason: None,
+            },
         },
     );
 
@@ -632,7 +639,10 @@ fn matching_session_update_is_dispatched() {
         &mut app,
         ClientEvent::SessionUpdate {
             session_id: "current-session".to_owned(),
-            update: model::SessionUpdate::FastModeUpdate(model::FastModeState::Cooldown),
+            update: model::SessionUpdate::FastModeUpdate {
+                state: model::FastModeState::Cooldown,
+                disabled_reason: None,
+            },
         },
     );
 
@@ -647,7 +657,10 @@ fn connected_snapshot_recovers_fast_mode_dropped_before_authority() {
         &mut app,
         ClientEvent::SessionUpdate {
             session_id: "new-session".to_owned(),
-            update: model::SessionUpdate::FastModeUpdate(model::FastModeState::On),
+            update: model::SessionUpdate::FastModeUpdate {
+                state: model::FastModeState::On,
+                disabled_reason: None,
+            },
         },
     );
     assert_eq!(app.session_runtime.fast_mode_state, model::FastModeState::Off);
@@ -661,6 +674,7 @@ fn connected_snapshot_recovers_fast_mode_dropped_before_authority() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::On,
+            fast_mode_disabled_reason: None,
             history_updates: Vec::new(),
         },
     );
@@ -677,12 +691,16 @@ fn replacement_snapshot_owns_fast_mode_before_and_after_stale_updates() {
     let mut app = make_test_app();
     app.session_runtime.session_id = Some(model::SessionId::new("old-session"));
     app.session_runtime.fast_mode_state = model::FastModeState::On;
+    app.session_runtime.fast_mode_disabled_reason = Some("stale-reason".to_owned());
 
     handle_client_event(
         &mut app,
         ClientEvent::SessionUpdate {
             session_id: "new-session".to_owned(),
-            update: model::SessionUpdate::FastModeUpdate(model::FastModeState::Cooldown),
+            update: model::SessionUpdate::FastModeUpdate {
+                state: model::FastModeState::Cooldown,
+                disabled_reason: None,
+            },
         },
     );
     assert_eq!(app.session_runtime.fast_mode_state, model::FastModeState::On);
@@ -696,6 +714,7 @@ fn replacement_snapshot_owns_fast_mode_before_and_after_stale_updates() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Cooldown,
+            fast_mode_disabled_reason: None,
             history_updates: Vec::new(),
             restored_input: None,
         },
@@ -705,7 +724,10 @@ fn replacement_snapshot_owns_fast_mode_before_and_after_stale_updates() {
         &mut app,
         ClientEvent::SessionUpdate {
             session_id: "old-session".to_owned(),
-            update: model::SessionUpdate::FastModeUpdate(model::FastModeState::Off),
+            update: model::SessionUpdate::FastModeUpdate {
+                state: model::FastModeState::Off,
+                disabled_reason: None,
+            },
         },
     );
 
@@ -714,6 +736,7 @@ fn replacement_snapshot_owns_fast_mode_before_and_after_stale_updates() {
         Some("new-session")
     );
     assert_eq!(app.session_runtime.fast_mode_state, model::FastModeState::Cooldown);
+    assert!(app.session_runtime.fast_mode_disabled_reason.is_none());
 }
 
 #[test]
@@ -1545,6 +1568,7 @@ fn resume_does_not_add_confirmation_system_message() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates: Vec::new(),
             restored_input: None,
         },
@@ -1577,6 +1601,7 @@ fn resume_history_renders_user_message_chunks() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates,
             restored_input: None,
         },
@@ -1634,6 +1659,7 @@ fn session_replaced_restores_input_after_loading_history() {
             available_models: Vec::new(),
             mode: None,
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             history_updates,
             restored_input: Some("selected prompt".to_owned()),
         },

--- a/src/app/slash/tests.rs
+++ b/src/app/slash/tests.rs
@@ -251,7 +251,10 @@ async fn app_fast_shadows_advertised_command_and_toggles_authoritative_state() {
 
                 super::super::events::handle_client_event(
                     &mut app,
-                    session_update(model::SessionUpdate::FastModeUpdate(acknowledged)),
+                    session_update(model::SessionUpdate::FastModeUpdate {
+                        state: acknowledged,
+                        disabled_reason: None,
+                    }),
                 );
                 assert_eq!(app.session_runtime.fast_mode_state, acknowledged);
                 assert!(matches!(app.status, AppStatus::Ready));

--- a/src/app/state/session_runtime.rs
+++ b/src/app/state/session_runtime.rs
@@ -24,6 +24,8 @@ pub struct SessionRuntimeState {
     pub session_usage: SessionUsageState,
     /// Fast mode state telemetry from the SDK.
     pub fast_mode_state: model::FastModeState,
+    /// Open-set reason reported by the SDK when fast mode cannot activate.
+    pub fast_mode_disabled_reason: Option<String>,
     /// Latest SDK runtime liveness state.
     pub runtime_session_state: Option<model::RuntimeSessionState>,
     /// Latest prompt suggestion from the SDK, shown in the input hint band.
@@ -46,6 +48,7 @@ impl Default for SessionRuntimeState {
             login_hint: None,
             session_usage: SessionUsageState::default(),
             fast_mode_state: model::FastModeState::Off,
+            fast_mode_disabled_reason: None,
             runtime_session_state: None,
             prompt_suggestion: None,
             last_rate_limit_update: None,
@@ -75,6 +78,7 @@ impl SessionRuntimeState {
         self.current_model = None;
         self.mode = None;
         self.fast_mode_state = model::FastModeState::Off;
+        self.fast_mode_disabled_reason = None;
         self.session_usage = SessionUsageState::default();
     }
 }

--- a/src/app/state/tool_call_info.rs
+++ b/src/app/state/tool_call_info.rs
@@ -108,6 +108,20 @@ impl ToolCallInfo {
     }
 
     #[must_use]
+    pub fn skill_is_backgrounded(&self) -> bool {
+        self.output_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.skill.as_ref())
+            .and_then(|metadata| metadata.background)
+            .unwrap_or(false)
+    }
+
+    #[must_use]
+    pub fn non_execution_metadata(&self) -> Option<&model::ToolNonExecutionMetadata> {
+        self.output_metadata.as_ref()?.non_execution.as_ref()
+    }
+
+    #[must_use]
     pub fn hidden_unless_focused_interaction(&self) -> bool {
         self.hidden && self.pending_permission.is_none() && self.pending_question.is_none()
     }

--- a/src/ui/tool_call/artifact.rs
+++ b/src/ui/tool_call/artifact.rs
@@ -138,6 +138,9 @@ fn render_output_object(object: &Map<String, Value>) -> Vec<Line<'static>> {
     if let Some(updated) = typed::json_bool(object, "updated") {
         artifact_fields.push(ToolField::new("Updated", typed::bool_label(updated)));
     }
+    if let Some(live_subscription) = typed::json_string(object, "liveSubscription") {
+        artifact_fields.push(ToolField::new("Live subscription", live_subscription));
+    }
     if let Some(additional) = additional_json(
         object,
         &[
@@ -154,6 +157,7 @@ fn render_output_object(object: &Map<String, Value>) -> Vec<Line<'static>> {
             "warnings",
             "contract",
             "updated",
+            "liveSubscription",
         ],
     ) {
         artifact_fields.push(ToolField::new("Additional output", additional));
@@ -256,7 +260,7 @@ mod tests {
                 "futureInput": {"enabled": true}
             }),
             Some(
-                r#"{"title":"Dashboard","url":"https://artifact.local/dashboard","path":"C:/work/dashboard.html","version":"v3","capabilities":{"storage":true},"stored":{"contract":"artifact-v1","capabilities":{"persist":true}},"warnings":["legacy contract"],"contract":"artifact-v2","updated":true,"futureOutput":{"revision":4}}"#,
+                r#"{"title":"Dashboard","url":"https://artifact.local/dashboard","path":"C:/work/dashboard.html","version":"v3","capabilities":{"storage":true},"stored":{"contract":"artifact-v1","capabilities":{"persist":true}},"warnings":["legacy contract"],"contract":"artifact-v2","updated":true,"liveSubscription":"subscription-42","futureOutput":{"revision":4}}"#,
             ),
         );
 
@@ -280,6 +284,7 @@ mod tests {
                 "Warnings: legacy contract",
                 "Contract: artifact-v2",
                 "Updated: yes",
+                "Live subscription: subscription-42",
                 "Additional output: {\"futureOutput\":{\"revision\":4}}",
             ]
         );

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -210,7 +210,7 @@ fn tool_output_badge_spans(tc: &ToolCallInfo) -> Vec<Span<'static>> {
         }
     }
 
-    if tc.task_is_backgrounded() {
+    if tc.task_is_backgrounded() || tc.skill_is_backgrounded() {
         badges.push(Span::styled(
             "  [backgrounded]",
             Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),

--- a/src/ui/tool_call/standard.rs
+++ b/src/ui/tool_call/standard.rs
@@ -107,12 +107,14 @@ pub(super) fn tool_call_has_body(tc: &ToolCallInfo) -> bool {
     if let Some(renderer) = typed::renderer_for(tc) {
         return (renderer.has_structured_body)(tc)
             || tc.pending_permission.is_some()
-            || tc.pending_question.is_some();
+            || tc.pending_question.is_some()
+            || tc.non_execution_metadata().is_some();
     }
 
     !tc.content.is_empty()
         || tc.pending_permission.is_some()
         || tc.pending_question.is_some()
+        || tc.non_execution_metadata().is_some()
         || renders_structured_ask_user_question_result(tc)
         || (tc.is_execute_tool()
             && (tc.terminal_output.is_some()
@@ -132,6 +134,7 @@ fn render_standard_body(tc: &ToolCallInfo, width: u16, lines: &mut Vec<Line<'sta
         if is_execute { EXECUTE_BODY_INDENT_WIDTH } else { STANDARD_BODY_PREFIX_WIDTH };
     let content_width = width.saturating_sub(prefix_width);
     let mut content_lines = render_tool_content(tc, content_width);
+    content_lines.extend(render_non_execution_metadata(tc));
     content_lines = match tool_content_height_policy(tc) {
         ToolContentHeightPolicy::Bounded => {
             let protected_source_lines = protected_content_source_lines(tc, &content_lines);
@@ -170,6 +173,33 @@ fn render_standard_body(tc: &ToolCallInfo, width: u16, lines: &mut Vec<Line<'sta
         spans.extend(truncate_spans_to_width(content_line.spans, usize::from(content_width)));
         lines.push(Line::from(spans));
     }
+}
+
+fn render_non_execution_metadata(tc: &ToolCallInfo) -> Vec<Line<'static>> {
+    let Some(metadata) = tc.non_execution_metadata() else {
+        return Vec::new();
+    };
+    let reason = match metadata.kind.as_str() {
+        "user-rejected" => "rejected by the user".to_owned(),
+        "permission-rule" => "blocked by a permission rule".to_owned(),
+        "automode-unavailable" => "automatic mode was unavailable".to_owned(),
+        "automode-parsing-error" => "automatic mode could not parse the request".to_owned(),
+        "automode-blocked" => "automatic mode blocked the request".to_owned(),
+        "cancelled" => "cancelled".to_owned(),
+        "interrupted" => "interrupted".to_owned(),
+        other => other.to_owned(),
+    };
+    let mut lines = vec![Line::from(vec![
+        Span::styled("Not executed: ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(reason),
+    ])];
+    if let Some(feedback) = metadata.user_feedback.as_deref() {
+        lines.push(Line::from(vec![
+            Span::styled("Feedback: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(feedback.to_owned()),
+        ]));
+    }
+    lines
 }
 
 /// One-line summary for tools that should not render expanded content.

--- a/src/ui/tool_call/tests.rs
+++ b/src/ui/tool_call/tests.rs
@@ -163,6 +163,42 @@ fn render_tool_call_title_shows_backgrounded_badge() {
 }
 
 #[test]
+fn render_skill_title_shows_backgrounded_badge() {
+    let mut tc = test_tool_call("tc-skill-bg", "Skill", model::ToolCallStatus::Completed);
+    tc.output_metadata = Some(
+        model::ToolOutputMetadata::new()
+            .skill(Some(model::SkillOutputMetadata::new().background(Some(true)))),
+    );
+
+    let line = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 80, 0);
+    let rendered: String = line.spans.iter().map(|span| span.content.as_ref()).collect();
+
+    assert!(rendered.contains("[backgrounded]"));
+}
+
+#[test]
+fn render_tool_call_preserves_non_execution_reason_and_feedback() {
+    let mut tc = test_tool_call("tc-rejected", "Bash", model::ToolCallStatus::Failed);
+    tc.output_metadata = Some(
+        model::ToolOutputMetadata::new().non_execution(Some(
+            model::ToolNonExecutionMetadata::new("user-rejected")
+                .user_feedback(Some("Use a read-only command.".to_owned())),
+        )),
+    );
+
+    let mut rendered = Vec::new();
+    render_tool_call_cached(&mut tc, ToolCallRenderContext::default(), 100, 0, &mut rendered);
+    let text = rendered
+        .iter()
+        .flat_map(|line| line.spans.iter())
+        .map(|span| span.content.as_ref())
+        .collect::<String>();
+
+    assert!(text.contains("Not executed: rejected by the user"));
+    assert!(text.contains("Feedback: Use a read-only command."));
+}
+
+#[test]
 fn render_tool_call_title_shows_resolved_model_badge_for_subagents() {
     let mut tc = test_tool_call("reviewer", "Agent", model::ToolCallStatus::Completed);
     tc.output_metadata = Some(model::ToolOutputMetadata::new().agent(Some(


### PR DESCRIPTION
## Summary

- Upgrade `@anthropic-ai/claude-agent-sdk` from `0.3.214` to `0.3.220`, bundling Claude Code `2.1.220` and Opus 5 support.
- Preserve rewind skip counts, structured rejected and cancelled tool outcomes, detached Skill state, Artifact live subscriptions, and fast-mode disabled reasons across the bridge, Rust model, and TUI.
- Add target-shaped compatibility coverage for API error status, dynamic command refresh, sandbox forwarding, session reset, and forward-compatible metadata values.

## Why

SDK `0.3.220` introduces user-visible runtime metadata that the previous bridge either dropped or could present misleadingly. This migration keeps the TUI aligned with the bundled runtime so partial rewinds warn clearly, nonexecuted tools do not appear completed, detached work is visible, and fast-mode failures explain why the requested mode is unavailable.

Closes #301 

## Validation

- Automated: `npm.cmd --prefix agent-sdk test` (320 passed); bridge build, Biome lint, knip, and direct-dependency audit; `cargo fmt --all -- --check`; `cargo check --offline`; `cargo clippy --all-targets --all-features --offline -- -D warnings`; `cargo test --all-features --offline` (1,711 library tests plus binary, integration, CLI contract, logging contract, and doc-test targets); `git diff --check`.
- Manual: No authenticated live Claude session was run because it requires external account access and may mutate remote session state; target-shaped bridge and renderer fixtures cover the changed paths.
- Screenshot/video (if UI changed): Not captured; UI changes are compact metadata rows and badges covered by renderer tests.

## Notes

- Breaking changes: N/A
- Docs updated: Add the Unreleased changelog entry for Opus 5 and the Agent SDK `0.3.220` migration.
- Governance/release impact: Updates the bundled Agent SDK and Claude Code runtime; no workflow, permission, or release-process changes.
- Private SDK protocol: `cancel_queued` remains intentionally unused because the public `Query.interrupt()` API exposes no corresponding option.
- Dependency audit: No direct dependency advisories at moderate or higher severity; existing transitive npm advisories remain outside this migration's scope.
