### PR TITLE
fix(core): harden diagnostics, resume hints, and tool progress

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       package: ${{ steps.filter.outputs.package }}
       agent_sdk: ${{ steps.filter.outputs.agent_sdk }}
+      cargo_deps: ${{ steps.filter.outputs.cargo_deps }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -48,6 +49,7 @@ jobs:
 
           package=false
           agent_sdk=false
+          cargo_deps=false
           while IFS= read -r path; do
             case "$path" in
               Cargo.toml|Cargo.lock|deny.toml|package.json|package-lock.json|bin/*|agent-sdk/*|scripts/npm/*|scripts/runtime/*|scripts/shared/*|scripts/install/*|scripts/release/*|scripts/README.md|.github/workflows/pr.yml|.github/workflows/_agent-sdk.yml|.github/workflows/_release-build.yml|.github/workflows/release.yml|.github/workflows/nightly.yml)
@@ -59,10 +61,16 @@ jobs:
                 agent_sdk=true
                 ;;
             esac
+            case "$path" in
+              Cargo.toml|Cargo.lock|deny.toml)
+                cargo_deps=true
+                ;;
+            esac
           done < changed-files.txt
 
           echo "package=$package" >> "$GITHUB_OUTPUT"
           echo "agent_sdk=$agent_sdk" >> "$GITHUB_OUTPUT"
+          echo "cargo_deps=$cargo_deps" >> "$GITHUB_OUTPUT"
 
   rustfmt:
     name: Rustfmt
@@ -117,6 +125,22 @@ jobs:
           command: check bans licenses sources
           arguments: --all-features
 
+  # Advisories also run weekly and non-blocking in dependency-monitor.yml so that newly
+  # disclosed vulnerabilities never block unrelated PRs. Here they gate only the PRs that
+  # actually change the dependency graph, which must not introduce a known advisory.
+  cargo-deny-advisories:
+    name: Cargo Deny Advisories
+    needs: [changes]
+    if: needs.changes.outputs.cargo_deps == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
+        with:
+          rust-version: "1.88.0"
+          command: check advisories
+          arguments: --all-features
+
   agent-sdk-check:
     name: Agent SDK
     needs: [changes]
@@ -154,7 +178,7 @@ jobs:
         run: |
           node scripts/runtime/stage-bun-runtime.mjs --check
           node scripts/shared/verify-third-party-notices.mjs
-          node --test scripts/npm/npm-resolver.test.cjs scripts/npm/smoke-npm-package-install.test.mjs scripts/runtime/verify-staged-bun-runtimes.test.mjs scripts/npm/dry-run-npm-publish.test.mjs scripts/npm/publish-npm-platform-packages.test.mjs
+          node --test scripts/npm/npm-resolver.test.cjs scripts/npm/smoke-npm-package-install.test.mjs scripts/runtime/verify-staged-bun-runtimes.test.mjs scripts/npm/dry-run-npm-publish.test.mjs scripts/npm/publish-npm-platform-packages.test.mjs scripts/shared/deny-targets.test.mjs
 
       - name: Check public installer syntax
         shell: bash
@@ -288,6 +312,7 @@ jobs:
       - test-ubuntu
       - lockfile
       - cargo-deny-policy
+      - cargo-deny-advisories
       - agent-sdk-check
       - npm-package-layout
       - duplicate-code
@@ -302,6 +327,7 @@ jobs:
           TEST_UBUNTU: ${{ needs.test-ubuntu.result }}
           LOCKFILE: ${{ needs.lockfile.result }}
           CARGO_DENY_POLICY: ${{ needs.cargo-deny-policy.result }}
+          CARGO_DENY_ADVISORIES: ${{ needs.cargo-deny-advisories.result }}
           AGENT_SDK: ${{ needs.agent-sdk-check.result }}
           NPM_PACKAGE_LAYOUT: ${{ needs.npm-package-layout.result }}
           DUPLICATE_CODE: ${{ needs.duplicate-code.result }}
@@ -336,5 +362,6 @@ jobs:
           require_success "duplicate-code" "$DUPLICATE_CODE"
           require_success "codeql" "$CODEQL"
 
+          allow_success_or_skipped "cargo-deny-advisories" "$CARGO_DENY_ADVISORIES"
           allow_success_or_skipped "agent-sdk-check" "$AGENT_SDK"
           allow_success_or_skipped "npm-package-layout" "$NPM_PACKAGE_LAYOUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - **Installer download progress** (#312, @srothgan): Stream release archives with curl retries and stall detection, show matching fixed-width bars on PowerShell and Unix, and add opt-in size, speed, and ETA diagnostics while keeping redirected and CI output plain.
 
+### Fixes
+
+- **Runtime and tooling hardening** (#317, @srothgan): Add privacy-minimized baseline diagnostics with bounded retention, preserve resumable session hints through teardown, stop progress heartbeats from creating duplicate tool rows, update base64 to 0.23, and align cargo-deny targets and advisory gating with release packaging.
+
 ## [0.14.2] - 2026-07-26 [Changes][v0.14.2]
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,7 +515,7 @@ dependencies = [
  "ansi-to-tui",
  "anyhow",
  "arboard",
- "base64",
+ "base64 0.23.0",
  "clap",
  "crossterm",
  "dirs",
@@ -1446,7 +1452,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2464,7 +2470,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap",
  "quick-xml",
  "serde",
@@ -2921,7 +2927,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -3524,7 +3530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "fancy-regex 0.11.0",
  "filedescriptor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 anyhow = "1.0.101"
 ansi-to-tui = "8.0.1"
 arboard = { version = "3.6.1", features = ["image-data"] }
-base64 = "0.22"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 clap = { version = "4.6.1", features = ["derive"] }
 crossterm = { version = "0.29.0", features = ["event-stream"] }

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -4040,11 +4040,83 @@ test("emitToolProgressUpdate does not reopen completed tools", () => {
   });
 
   const events = captureBridgeEvents(() => {
-    emitToolProgressUpdate(session, "tool-1", "Bash");
+    emitToolProgressUpdate(session, "tool-1");
   });
 
   assert.equal(events.length, 0);
   assert.equal(session.toolCalls.get("tool-1")?.status, "completed");
+});
+
+test("emitToolProgressUpdate does not create tools from progress", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    emitToolProgressUpdate(session, "tool-progress-only");
+  });
+
+  assert.equal(events.length, 0);
+  assert.equal(session.toolCalls.has("tool-progress-only"), false);
+});
+
+test("handleSdkMessage correlates heartbeat progress to its existing parent tool", () => {
+  const session = makeSessionState();
+  const parentToolCall = createToolCall("tool-shell-parent", "PowerShell", {
+    command: "cargo test --all-features",
+  });
+  session.toolCalls.set(parentToolCall.tool_call_id, parentToolCall);
+
+  const events = captureBridgeEvents(() => {
+    for (let heartbeat = 0; heartbeat < 3; heartbeat += 1) {
+      handleSdkMessage(session, {
+        type: "tool_progress",
+        tool_use_id: `tool-shell-parent-heartbeat-${heartbeat}`,
+        tool_name: "PowerShell",
+        parent_tool_use_id: parentToolCall.tool_call_id,
+        elapsed_time_seconds: heartbeat + 1,
+        heartbeat: true,
+        uuid: `message-heartbeat-${heartbeat}`,
+        session_id: "session-1",
+      } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    }
+  });
+
+  assert.equal(events.length, 1);
+  assert.deepEqual(events[0], {
+    event: "session_update",
+    session_id: "session-1",
+    update: {
+      type: "tool_call_update",
+      tool_call_update: {
+        tool_call_id: "tool-shell-parent",
+        fields: { status: "in_progress" },
+      },
+    },
+  });
+  assert.equal(session.toolCalls.size, 1);
+  assert.equal(session.toolCalls.get(parentToolCall.tool_call_id)?.status, "in_progress");
+  for (let heartbeat = 0; heartbeat < 3; heartbeat += 1) {
+    assert.equal(session.toolCalls.has(`tool-shell-parent-heartbeat-${heartbeat}`), false);
+  }
+});
+
+test("handleSdkMessage ignores orphaned tool progress", () => {
+  const session = makeSessionState();
+
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "tool_progress",
+      tool_use_id: "tool-orphaned-heartbeat",
+      tool_name: "PowerShell",
+      parent_tool_use_id: "tool-missing-parent",
+      elapsed_time_seconds: 1,
+      heartbeat: true,
+      uuid: "message-orphaned-heartbeat",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.equal(events.length, 0);
+  assert.equal(session.toolCalls.size, 0);
 });
 
 test("handleSdkMessage updates and clears subagent retry progress in place", () => {

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -735,6 +735,26 @@ function logContentBlockLinkage(
   });
 }
 
+type ToolProgressCorrelationSource = "task" | "tool" | "parent";
+
+function resolveToolProgressTarget(
+  session: SessionState,
+  taskToolUseId: string,
+  toolUseId: string,
+  parentToolUseId: string,
+): { toolUseId: string; source: ToolProgressCorrelationSource } | null {
+  if (taskToolUseId && session.toolCalls.has(taskToolUseId)) {
+    return { toolUseId: taskToolUseId, source: "task" };
+  }
+  if (toolUseId && session.toolCalls.has(toolUseId)) {
+    return { toolUseId, source: "tool" };
+  }
+  if (parentToolUseId && session.toolCalls.has(parentToolUseId)) {
+    return { toolUseId: parentToolUseId, source: "parent" };
+  }
+  return null;
+}
+
 function hideToolUse(session: SessionState, toolUseId: string): void {
   if (toolUseId) {
     session.hiddenToolUseIds.add(toolUseId);
@@ -1412,26 +1432,34 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
   if (type === "tool_progress") {
     const toolUseId = typeof msg.tool_use_id === "string" ? msg.tool_use_id : "";
     const toolName = typeof msg.tool_name === "string" ? msg.tool_name : "Tool";
+    const parentToolUseId = typeof msg.parent_tool_use_id === "string" ? msg.parent_tool_use_id : "";
     const taskId = typeof msg.task_id === "string" ? msg.task_id : "";
     const taskToolUseId = taskId ? session.taskToolUseIds.get(taskId) ?? "" : "";
-    const resolvedToolUseId = taskToolUseId || toolUseId;
-    if (isHiddenToolUse(session, resolvedToolUseId, toolName)) {
+    if (isHiddenToolUse(session, toolUseId, toolName)) {
       return;
     }
+    const progressTarget = resolveToolProgressTarget(
+      session,
+      taskToolUseId,
+      toolUseId,
+      parentToolUseId,
+    );
+    const resolvedToolUseId = progressTarget?.toolUseId ?? "";
     bridgeLogger.debug({
       target: LOG_TARGETS.APP_TOOL,
       eventName: "sdk_tool_progress_linkage_observed",
       message: "SDK tool progress linkage observed",
-      outcome: typeof msg.parent_tool_use_id === "string" ? "child" : "root_or_unknown",
+      outcome: progressTarget?.source ?? "orphaned",
       sessionId: session.sessionId,
-      toolCallId: resolvedToolUseId || undefined,
+      toolCallId: resolvedToolUseId || toolUseId || undefined,
       fields: {
         tool_name: toolName,
         tool_use_id: toolUseId || undefined,
-        parent_tool_use_id:
-          typeof msg.parent_tool_use_id === "string" ? msg.parent_tool_use_id : undefined,
+        parent_tool_use_id: parentToolUseId || undefined,
         task_id: taskId || undefined,
         task_resolved_tool_use_id: taskToolUseId || undefined,
+        resolved_tool_use_id: resolvedToolUseId || undefined,
+        correlation_source: progressTarget?.source,
       },
     });
     if (resolvedToolUseId) {
@@ -1451,7 +1479,7 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         typeof msg.subagent_type === "string" && msg.subagent_type.trim()
           ? msg.subagent_type.trim()
           : undefined;
-      emitToolProgressUpdate(session, resolvedToolUseId, toolName, {
+      emitToolProgressUpdate(session, resolvedToolUseId, {
         ...(subagentRetry
           ? { subagentRetry }
           : hasSubagentRetry

--- a/agent-sdk/src/bridge/tool_calls.ts
+++ b/agent-sdk/src/bridge/tool_calls.ts
@@ -483,21 +483,22 @@ export function finalizeOpenToolCalls(session: SessionState, status: "completed"
   }
 }
 
+/**
+ * Apply advisory progress only to a tool created by an authoritative tool-use event.
+ */
 export function emitToolProgressUpdate(
   session: SessionState,
   toolUseId: string,
-  toolName: string,
   progress: {
     subagentRetry?: import("../types.js").SubagentRetryUpdate;
     subagentType?: string;
   } = {},
 ): void {
-  let existing = session.toolCalls.get(toolUseId);
+  const existing = session.toolCalls.get(toolUseId);
   if (!existing) {
-    emitToolCall(session, toolUseId, toolName, {});
-    existing = session.toolCalls.get(toolUseId);
+    return;
   }
-  if (!existing ||
+  if (
     existing.status === "completed" ||
     existing.status === "failed" ||
     existing.status === "killed"

--- a/deny.toml
+++ b/deny.toml
@@ -3,9 +3,13 @@
 
 [graph]
 all-features = true
+# Must stay in sync with PLATFORM_PACKAGES[].rustTarget in
+# scripts/shared/npm-package-config.mjs; enforced by scripts/shared/deny-targets.test.mjs.
 targets = [
     "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
     "x86_64-pc-windows-msvc",
+    "aarch64-pc-windows-msvc",
     "x86_64-apple-darwin",
     "aarch64-apple-darwin",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,7 @@ wildcards = "warn"
 highlight = "all"
 deny = []
 skip = [
+    { name = "base64", version = "0.22.1", reason = "hyper-util, plist, and reqwest still use base64 0.22 while the CLI uses 0.23." },
     { name = "getrandom", version = "0.3.4", reason = "build-time dependencies still use getrandom 0.3 while runtime/dev dependencies have moved to 0.4." },
     { name = "hashbrown", version = "0.16.1", reason = "ratatui-core still uses hashbrown 0.16 while other transitive dependencies use 0.17." },
     { name = "itertools", version = "0.14.0", reason = "ratatui-core still uses itertools 0.14 while tui-markdown uses 0.15." },

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -1,6 +1,6 @@
 # Diagnostics
 
-Diagnostics are off by default. Enable them only when debugging or preparing a useful issue report because verbose logs can grow quickly.
+Interactive TUI runs write a small local diagnostics baseline by default. The baseline records warnings, errors, and minimal application lifecycle metadata using a restricted field set; detailed diagnostics remain opt-in because verbose logs can grow quickly and may contain private context.
 
 ## Doctor
 
@@ -64,7 +64,7 @@ Config output redacts obvious credentials by default. Export refuses to overwrit
 
 ## Logging
 
-Enable runtime diagnostics with a named preset:
+Expand the baseline with a named diagnostics preset:
 
 ```bash
 claude-rs --enable-logs --diagnostics-preset session
@@ -93,7 +93,9 @@ Use an explicit tracing filter for targeted debugging:
 claude-rs --log-filter "info,app.render=trace,bridge.protocol=debug"
 ```
 
-`--log-filter` overrides `--diagnostics-preset`. If `--log-file` is omitted but logging is enabled through `--enable-logs`, `--diagnostics-preset`, `--log-filter`, or `RUST_LOG`, the app writes to a timestamped default diagnostics file.
+`--log-filter` overrides `--diagnostics-preset`. Every interactive run writes to a timestamped default diagnostics file when `--log-file` is omitted. With no logging options, the filter is `warn,app.lifecycle=info` and versioned `claude-rs-baseline/v1` records retain only stable event metadata such as event name, message, outcome, error classification, duration, counts, and logging policy. Session and request identifiers, paths, commands, content, previews, and raw error payloads are omitted from the baseline format.
+
+Baseline logging is best-effort: if the default log cannot be initialized, the app continues without disrupting the TUI. Explicitly requested detailed logging still reports initialization failures as startup errors.
 
 The default diagnostics directory is under the platform local data directory:
 
@@ -107,7 +109,7 @@ Default runtime log files include the UTC start timestamp, process id, and a sho
 claude-rs-20260614T075924Z-p12345-r8f3a2c1.log
 ```
 
-Logs rotate at 10 MB and keep up to five rotated files per run. Default runtime logs are retained up to 256 MB or 30 days, while always preserving at least 10 newest files. Retention only applies to app-managed timestamped files in the default runtime log directory; explicit `--log-file` paths are never cleaned up by the app.
+Logs rotate at 10 MB and keep up to five rotated files per run. Default runtime logs are retained up to 256 MB, 30 days, or 100 managed files, while always preserving at least 10 newest files. Retention only applies to app-managed timestamped files in the default runtime log directory; explicit `--log-file` paths are never cleaned up by the app.
 
 `--log-append` appends to an explicit `--log-file`. When used without `--log-file`, it appends to the legacy shared default file `claude-rs.log` for compatibility; prefer the normal timestamped defaults for new diagnostics.
 
@@ -151,7 +153,7 @@ The bundle includes:
 - `last-crash.json` when the previous run crashed
 - diagnostics paths
 
-The bundle excludes full config files, Claude credentials, environment dumps, and arbitrary project files. Redaction removes obvious credentials, but logs can still contain private conversation text, local file paths, command output, or project-specific context. Review a bundle before sharing it publicly.
+The bundle excludes full config files, Claude credentials, environment dumps, and arbitrary project files. Redaction removes obvious credentials, and baseline logs omit common sensitive diagnostic fields. Detailed logs can still contain private conversation text, local file paths, command output, session identifiers, or project-specific context. Review a bundle before sharing it publicly.
 
 ## Failure Reports
 
@@ -161,7 +163,7 @@ Unexpected Rust panics install a local panic hook. The hook writes a redacted `l
 
 ## Bridge Diagnostics
 
-When runtime logging is active, bridge diagnostics are enabled and bridge stderr is captured into the structured log. This is useful for Agent SDK startup, authentication, MCP, permission, and protocol issues.
+When detailed diagnostics are requested through `--enable-logs`, a preset, `--log-file`, `--log-filter`, `--log-append`, or `RUST_LOG`, bridge diagnostics are enabled and bridge stderr is captured into the structured log. The always-on baseline leaves the high-volume bridge diagnostic stream disabled while retaining native bridge lifecycle warnings and errors.
 
 The bridge script can be overridden with:
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -52,7 +52,7 @@ The installed `claude-rs --help` command exposes these options:
 | `--no-update-check` | Disable startup update checks. |
 | `-C, --dir <DIR>` | Run in a specific working directory. |
 | `--bridge-script <PATH>` | Use a specific Agent SDK bridge script. |
-| `--enable-logs` | Enable diagnostics using the default log path when no `--log-file` is set. |
+| `--enable-logs` | Expand the always-on baseline to detailed info-level diagnostics. |
 | `--diagnostics-preset <runtime|session|render|bridge|full>` | Use a named diagnostics filter. |
 | `--log-file <PATH>` | Write tracing diagnostics to a specific file. |
 | `--log-filter <FILTER>` | Use explicit tracing filter directives. |

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -24,7 +24,7 @@ Resume by session id:
 claude-rs resume <session_id>
 ```
 
-The app prints a resume hint on clean exit when the active session has an id.
+After the TUI exits, the app prints a resume hint whenever a session was established, using the active or most recently established session id.
 
 ## Support And Diagnostics
 

--- a/scripts/shared/deny-targets.test.mjs
+++ b/scripts/shared/deny-targets.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { resolveRepoRoot } from "./repo-root.mjs";
+import { PLATFORM_PACKAGES } from "./npm-package-config.mjs";
+
+const repoRoot = resolveRepoRoot(import.meta.url);
+
+function readTomlSection(toml, sectionName) {
+  const sectionHeader = new RegExp(`^\\s*\\[${sectionName}\\]\\s*$`);
+  const anySectionHeader = /^\s*\[/;
+  const sectionLines = [];
+  let inSection = false;
+
+  for (const line of toml.split(/\r?\n/)) {
+    if (sectionHeader.test(line)) {
+      inSection = true;
+      continue;
+    }
+
+    if (inSection && anySectionHeader.test(line)) {
+      break;
+    }
+
+    if (inSection) {
+      sectionLines.push(line);
+    }
+  }
+
+  return sectionLines.join("\n");
+}
+
+function readDenyGraphTargets(denyTomlPath) {
+  const graphBody = readTomlSection(fs.readFileSync(denyTomlPath, "utf8"), "graph");
+  if (!graphBody) {
+    throw new Error(`Could not find [graph] section in ${denyTomlPath}`);
+  }
+
+  const targetsMatch = graphBody.match(/targets\s*=\s*\[([^\]]*)\]/);
+  if (!targetsMatch) {
+    throw new Error(`Could not find targets array in the [graph] section of ${denyTomlPath}`);
+  }
+
+  return [...targetsMatch[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]);
+}
+
+test("deny.toml checks every released Rust target", () => {
+  const denyTargets = readDenyGraphTargets(path.join(repoRoot, "deny.toml"));
+  const releaseTargets = PLATFORM_PACKAGES.map((platformPackage) => platformPackage.rustTarget);
+
+  assert.deepEqual(
+    [...denyTargets].sort(),
+    [...releaseTargets].sort(),
+    "deny.toml [graph] targets must match PLATFORM_PACKAGES[].rustTarget in scripts/shared/npm-package-config.mjs",
+  );
+});
+
+test("deny.toml lists each target exactly once", () => {
+  const denyTargets = readDenyGraphTargets(path.join(repoRoot, "deny.toml"));
+
+  assert.equal(new Set(denyTargets).size, denyTargets.length, "deny.toml [graph] targets must not contain duplicates");
+});

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -36,7 +36,7 @@ fn reset_session_identity_state(
     fast_mode: model::FastModeSnapshot,
 ) {
     app.bump_session_scope_epoch();
-    app.session_runtime.session_id = Some(session_id);
+    app.session_runtime.activate_session(session_id);
     app.session_runtime.current_model = Some(current_model.clone());
     app.session_runtime.mode = mode;
     app.session_runtime.config_options.clear();

--- a/src/app/events/tests/client_events.rs
+++ b/src/app/events/tests/client_events.rs
@@ -491,6 +491,10 @@ fn session_replaced_resets_chat_and_transient_state() {
         Some("replacement")
     );
     assert_eq!(
+        app.session_runtime.resumable_session_id().map(model::SessionId::as_str),
+        Some("replacement")
+    );
+    assert_eq!(
         app.session_runtime.current_model.as_ref().map(|model| model.resolved_id.as_str()),
         Some("new-model")
     );

--- a/src/app/state/session_runtime.rs
+++ b/src/app/state/session_runtime.rs
@@ -10,6 +10,8 @@ use std::rc::Rc;
 /// State owned by the active SDK session/runtime boundary.
 pub struct SessionRuntimeState {
     pub session_id: Option<model::SessionId>,
+    /// Most recently established session, retained across live identity resets for the exit hint.
+    last_resumable_session_id: Option<model::SessionId>,
     /// Agent connection handle. `None` while connecting (before bridge is ready).
     pub conn: Option<Rc<AgentConnection>>,
     /// Monotonic session authority epoch used to ignore stale async view data.
@@ -40,6 +42,7 @@ impl Default for SessionRuntimeState {
     fn default() -> Self {
         Self {
             session_id: None,
+            last_resumable_session_id: None,
             conn: None,
             session_scope_epoch: 0,
             current_model: None,
@@ -71,6 +74,17 @@ impl SessionRuntimeState {
 
     pub fn bump_session_scope_epoch(&mut self) {
         self.session_scope_epoch = self.session_scope_epoch.saturating_add(1);
+    }
+
+    pub(crate) fn activate_session(&mut self, session_id: model::SessionId) {
+        self.last_resumable_session_id = Some(session_id.clone());
+        self.session_id = Some(session_id);
+    }
+
+    /// Return the active or most recently established session that can be resumed after exit.
+    #[must_use]
+    pub fn resumable_session_id(&self) -> Option<&model::SessionId> {
+        self.session_id.as_ref().or(self.last_resumable_session_id.as_ref())
     }
 
     pub fn clear_identity(&mut self) {

--- a/src/app/state/tests.rs
+++ b/src/app/state/tests.rs
@@ -176,9 +176,9 @@ fn cache_height_invalidated_returns_none() {
 }
 
 #[test]
-fn clear_session_runtime_identity_resets_session_usage() {
+fn clear_session_runtime_identity_resets_active_state_and_preserves_resumable_session_id() {
     let mut app = App::test_default();
-    app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("session-1"));
+    app.session_runtime.activate_session(crate::agent::model::SessionId::new("session-1"));
     app.session_runtime.current_model = Some(
         crate::agent::model::CurrentModel::new("sonnet", "Claude Sonnet", "Claude Sonnet")
             .authoritative(true),
@@ -197,6 +197,10 @@ fn clear_session_runtime_identity_resets_session_usage() {
     app.clear_session_runtime_identity();
 
     assert!(app.session_runtime.session_id.is_none());
+    assert_eq!(
+        app.session_runtime.resumable_session_id().map(crate::agent::model::SessionId::as_str),
+        Some("session-1")
+    );
     assert!(app.session_runtime.current_model.is_none());
     assert!(app.session_runtime.mode.is_none());
     assert_eq!(app.session_runtime.session_usage, SessionUsageState::default());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub struct Cli {
     #[arg(long)]
     pub bridge_script: Option<std::path::PathBuf>,
 
-    /// Enable runtime diagnostics using a timestamped default log file when `--log-file` is omitted.
+    /// Enable detailed info-level diagnostics in addition to the always-on warning/error baseline.
     #[arg(long)]
     pub enable_logs: bool,
 
@@ -82,9 +82,7 @@ pub struct Cli {
 
     /// Write tracing diagnostics to a file.
     ///
-    /// When omitted but logging is otherwise enabled via `--enable-logs`,
-    /// `--diagnostics-preset`, `--log-filter`, or `RUST_LOG`, a timestamped
-    /// default log path is used.
+    /// When omitted, interactive runs use a timestamped default log path.
     #[arg(long, value_name = "PATH")]
     pub log_file: Option<std::path::PathBuf>,
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,13 +5,19 @@ use crate::{Cli, DiagnosticsPreset};
 use anyhow::Context as _;
 use serde::Deserialize;
 use serde_json::{Map, Value};
+use std::fmt;
 use std::fs::{File, OpenOptions, create_dir_all, metadata, read_dir, remove_file, rename};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
-use time::{OffsetDateTime, macros::format_description};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339, macros::format_description};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::fmt::FmtContext;
+use tracing_subscriber::fmt::format::{FormatEvent, FormatFields, Writer};
+use tracing_subscriber::registry::LookupSpan;
 
 pub mod targets {
     pub const APP_AUTH: &str = "app.auth";
@@ -37,6 +43,7 @@ pub mod targets {
 }
 
 const BRIDGE_LOG_SCHEMA: &str = "claude-rs-log/v1";
+const BASELINE_LOG_SCHEMA: &str = "claude-rs-baseline/v1";
 const BRIDGE_LINE_PREVIEW_LIMIT: usize = 240;
 const DEFAULT_LOG_DIR: &str = "claude-code-rust";
 const DEFAULT_LOG_FILE_NAME: &str = "claude-rs.log";
@@ -50,7 +57,9 @@ const LOG_ROTATION_MAX_BYTES: u64 = 10 * 1024 * 1024;
 const LOG_ROTATION_MAX_FILES: usize = 5;
 const LOG_RETENTION_MAX_BYTES: u64 = 256 * 1024 * 1024;
 const LOG_RETENTION_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+const LOG_RETENTION_MAX_FILES: usize = 100;
 const LOG_RETENTION_MIN_FILES: usize = 10;
+const DEFAULT_BASELINE_FILTER: &str = "warn,app.lifecycle=info";
 static BRIDGE_DIAGNOSTICS_ENABLED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -74,11 +83,19 @@ pub struct LoggingRuntime {
 
 impl LoggingRuntime {
     pub fn init(cli: &Cli) -> anyhow::Result<Self> {
-        let Some(log_path) = resolve_log_path(cli)? else {
-            BRIDGE_DIAGNOSTICS_ENABLED.store(false, Ordering::Relaxed);
-            return Ok(Self { _guard: None });
-        };
+        let detailed_diagnostics = detailed_diagnostics_requested(cli);
+        match Self::try_init(cli, detailed_diagnostics) {
+            Ok(runtime) => Ok(runtime),
+            Err(_) if !detailed_diagnostics => {
+                BRIDGE_DIAGNOSTICS_ENABLED.store(false, Ordering::Relaxed);
+                Ok(Self { _guard: None })
+            }
+            Err(error) => Err(error),
+        }
+    }
 
+    fn try_init(cli: &Cli, detailed_diagnostics: bool) -> anyhow::Result<Self> {
+        let log_path = resolve_log_path(cli)?.context("runtime log path was not resolved")?;
         let directives = build_filter_directives(cli);
         let filter = tracing_subscriber::EnvFilter::try_new(directives.as_str())
             .map_err(|e| anyhow::anyhow!("invalid tracing filter `{directives}`: {e}"))?;
@@ -90,17 +107,26 @@ impl LoggingRuntime {
         )?;
         let (non_blocking, guard) = tracing_appender::non_blocking(writer);
 
-        tracing_subscriber::fmt()
-            .json()
-            .flatten_event(true)
-            .with_env_filter(filter)
-            .with_writer(non_blocking)
-            .with_ansi(false)
-            .with_file(true)
-            .with_line_number(true)
-            .with_target(true)
-            .try_init()
-            .map_err(|e| anyhow::anyhow!("failed to initialize tracing subscriber: {e}"))?;
+        if detailed_diagnostics {
+            tracing_subscriber::fmt()
+                .json()
+                .flatten_event(true)
+                .with_env_filter(filter)
+                .with_writer(non_blocking)
+                .with_ansi(false)
+                .with_file(true)
+                .with_line_number(true)
+                .with_target(true)
+                .try_init()
+                .map_err(|e| anyhow::anyhow!("failed to initialize tracing subscriber: {e}"))?;
+        } else {
+            tracing_subscriber::fmt()
+                .event_format(BaselineEventFormatter)
+                .with_env_filter(filter)
+                .with_writer(non_blocking)
+                .try_init()
+                .map_err(|e| anyhow::anyhow!("failed to initialize tracing subscriber: {e}"))?;
+        }
 
         tracing::info!(
             target: targets::APP_LIFECYCLE,
@@ -114,7 +140,9 @@ impl LoggingRuntime {
             log_rotation_max_files = LOG_ROTATION_MAX_FILES,
             log_retention_max_bytes = LOG_RETENTION_MAX_BYTES,
             log_retention_max_age_seconds = LOG_RETENTION_MAX_AGE.as_secs(),
+            log_retention_max_files = LOG_RETENTION_MAX_FILES,
             log_retention_min_files = LOG_RETENTION_MIN_FILES,
+            detailed_diagnostics,
             version = env!("CARGO_PKG_VERSION"),
         );
         if let Some(retention) = &log_path.retention {
@@ -145,7 +173,7 @@ impl LoggingRuntime {
                 }
             }
         }
-        BRIDGE_DIAGNOSTICS_ENABLED.store(true, Ordering::Relaxed);
+        BRIDGE_DIAGNOSTICS_ENABLED.store(detailed_diagnostics, Ordering::Relaxed);
 
         Ok(Self { _guard: Some(guard) })
     }
@@ -157,6 +185,7 @@ pub fn bridge_diagnostics_enabled() -> bool {
 }
 
 fn build_filter_directives(cli: &Cli) -> String {
+    let detailed_diagnostics = detailed_diagnostics_requested(cli);
     let mut directives = cli
         .log_filter
         .clone()
@@ -167,11 +196,129 @@ fn build_filter_directives(cli: &Cli) -> String {
                 .map(str::to_owned)
         })
         .or_else(|| std::env::var("RUST_LOG").ok())
-        .unwrap_or_else(|| "info".to_owned());
-    if !directives.contains("tui_markdown=") {
+        .unwrap_or_else(|| {
+            if detailed_diagnostics {
+                "info".to_owned()
+            } else {
+                DEFAULT_BASELINE_FILTER.to_owned()
+            }
+        });
+    if detailed_diagnostics && !directives.contains("tui_markdown=") {
         directives.push_str(",tui_markdown=info");
     }
     directives
+}
+
+fn detailed_diagnostics_requested(cli: &Cli) -> bool {
+    cli.enable_logs
+        || cli.diagnostics_preset.is_some()
+        || cli.log_file.is_some()
+        || cli.log_filter.is_some()
+        || cli.log_append
+        || std::env::var_os("RUST_LOG").is_some()
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BaselineEventFormatter;
+
+impl<S, N> FormatEvent<S, N> for BaselineEventFormatter
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        _ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let metadata = event.metadata();
+        let timestamp = OffsetDateTime::now_utc().format(&Rfc3339).map_err(|_| fmt::Error)?;
+        let mut fields = Map::new();
+        event.record(&mut BaselineFieldVisitor { fields: &mut fields });
+
+        if !fields.contains_key("event_name") {
+            fields.remove("message");
+        }
+
+        let mut record = Map::new();
+        record.insert("schema".to_owned(), Value::String(BASELINE_LOG_SCHEMA.to_owned()));
+        record.insert("timestamp".to_owned(), Value::String(timestamp));
+        record.insert("level".to_owned(), Value::String(metadata.level().as_str().to_owned()));
+        record.extend(fields);
+        record.insert("target".to_owned(), Value::String(metadata.target().to_owned()));
+        if let Some(filename) = metadata.file() {
+            record.insert("filename".to_owned(), Value::String(filename.to_owned()));
+        }
+        if let Some(line_number) = metadata.line() {
+            record.insert("line_number".to_owned(), Value::from(line_number));
+        }
+
+        let line = serde_json::to_string(&record).map_err(|_| fmt::Error)?;
+        writer.write_str(&line)?;
+        writer.write_char('\n')
+    }
+}
+
+struct BaselineFieldVisitor<'a> {
+    fields: &'a mut Map<String, Value>,
+}
+
+impl BaselineFieldVisitor<'_> {
+    fn record(&mut self, field: &Field, value: Value) {
+        if baseline_field_allowed(field.name()) {
+            self.fields.insert(field.name().to_owned(), value);
+        }
+    }
+}
+
+impl Visit for BaselineFieldVisitor<'_> {
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.record(field, Value::from(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.record(field, Value::from(value));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.record(field, Value::from(value));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record(field, Value::String(value.to_owned()));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.record(field, Value::String(format!("{value:?}")));
+    }
+}
+
+fn baseline_field_allowed(name: &str) -> bool {
+    matches!(
+        name,
+        "event_name"
+            | "message"
+            | "outcome"
+            | "reason"
+            | "error_kind"
+            | "error_code"
+            | "duration_ms"
+            | "count"
+            | "size_bytes"
+            | "exit_code"
+            | "version"
+            | "log_path_source"
+            | "log_filter"
+            | "log_open_mode"
+            | "log_rotation_max_bytes"
+            | "log_rotation_max_files"
+            | "log_retention_max_bytes"
+            | "log_retention_max_age_seconds"
+            | "log_retention_max_files"
+            | "log_retention_min_files"
+            | "detailed_diagnostics"
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -228,6 +375,7 @@ struct LogRetentionTarget {
 struct LogRetentionPolicy {
     max_total_bytes: u64,
     max_age: Duration,
+    max_files: usize,
     min_files: usize,
 }
 
@@ -236,6 +384,7 @@ impl Default for LogRetentionPolicy {
         Self {
             max_total_bytes: LOG_RETENTION_MAX_BYTES,
             max_age: LOG_RETENTION_MAX_AGE,
+            max_files: LOG_RETENTION_MAX_FILES,
             min_files: LOG_RETENTION_MIN_FILES,
         }
     }
@@ -255,9 +404,6 @@ fn resolve_log_path(cli: &Cli) -> anyhow::Result<Option<ResolvedLogPath>> {
             open_mode: if cli.log_append { LogOpenMode::Append } else { LogOpenMode::Truncate },
             retention: None,
         }));
-    }
-    if !logging_enabled_without_explicit_path(cli) {
-        return Ok(None);
     }
     if cli.log_append {
         return Ok(Some(ResolvedLogPath {
@@ -280,14 +426,6 @@ fn resolve_log_path(cli: &Cli) -> anyhow::Result<Option<ResolvedLogPath>> {
             policy: LogRetentionPolicy::default(),
         }),
     }))
-}
-
-fn logging_enabled_without_explicit_path(cli: &Cli) -> bool {
-    cli.enable_logs
-        || cli.diagnostics_preset.is_some()
-        || cli.log_filter.is_some()
-        || cli.log_append
-        || std::env::var_os("RUST_LOG").is_some()
 }
 
 pub fn default_legacy_log_path() -> anyhow::Result<PathBuf> {
@@ -648,7 +786,8 @@ fn enforce_log_retention_at(
     for candidate in candidates {
         let expired =
             now.duration_since(candidate.modified).is_ok_and(|age| age > target.policy.max_age);
-        if expired && remaining_files > target.policy.min_files {
+        let over_file_limit = remaining_files > target.policy.max_files;
+        if (expired || over_file_limit) && remaining_files > target.policy.min_files {
             remove_retention_candidate(&candidate, &mut report, &mut total_size)?;
             remaining_files = remaining_files.saturating_sub(1);
         } else {
@@ -890,9 +1029,11 @@ impl BridgeDiagnosticRecord {
 #[cfg(test)]
 mod tests {
     use super::{
-        BridgeDiagnosticRecord, LogOpenMode, LogPathSource, LogRetentionPolicy, LogRetentionTarget,
-        RollingFileWriter, clear_rotated_files, enforce_log_retention_at, generated_log_file_name,
-        is_managed_log_file, preview_text, resolve_log_path, resolve_perf_path, rotated_log_path,
+        BaselineEventFormatter, BridgeDiagnosticRecord, LogOpenMode, LogPathSource,
+        LogRetentionPolicy, LogRetentionTarget, RollingFileWriter, baseline_field_allowed,
+        clear_rotated_files, enforce_log_retention_at, generated_log_file_name,
+        is_managed_log_file, list_managed_runtime_logs_in, preview_text, resolve_log_path,
+        resolve_perf_path, rotated_log_path,
     };
     use crate::{Cli, DiagnosticsPreset};
     use std::fs;
@@ -901,6 +1042,30 @@ mod tests {
     use std::time::{Duration, SystemTime};
     use tempfile::tempdir;
     use time::macros::datetime;
+
+    #[derive(Clone)]
+    struct SharedLogWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    struct LogWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl<'writer> tracing_subscriber::fmt::MakeWriter<'writer> for SharedLogWriter {
+        type Writer = LogWriter;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            LogWriter(std::sync::Arc::clone(&self.0))
+        }
+    }
+
+    impl std::io::Write for LogWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("log buffer lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn parses_structured_bridge_diagnostic() {
@@ -917,6 +1082,99 @@ mod tests {
     fn preview_truncates_with_ellipsis() {
         let preview = preview_text("abcdefgh", 5);
         assert_eq!(preview, "abcde...");
+    }
+
+    #[test]
+    fn baseline_fields_exclude_sensitive_diagnostic_payloads() {
+        for allowed in [
+            "event_name",
+            "message",
+            "outcome",
+            "error_kind",
+            "error_code",
+            "duration_ms",
+            "version",
+        ] {
+            assert!(baseline_field_allowed(allowed), "{allowed} should be retained");
+        }
+        for excluded in [
+            "session_id",
+            "request_id",
+            "tool_call_id",
+            "prompt",
+            "content",
+            "command",
+            "path",
+            "preview",
+            "error",
+            "error_message",
+        ] {
+            assert!(!baseline_field_allowed(excluded), "{excluded} should be excluded");
+        }
+    }
+
+    #[test]
+    fn baseline_formatter_writes_structured_metadata_without_sensitive_fields() {
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .event_format(BaselineEventFormatter)
+            .with_writer(SharedLogWriter(std::sync::Arc::clone(&buffer)))
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::warn!(
+                target: "app.session",
+                event_name = "session_operation_failed",
+                message = "session operation failed",
+                outcome = "failure",
+                error_code = "timeout",
+                duration_ms = 250_u64,
+                session_id = "session-secret",
+                path = "C:/private/project",
+                error_message = "token=secret",
+            );
+        });
+
+        let output =
+            String::from_utf8(buffer.lock().expect("log buffer lock").clone()).expect("utf8 log");
+        let record: serde_json::Value = serde_json::from_str(output.trim()).expect("json log");
+        assert_eq!(record["event_name"], "session_operation_failed");
+        assert_eq!(record["schema"], "claude-rs-baseline/v1");
+        assert_eq!(record["message"], "session operation failed");
+        assert_eq!(record["outcome"], "failure");
+        assert_eq!(record["error_code"], "timeout");
+        assert_eq!(record["duration_ms"], 250);
+        assert_eq!(record["target"], "app.session");
+        assert!(record.get("timestamp").is_some());
+        assert!(record.get("session_id").is_none());
+        assert!(record.get("path").is_none());
+        assert!(record.get("error_message").is_none());
+        assert!(!output.contains("session-secret"));
+        assert!(!output.contains("private/project"));
+        assert!(!output.contains("token=secret"));
+    }
+
+    #[test]
+    fn resolve_log_path_uses_default_for_always_on_baseline() {
+        let cli = Cli {
+            command: None,
+            no_update_check: false,
+            dir: None,
+            bridge_script: None,
+            enable_logs: false,
+            diagnostics_preset: None,
+            log_file: None,
+            log_filter: None,
+            log_append: false,
+            enable_perf: false,
+            perf_log: None,
+            perf_append: false,
+        };
+
+        let resolved = resolve_log_path(&cli).expect("resolve succeeds").expect("path exists");
+        assert_eq!(resolved.source, LogPathSource::Default);
+        assert_eq!(resolved.open_mode, LogOpenMode::CreateNew);
+        assert!(resolved.retention.is_some());
     }
 
     #[test]
@@ -1170,6 +1428,7 @@ mod tests {
             policy: LogRetentionPolicy {
                 max_total_bytes: 1,
                 max_age: Duration::from_secs(60),
+                max_files: 10,
                 min_files: 1,
             },
         };
@@ -1181,5 +1440,32 @@ mod tests {
         assert!(protected.exists());
         assert!(!removable.exists());
         assert!(legacy.exists());
+    }
+
+    #[test]
+    fn retention_caps_managed_log_file_count() {
+        let dir = tempdir().expect("temp dir");
+        for index in 0..5 {
+            let path =
+                dir.path().join(format!("claude-rs-20260614T07000{index}Z-p1-rrun{index}.log"));
+            fs::write(path, "log").expect("write managed log");
+        }
+        let target = LogRetentionTarget {
+            directory: dir.path().to_path_buf(),
+            prefix: "claude-rs",
+            extension: "log",
+            policy: LogRetentionPolicy {
+                max_total_bytes: u64::MAX,
+                max_age: Duration::MAX,
+                max_files: 3,
+                min_files: 1,
+            },
+        };
+
+        let report =
+            enforce_log_retention_at(&target, None, SystemTime::now()).expect("retention succeeds");
+
+        assert_eq!(report.removed_files, 2);
+        assert_eq!(list_managed_runtime_logs_in(dir.path()).expect("list logs").len(), 3);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn run() -> anyhow::Result<i32> {
         claude_code_rust::app::start_update_check(&app, &cli);
         let result = claude_code_rust::app::run_tui(&mut app).await;
         let post_exit_action = app.post_exit_action.take();
-        maybe_print_resume_hint(&app, result.is_ok() && post_exit_action.is_none());
+        maybe_print_resume_hint(&app);
 
         // Kill any spawned terminal child processes before exiting
 
@@ -358,15 +358,9 @@ fn extract_app_error(err: &anyhow::Error) -> Option<AppError> {
     err.chain().find_map(|cause| cause.downcast_ref::<AppError>().cloned())
 }
 
-fn maybe_print_resume_hint(app: &claude_code_rust::app::App, success: bool) {
-    if !success {
-        return;
-    }
-    let Some(session_id) = app.session_runtime.session_id.as_ref() else {
-        return;
-    };
+fn maybe_print_resume_hint(app: &claude_code_rust::app::App) {
     let mut stderr = std::io::stderr().lock();
-    if let Err(err) = write_resume_hint(&mut stderr, session_id) {
+    if let Err(err) = write_resume_hint_for_app(&mut stderr, app) {
         tracing::warn!(
             target: claude_code_rust::logging::targets::APP_LIFECYCLE,
             event_name = "resume_hint_write_failed",
@@ -375,6 +369,16 @@ fn maybe_print_resume_hint(app: &claude_code_rust::app::App, success: bool) {
             error_message = %err,
         );
     }
+}
+
+fn write_resume_hint_for_app(
+    mut writer: impl std::io::Write,
+    app: &claude_code_rust::app::App,
+) -> std::io::Result<()> {
+    let Some(session_id) = app.session_runtime.resumable_session_id() else {
+        return Ok(());
+    };
+    write_resume_hint(&mut writer, session_id)
 }
 
 fn write_resume_hint(
@@ -386,7 +390,9 @@ fn write_resume_hint(
 
 #[cfg(test)]
 mod tests {
-    use super::write_resume_hint;
+    use super::{write_resume_hint, write_resume_hint_for_app};
+    use claude_code_rust::agent::model::SessionId;
+    use claude_code_rust::app::App;
 
     #[test]
     fn resume_hint_starts_on_fresh_line_and_ends_with_newline() {
@@ -395,5 +401,26 @@ mod tests {
         assert!(write_resume_hint(&mut output, "abc-123").is_ok());
 
         assert_eq!(output, b"\r\nResume this session: claude-rs resume abc-123\n");
+    }
+
+    #[test]
+    fn app_resume_hint_uses_available_session_id() {
+        let mut app = App::test_default();
+        app.session_runtime.session_id = Some(SessionId::new("session-123"));
+        let mut output = Vec::new();
+
+        assert!(write_resume_hint_for_app(&mut output, &app).is_ok());
+
+        assert_eq!(output, b"\r\nResume this session: claude-rs resume session-123\n");
+    }
+
+    #[test]
+    fn app_resume_hint_is_empty_before_session_establishment() {
+        let app = App::test_default();
+        let mut output = Vec::new();
+
+        assert!(write_resume_hint_for_app(&mut output, &app).is_ok());
+
+        assert!(output.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Enable privacy-minimized baseline diagnostics with bounded managed-log retention while keeping detailed bridge diagnostics opt-in.
- Preserve the exit resume hint across session teardown and prevent progress heartbeats from creating duplicate PowerShell tool rows.
- Update base64 to 0.23 and align cargo-deny target coverage and advisory gating with release packaging.

## Why

These changes close small observability, session-exit, tool-rendering, dependency-policy, and CI coverage gaps found during local diagnostics.

Closes: N/A

## Validation

- Automated: `npm test` (323 tests), `npm run lint`, `npm run knip`, `npm run audit`, `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, `cargo check --offline`, cargo-deny policy and advisory checks, deny-target drift tests, and `mdbook build docs`.
- Manual: Correlated the repeated PowerShell rows in session `a16b1ea8-1723-425a-8b32-c7f07bce07a3` with synthetic heartbeat IDs linked to one authoritative parent tool.
- Screenshot/video (if UI changed): N/A; the rendering data-source regression is covered by Agent SDK tests.

## Notes

- Breaking changes: N/A
- Docs updated: `docs/src/diagnostics.md`, `docs/src/usage.md`, and `CHANGELOG.md`
- Governance/release impact: The base64 direct dependency moves to 0.23; cargo-deny checks all release targets and gates advisories only for dependency-changing pull requests.
