### PR TITLE
feat(ui): render image reads as compact confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - **Installer download progress** (#312, @srothgan): Stream release archives with curl retries and stall detection, show matching fixed-width bars on PowerShell and Unix, and add opt-in size, speed, and ETA diagnostics while keeping redirected and CI output plain.
 - **Skill tool rendering** (#318, @srothgan): Show Skill calls with a dedicated icon, readable names, compact arguments, and no redundant launch output.
+- **Image read confirmations** (#319, @srothgan): Replace image payloads with compact filename confirmations while preserving Read titles and errors.
 
 ### Fixes
 

--- a/agent-sdk/src/bridge/tooling.test.ts
+++ b/agent-sdk/src/bridge/tooling.test.ts
@@ -1276,6 +1276,98 @@ test("unwrapToolUseResult extracts error/content payload", () => {
   assert.deepEqual(parsed.content, [{ text: "failure output" }]);
 });
 
+test("buildToolResultFields replaces a structured Read image result with its filename", () => {
+  const base = createToolCall("tc-image-read", "Read", {
+    file_path: "C:\\work\\captures\\screen.png",
+  });
+  const fields = buildToolResultFields(
+    false,
+    [
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: "raw-content-image-data",
+        },
+      },
+    ],
+    base,
+    {
+      type: "image",
+      file: {
+        base64: "structured-image-data",
+        type: "image/png",
+      },
+    },
+  );
+
+  assert.equal(base.title, "Read C:\\work\\captures\\screen.png");
+  assert.deepEqual(fields, {
+    status: "completed",
+    raw_output: "Viewed Image screen.png",
+    content: [
+      {
+        type: "content",
+        content: { type: "text", text: "Viewed Image screen.png" },
+      },
+    ],
+  });
+  assert.equal(JSON.stringify(fields).includes("raw-content-image-data"), false);
+  assert.equal(JSON.stringify(fields).includes("structured-image-data"), false);
+});
+
+test("buildToolResultFields recognizes Read image content blocks without structured output", () => {
+  const base = createToolCall("tc-image-block-read", "Read", {
+    file_path: "assets/capture.unknown",
+  });
+  const fields = buildToolResultFields(
+    false,
+    [
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/webp",
+          data: "compatibility-image-data",
+        },
+      },
+    ],
+    base,
+  );
+
+  assert.equal(base.title, "Read assets/capture.unknown");
+  assert.equal(fields.raw_output, "Viewed Image capture.unknown");
+  assert.deepEqual(fields.content, [
+    {
+      type: "content",
+      content: { type: "text", text: "Viewed Image capture.unknown" },
+    },
+  ]);
+  assert.equal(JSON.stringify(fields).includes("compatibility-image-data"), false);
+});
+
+test("buildToolResultFields preserves failed Read image output", () => {
+  const base = createToolCall("tc-image-read-error", "Read", {
+    file_path: "assets/broken.png",
+  });
+  const fields = buildToolResultFields(
+    true,
+    [{ type: "text", text: "Image data could not be decoded." }],
+    base,
+    { type: "image" },
+  );
+
+  assert.equal(fields.status, "failed");
+  assert.equal(fields.raw_output, "Image data could not be decoded.");
+  assert.deepEqual(fields.content, [
+    {
+      type: "content",
+      content: { type: "text", text: "Image data could not be decoded." },
+    },
+  ]);
+});
+
 test("buildToolResultFields renders file_unchanged Read results compactly", () => {
   const base = createToolCall("tc-read", "Read", { file_path: "src/main.rs" });
   const fields = buildToolResultFields(

--- a/agent-sdk/src/bridge/tooling.ts
+++ b/agent-sdk/src/bridge/tooling.ts
@@ -484,6 +484,25 @@ function resultRecordCandidates(rawResult: unknown, rawContent: unknown): Record
   return candidates;
 }
 
+function imageReadResultText(
+  rawResult: unknown,
+  rawContent: unknown,
+  rawInput: ToolCall["raw_input"] | undefined,
+): string | undefined {
+  const isImage = resultRecordCandidates(rawResult, rawContent).some(
+    (candidate) => candidate.type === "image",
+  );
+  if (!isImage) {
+    return undefined;
+  }
+
+  const input = asRecordOrNull(rawInput);
+  const filePath = typeof input?.file_path === "string" ? input.file_path.trim() : "";
+  const normalizedPath = filePath.replaceAll("\\", "/");
+  const fileName = normalizedPath.slice(normalizedPath.lastIndexOf("/") + 1);
+  return fileName ? `Viewed Image ${fileName}` : "Viewed Image";
+}
+
 function parseJsonCandidate(value: unknown): unknown {
   const text = typeof value === "string" ? value : extractText(value);
   const trimmed = text.trim();
@@ -2321,6 +2340,14 @@ export function buildToolResultFields(
       }
       return fields;
     }
+  }
+  const imageReadText = !isError && toolName === "Read"
+    ? imageReadResultText(rawResult, rawContent, base?.raw_input)
+    : undefined;
+  if (imageReadText !== undefined) {
+    fields.raw_output = imageReadText;
+    fields.content = [{ type: "content", content: { type: "text", text: imageReadText } }];
+    return fields;
   }
   const fileUnchangedText = !isError && toolName === "Read" ? fileUnchangedResultText(rawResult, rawContent) : "";
   if (fileUnchangedText) {

--- a/src/ui/tool_call/standard.rs
+++ b/src/ui/tool_call/standard.rs
@@ -39,6 +39,7 @@ const EXECUTE_BODY_INDENT: &str = "      ";
 const EXECUTE_BODY_INDENT_WIDTH: u16 = 6;
 const ASK_USER_QUESTION_RESULT_TEXT_INDENT: &str = "      ";
 const READ_SYNTAX_THEME: EmbeddedThemeName = EmbeddedThemeName::MonokaiExtendedBright;
+const VIEWED_IMAGE_RESULT_PREFIX: &str = "Viewed Image ";
 
 /// Render just the title line for a tool call (the line containing the spinner icon).
 /// Used for in-progress tool calls where only the spinner changes each frame.
@@ -616,6 +617,10 @@ fn render_read_text_content(tc: &ToolCallInfo, text: &str, lines: &mut Vec<Line<
         lines.extend(failed_lines);
         return;
     }
+    if let Some(viewed_image) = render_viewed_image_content(tc, &stripped) {
+        lines.push(viewed_image);
+        return;
+    }
     if read_content_is_markdown(tc) {
         render_markdown_content(&stripped, lines);
         return;
@@ -646,6 +651,28 @@ fn render_read_text_content(tc: &ToolCallInfo, text: &str, lines: &mut Vec<Line<
 
     let fallback_lang = (!title_lang.is_empty()).then_some(title_lang.as_str()).or(fenced_language);
     lines.extend(highlight::highlight_code_with_theme(&clean, fallback_lang, READ_SYNTAX_THEME));
+}
+
+fn render_viewed_image_content(tc: &ToolCallInfo, text: &str) -> Option<Line<'static>> {
+    let file_name = text.strip_prefix(VIEWED_IMAGE_RESULT_PREFIX)?.trim();
+    if file_name.is_empty() || file_name.contains(['\r', '\n']) {
+        return None;
+    }
+
+    let read_path = read_syntax_path(tc)?.as_os_str().to_str()?.trim_end_matches(['/', '\\']);
+    let expected_file_name = read_path.rsplit(['/', '\\']).next()?;
+    if file_name != expected_file_name {
+        return None;
+    }
+
+    Some(Line::from(vec![
+        Span::styled(
+            "Viewed image",
+            Style::default().fg(theme::DIM).add_modifier(Modifier::ITALIC),
+        ),
+        Span::raw(" "),
+        Span::styled(file_name.to_owned(), Style::default().fg(ratatui::style::Color::White)),
+    ]))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/ui/tool_call/tests.rs
+++ b/src/ui/tool_call/tests.rs
@@ -491,6 +491,44 @@ fn read_body_strips_ansi_before_syntax_coloring() {
 }
 
 #[test]
+fn read_image_body_distinguishes_status_from_filename() {
+    let tc = read_tool_call(r"C:\work\captures\screen.png", "Viewed Image screen.png");
+    let body = standard::render_tool_call_body(&tc, 120);
+
+    assert_eq!(
+        rendered_line_texts_trimmed(&body),
+        vec!["  \u{2514}\u{2500} Viewed image screen.png"]
+    );
+    assert_eq!(body.len(), 1);
+    assert!(body[0].spans.len() >= 4);
+
+    let status = &body[0].spans[1];
+    assert_eq!(status.content.as_ref(), "Viewed image");
+    assert_eq!(status.style.fg, Some(theme::DIM));
+    assert!(status.style.add_modifier.contains(Modifier::ITALIC));
+
+    let separator = &body[0].spans[2];
+    assert_eq!(separator.content.as_ref(), " ");
+
+    let file_name = &body[0].spans[3];
+    assert_eq!(file_name.content.as_ref(), "screen.png");
+    assert_eq!(file_name.style.fg, Some(Color::White));
+    assert!(!file_name.style.add_modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn read_body_does_not_style_unrelated_text_as_an_image_result() {
+    let tc = read_tool_call("notes/status.txt", "Viewed Image screen.png");
+    let body = standard::render_tool_call_body(&tc, 120);
+
+    assert_eq!(
+        rendered_line_texts_trimmed(&body),
+        vec!["  \u{2514}\u{2500} Viewed Image screen.png"]
+    );
+    assert!(!body[0].spans.iter().any(|span| span.content.as_ref() == "Viewed image"));
+}
+
+#[test]
 fn read_body_renders_sdk_line_numbers_as_dim_gutter() {
     let tc = read_tool_call("Cargo.toml", "1[package]\n2name = \"demo\"\n3version = \"0.1.0\"");
     let body = standard::render_tool_call_body(&tc, 120);


### PR DESCRIPTION
## Summary

- Detect successful image results from the Read tool and replace internal image payloads with a compact `Viewed Image <filename>` confirmation.
- Preserve the existing Read tool identity and title while keeping failed-read error output visible.
- Render the confirmation with a dim italic status label and a normal-weight white filename.
- Cover structured SDK results, resumed content blocks, failures, filename extraction, styling, and false-positive handling.

## Why

Image Read results can contain structured image data or base64 content that is useful to the model but noisy and unhelpful in the terminal. Replacing that payload with a compact confirmation keeps the transcript readable without changing the tool lifecycle or making the title switch from Read to View after execution.

<!-- Closes #-->

## Validation

- Automated: `npm test` (330 passed), `npm run lint`, `npm run knip`, `cargo fmt --all -- --check`, `cargo check --offline`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (1,767 passed), and `git diff --check`.
- Manual: Read an image in the TUI and confirmed the title remains `Read <path>` while the body renders `Viewed image <filename>` with the intended visual hierarchy.
- Screenshot/video (if UI changed): Not included; local screenshots are intentionally excluded from the branch.

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: N/A
