### PR TITLE
feat(install): add fixed-width streaming download progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **Installer download progress** (#312, @srothgan): Stream release archives with curl retries and stall detection, show matching fixed-width bars on PowerShell and Unix, and add opt-in size, speed, and ETA diagnostics while keeping redirected and CI output plain.
+
 ## [0.14.2] - 2026-07-26 [Changes][v0.14.2]
 
 ### Features

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -10,9 +10,9 @@ The recommended script install includes the application and its runtime dependen
 
 Install scripts are available in GitHub Releases starting with `v0.14.0` and are the recommended install path. They install a self-contained release without requiring npm, Node.js, or Bun on the user's machine.
 
-The scripts download a complete release archive from GitHub, verify the release archive integrity, install the native binary with the bundled private Bun runtime, Agent SDK bridge, and production `node_modules`, then run a quiet `claude-rs --version` check. Strict runtime diagnostics are available with the opt-in verify flag.
+The scripts download a complete release archive from GitHub, verify the release archive integrity, install the native binary with the bundled private Bun runtime, Agent SDK bridge, and production `node_modules`, then run a quiet `claude-rs --version` check. Download diagnostics and strict runtime diagnostics are available with the opt-in verify flag.
 
-Interactive terminals display live progress for longer installation steps. Redirected output and CI remain plain and log-friendly, and `NO_COLOR` disables colored status output.
+Interactive terminals display a fixed-width 10-cell progress bar while downloading the release archive and a spinner for other longer installation steps. The verify flag adds transferred size, total size, average speed, and ETA to the live download bar, followed by the final transfer size, elapsed time, average speed, and HTTP status. Redirected output and CI remain plain and log-friendly, and `NO_COLOR` disables colored status output.
 
 **macOS/Linux:**
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,12 +38,10 @@ active release tooling and are validated by PR, release, or nightly workflows.
   for verifying install archive contents and manifests.
 - `install/smoke-install-archive.mjs` is a maintainer and workflow entry point
   for archive extraction and startup smoke tests.
-- `install/install-progress.test.mjs` executes the Unix installer with redirected
-  output and local release fixtures to verify progress suppression and cleanup.
+- `install/install-progress.test.mjs` executes the Unix installer with redirected output and local release fixtures to verify download transport settings, diagnostic summaries, progress suppression, and cleanup.
 - `install/install-version-guard.test.mjs` verifies Unix same-version no-op,
   explicit reinstall, update, exact-version, and `latest` metadata behavior.
-- `install/test-install-progress.ps1` validates the PowerShell progress and
-  output-helper behavior without executing the installer body.
+- `install/test-install-progress.ps1` validates the PowerShell spinner, fixed-width download progress, streaming transfer, and output-helper behavior without executing the installer body.
 - `install/test-install-version-guard.ps1` validates PowerShell version metadata,
   decision precedence, and release-download boundaries under Windows PowerShell.
 - `install/install.sh` and `install/install.ps1` are maintained public installer

--- a/scripts/install/install-progress.test.mjs
+++ b/scripts/install/install-progress.test.mjs
@@ -41,6 +41,36 @@ test("Unix installer keeps successful redirected output completed-step-only", { 
   assertScenarioResult(result, 0, successfulMessages);
   assert.equal(result.installed, true, "successful install did not create the installed command");
   assert.equal(result.launcherInstalled, true, "successful install did not create the launcher");
+  const archiveInvocation = result.curlInvocations.find(
+    (line) => line.includes(result.archiveName) && line.includes("--write-out"),
+  );
+  assert.ok(archiveInvocation, "archive download did not use the streaming curl path");
+  for (const expectedArgument of [
+    "--retry 3",
+    "--connect-timeout 30",
+    "--speed-limit 1024",
+    "--speed-time 30",
+    "--silent",
+    "--show-error",
+    "--dump-header",
+  ]) {
+    assert.match(
+      archiveInvocation,
+      new RegExp(escapeRegex(expectedArgument)),
+      `archive download omitted ${expectedArgument}`,
+    );
+  }
+  assert.doesNotMatch(archiveInvocation, /--progress-bar/, "archive download delegated rendering to curl");
+});
+
+test("Unix installer verify mode reports archive transfer diagnostics", { skip: skipReason }, () => {
+  const result = runInstallerScenario("success", { verify: true });
+  assertScenarioResult(result, 0, [
+    "Download:",
+    "in 2.000s",
+    "HTTP 200",
+    "Runtime diagnostics passed",
+  ]);
 });
 
 test("Unix installer warns when the Claude Code CLI is missing", { skip: skipReason }, () => {
@@ -92,7 +122,7 @@ test("Unix installer keeps NO_COLOR output plain and completed-step-only", { ski
   assertScenarioResult(result, 0, successfulMessages);
 });
 
-function runInstallerScenario(scenario, { claudeCliAvailable = true } = {}) {
+function runInstallerScenario(scenario, { claudeCliAvailable = true, verify = false } = {}) {
   const archiveName = installArchiveName(platformPackage, cargoPackage.version);
   const archivePath = path.join(repoRoot, "dist-install", archiveName);
   assert.ok(
@@ -107,6 +137,7 @@ function runInstallerScenario(scenario, { claudeCliAvailable = true } = {}) {
   const binDir = path.join(sandbox, "bin");
   const shimDir = path.join(sandbox, "shims");
   const checksumsPath = path.join(sandbox, "SHA256SUMS");
+  const curlLogPath = path.join(sandbox, "curl.log");
   for (const directory of [homeDir, tempDir, binDir, shimDir]) {
     fs.mkdirSync(directory, { recursive: true });
   }
@@ -131,6 +162,7 @@ function runInstallerScenario(scenario, { claudeCliAvailable = true } = {}) {
     TERM: "xterm",
     MOCK_ARCHIVE_FILE: archivePath,
     MOCK_CHECKSUM_FILE: checksumsPath,
+    MOCK_CURL_LOG: curlLogPath,
     MOCK_DOWNLOAD_MODE: scenario,
   });
   if (scenario === "ci") {
@@ -142,21 +174,25 @@ function runInstallerScenario(scenario, { claudeCliAvailable = true } = {}) {
 
   let commandResult;
   try {
+    const installerArgs = [
+      installerPath,
+      "--release",
+      releaseTag,
+      "--install-dir",
+      installDir,
+      "--bin-dir",
+      binDir,
+      "--yes",
+      "--non-interactive",
+      "--no-modify-path",
+      "--keep-npm",
+    ];
+    if (verify) {
+      installerArgs.push("--verify");
+    }
     commandResult = spawnSync(
       "sh",
-      [
-        installerPath,
-        "--release",
-        releaseTag,
-        "--install-dir",
-        installDir,
-        "--bin-dir",
-        binDir,
-        "--yes",
-        "--non-interactive",
-        "--no-modify-path",
-        "--keep-npm",
-      ],
+      installerArgs,
       {
         encoding: "utf8",
         env,
@@ -174,6 +210,9 @@ function runInstallerScenario(scenario, { claudeCliAvailable = true } = {}) {
 
     return {
       archiveName,
+      curlInvocations: fs.existsSync(curlLogPath)
+        ? fs.readFileSync(curlLogPath, "utf8").trim().split(/\r?\n/)
+        : [],
       installed: fs.existsSync(path.join(installDir, platformPackage.binaryName)),
       launcherInstalled: fs.existsSync(path.join(binDir, "claude-rs")),
       status: commandResult.status,
@@ -212,11 +251,31 @@ function writeCommandShims(shimDir, { claudeCliAvailable }) {
     `#!/bin/sh
 url=""
 destination=""
+headers=""
+stderr_destination=""
+write_out=""
+head_only=0
+printf '%s\\n' "$*" >> "$MOCK_CURL_LOG"
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    -o)
+    -o | --output)
       shift
       destination="$1"
+      ;;
+    --dump-header)
+      shift
+      headers="$1"
+      ;;
+    --stderr)
+      shift
+      stderr_destination="$1"
+      ;;
+    --write-out)
+      shift
+      write_out="$1"
+      ;;
+    --head)
+      head_only=1
       ;;
     http://* | https://*)
       url="$1"
@@ -224,20 +283,37 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+[ -z "$stderr_destination" ] || : > "$stderr_destination"
+emit_error() {
+  if [ -n "$stderr_destination" ]; then
+    printf '%s\\n' "$1" > "$stderr_destination"
+  else
+    printf '%s\\n' "$1" >&2
+  fi
+}
 case "$url" in
   */SHA256SUMS)
     if [ "$MOCK_DOWNLOAD_MODE" = "checksum-download-failure" ]; then
-      printf '%s\\n' 'mock checksum download failed' >&2
+      emit_error 'mock checksum download failed'
       exit 22
     fi
+    [ -z "$headers" ] || printf 'HTTP/1.1 200 OK\\r\\nContent-Length: %s\\r\\n\\r\\n' "$(wc -c < "$MOCK_CHECKSUM_FILE")" > "$headers"
+    [ "$head_only" -eq 1 ] && exit 0
     cp "$MOCK_CHECKSUM_FILE" "$destination"
     ;;
   *)
     if [ "$MOCK_DOWNLOAD_MODE" = "archive-unavailable" ]; then
-      printf '%s\\n' 'mock archive download failed' >&2
+      emit_error 'mock archive download failed'
       exit 22
     fi
+    archive_size="$(wc -c < "$MOCK_ARCHIVE_FILE")"
+    [ -z "$headers" ] || printf 'HTTP/1.1 200 OK\\r\\nContent-Length: %s\\r\\n\\r\\n' "$archive_size" > "$headers"
+    [ "$head_only" -eq 1 ] && exit 0
     cp "$MOCK_ARCHIVE_FILE" "$destination"
+    if [ -n "$write_out" ]; then
+      archive_speed="$((archive_size / 2))"
+      printf '__CLAUDE_RS_DOWNLOAD_STATS__200\\t%s\\t%s\\t2.000' "$archive_size" "$archive_speed"
+    fi
     ;;
 esac
 `,

--- a/scripts/install/install-version-guard.test.mjs
+++ b/scripts/install/install-version-guard.test.mjs
@@ -233,11 +233,15 @@ function writeCommandShims(shimDir) {
     `#!/bin/sh
 url=""
 destination=""
+head_only=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    -o)
+    -o | --output)
       shift
       destination="$1"
+      ;;
+    --head)
+      head_only=1
       ;;
     http://* | https://*)
       url="$1"
@@ -245,6 +249,7 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+[ "$head_only" -eq 0 ] || exit 0
 printf '%s\\n' "$url" >> "$MOCK_DOWNLOAD_LOG"
 case "$url" in
   */releases/latest)

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -513,9 +513,12 @@ function Invoke-ArchiveDownload {
     )
 
     Stop-InstallerProgress
-    $curl = Get-Command "curl.exe" -ErrorAction SilentlyContinue
+    $curl = Get-Command "curl.exe" -CommandType Application -ErrorAction SilentlyContinue
     if (-not $curl) {
-        Write-WarnLine "curl.exe not found; using the slower PowerShell downloader"
+        $curl = Get-Command "curl" -CommandType Application -ErrorAction SilentlyContinue
+    }
+    if (-not $curl) {
+        Write-WarnLine "curl executable not found; using the slower PowerShell downloader"
         Start-InstallerProgress "Downloading release archive"
         $stopwatch = [Diagnostics.Stopwatch]::StartNew()
         Invoke-WebRequest -Uri $Uri -OutFile $Destination
@@ -541,7 +544,7 @@ function Invoke-ArchiveDownload {
         "--retry" "$DownloadRetryCount" `
         "--connect-timeout" "$DownloadConnectTimeoutSeconds" `
         "--dump-header" $headersPath `
-        "--output" "NUL" `
+        "--output" "-" `
         $Uri 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
         $totalBytes = Get-DownloadContentLength -HeadersPath $headersPath
@@ -577,7 +580,7 @@ function Invoke-ArchiveDownload {
         $startInfo.RedirectStandardOutput = $true
         $process = [Diagnostics.Process]::Start($startInfo)
         if (-not $process) {
-            throw "could not start curl.exe"
+            throw "could not start curl executable"
         }
 
         while (-not $process.WaitForExit(200)) {
@@ -604,7 +607,7 @@ function Invoke-ArchiveDownload {
                     }
                 }
             }
-            throw "curl.exe failed with exit code $($process.ExitCode)"
+            throw "curl executable failed with exit code $($process.ExitCode)"
         }
 
         if ($script:InstallerProgressSupported) {

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -21,6 +21,10 @@ $RepoOwner = "srothgan"
 $RepoName = "claude-code-rust"
 $RepoSlug = "$RepoOwner/$RepoName"
 $RootPackage = "claude-code-rust"
+$DownloadRetryCount = 3
+$DownloadConnectTimeoutSeconds = 30
+$DownloadLowSpeedBytesPerSecond = 1024
+$DownloadLowSpeedTimeSeconds = 30
 
 function Show-Usage {
     @"
@@ -32,7 +36,8 @@ Options:
   -Yes                   Reinstall the selected version when already installed;
                          skip optional installer prompts.
   -NoModifyPath          Do not update the user PATH.
-  -Verify                Run strict runtime diagnostics after install.
+  -Verify                Show download diagnostics and run strict runtime
+                         diagnostics after install.
   -Run                   Start claude-rs after a successful install.
   -RemoveNpm             Remove an existing global npm install when found.
   -KeepNpm               Keep an existing global npm install without prompting.
@@ -130,6 +135,7 @@ $FailMark = [char]0x2717
 $script:InstallerProgressSupported = $false
 $script:InstallerProgressActive = $false
 $script:InstallerProgressWorker = $null
+$script:DownloadProgressWidth = 0
 
 if (-not $env:CI -and $env:TERM -ne "dumb") {
     try {
@@ -338,6 +344,295 @@ function Write-InstallerDiagnostic {
     param([string]$Message)
     Stop-InstallerProgress
     Write-Host $Message
+}
+
+function Format-DownloadBytes {
+    param([double]$Bytes)
+
+    $units = @("B", "KiB", "MiB", "GiB")
+    $value = $Bytes
+    $unitIndex = 0
+    while ($value -ge 1024 -and $unitIndex -lt ($units.Count - 1)) {
+        $value /= 1024
+        $unitIndex++
+    }
+
+    if ($unitIndex -eq 0) {
+        return [string]::Format(
+            [Globalization.CultureInfo]::InvariantCulture,
+            "{0:0} {1}",
+            $value,
+            $units[$unitIndex]
+        )
+    }
+    return [string]::Format(
+        [Globalization.CultureInfo]::InvariantCulture,
+        "{0:0.0} {1}",
+        $value,
+        $units[$unitIndex]
+    )
+}
+
+function Write-DownloadDiagnostic {
+    param(
+        [string]$StatsLine,
+        [string]$Label
+    )
+
+    if (-not $Verify -or [string]::IsNullOrWhiteSpace($StatsLine)) {
+        return
+    }
+
+    $prefix = "__CLAUDE_RS_DOWNLOAD_STATS__"
+    if (-not $StatsLine.StartsWith($prefix, [StringComparison]::Ordinal)) {
+        return
+    }
+
+    $parts = $StatsLine.Substring($prefix.Length).Split([char]9)
+    if ($parts.Count -ne 4) {
+        return
+    }
+
+    $culture = [Globalization.CultureInfo]::InvariantCulture
+    $size = [double]::Parse($parts[1], $culture)
+    $speed = [double]::Parse($parts[2], $culture)
+    $elapsed = [double]::Parse($parts[3], $culture)
+    $elapsedText = $elapsed.ToString("0.000", $culture)
+    Write-InstallerDiagnostic "  ${Label}: $(Format-DownloadBytes $size) in ${elapsedText}s ($(Format-DownloadBytes $speed)/s, HTTP $($parts[0]))"
+}
+
+function Format-DownloadEta {
+    param([double]$Seconds)
+
+    if ([double]::IsNaN($Seconds) -or [double]::IsInfinity($Seconds) -or $Seconds -lt 0) {
+        return "--:--"
+    }
+
+    $rounded = [Math]::Ceiling($Seconds)
+    $span = [TimeSpan]::FromSeconds($rounded)
+    if ($span.TotalHours -ge 1) {
+        return "{0:00}:{1:00}:{2:00}" -f [Math]::Floor($span.TotalHours), $span.Minutes, $span.Seconds
+    }
+    return "{0:00}:{1:00}" -f $span.Minutes, $span.Seconds
+}
+
+function Format-DownloadProgress {
+    param(
+        [long]$DownloadedBytes,
+        [long]$TotalBytes,
+        [double]$ElapsedSeconds,
+        [bool]$IncludeDiagnostics,
+        [int]$UnknownPosition = 0
+    )
+
+    $barWidth = 10
+    if ($TotalBytes -gt 0) {
+        $percent = [Math]::Min(100, [Math]::Max(0, [Math]::Floor(($DownloadedBytes * 100.0) / $TotalBytes)))
+        $completedCells = [int][Math]::Floor(($percent * $barWidth) / 100)
+        if ($percent -ge 100) {
+            $bar = "=" * $barWidth
+        } else {
+            $equalsCount = [Math]::Min($completedCells, $barWidth - 1)
+            $bar = ("=" * $equalsCount) + ">" + ("." * ($barWidth - $equalsCount - 1))
+        }
+        $line = "[{0}] {1,3}% Downloading release archive" -f $bar, $percent
+    } else {
+        $position = $UnknownPosition % $barWidth
+        $bar = ("." * $position) + ">" + ("." * ($barWidth - $position - 1))
+        $line = "[$bar]  --% Downloading release archive"
+    }
+
+    if ($IncludeDiagnostics) {
+        $elapsed = [Math]::Max($ElapsedSeconds, 0.001)
+        $speed = $DownloadedBytes / $elapsed
+        $eta = if ($TotalBytes -gt 0 -and $speed -gt 0) {
+            Format-DownloadEta (($TotalBytes - $DownloadedBytes) / $speed)
+        } else {
+            "--:--"
+        }
+        $totalText = if ($TotalBytes -gt 0) { Format-DownloadBytes $TotalBytes } else { "unknown" }
+        $line += " | $(Format-DownloadBytes $DownloadedBytes) / $totalText | $(Format-DownloadBytes $speed)/s | ETA $eta"
+    }
+
+    return $line
+}
+
+function Write-DownloadProgress {
+    param(
+        [string]$Text,
+        [switch]$Complete
+    )
+
+    $previousWidth = $script:DownloadProgressWidth
+    $width = [Math]::Max($previousWidth, $Text.Length)
+    [Console]::Write("`r" + $Text.PadRight($width))
+    $script:DownloadProgressWidth = $Text.Length
+    if ($Complete) {
+        [Console]::WriteLine()
+        $script:DownloadProgressWidth = 0
+    }
+}
+
+function Clear-DownloadProgress {
+    if ($script:DownloadProgressWidth -gt 0) {
+        [Console]::Write("`r" + (" " * $script:DownloadProgressWidth) + "`r")
+        $script:DownloadProgressWidth = 0
+    }
+}
+
+function ConvertTo-CurlConfigValue {
+    param([string]$Value)
+
+    return '"' + $Value.Replace("\", "\\").Replace('"', '\"').Replace("`r", "\r").Replace("`n", "\n") + '"'
+}
+
+function Get-DownloadContentLength {
+    param([string]$HeadersPath)
+
+    if (-not (Test-Path -LiteralPath $HeadersPath -PathType Leaf)) {
+        return 0
+    }
+
+    try {
+        $contentLength = 0
+        foreach ($line in [IO.File]::ReadAllLines($HeadersPath)) {
+            if ($line -match "^[Cc]ontent-[Ll]ength:\s*(\d+)\s*$") {
+                $contentLength = [long]$Matches[1]
+            }
+        }
+        return $contentLength
+    } catch {
+        return 0
+    }
+}
+
+function Invoke-ArchiveDownload {
+    param(
+        [string]$Uri,
+        [string]$Destination
+    )
+
+    Stop-InstallerProgress
+    $curl = Get-Command "curl.exe" -ErrorAction SilentlyContinue
+    if (-not $curl) {
+        Write-WarnLine "curl.exe not found; using the slower PowerShell downloader"
+        Start-InstallerProgress "Downloading release archive"
+        $stopwatch = [Diagnostics.Stopwatch]::StartNew()
+        Invoke-WebRequest -Uri $Uri -OutFile $Destination
+        $stopwatch.Stop()
+        if ($Verify) {
+            $downloadedBytes = (Get-Item -LiteralPath $Destination).Length
+            $elapsedSeconds = [Math]::Max($stopwatch.Elapsed.TotalSeconds, 0.001)
+            $elapsedText = $elapsedSeconds.ToString("0.000", [Globalization.CultureInfo]::InvariantCulture)
+            Write-InstallerDiagnostic "  Download: $(Format-DownloadBytes $downloadedBytes) in ${elapsedText}s ($(Format-DownloadBytes ($downloadedBytes / $elapsedSeconds))/s, HTTP unavailable)"
+        }
+        return
+    }
+
+    $headersPath = "$Destination.headers"
+    $stderrPath = "$Destination.stderr"
+    $configPath = "$Destination.curlrc"
+    $totalBytes = 0
+    & $curl.Source `
+        "--fail" `
+        "--location" `
+        "--head" `
+        "--silent" `
+        "--retry" "$DownloadRetryCount" `
+        "--connect-timeout" "$DownloadConnectTimeoutSeconds" `
+        "--dump-header" $headersPath `
+        "--output" "NUL" `
+        $Uri 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        $totalBytes = Get-DownloadContentLength -HeadersPath $headersPath
+    }
+
+    $statsFormat = "__CLAUDE_RS_DOWNLOAD_STATS__%{http_code}\t%{size_download}\t%{speed_download}\t%{time_total}"
+    $configLines = @(
+        "fail",
+        "location",
+        "retry = $DownloadRetryCount",
+        "connect-timeout = $DownloadConnectTimeoutSeconds",
+        "speed-limit = $DownloadLowSpeedBytesPerSecond",
+        "speed-time = $DownloadLowSpeedTimeSeconds",
+        "silent",
+        "show-error",
+        "dump-header = $(ConvertTo-CurlConfigValue $headersPath)",
+        "stderr = $(ConvertTo-CurlConfigValue $stderrPath)",
+        "output = $(ConvertTo-CurlConfigValue $Destination)",
+        "write-out = $(ConvertTo-CurlConfigValue $statsFormat)",
+        "url = $(ConvertTo-CurlConfigValue $Uri)"
+    )
+    [IO.File]::WriteAllLines($configPath, $configLines, (New-Object Text.UTF8Encoding($false)))
+
+    $process = $null
+    $stopwatch = [Diagnostics.Stopwatch]::StartNew()
+    $unknownPosition = 0
+    try {
+        $startInfo = New-Object Diagnostics.ProcessStartInfo
+        $startInfo.FileName = $curl.Source
+        $startInfo.Arguments = "--config `"$configPath`""
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardOutput = $true
+        $process = [Diagnostics.Process]::Start($startInfo)
+        if (-not $process) {
+            throw "could not start curl.exe"
+        }
+
+        while (-not $process.WaitForExit(200)) {
+            if ($script:InstallerProgressSupported) {
+                $downloadedBytes = if (Test-Path -LiteralPath $Destination -PathType Leaf) {
+                    (Get-Item -LiteralPath $Destination).Length
+                } else {
+                    0
+                }
+                $progressText = Format-DownloadProgress -DownloadedBytes $downloadedBytes -TotalBytes $totalBytes -ElapsedSeconds $stopwatch.Elapsed.TotalSeconds -IncludeDiagnostics $Verify -UnknownPosition $unknownPosition
+                Write-DownloadProgress -Text $progressText
+                $unknownPosition++
+            }
+        }
+
+        $curlOutput = $process.StandardOutput.ReadToEnd()
+        $stopwatch.Stop()
+        if ($process.ExitCode -ne 0) {
+            Clear-DownloadProgress
+            if (Test-Path -LiteralPath $stderrPath -PathType Leaf) {
+                foreach ($line in Get-Content -LiteralPath $stderrPath) {
+                    if (-not [string]::IsNullOrWhiteSpace($line)) {
+                        [Console]::Error.WriteLine($line)
+                    }
+                }
+            }
+            throw "curl.exe failed with exit code $($process.ExitCode)"
+        }
+
+        if ($script:InstallerProgressSupported) {
+            $downloadedBytes = (Get-Item -LiteralPath $Destination).Length
+            if ($totalBytes -le 0) {
+                $totalBytes = $downloadedBytes
+            }
+            $progressText = Format-DownloadProgress -DownloadedBytes $downloadedBytes -TotalBytes $totalBytes -ElapsedSeconds $stopwatch.Elapsed.TotalSeconds -IncludeDiagnostics $Verify
+            Write-DownloadProgress -Text $progressText -Complete
+        }
+
+        $statsLine = @($curlOutput -split "\r?\n" | Where-Object {
+            $_.StartsWith("__CLAUDE_RS_DOWNLOAD_STATS__", [StringComparison]::Ordinal)
+        } | Select-Object -Last 1)
+        if ($statsLine.Count -gt 0) {
+            Write-DownloadDiagnostic -StatsLine "$($statsLine[0])" -Label "Download"
+        }
+    } finally {
+        if ($process) {
+            if (-not $process.HasExited) {
+                $process.Kill()
+                $process.WaitForExit()
+            }
+            $process.Dispose()
+        }
+        Clear-DownloadProgress
+        Remove-Item -LiteralPath $headersPath, $stderrPath, $configPath -Force -ErrorAction SilentlyContinue
+    }
 }
 
 function Test-CanPrompt {
@@ -910,8 +1205,9 @@ try {
     Start-InstallerProgress "Downloading release archive"
     Invoke-WebRequest -Uri "$baseUrl/SHA256SUMS" -OutFile $checksumsPath
     try {
-        Invoke-WebRequest -Uri "$baseUrl/$archiveName" -OutFile $archivePath
+        Invoke-ArchiveDownload -Uri "$baseUrl/$archiveName" -Destination $archivePath
     } catch {
+        Write-WarnDetail "  Download failed: $($_.Exception.GetBaseException().Message)"
         Fail-Unavailable
     }
     Complete-InstallerProgress "Downloaded release archive"

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -506,6 +506,16 @@ function Get-DownloadContentLength {
     }
 }
 
+function Get-CurlApplication {
+    $curl = Get-Command "curl.exe" -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if (-not $curl) {
+        $curl = Get-Command "curl" -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+    }
+    return $curl
+}
+
 function Invoke-ArchiveDownload {
     param(
         [string]$Uri,
@@ -513,10 +523,7 @@ function Invoke-ArchiveDownload {
     )
 
     Stop-InstallerProgress
-    $curl = Get-Command "curl.exe" -CommandType Application -ErrorAction SilentlyContinue
-    if (-not $curl) {
-        $curl = Get-Command "curl" -CommandType Application -ErrorAction SilentlyContinue
-    }
+    $curl = Get-CurlApplication
     if (-not $curl) {
         Write-WarnLine "curl executable not found; using the slower PowerShell downloader"
         Start-InstallerProgress "Downloading release archive"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -5,6 +5,10 @@ repo_owner="srothgan"
 repo_name="claude-code-rust"
 repo_slug="$repo_owner/$repo_name"
 root_package="claude-code-rust"
+download_retry_count=3
+download_connect_timeout_seconds=30
+download_low_speed_bytes_per_second=1024
+download_low_speed_time_seconds=30
 
 release="${CLAUDE_RS_RELEASE:-latest}"
 install_dir="${CLAUDE_RS_INSTALL_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/claude-rs}"
@@ -60,7 +64,8 @@ Options:
                             accept safe prompts; optional prompts are skipped.
   --non-interactive         Do not prompt.
   --no-modify-path          Do not update shell profile PATH.
-  --verify                  Run strict runtime diagnostics after install.
+  --verify                  Show download diagnostics and run strict runtime
+                            diagnostics after install.
   --run                     Start claude-rs after a successful install.
   --remove-npm              Remove an existing global npm install when found.
   --keep-npm                Keep an existing global npm install without prompting.
@@ -185,6 +190,7 @@ progress_frames="$(printf '| / - \134')"
 progress_enabled=0
 progress_pid=""
 progress_rendered_file=""
+download_pid=""
 if [ -t 1 ] && [ -z "${CI:-}" ] && [ "${TERM:-}" != "dumb" ] && [ -w /dev/tty ]; then
   progress_enabled=1
 fi
@@ -305,10 +311,20 @@ download() {
   destination="$2"
   if command -v curl >/dev/null 2>&1; then
     if [ "$progress_enabled" -eq 0 ]; then
-      curl -fsSL "$url" -o "$destination"
+      curl -fsSL \
+        --retry "$download_retry_count" \
+        --connect-timeout "$download_connect_timeout_seconds" \
+        --speed-limit "$download_low_speed_bytes_per_second" \
+        --speed-time "$download_low_speed_time_seconds" \
+        "$url" -o "$destination"
       return $?
     fi
-    if curl -fsSL "$url" -o "$destination" 2>"$tmpdir/download.stderr"; then
+    if curl -fsSL \
+      --retry "$download_retry_count" \
+      --connect-timeout "$download_connect_timeout_seconds" \
+      --speed-limit "$download_low_speed_bytes_per_second" \
+      --speed-time "$download_low_speed_time_seconds" \
+      "$url" -o "$destination" 2>"$tmpdir/download.stderr"; then
       return 0
     else
       download_status=$?
@@ -336,6 +352,284 @@ download() {
     return "$download_status"
   fi
   die "required command not found: curl or wget"
+}
+
+format_download_bytes() {
+  awk -v bytes="$1" 'BEGIN {
+    split("B KiB MiB GiB", units, " ")
+    value = bytes + 0
+    unit = 1
+    while (value >= 1024 && unit < 4) {
+      value /= 1024
+      unit++
+    }
+    if (unit == 1) {
+      printf "%.0f %s", value, units[unit]
+    } else {
+      printf "%.1f %s", value, units[unit]
+    }
+  }'
+}
+
+write_download_diagnostic() {
+  download_stats="$1"
+  download_label="$2"
+  [ "$verify" -eq 1 ] || return 0
+
+  download_stats="${download_stats#__CLAUDE_RS_DOWNLOAD_STATS__}"
+  saved_ifs="$IFS"
+  IFS="$(printf '\t')"
+  # shellcheck disable=SC2086 # curl's tab-separated fields are intentionally split.
+  set -- $download_stats
+  IFS="$saved_ifs"
+  [ "$#" -eq 4 ] || return 0
+
+  download_http_code="$1"
+  download_size="$2"
+  download_speed="$3"
+  download_elapsed="$4"
+  download_size_text="$(format_download_bytes "$download_size")"
+  download_speed_text="$(format_download_bytes "$download_speed")"
+  info "  $download_label: $download_size_text in ${download_elapsed}s ($download_speed_text/s, HTTP $download_http_code)"
+}
+
+download_content_length() {
+  headers_path="$1"
+  [ -f "$headers_path" ] || {
+    printf '0\n'
+    return
+  }
+  awk '
+    tolower($1) == "content-length:" {
+      gsub("\r", "", $2)
+      length = $2
+    }
+    END { print length + 0 }
+  ' "$headers_path"
+}
+
+format_download_progress() {
+  downloaded_bytes="$1"
+  total_bytes="$2"
+  elapsed_seconds="$3"
+  include_diagnostics="$4"
+  unknown_position="$5"
+
+  awk \
+    -v downloaded="$downloaded_bytes" \
+    -v total="$total_bytes" \
+    -v elapsed="$elapsed_seconds" \
+    -v diagnostics="$include_diagnostics" \
+    -v unknown_position="$unknown_position" '
+    function repeat(character, count, result) {
+      result = ""
+      while (count-- > 0) {
+        result = result character
+      }
+      return result
+    }
+    function human(bytes, value, unit) {
+      split("B KiB MiB GiB", units, " ")
+      value = bytes + 0
+      unit = 1
+      while (value >= 1024 && unit < 4) {
+        value /= 1024
+        unit++
+      }
+      return unit == 1 ? sprintf("%.0f %s", value, units[unit]) : sprintf("%.1f %s", value, units[unit])
+    }
+    function eta_text(seconds, hours, minutes) {
+      if (seconds < 0) {
+        return "--:--"
+      }
+      seconds = int(seconds + 0.999)
+      hours = int(seconds / 3600)
+      minutes = int((seconds % 3600) / 60)
+      seconds %= 60
+      return hours > 0 ? sprintf("%02d:%02d:%02d", hours, minutes, seconds) : sprintf("%02d:%02d", minutes, seconds)
+    }
+    BEGIN {
+      width = 10
+      if (total > 0) {
+        percent = int((downloaded * 100) / total)
+        if (percent < 0) percent = 0
+        if (percent > 100) percent = 100
+        completed = int((percent * width) / 100)
+        if (percent >= 100) {
+          bar = repeat("=", width)
+        } else {
+          equals = completed < width ? completed : width - 1
+          bar = repeat("=", equals) ">" repeat(".", width - equals - 1)
+        }
+        line = sprintf("[%s] %3d%% Downloading release archive", bar, percent)
+      } else {
+        position = unknown_position % width
+        bar = repeat(".", position) ">" repeat(".", width - position - 1)
+        line = sprintf("[%s]  --%% Downloading release archive", bar)
+      }
+
+      if (diagnostics == 1) {
+        safe_elapsed = elapsed > 0 ? elapsed : 1
+        speed = downloaded / safe_elapsed
+        eta = total > 0 && speed > 0 ? eta_text((total - downloaded) / speed) : "--:--"
+        total_text = total > 0 ? human(total) : "unknown"
+        line = sprintf("%s | %s / %s | %s/s | ETA %s", line, human(downloaded), total_text, human(speed), eta)
+      }
+      print line
+    }
+  '
+}
+
+render_download_progress() {
+  downloaded_bytes="$1"
+  total_bytes="$2"
+  elapsed_seconds="$3"
+  unknown_position="$4"
+  progress_text="$(format_download_progress "$downloaded_bytes" "$total_bytes" "$elapsed_seconds" "$verify" "$unknown_position")"
+  printf '\r\033[2K%s' "$progress_text" > /dev/tty
+}
+
+finish_download_progress() {
+  downloaded_bytes="$1"
+  total_bytes="$2"
+  elapsed_seconds="$3"
+  progress_text="$(format_download_progress "$downloaded_bytes" "$total_bytes" "$elapsed_seconds" "$verify" 0)"
+  printf '\r\033[2K%s\n' "$progress_text" > /dev/tty
+}
+
+clear_download_progress() {
+  [ "$progress_enabled" -eq 1 ] || return 0
+  printf '\r\033[2K' > /dev/tty 2>/dev/null || :
+}
+
+wait_for_download() {
+  destination="$1"
+  headers_path="$2"
+  started_at="$3"
+  total_bytes="$4"
+  unknown_position=0
+
+  if [ "$progress_enabled" -eq 1 ]; then
+    while kill -0 "$download_pid" 2>/dev/null; do
+      [ "$total_bytes" -gt 0 ] || total_bytes="$(download_content_length "$headers_path")"
+      downloaded_bytes=0
+      [ ! -f "$destination" ] || downloaded_bytes="$(wc -c < "$destination")"
+      elapsed_seconds=0
+      [ "$verify" -eq 0 ] || elapsed_seconds="$(($(date +%s) - started_at))"
+      render_download_progress "$downloaded_bytes" "$total_bytes" "$elapsed_seconds" "$unknown_position"
+      unknown_position="$((unknown_position + 1))"
+      sleep 0.2
+    done
+  fi
+
+  if wait "$download_pid"; then
+    download_status=0
+  else
+    download_status=$?
+  fi
+  download_pid=""
+  return "$download_status"
+}
+
+download_archive() {
+  url="$1"
+  destination="$2"
+  progress_stop
+  headers_path="$tmpdir/download.headers"
+  stderr_path="$tmpdir/download.stderr"
+  stats_path="$tmpdir/download.stats"
+  rm -f "$headers_path" "$stderr_path" "$stats_path"
+  download_started_at="$(date +%s)"
+
+  if command -v curl >/dev/null 2>&1; then
+    total_bytes=0
+    if curl --fail --location --head --silent \
+      --retry "$download_retry_count" \
+      --connect-timeout "$download_connect_timeout_seconds" \
+      --dump-header "$headers_path" \
+      --output /dev/null \
+      "$url"; then
+      total_bytes="$(download_content_length "$headers_path")"
+    fi
+
+    curl_stats_format='__CLAUDE_RS_DOWNLOAD_STATS__%{http_code}\t%{size_download}\t%{speed_download}\t%{time_total}'
+    curl --fail --location \
+      --retry "$download_retry_count" \
+      --connect-timeout "$download_connect_timeout_seconds" \
+      --speed-limit "$download_low_speed_bytes_per_second" \
+      --speed-time "$download_low_speed_time_seconds" \
+      --silent --show-error \
+      --dump-header "$headers_path" \
+      --stderr "$stderr_path" \
+      --output "$destination" \
+      --write-out "$curl_stats_format" \
+      "$url" > "$stats_path" &
+    download_pid=$!
+
+    if wait_for_download "$destination" "$headers_path" "$download_started_at" "$total_bytes"; then
+      download_status=0
+    else
+      download_status=$?
+    fi
+    if [ "$download_status" -ne 0 ]; then
+      clear_download_progress
+      while IFS= read -r download_detail || [ -n "$download_detail" ]; do
+        warn_detail "$download_detail"
+      done < "$stderr_path"
+      return "$download_status"
+    fi
+
+    download_finished_at="$(date +%s)"
+    download_elapsed="$((download_finished_at - download_started_at))"
+    downloaded_bytes="$(wc -c < "$destination")"
+    [ "$total_bytes" -gt 0 ] || total_bytes="$downloaded_bytes"
+    [ "$progress_enabled" -eq 0 ] || finish_download_progress "$downloaded_bytes" "$total_bytes" "$download_elapsed"
+    curl_stats="$(cat "$stats_path")"
+    write_download_diagnostic "$curl_stats" "Download"
+    return 0
+  fi
+
+  if command -v wget >/dev/null 2>&1; then
+    wget -q \
+      --timeout="$download_connect_timeout_seconds" \
+      --tries="$((download_retry_count + 1))" \
+      -O "$destination" "$url" 2>"$stderr_path" &
+    download_pid=$!
+
+    if wait_for_download "$destination" "$headers_path" "$download_started_at" 0; then
+      download_status=0
+    else
+      download_status=$?
+    fi
+    if [ "$download_status" -ne 0 ]; then
+      clear_download_progress
+      while IFS= read -r download_detail || [ -n "$download_detail" ]; do
+        warn_detail "$download_detail"
+      done < "$stderr_path"
+      return "$download_status"
+    fi
+
+    download_finished_at="$(date +%s)"
+    download_elapsed="$((download_finished_at - download_started_at))"
+    [ "$download_elapsed" -gt 0 ] || download_elapsed=1
+    downloaded_bytes="$(wc -c < "$destination")"
+    [ "$progress_enabled" -eq 0 ] || finish_download_progress "$downloaded_bytes" "$downloaded_bytes" "$download_elapsed"
+    if [ "$verify" -eq 1 ]; then
+      download_speed="$((downloaded_bytes / download_elapsed))"
+      info "  Download: $(format_download_bytes "$downloaded_bytes") in ${download_elapsed}s ($(format_download_bytes "$download_speed")/s, HTTP unavailable)"
+    fi
+    return 0
+  fi
+
+  die "required command not found: curl or wget"
+}
+
+stop_download_process() {
+  if [ -n "${download_pid:-}" ]; then
+    kill "$download_pid" 2>/dev/null || :
+    wait "$download_pid" 2>/dev/null || :
+    download_pid=""
+  fi
 }
 
 sha256_file() {
@@ -839,10 +1133,14 @@ need_cmd tar
 need_cmd chmod
 need_cmd grep
 need_cmd awk
+need_cmd cat
+need_cmd date
+need_cmd wc
 
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/claude-rs-install.XXXXXX")"
 same_version_reinstall_approved=0
 cleanup() {
+  stop_download_process
   progress_stop
   [ -z "${lock_dir:-}" ] || rm -rf "$lock_dir"
   rm -rf "$tmpdir"
@@ -896,7 +1194,7 @@ guard_same_version_before_download "$selected_version"
 
 progress_start "Downloading release archive"
 download "$base_url/SHA256SUMS" "$checksum_file" || die "could not download SHA256SUMS for $tag"
-if ! download "$base_url/$archive_name" "$archive_file"; then
+if ! download_archive "$base_url/$archive_name" "$archive_file"; then
   die_unavailable
 fi
 progress_done "Downloaded release archive"

--- a/scripts/install/test-install-progress.ps1
+++ b/scripts/install/test-install-progress.ps1
@@ -35,6 +35,15 @@ $helperNames = @(
     "Write-WarnDetail",
     "Write-FailLine",
     "Write-InstallerDiagnostic",
+    "Format-DownloadBytes",
+    "Write-DownloadDiagnostic",
+    "Format-DownloadEta",
+    "Format-DownloadProgress",
+    "Write-DownloadProgress",
+    "Clear-DownloadProgress",
+    "ConvertTo-CurlConfigValue",
+    "Get-DownloadContentLength",
+    "Invoke-ArchiveDownload",
     "Test-CanPrompt",
     "Confirm-DefaultNo",
     "Warn-MissingClaudeCli"
@@ -72,11 +81,70 @@ $NonInteractive = $true
 $script:InstallerProgressSupported = $true
 $script:InstallerProgressActive = $false
 $script:InstallerProgressWorker = $null
+$script:DownloadProgressWidth = 0
+$Verify = $false
+$DownloadRetryCount = 3
+$DownloadConnectTimeoutSeconds = 30
+$DownloadLowSpeedBytesPerSecond = 1024
+$DownloadLowSpeedTimeSeconds = 30
+
+Assert-Equal "[>.........]   0% Downloading release archive" `
+    (Format-DownloadProgress -DownloadedBytes 0 -TotalBytes 1000 -ElapsedSeconds 0 -IncludeDiagnostics $false) `
+    "Download progress did not render the empty fixed-width bar"
+Assert-Equal "[=====>....]  50% Downloading release archive" `
+    (Format-DownloadProgress -DownloadedBytes 500 -TotalBytes 1000 -ElapsedSeconds 2 -IncludeDiagnostics $false) `
+    "Download progress did not render the half-filled fixed-width bar"
+Assert-Equal "[==========] 100% Downloading release archive" `
+    (Format-DownloadProgress -DownloadedBytes 1000 -TotalBytes 1000 -ElapsedSeconds 4 -IncludeDiagnostics $false) `
+    "Download progress did not render the completed fixed-width bar"
+Assert-Equal "[...>......]  --% Downloading release archive" `
+    (Format-DownloadProgress -DownloadedBytes 0 -TotalBytes 0 -ElapsedSeconds 0 -IncludeDiagnostics $false -UnknownPosition 3) `
+    "Download progress did not render the fixed-width unknown-length bar"
+Assert-Equal "[=====>....]  50% Downloading release archive | 512.0 KiB / 1.0 MiB | 256.0 KiB/s | ETA 00:02" `
+    (Format-DownloadProgress -DownloadedBytes 524288 -TotalBytes 1048576 -ElapsedSeconds 2 -IncludeDiagnostics $true) `
+    "Download diagnostics did not include fixed-width transfer details"
+
+$downloadOutputWriter = New-Object System.IO.StringWriter
+$originalConsoleOut = [Console]::Out
+[Console]::SetOut($downloadOutputWriter)
+try {
+    Write-DownloadProgress -Text "[=====>....]  50% Downloading release archive"
+    Write-DownloadProgress -Text "[==========] 100% Downloading release archive" -Complete
+} finally {
+    [Console]::SetOut($originalConsoleOut)
+    $downloadOutput = $downloadOutputWriter.ToString()
+    $downloadOutputWriter.Dispose()
+}
+Assert-True $downloadOutput.Contains("`r[=====>....]  50% Downloading release archive") "Download progress did not update in place"
+Assert-True $downloadOutput.Contains("`r[==========] 100% Downloading release archive") "Download progress did not render completion"
+Assert-Equal 0 $script:DownloadProgressWidth "Download progress retained width after completion"
+
+$downloadSandbox = Join-Path ([IO.Path]::GetTempPath()) "claude-rs-download-test-$PID"
+$downloadSource = Join-Path $downloadSandbox "source.bin"
+$downloadDestination = Join-Path $downloadSandbox "destination.bin"
+New-Item -ItemType Directory -Path $downloadSandbox -Force | Out-Null
+try {
+    $sourceBytes = New-Object byte[] 65536
+    (New-Object Random 42).NextBytes($sourceBytes)
+    [IO.File]::WriteAllBytes($downloadSource, $sourceBytes)
+    $downloadUri = (New-Object Uri($downloadSource)).AbsoluteUri
+    $script:InstallerProgressSupported = $false
+    Invoke-ArchiveDownload -Uri $downloadUri -Destination $downloadDestination
+    Assert-Equal `
+        (Get-FileHash -LiteralPath $downloadSource -Algorithm SHA256).Hash `
+        (Get-FileHash -LiteralPath $downloadDestination -Algorithm SHA256).Hash `
+        "Streaming downloader changed the downloaded bytes"
+    foreach ($suffix in @(".headers", ".stderr", ".curlrc")) {
+        Assert-True (-not (Test-Path -LiteralPath "$downloadDestination$suffix")) "Streaming downloader left $suffix state behind"
+    }
+} finally {
+    Remove-Item -LiteralPath $downloadSandbox -Recurse -Force -ErrorAction SilentlyContinue
+}
+$script:InstallerProgressSupported = $true
 
 # Exercise the real background runspace with Console.Out captured. This verifies
 # that the renderer emits an inline animated line and that stopping it erases
 # the line without relying on the host-native progress area.
-$originalConsoleOut = [Console]::Out
 $spinnerOutputWriter = New-Object System.IO.StringWriter
 $spinnerOutput = ""
 [Console]::SetOut($spinnerOutputWriter)

--- a/scripts/install/test-install-progress.ps1
+++ b/scripts/install/test-install-progress.ps1
@@ -43,6 +43,7 @@ $helperNames = @(
     "Clear-DownloadProgress",
     "ConvertTo-CurlConfigValue",
     "Get-DownloadContentLength",
+    "Get-CurlApplication",
     "Invoke-ArchiveDownload",
     "Test-CanPrompt",
     "Confirm-DefaultNo",
@@ -87,6 +88,27 @@ $DownloadRetryCount = 3
 $DownloadConnectTimeoutSeconds = 30
 $DownloadLowSpeedBytesPerSecond = 1024
 $DownloadLowSpeedTimeSeconds = 30
+
+function Get-Command {
+    param(
+        [string]$Name,
+        [object]$CommandType,
+        [object]$ErrorAction
+    )
+
+    if ($Name -eq "curl") {
+        return @(
+            [pscustomobject]@{ Source = "/usr/bin/curl" },
+            [pscustomobject]@{ Source = "/bin/curl" }
+        )
+    }
+}
+try {
+    $resolvedCurl = Get-CurlApplication
+    Assert-Equal "/usr/bin/curl" $resolvedCurl.Source "Curl resolution returned multiple application paths"
+} finally {
+    Remove-Item Function:\Get-Command
+}
 
 Assert-Equal "[>.........]   0% Downloading release archive" `
     (Format-DownloadProgress -DownloadedBytes 0 -TotalBytes 1000 -ElapsedSeconds 0 -IncludeDiagnostics $false) `


### PR DESCRIPTION
## Summary

- Stream release archives with curl on PowerShell and Unix instead of hiding the large Windows transfer behind `Invoke-WebRequest`.
- Render the same fixed-width 10-cell progress bar on both installers, with percentage-only output by default and size, speed, and ETA details in verify mode.
- Resolve the archive size before transfer, retry transient failures, detect stalled downloads, preserve quiet redirected/CI output, and retain platform fallbacks.
- Expand installer coverage and document the download and diagnostics behavior.

## Why

The Windows installer suppressed native transfer progress while `Invoke-WebRequest` downloaded the 136 MB release archive slowly, making a healthy installation appear stuck for several minutes. The public installers need visible, bounded, and consistent transfer behavior across Windows, macOS, and Linux without adding noisy progress output to CI or redirected logs.

## Validation

- Automated: Parsed `install.ps1` with the Windows PowerShell parser; ran `powershell -NoLogo -NoProfile -File scripts/install/install.ps1 -Help`, `powershell -NoLogo -NoProfile -File scripts/install/test-install-progress.ps1`, and `powershell -NoLogo -NoProfile -File scripts/install/test-install-version-guard.ps1`; syntax-checked `install.sh` with Git's POSIX shell; ran `node --check scripts/install/install-progress.test.mjs`.
- Manual: Reinstalled `v0.14.2` on Windows with `-Yes -Verify` and verified the determinate 10-cell bar, resolved archive size, transfer speed, and ETA against the live GitHub Release asset.
- Screenshot/video (if UI changed): `Screenshot 2026-07-26 225820.png` is available for manual attachment and is intentionally not tracked.

## Notes

- Breaking changes: N/A
- Docs updated: Updated the installation guide and release-tooling documentation.
- Governance/release impact: The raw public installers change when this branch reaches `main`; existing release archives and package versions are unchanged.
- Local limitation: Unix integration scenarios are skipped on the Windows host and remain covered by Linux CI.
- Changelog: Not updated in this branch.
