### PR TITLE
chore(release): publish version 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-07-26 [Changes][v0.14.2]
+
 ### Features
 
 - **Readline line-stepping** (#305, @srothgan): Make `Ctrl+A`/`Ctrl+E` move to the line start/end, then step to the previous/next logical line on repeat.
+- **Live fast-mode control** (#309, @srothgan): Make `/fast` control the active SDK session with capability checks and synchronized state.
 - **Opus 5 and Claude Agent SDK 0.3.220 migration** (#310, @srothgan): Add Opus 5 support, preserve rejected and cancelled tool outcomes, warn on partial rewinds, and surface detached Skills, fast-mode failures, and Artifact live subscriptions.
 
 ### Fixes
 
-- **Lifecycle and bridge hardening** (#309, @srothgan): Enforce session-authoritative state, make `/fast` control the live SDK session, serialize and bound bridge traffic, and give MCP monitoring and shutdown explicit ownership.
+- **Lifecycle and bridge hardening** (#309, @srothgan): Enforce session-authoritative state, prevent idle event-loop spin, serialize and bound bridge traffic, and give MCP monitoring and shutdown explicit ownership.
+
+### Release and Packaging
+
+- **Claude CLI installer warning** (#311, @srothgan): Warn when `claude` is missing from `PATH` and link to the Claude Code install guide without blocking `claude-rs` installation.
 
 ## [0.14.1] - 2026-07-18 [Changes][v0.14.1]
 
@@ -784,6 +791,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.14.2]: https://github.com/srothgan/claude-code-rust/compare/v0.14.1...v0.14.2
 [v0.14.1]: https://github.com/srothgan/claude-code-rust/compare/v0.14.0...v0.14.1
 [v0.14.0]: https://github.com/srothgan/claude-code-rust/compare/v0.13.4...v0.14.0
 [v0.13.4]: https://github.com/srothgan/claude-code-rust/compare/v0.13.3...v0.13.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rust",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.220"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Claude Code Rust - native Rust terminal interface for Claude Code",
   "keywords": [
     "cli",

--- a/scripts/install/install-progress.test.mjs
+++ b/scripts/install/install-progress.test.mjs
@@ -43,6 +43,20 @@ test("Unix installer keeps successful redirected output completed-step-only", { 
   assert.equal(result.launcherInstalled, true, "successful install did not create the launcher");
 });
 
+test("Unix installer warns when the Claude Code CLI is missing", { skip: skipReason }, () => {
+  const result = runInstallerScenario("success", { claudeCliAvailable: false });
+  assertScenarioResult(result, 0, [
+    "Claude Code CLI ('claude') not found on PATH",
+    "Install it from https://claude.com/claude-code",
+  ]);
+});
+
+test("Unix installer stays silent when the Claude Code CLI is available", { skip: skipReason }, () => {
+  const result = runInstallerScenario("success", { claudeCliAvailable: true });
+  const output = `${result.stdout}${result.stderr}`;
+  assert.doesNotMatch(output, /Claude Code CLI \('claude'\) not found on PATH/);
+});
+
 test("Unix installer preserves checksum-download failures without progress noise", { skip: skipReason }, () => {
   const result = runInstallerScenario("checksum-download-failure");
   assertScenarioResult(result, 1, [
@@ -78,7 +92,7 @@ test("Unix installer keeps NO_COLOR output plain and completed-step-only", { ski
   assertScenarioResult(result, 0, successfulMessages);
 });
 
-function runInstallerScenario(scenario) {
+function runInstallerScenario(scenario, { claudeCliAvailable = true } = {}) {
   const archiveName = installArchiveName(platformPackage, cargoPackage.version);
   const archivePath = path.join(repoRoot, "dist-install", archiveName);
   assert.ok(
@@ -100,7 +114,7 @@ function runInstallerScenario(scenario) {
   const archiveSha256 = crypto.createHash("sha256").update(fs.readFileSync(archivePath)).digest("hex");
   const expectedSha256 = scenario === "checksum-mismatch" ? "0".repeat(64) : archiveSha256;
   fs.writeFileSync(checksumsPath, `${expectedSha256}  dist-install/${archiveName}\n`, "utf8");
-  writeCommandShims(shimDir);
+  writeCommandShims(shimDir, { claudeCliAvailable });
 
   const env = { ...process.env };
   for (const name of Object.keys(env)) {
@@ -113,7 +127,7 @@ function runInstallerScenario(scenario) {
   Object.assign(env, {
     HOME: homeDir,
     TMPDIR: tempDir,
-    PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    PATH: `${shimDir}${path.delimiter}${pathWithoutClaude(process.env.PATH ?? "")}`,
     TERM: "xterm",
     MOCK_ARCHIVE_FILE: archivePath,
     MOCK_CHECKSUM_FILE: checksumsPath,
@@ -191,7 +205,7 @@ function assertScenarioResult(result, expectedStatus, expectedMessages) {
   }
 }
 
-function writeCommandShims(shimDir) {
+function writeCommandShims(shimDir, { claudeCliAvailable }) {
   const curlPath = path.join(shimDir, "curl");
   fs.writeFileSync(
     curlPath,
@@ -234,6 +248,19 @@ esac
   const npmPath = path.join(shimDir, "npm");
   fs.writeFileSync(npmPath, "#!/bin/sh\nexit 1\n", "utf8");
   fs.chmodSync(npmPath, 0o755);
+
+  if (claudeCliAvailable) {
+    const claudePath = path.join(shimDir, "claude");
+    fs.writeFileSync(claudePath, "#!/bin/sh\nexit 0\n", "utf8");
+    fs.chmodSync(claudePath, 0o755);
+  }
+}
+
+function pathWithoutClaude(pathValue) {
+  return pathValue
+    .split(path.delimiter)
+    .filter((directory) => directory && !fs.existsSync(path.join(directory, "claude")))
+    .join(path.delimiter);
 }
 
 function unixPlatformPackage() {

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -809,6 +809,15 @@ function Invoke-InstallDoctor {
     Complete-InstallerProgress "Runtime diagnostics passed"
 }
 
+function Warn-MissingClaudeCli {
+    # -ErrorAction SilentlyContinue keeps the check silent; resolves claude.cmd/.ps1/.exe via PATHEXT.
+    if (Get-Command "claude" -ErrorAction SilentlyContinue) {
+        return
+    }
+    Write-WarnLine "Claude Code CLI ('claude') not found on PATH"
+    Write-WarnDetail "  Install it from https://claude.com/claude-code"
+}
+
 function Warn-OtherClaudeRsCommands {
     param([string]$ExpectedCommand)
     $commands = @(Get-Command "claude-rs" -All -ErrorAction SilentlyContinue)
@@ -871,6 +880,7 @@ try {
     Write-Host
     Write-Ok "$targetLabel detected"
     Write-Ok "Install location: $InstallDir"
+    Warn-MissingClaudeCli
 
     Start-InstallerProgress "Resolving release"
     $tag = Resolve-ReleaseTag -RequestedRelease $Release -TempDir $tempDir

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -294,6 +294,12 @@ need_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
 
+warn_missing_claude_cli() {
+  command -v claude >/dev/null 2>&1 && return 0
+  warn "Claude Code CLI ('claude') not found on PATH"
+  warn_detail "  Install it from https://claude.com/claude-code"
+}
+
 download() {
   url="$1"
   destination="$2"
@@ -874,6 +880,7 @@ info "Installing claude-rs"
 info ""
 ok "$target_label detected"
 ok "Install location: $install_dir"
+warn_missing_claude_cli
 
 progress_start "Resolving release"
 tag="$(resolve_tag "$release")"

--- a/scripts/install/test-install-progress.ps1
+++ b/scripts/install/test-install-progress.ps1
@@ -36,7 +36,8 @@ $helperNames = @(
     "Write-FailLine",
     "Write-InstallerDiagnostic",
     "Test-CanPrompt",
-    "Confirm-DefaultNo"
+    "Confirm-DefaultNo",
+    "Warn-MissingClaudeCli"
 )
 $helperDefinitions = @($installerAst.FindAll({
     param($node)
@@ -213,6 +214,31 @@ Assert-OutputBoundaryClearsProgress "warning detail" { Write-WarnDetail "warning
 Assert-OutputBoundaryClearsProgress "failure" { Write-FailLine "failure" }
 Assert-OutputBoundaryClearsProgress "prompt" { [void](Confirm-DefaultNo "prompt") }
 Assert-OutputBoundaryClearsProgress "diagnostic" { Write-InstallerDiagnostic "diagnostic" }
+
+$originalPath = $env:PATH
+$originalConsoleError = [Console]::Error
+$warningOutputWriter = New-Object System.IO.StringWriter
+try {
+    $env:PATH = ""
+    [Console]::SetError($warningOutputWriter)
+    Reset-RecordedEvents
+    Warn-MissingClaudeCli
+    $warningText = $warningOutputWriter.ToString()
+    Assert-True $warningText.Contains("Claude Code CLI ('claude') not found on PATH") "Missing Claude CLI warning was not emitted"
+    Assert-True $warningText.Contains("Install it from https://claude.com/claude-code") "Missing Claude CLI install guidance was not emitted"
+
+    $warningOutputWriter.GetStringBuilder().Clear() | Out-Null
+    Set-Item -Path Function:\claude -Value {}
+    Reset-RecordedEvents
+    Warn-MissingClaudeCli
+    Assert-Equal 0 $script:RecordedEvents.Count "Available Claude CLI emitted a missing-CLI warning"
+    Assert-Equal "" $warningOutputWriter.ToString() "Available Claude CLI wrote a missing-CLI warning to stderr"
+} finally {
+    [Console]::SetError($originalConsoleError)
+    $warningOutputWriter.Dispose()
+    Remove-Item -Path Function:\claude -ErrorAction SilentlyContinue
+    $env:PATH = $originalPath
+}
 
 Assert-Equal "SilentlyContinue" $ProgressPreference "Installer helpers changed the script-wide progress preference"
 Write-Output "PowerShell installer inline progress helper tests passed"


### PR DESCRIPTION
## Summary

- Prepare the `0.14.2` release by synchronizing Cargo and npm package metadata and promoting the audited post-`0.14.1` changelog entries.
- Add a non-blocking warning to the PowerShell and Unix installers when the Claude Code CLI is missing from `PATH`.
- Cover both missing and available Claude CLI behavior in the installer test harnesses.

## Why

The accumulated release includes readline line-stepping, live `/fast` control, lifecycle and bridge hardening, Opus 5 through Agent SDK `0.3.220`, and clearer SDK tool and rewind state. The release metadata must advance together, and fresh script installs should explain the separate Claude Code CLI prerequisite without failing installation.

Closes #<!-- add issue number if applicable -->

## Validation

- Automated: `cargo check --offline` passed with `Cargo.toml` and `Cargo.lock` synchronized at `0.14.2`. Full installer, bridge, Cargo, and release-package validation remains pending.
- Manual: Not run.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: `CHANGELOG.md` promotes the audited Unreleased entries into the `0.14.2` section and adds the release comparison link.
- Governance/release impact: Merging the `Cargo.toml` version bump to `main` triggers the protected release workflow, which builds and attests platform artifacts, publishes npm packages, creates `v0.14.2`, and publishes the GitHub release.
