### PR TITLE
feat(ui): add dedicated Skill tool rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - **Installer download progress** (#312, @srothgan): Stream release archives with curl retries and stall detection, show matching fixed-width bars on PowerShell and Unix, and add opt-in size, speed, and ETA diagnostics while keeping redirected and CI output plain.
+- **Skill tool rendering** (#318, @srothgan): Show Skill calls with a dedicated icon, readable names, compact arguments, and no redundant launch output.
 
 ### Fixes
 

--- a/agent-sdk/src/bridge/tooling.test.ts
+++ b/agent-sdk/src/bridge/tooling.test.ts
@@ -219,6 +219,30 @@ test("createToolCall maps Workflow to other kind and name title", () => {
   assert.equal(fallbackWorkflow.title, "Workflow");
 });
 
+test("createToolCall maps Skill to other kind and formats its name for display", () => {
+  const cases = [
+    ["claude-api", "Skill: Claude API"],
+    ["dataviz", "Skill: Dataviz"],
+    [" frontend-design:frontend-design ", "Skill: Frontend Design"],
+    ["keybindings_help", "Skill: Keybindings Help"],
+    ["strava-coach", "Skill: Strava Coach"],
+    ["github:gh-fix-ci", "Skill: GitHub / GH Fix CI"],
+    ["mobile:iOS-debug", "Skill: Mobile / iOS Debug"],
+    ["future-widget", "Skill: Future Widget"],
+    ["future::widget", "Skill: future::widget"],
+    ["future.widget", "Skill: future.widget"],
+  ];
+
+  for (const [skill, expectedTitle] of cases) {
+    const toolCall = createToolCall(`tc-skill-${skill}`, "Skill", { skill });
+    assert.equal(toolCall.kind, "other");
+    assert.equal(toolCall.title, expectedTitle);
+  }
+  const incompleteSkill = createToolCall("tc-skill-incomplete", "Skill", {});
+
+  assert.equal(incompleteSkill.title, "Skill");
+});
+
 test("createToolCall maps project and artifact tools to compact titles", () => {
   const projectInfo = createToolCall("tc-project-info", "Projects", {
     method: "project_info",
@@ -1059,6 +1083,62 @@ test("buildToolResultFields marks only structured Skill background launches", ()
     buildToolResultFields(false, "ok", bash, { background: true }).output_metadata,
     undefined,
   );
+});
+
+test("buildToolResultFields suppresses successful inline Skill launch text", () => {
+  const skill = createToolCall("tc-skill-inline", "Skill", {
+    skill: "frontend-design:frontend-design",
+  });
+  const fields = buildToolResultFields(
+    false,
+    "Launching skill: frontend-design:frontend-design",
+    skill,
+    {
+      success: true,
+      commandName: "frontend-design:frontend-design",
+      allowedTools: ["Read"],
+    },
+  );
+
+  assert.equal(fields.status, "completed");
+  assert.equal(fields.title, "Skill: Frontend Design");
+  assert.equal(fields.raw_output, undefined);
+  assert.equal(fields.content, undefined);
+});
+
+test("buildToolResultFields preserves forked Skill results and background metadata", () => {
+  const skill = createToolCall("tc-skill-forked", "Skill", { skill: "review" });
+  const fields = buildToolResultFields(false, "model-facing launch text", skill, {
+    success: true,
+    commandName: "code-review",
+    status: "forked",
+    agentId: "agent-1",
+    result: "Review worker launched",
+    background: true,
+  });
+
+  assert.equal(fields.title, "Skill: Code Review");
+  assert.equal(fields.raw_output, "Review worker launched");
+  assert.deepEqual(fields.content, [
+    { type: "content", content: { type: "text", text: "Review worker launched" } },
+  ]);
+  assert.deepEqual(fields.output_metadata, { skill: { background: true } });
+});
+
+test("buildToolResultFields falls back losslessly for malformed Skill results", () => {
+  const skill = createToolCall("tc-skill-malformed", "Skill", { skill: "review" });
+  const fields = buildToolResultFields(false, "Launching skill: review", skill, {
+    success: true,
+    commandName: "review",
+    status: "forked",
+    result: "missing agent ID",
+  });
+
+  assert.equal(fields.title, undefined);
+  assert.equal(fields.raw_output, "Launching skill: review");
+  assert.deepEqual(fields.content, [
+    { type: "content", content: { type: "text", text: "Launching skill: review" } },
+  ]);
 });
 
 test("buildToolResultFields preserves Agent resolvedModel metadata", () => {

--- a/agent-sdk/src/bridge/tooling.ts
+++ b/agent-sdk/src/bridge/tooling.ts
@@ -1,4 +1,4 @@
-﻿import type { Json, ToolCall, ToolCallUpdateFields } from "../types.js";
+import type { Json, ToolCall, ToolCallUpdateFields } from "../types.js";
 import { asRecordOrNull } from "./shared.js";
 import { CACHE_SPLIT_POLICY, previewKilobyteLabel } from "./cache_policy.js";
 import {
@@ -32,6 +32,19 @@ const WORKFLOW_TOOL_NAME = "Workflow";
 const PROJECTS_TOOL_NAME = "Projects";
 const ARTIFACT_TOOL_NAME = "Artifact";
 const SHOW_ONBOARDING_ROLE_PICKER_TOOL_NAME = "ShowOnboardingRolePicker";
+const SKILL_TOOL_NAME = "Skill";
+const SKILL_WORD_OVERRIDES: Readonly<Record<string, string>> = {
+  api: "API",
+  ci: "CI",
+  cli: "CLI",
+  gh: "GH",
+  github: "GitHub",
+  mcp: "MCP",
+  pdf: "PDF",
+  sdk: "SDK",
+  ui: "UI",
+  ux: "UX",
+};
 const READ_MCP_RESOURCE_TOOL_NAME = "ReadMcpResource";
 const READ_MCP_RESOURCE_DIR_TOOL_NAME = "ReadMcpResourceDir";
 const SEARCH_OUTPUT_MODES = new Set(["content", "files_with_matches", "count"]);
@@ -212,6 +225,7 @@ export function normalizeToolKind(name: string): string {
     case "Projects":
     case "Artifact":
     case "ShowOnboardingRolePicker":
+    case SKILL_TOOL_NAME:
       return "other";
     case "Task":
     case "Agent":
@@ -222,6 +236,48 @@ export function normalizeToolKind(name: string): string {
     default:
       return "think";
   }
+}
+
+function skillDisplayName(rawName: string): string {
+  const trimmed = rawName.trim();
+  const segments = trimmed.split(":");
+  if (
+    segments.length > 2 ||
+    segments.some(
+      (segment) =>
+        !segment || !/^[a-zA-Z0-9]+(?:[-_][a-zA-Z0-9]+)*$/.test(segment),
+    )
+  ) {
+    return trimmed;
+  }
+
+  const displaySegments = segments.map((segment) =>
+    segment
+      .split(/[-_]/)
+      .map((word) => skillDisplayWord(word))
+      .join(" "),
+  );
+  if (
+    displaySegments.length === 2 &&
+    displaySegments[0].toLowerCase() === displaySegments[1].toLowerCase()
+  ) {
+    return displaySegments[1];
+  }
+  return displaySegments.join(" / ");
+}
+
+function skillDisplayWord(word: string): string {
+  const override = SKILL_WORD_OVERRIDES[word.toLowerCase()];
+  if (override) {
+    return override;
+  }
+  if (
+    /^[A-Z0-9]+$/.test(word) ||
+    (/[a-z]/.test(word) && /[A-Z]/.test(word) && !/^[A-Z][a-z0-9]*$/.test(word))
+  ) {
+    return word;
+  }
+  return `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}`;
 }
 
 export function toolTitle(
@@ -296,6 +352,12 @@ export function toolTitle(
   }
   if (name === SHOW_ONBOARDING_ROLE_PICKER_TOOL_NAME) {
     return SHOW_ONBOARDING_ROLE_PICKER_TOOL_NAME;
+  }
+  if (name === SKILL_TOOL_NAME) {
+    const skillName = nonEmptyString(input.skill);
+    return skillName
+      ? `${SKILL_TOOL_NAME}: ${skillDisplayName(skillName)}`
+      : SKILL_TOOL_NAME;
   }
   if (name === "EnterWorktree") {
     const worktreeName = typeof input.name === "string" ? input.name.trim() : "";
@@ -1903,6 +1965,78 @@ function collectResultCandidates(rawResult: unknown, rawContent: unknown): Recor
   return candidates;
 }
 
+type InlineSkillResult = {
+  success: boolean;
+  commandName: string;
+  status: "inline";
+};
+
+type ForkedSkillResult = {
+  success: boolean;
+  commandName: string;
+  status: "forked";
+  agentId: string;
+  result: string;
+  background?: boolean;
+};
+
+type SkillResult = InlineSkillResult | ForkedSkillResult;
+
+function parseSkillResult(
+  toolName: string,
+  rawResult: unknown,
+  rawContent: unknown,
+): SkillResult | undefined {
+  if (toolName !== SKILL_TOOL_NAME) {
+    return undefined;
+  }
+
+  for (const candidate of collectResultCandidates(rawResult, rawContent)) {
+    const commandName = nonEmptyString(candidate.commandName);
+    if (!commandName || typeof candidate.success !== "boolean") {
+      continue;
+    }
+
+    if (candidate.status === "forked") {
+      const agentId = nonEmptyString(candidate.agentId);
+      if (!agentId || typeof candidate.result !== "string") {
+        continue;
+      }
+      if (candidate.background !== undefined && typeof candidate.background !== "boolean") {
+        continue;
+      }
+      return {
+        success: candidate.success,
+        commandName,
+        status: "forked",
+        agentId,
+        result: candidate.result,
+        ...(typeof candidate.background === "boolean"
+          ? { background: candidate.background }
+          : {}),
+      };
+    }
+
+    if (candidate.status === undefined || candidate.status === "inline") {
+      const allowedToolsValid =
+        candidate.allowedTools === undefined ||
+        (Array.isArray(candidate.allowedTools) &&
+          candidate.allowedTools.every((tool): tool is string => typeof tool === "string"));
+      const modelValid = candidate.model === undefined || typeof candidate.model === "string";
+      if (!allowedToolsValid || !modelValid) {
+        continue;
+      }
+      return {
+        success: candidate.success,
+        commandName,
+        status: "inline",
+      };
+    }
+  }
+
+  return undefined;
+}
+
 function monitorResultFields(
   toolName: string,
   rawResult: unknown,
@@ -2171,6 +2305,22 @@ export function buildToolResultFields(
   const outputMetadata = extractToolOutputMetadata(toolName, rawResult, rawContent);
   if (outputMetadata) {
     fields.output_metadata = outputMetadata;
+  }
+  const skillResult = !isError ? parseSkillResult(toolName, rawResult, rawContent) : undefined;
+  if (skillResult) {
+    fields.title = `${SKILL_TOOL_NAME}: ${skillDisplayName(skillResult.commandName)}`;
+    if (!skillResult.success) {
+      fields.status = "failed";
+    } else if (skillResult.status === "inline") {
+      return fields;
+    } else {
+      const output = skillResult.result.trim();
+      if (output) {
+        fields.raw_output = output;
+        fields.content = [{ type: "content", content: { type: "text", text: output } }];
+      }
+      return fields;
+    }
   }
   const fileUnchangedText = !isError && toolName === "Read" ? fileUnchangedResultText(rawResult, rawContent) : "";
   if (fileUnchangedText) {

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -62,6 +62,7 @@ pub fn tool_name_label(sdk_tool_name: &str) -> (&'static str, &'static str) {
         "Projects" => ("\u{25a6}", "Projects"),
         "Artifact" => ("\u{25c8}", "Artifact"),
         "ShowOnboardingRolePicker" => ("\u{2299}", "Role"),
+        "Skill" => ("\u{2726}", "Skill"),
         "EnterWorktree" => ("\u{21c4}", "EnterWorktree"),
         "ExitWorktree" => ("\u{21c4}", "ExitWorktree"),
         _ => ("\u{25cb}", "Tool"),
@@ -71,6 +72,7 @@ pub fn tool_name_label(sdk_tool_name: &str) -> (&'static str, &'static str) {
 #[cfg(test)]
 mod tests {
     use super::tool_name_label;
+    use unicode_width::UnicodeWidthStr;
 
     #[test]
     fn task_and_agent_share_subagent_label_and_icon() {
@@ -131,6 +133,12 @@ mod tests {
         assert_eq!(tool_name_label("Projects"), ("\u{25a6}", "Projects"));
         assert_eq!(tool_name_label("Artifact"), ("\u{25c8}", "Artifact"));
         assert_eq!(tool_name_label("ShowOnboardingRolePicker"), ("\u{2299}", "Role"));
+    }
+
+    #[test]
+    fn skill_tool_uses_spark_icon() {
+        assert_eq!(tool_name_label("Skill"), ("\u{2726}", "Skill"));
+        assert_eq!(UnicodeWidthStr::width("\u{2726}"), 1);
     }
 
     #[test]

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -20,6 +20,7 @@ mod push_notification;
 mod remote_trigger;
 mod repl;
 mod schedule_wakeup;
+mod skill;
 mod standard;
 mod tasks;
 mod typed;

--- a/src/ui/tool_call/skill.rs
+++ b/src/ui/tool_call/skill.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Simon Peter Rothgang
+
+//! Rendering helpers for SDK `Skill` tool calls.
+
+use crate::agent::model;
+use crate::app::ToolCallInfo;
+use crate::ui::diff::strip_outer_code_fence;
+use ratatui::text::Line;
+
+use super::typed;
+
+pub(super) fn is_skill_tool(tc: &ToolCallInfo) -> bool {
+    tc.sdk_tool_name == "Skill"
+}
+
+pub(super) fn has_structured_body(tc: &ToolCallInfo) -> bool {
+    invocation_text(tc).is_some() || typed::text_blocks(tc).any(|text| has_visible_output(tc, text))
+}
+
+pub(super) fn render_tool_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
+    let mut lines = invocation_text(tc).map_or_else(Vec::new, render_plain_lines);
+    lines.extend(typed::render_processed_text_blocks(tc, |text| {
+        if is_redundant_launch_message(tc, text) { Vec::new() } else { render_plain_lines(text) }
+    }));
+    lines
+}
+
+fn invocation_text(tc: &ToolCallInfo) -> Option<&str> {
+    typed::input_string(tc, "args").map(str::trim).filter(|args| !args.is_empty())
+}
+
+fn render_plain_lines(text: &str) -> Vec<Line<'static>> {
+    typed::non_empty_trimmed_lines(text.trim()).map(|line| Line::from(line.to_owned())).collect()
+}
+
+fn has_visible_output(tc: &ToolCallInfo, text: &str) -> bool {
+    let stripped = strip_outer_code_fence(text);
+    !stripped.trim().is_empty() && !is_redundant_launch_message(tc, &stripped)
+}
+
+fn is_redundant_launch_message(tc: &ToolCallInfo, text: &str) -> bool {
+    if !matches!(tc.status, model::ToolCallStatus::Completed) {
+        return false;
+    }
+    let Some(skill_name) = typed::input_string(tc, "skill").map(str::trim) else {
+        return false;
+    };
+    text.trim() == format!("Launching skill: {skill_name}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::tool_call::test_support::{rendered_line_texts, tool_call};
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    fn skill_tool_call(
+        raw_input: serde_json::Value,
+        content: Option<&str>,
+        status: model::ToolCallStatus,
+    ) -> ToolCallInfo {
+        tool_call("tc-skill", "Skill", "Skill: review", raw_input, content, status)
+    }
+
+    #[test]
+    fn successful_inline_skill_has_no_redundant_body() {
+        let tc = skill_tool_call(
+            json!({ "skill": "frontend-design:frontend-design" }),
+            Some("Launching skill: frontend-design:frontend-design"),
+            model::ToolCallStatus::Completed,
+        );
+
+        assert!(!has_structured_body(&tc));
+        assert!(render_tool_content(&tc).is_empty());
+    }
+
+    #[test]
+    fn invocation_text_renders_without_an_internal_field_label() {
+        let tc = skill_tool_call(
+            json!({
+                "skill": "code-review",
+                "args": "high src/foo.ts\nfocus on error handling"
+            }),
+            None,
+            model::ToolCallStatus::InProgress,
+        );
+
+        assert!(has_structured_body(&tc));
+        assert_eq!(
+            rendered_line_texts(&render_tool_content(&tc)),
+            vec!["high src/foo.ts", "focus on error handling"]
+        );
+    }
+
+    #[test]
+    fn unknown_and_failed_outputs_are_preserved() {
+        let completed = skill_tool_call(
+            json!({ "skill": "review" }),
+            Some("Future structured skill result"),
+            model::ToolCallStatus::Completed,
+        );
+        let failed = skill_tool_call(
+            json!({ "skill": "review" }),
+            Some("Launching skill: review"),
+            model::ToolCallStatus::Failed,
+        );
+
+        assert_eq!(
+            rendered_line_texts(&render_tool_content(&completed)),
+            vec!["Future structured skill result"]
+        );
+        assert_eq!(
+            rendered_line_texts(&render_tool_content(&failed)),
+            vec!["Launching skill: review"]
+        );
+    }
+}

--- a/src/ui/tool_call/tests.rs
+++ b/src/ui/tool_call/tests.rs
@@ -177,6 +177,18 @@ fn render_skill_title_shows_backgrounded_badge() {
 }
 
 #[test]
+fn render_skill_title_uses_dedicated_icon_and_named_title() {
+    let mut tc = test_tool_call("tc-skill", "Skill", model::ToolCallStatus::Completed);
+    tc.title = "Skill: Frontend Design".to_owned();
+
+    let line = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 100, 0);
+    let rendered: String = line.spans.iter().map(|span| span.content.as_ref()).collect();
+
+    assert!(rendered.contains("\u{2726} Skill: Frontend Design"));
+    assert!(!rendered.contains("\u{25cb}"));
+}
+
+#[test]
 fn render_tool_call_preserves_non_execution_reason_and_feedback() {
     let mut tc = test_tool_call("tc-rejected", "Bash", model::ToolCallStatus::Failed);
     tc.output_metadata = Some(

--- a/src/ui/tool_call/typed.rs
+++ b/src/ui/tool_call/typed.rs
@@ -12,7 +12,7 @@ use serde_json::{Map, Value};
 use super::errors::render_failed_tool_text_content;
 use super::{
     artifact, cron, fields, monitor, projects, push_notification, remote_trigger, repl,
-    schedule_wakeup, tasks, workflow, worktree,
+    schedule_wakeup, skill, tasks, workflow, worktree,
 };
 
 pub(super) struct TypedToolRenderer {
@@ -88,6 +88,12 @@ const RENDERERS: &[TypedToolRenderer] = &[
         matches: artifact::is_artifact_tool,
         has_structured_body: artifact::has_structured_body,
         render: artifact::render_tool_content,
+    },
+    TypedToolRenderer {
+        name: "skill",
+        matches: skill::is_skill_tool,
+        has_structured_body: skill::has_structured_body,
+        render: skill::render_tool_content,
     },
 ];
 


### PR DESCRIPTION
## Summary

- Add guarded bridge handling for inline and forked Claude Skill tool results while preserving unknown or malformed output through the generic fallback.
- Render Skill calls with a dedicated `✦` icon, compact arguments without an internal `Args` label, and no redundant successful `Launching skill: ...` body.
- Humanize skill identifiers for display, including duplicated namespaces, separators, common acronyms, and intentional mixed casing, while retaining raw command names in tool input and logs.

## Why

Claude Skill calls previously used the generic tool fallback, which exposed implementation-oriented identifiers and redundant launch output. Dedicated parsing and rendering makes these calls easier to scan without discarding failure details, background state, or future SDK result shapes.

<!-- Closes #-->

## Validation

- Automated: `npm --prefix agent-sdk test` (327 passed), `npm --prefix agent-sdk run lint`, `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, focused Skill renderer tests, `cargo check --offline`, and `git diff --check`.
- Manual: Inspected a session ui and its runtime log to validate the observed inline Skill input and result shapes.
- Screenshot/video (if UI changed): N/A — terminal text rendering is covered by bridge and renderer regression tests.

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: N/A
