### PR TITLE
fix(core): unify context compaction lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- **Installer download progress** (#312, @srothgan): Stream release archives with curl retries and stall detection, show matching fixed-width bars on PowerShell and Unix, and add opt-in size, speed, and ETA diagnostics while keeping redirected and CI output plain.
+- **Installer download progress** (#312, @srothgan): Stream release downloads with reliable retries, fixed-width progress bars, and optional transfer diagnostics.
 - **Skill tool rendering** (#318, @srothgan): Show Skill calls with a dedicated icon, readable names, compact arguments, and no redundant launch output.
 - **Image read confirmations** (#319, @srothgan): Replace image payloads with compact filename confirmations while preserving Read titles and errors.
 
 ### Fixes
 
-- **Runtime and tooling hardening** (#317, @srothgan): Add privacy-minimized baseline diagnostics with bounded retention, preserve resumable session hints through teardown, stop progress heartbeats from creating duplicate tool rows, update base64 to 0.23, and align cargo-deny targets and advisory gating with release packaging.
+- **Runtime and tooling hardening** (#317, @srothgan): Add privacy-minimized diagnostics, preserve resume hints, prevent phantom tool progress, and align dependency checks with release targets.
+- **Compaction lifecycle** (#320, @srothgan): Unify compaction state, surface failures, and prevent duplicate indicators and completion notices.
 
 ## [0.14.2] - 2026-07-26 [Changes][v0.14.2]
 

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -4937,6 +4937,117 @@ test("handleSdkMessage emits lifecycle compatibility session updates", () => {
   );
 });
 
+test("handleSdkMessage emits one typed compaction lifecycle", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "status",
+      status: "compacting",
+      uuid: "compact-started",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "compact_boundary",
+      compact_metadata: {
+        trigger: "auto",
+        pre_tokens: 180_000,
+        post_tokens: 22_000,
+        duration_ms: 1_250,
+      },
+      uuid: "compact-boundary",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "status",
+      status: null,
+      compact_result: "success",
+      uuid: "compact-finished",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "status",
+      status: null,
+      compact_result: "failed",
+      compact_error: "  Prompt is too long  ",
+      uuid: "compact-failed",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      { type: "compaction_update", phase: "started" },
+      {
+        type: "compaction_update",
+        phase: "boundary",
+        trigger: "auto",
+        pre_tokens: 180_000,
+        post_tokens: 22_000,
+        duration_ms: 1_250,
+      },
+      { type: "compaction_update", phase: "finished", result: "success" },
+      { type: "session_status_update", status: "idle" },
+      {
+        type: "compaction_update",
+        phase: "finished",
+        result: "failed",
+        error_code: "unknown",
+        error: "Prompt is too long",
+      },
+      { type: "session_status_update", status: "idle" },
+    ],
+  );
+});
+
+test("handleSdkMessage classifies too_few_groups compaction failures", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "status",
+      status: null,
+      compact_result: "failed",
+      compact_error: "too_few_groups",
+      uuid: "compact-failed",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "compaction_update",
+        phase: "finished",
+        result: "failed",
+        error_code: "too_few_groups",
+        error: "too_few_groups",
+      },
+      { type: "session_status_update", status: "idle" },
+    ],
+  );
+});
+
+test("handleSdkMessage rejects invalid compaction boundary counters", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "system",
+      subtype: "compact_boundary",
+      compact_metadata: { trigger: "manual", pre_tokens: -1 },
+      uuid: "compact-boundary",
+      session_id: "session-1",
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events, []);
+});
+
 test("classifyTurnErrorKind prefers SDK assistant error codes", () => {
   assert.equal(classifyTurnErrorKind("error_during_execution", [], "model_not_found"), "model_unavailable");
   assert.equal(classifyTurnErrorKind("error_during_execution", [], "oauth_org_not_allowed"), "account_access");

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -57,6 +57,7 @@ import {
   buildRateLimitUpdate,
   buildSubagentRetryUpdate,
   normalizeSettingsParseErrors,
+  nonNegativeIntegerField,
   numberField,
   parseApiRetryError,
   parseRuntimeSessionState,
@@ -1310,10 +1311,29 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         emitSessionUpdate(session.sessionId, { type: "current_mode_update", current_mode_id: mode });
       }
       if (msg.status === "compacting") {
-        emitSessionUpdate(session.sessionId, { type: "session_status_update", status: "compacting" });
+        emitSessionUpdate(session.sessionId, { type: "compaction_update", phase: "started" });
       } else if (msg.status === "requesting") {
         emitSessionUpdate(session.sessionId, { type: "session_status_update", status: "requesting" });
       } else if (msg.status === null) {
+        if (msg.compact_result === "success") {
+          emitSessionUpdate(session.sessionId, {
+            type: "compaction_update",
+            phase: "finished",
+            result: "success",
+          });
+        } else if (msg.compact_result === "failed") {
+          const compactError =
+            typeof msg.compact_error === "string" && msg.compact_error.trim().length > 0
+              ? msg.compact_error.trim()
+              : undefined;
+          emitSessionUpdate(session.sessionId, {
+            type: "compaction_update",
+            phase: "finished",
+            result: "failed",
+            error_code: compactError === "too_few_groups" ? "too_few_groups" : "unknown",
+            ...(compactError ? { error: compactError } : {}),
+          });
+        }
         emitSessionUpdate(session.sessionId, { type: "session_status_update", status: "idle" });
       }
       emitFastModeUpdateIfChanged(
@@ -1330,12 +1350,17 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         return;
       }
       const trigger = compactMetadata.trigger;
-      const preTokens = numberField(compactMetadata, "pre_tokens", "preTokens");
+      const preTokens = nonNegativeIntegerField(compactMetadata, "pre_tokens", "preTokens");
+      const postTokens = nonNegativeIntegerField(compactMetadata, "post_tokens", "postTokens");
+      const durationMs = nonNegativeIntegerField(compactMetadata, "duration_ms", "durationMs");
       if ((trigger === "manual" || trigger === "auto") && preTokens !== undefined) {
         emitSessionUpdate(session.sessionId, {
-          type: "compaction_boundary",
+          type: "compaction_update",
+          phase: "boundary",
           trigger,
           pre_tokens: preTokens,
+          ...(postTokens !== undefined ? { post_tokens: postTokens } : {}),
+          ...(durationMs !== undefined ? { duration_ms: durationMs } : {}),
         });
       }
       return;

--- a/agent-sdk/src/bridge/state_parsing.ts
+++ b/agent-sdk/src/bridge/state_parsing.ts
@@ -27,7 +27,7 @@ function nonNegativeNumberField(record: Record<string, unknown>, ...keys: string
   return value;
 }
 
-function nonNegativeIntegerField(
+export function nonNegativeIntegerField(
   record: Record<string, unknown>,
   ...keys: string[]
 ): number | undefined {

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -339,9 +339,29 @@ export type SessionUpdate =
   | { type: "prompt_suggestion_update"; suggestion: string }
   | { type: "runtime_session_state_update"; state: RuntimeSessionState }
   | ({ type: "settings_parse_error" } & SettingsParseErrorUpdate)
-  | { type: "session_status_update"; status: "compacting" | "requesting" | "idle" }
+  | { type: "session_status_update"; status: "requesting" | "idle" }
   | { type: "system_notice_update"; severity: SystemNoticeSeverity; message: string }
-  | { type: "compaction_boundary"; trigger: "manual" | "auto"; pre_tokens: number };
+  | { type: "compaction_update"; phase: "started" }
+  | {
+      type: "compaction_update";
+      phase: "boundary";
+      trigger: "manual" | "auto";
+      pre_tokens: number;
+      post_tokens?: number;
+      duration_ms?: number;
+    }
+  | {
+      type: "compaction_update";
+      phase: "finished";
+      result: "success";
+    }
+  | {
+      type: "compaction_update";
+      phase: "finished";
+      result: "failed";
+      error_code: "too_few_groups" | "unknown";
+      error?: string;
+    };
 
 export interface PermissionOption {
   option_id: string;

--- a/src/agent/model/session.rs
+++ b/src/agent/model/session.rs
@@ -126,7 +126,6 @@ pub struct RateLimitUpdate {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionStatus {
-    Compacting,
     Requesting,
     Idle,
 }
@@ -142,6 +141,32 @@ pub enum CompactionTrigger {
 pub struct CompactionBoundary {
     pub trigger: CompactionTrigger,
     pub pre_tokens: u64,
+    pub post_tokens: Option<u64>,
+    pub duration_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompactionResult {
+    Success,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CompactionFailureCode {
+    TooFewGroups,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CompactionUpdate {
+    Started,
+    Boundary(CompactionBoundary),
+    Finished {
+        result: CompactionResult,
+        error_code: Option<CompactionFailureCode>,
+        error: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -205,5 +230,5 @@ pub enum SessionUpdate {
         severity: SystemNoticeSeverity,
         message: String,
     },
-    CompactionBoundary(CompactionBoundary),
+    CompactionUpdate(CompactionUpdate),
 }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -204,7 +204,6 @@ pub struct RateLimitUpdate {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionStatus {
-    Compacting,
     Requesting,
     Idle,
 }
@@ -214,6 +213,38 @@ pub enum SessionStatus {
 pub enum CompactionTrigger {
     Manual,
     Auto,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompactionResult {
+    Success,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompactionFailureCode {
+    TooFewGroups,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub enum CompactionUpdate {
+    Started,
+    Boundary {
+        trigger: CompactionTrigger,
+        pre_tokens: u64,
+        post_tokens: Option<u64>,
+        duration_ms: Option<u64>,
+    },
+    Finished {
+        result: CompactionResult,
+        error_code: Option<CompactionFailureCode>,
+        error: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -528,9 +559,9 @@ pub enum SessionUpdate {
         severity: SystemNoticeSeverity,
         message: String,
     },
-    CompactionBoundary {
-        trigger: CompactionTrigger,
-        pre_tokens: u64,
+    CompactionUpdate {
+        #[serde(flatten)]
+        update: CompactionUpdate,
     },
 }
 
@@ -997,7 +1028,8 @@ pub enum McpSnapshotSource {
 #[cfg(test)]
 mod tests {
     use super::{
-        AccountInfo, ApiRetryError, AvailableModel, EffortLevel, McpServerOrgMaxPermission,
+        AccountInfo, ApiRetryError, AvailableModel, CompactionFailureCode, CompactionResult,
+        CompactionTrigger, CompactionUpdate, EffortLevel, McpServerOrgMaxPermission,
         McpServerStatus, McpServerStatusConfig, McpServerToolPermissionPolicy, RateLimitStatus,
         SessionStatus, SessionUpdate, SubagentRetryUpdate, SystemNoticeSeverity, TaskMetadata,
         TaskUpdateSource, TerminalReason, TranscriptRetractionReason,
@@ -1120,6 +1152,51 @@ mod tests {
         assert!(matches!(
             update,
             SessionUpdate::SessionStatusUpdate { status: SessionStatus::Requesting }
+        ));
+    }
+
+    #[test]
+    fn compaction_updates_deserialize_typed_lifecycle_data() {
+        let boundary: SessionUpdate = serde_json::from_value(serde_json::json!({
+            "type": "compaction_update",
+            "phase": "boundary",
+            "trigger": "manual",
+            "pre_tokens": 123_456,
+            "post_tokens": 20_000,
+            "duration_ms": 1_500
+        }))
+        .expect("deserialize compaction boundary");
+
+        assert!(matches!(
+            boundary,
+            SessionUpdate::CompactionUpdate {
+                update: CompactionUpdate::Boundary {
+                    trigger: CompactionTrigger::Manual,
+                    pre_tokens: 123_456,
+                    post_tokens: Some(20_000),
+                    duration_ms: Some(1_500),
+                }
+            }
+        ));
+
+        let finished: SessionUpdate = serde_json::from_value(serde_json::json!({
+            "type": "compaction_update",
+            "phase": "finished",
+            "result": "failed",
+            "error_code": "too_few_groups",
+            "error": "Prompt is too long"
+        }))
+        .expect("deserialize compaction completion");
+
+        assert!(matches!(
+            finished,
+            SessionUpdate::CompactionUpdate {
+                update: CompactionUpdate::Finished {
+                    result: CompactionResult::Failed,
+                    error_code: Some(CompactionFailureCode::TooFewGroups),
+                    ref error,
+                }
+            } if error.as_deref() == Some("Prompt is too long")
         ));
     }
 

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -496,7 +496,6 @@ pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::
         }
         types::SessionUpdate::SessionStatusUpdate { status } => {
             Some(model::SessionUpdate::SessionStatusUpdate(match status {
-                types::SessionStatus::Compacting => model::SessionStatus::Compacting,
                 types::SessionStatus::Requesting => model::SessionStatus::Requesting,
                 types::SessionStatus::Idle => model::SessionStatus::Idle,
             }))
@@ -507,13 +506,40 @@ pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::
                 message,
             })
         }
-        types::SessionUpdate::CompactionBoundary { trigger, pre_tokens } => {
-            Some(model::SessionUpdate::CompactionBoundary(model::CompactionBoundary {
-                trigger: match trigger {
-                    types::CompactionTrigger::Manual => model::CompactionTrigger::Manual,
-                    types::CompactionTrigger::Auto => model::CompactionTrigger::Auto,
-                },
-                pre_tokens,
+        types::SessionUpdate::CompactionUpdate { update: compaction } => {
+            Some(model::SessionUpdate::CompactionUpdate(match compaction {
+                types::CompactionUpdate::Started => model::CompactionUpdate::Started,
+                types::CompactionUpdate::Boundary {
+                    trigger,
+                    pre_tokens,
+                    post_tokens,
+                    duration_ms,
+                } => model::CompactionUpdate::Boundary(model::CompactionBoundary {
+                    trigger: match trigger {
+                        types::CompactionTrigger::Manual => model::CompactionTrigger::Manual,
+                        types::CompactionTrigger::Auto => model::CompactionTrigger::Auto,
+                    },
+                    pre_tokens,
+                    post_tokens,
+                    duration_ms,
+                }),
+                types::CompactionUpdate::Finished { result, error_code, error } => {
+                    model::CompactionUpdate::Finished {
+                        result: match result {
+                            types::CompactionResult::Success => model::CompactionResult::Success,
+                            types::CompactionResult::Failed => model::CompactionResult::Failed,
+                        },
+                        error_code: error_code.map(|code| match code {
+                            types::CompactionFailureCode::TooFewGroups => {
+                                model::CompactionFailureCode::TooFewGroups
+                            }
+                            types::CompactionFailureCode::Unknown => {
+                                model::CompactionFailureCode::Unknown
+                            }
+                        }),
+                        error,
+                    }
+                }
             }))
         }
     }
@@ -1228,6 +1254,38 @@ mod tests {
                 severity: model::SystemNoticeSeverity::Warning,
                 message: "Plugin install failed.".to_owned(),
             })
+        );
+        assert_eq!(
+            map_session_update(types::SessionUpdate::CompactionUpdate {
+                update: types::CompactionUpdate::Boundary {
+                    trigger: types::CompactionTrigger::Manual,
+                    pre_tokens: 123_456,
+                    post_tokens: Some(20_000),
+                    duration_ms: Some(1_500),
+                },
+            }),
+            Some(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Boundary(
+                model::CompactionBoundary {
+                    trigger: model::CompactionTrigger::Manual,
+                    pre_tokens: 123_456,
+                    post_tokens: Some(20_000),
+                    duration_ms: Some(1_500),
+                }
+            )))
+        );
+        assert_eq!(
+            map_session_update(types::SessionUpdate::CompactionUpdate {
+                update: types::CompactionUpdate::Finished {
+                    result: types::CompactionResult::Failed,
+                    error_code: Some(types::CompactionFailureCode::TooFewGroups),
+                    error: Some("Prompt is too long".to_owned()),
+                },
+            }),
+            Some(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Finished {
+                result: model::CompactionResult::Failed,
+                error_code: Some(model::CompactionFailureCode::TooFewGroups),
+                error: Some("Prompt is too long".to_owned()),
+            }))
         );
     }
 

--- a/src/app/events/compaction.rs
+++ b/src/app/events/compaction.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Simon Peter Rothgang
+
+use super::super::{ActiveCompaction, App, SystemSeverity};
+use crate::agent::model;
+
+pub(super) fn handle_update(app: &mut App, update: model::CompactionUpdate) {
+    match update {
+        model::CompactionUpdate::Started => handle_started(app),
+        model::CompactionUpdate::Boundary(boundary) => handle_boundary(app, boundary),
+        model::CompactionUpdate::Finished { result, error_code, error } => {
+            handle_finished(app, result, error_code, error.as_deref());
+        }
+    }
+}
+
+fn handle_started(app: &mut App) {
+    let was_active = app.turn.compaction.is_active();
+    app.turn.compaction.begin();
+    tracing::debug!(
+        target: crate::logging::targets::APP_SESSION,
+        event_name = "compaction_started",
+        message = "context compaction started",
+        outcome = if was_active { "duplicate" } else { "success" },
+    );
+}
+
+fn handle_boundary(app: &mut App, boundary: model::CompactionBoundary) {
+    let attached_to_active = app.turn.compaction.apply_boundary(boundary);
+    app.session_runtime.session_usage.last_compaction_trigger = Some(boundary.trigger);
+    app.session_runtime.session_usage.last_compaction_pre_tokens = Some(boundary.pre_tokens);
+    app.session_runtime.session_usage.last_compaction_post_tokens = boundary.post_tokens;
+    app.session_runtime.session_usage.last_compaction_duration_ms = boundary.duration_ms;
+    tracing::debug!(
+        target: crate::logging::targets::APP_SESSION,
+        event_name = "compaction_boundary_applied",
+        message = "context compaction boundary recorded",
+        outcome = if attached_to_active { "active" } else { "metadata_only" },
+        attached_to_active,
+        trigger = ?boundary.trigger,
+        pre_tokens = boundary.pre_tokens,
+        post_tokens = boundary.post_tokens.unwrap_or_default(),
+        duration_ms = boundary.duration_ms.unwrap_or_default(),
+    );
+}
+
+fn handle_finished(
+    app: &mut App,
+    result: model::CompactionResult,
+    error_code: Option<model::CompactionFailureCode>,
+    error: Option<&str>,
+) {
+    let Some(active) = app.turn.compaction.finish() else {
+        tracing::debug!(
+            target: crate::logging::targets::APP_SESSION,
+            event_name = "compaction_finished",
+            message = "context compaction completion ignored without active state",
+            outcome = "ignored",
+            result = ?result,
+        );
+        return;
+    };
+
+    match result {
+        model::CompactionResult::Success => emit_manual_success_if_needed(app, &active),
+        model::CompactionResult::Failed => {
+            let message = format_failure(error_code, error);
+            super::push_system_message_with_severity(app, Some(SystemSeverity::Error), &message);
+        }
+    }
+    crate::app::session_runtime::request_context_usage_refresh(app);
+    tracing::debug!(
+        target: crate::logging::targets::APP_SESSION,
+        event_name = "compaction_finished",
+        message = "context compaction finished",
+        outcome = match result {
+            model::CompactionResult::Success => "success",
+            model::CompactionResult::Failed => "failure",
+        },
+        result = ?result,
+        trigger = ?active.trigger(),
+        boundary_received = active.boundary().is_some(),
+        error_code = ?error_code,
+        error_present = error.is_some(),
+    );
+}
+
+fn format_failure(error_code: Option<model::CompactionFailureCode>, error: Option<&str>) -> String {
+    match error_code {
+        Some(model::CompactionFailureCode::TooFewGroups) => "Context compaction cannot reduce a single oversized request because there are not enough earlier conversation turns to summarize. Start a new session and retry with a smaller request or a skill that loads less context.".to_owned(),
+        Some(model::CompactionFailureCode::Unknown) | None => error.map_or_else(
+            || "Context compaction failed.".to_owned(),
+            |error| format!("Context compaction failed: {error}"),
+        ),
+    }
+}
+
+pub(super) fn finish_inferred(app: &mut App, emit_manual_success: bool) {
+    let Some(active) = app.turn.compaction.finish() else {
+        return;
+    };
+    if emit_manual_success {
+        emit_manual_success_if_needed(app, &active);
+    }
+    tracing::debug!(
+        target: crate::logging::targets::APP_SESSION,
+        event_name = "compaction_finished",
+        message = "context compaction completion inferred from turn lifecycle",
+        outcome = "inferred",
+        trigger = ?active.trigger(),
+        boundary_received = active.boundary().is_some(),
+        manual_success_emitted = emit_manual_success
+            && matches!(active.trigger(), Some(model::CompactionTrigger::Manual)),
+    );
+}
+
+pub(super) fn reset(app: &mut App) {
+    app.turn.compaction.reset();
+}
+
+fn emit_manual_success_if_needed(app: &mut App, active: &ActiveCompaction) {
+    if matches!(active.trigger(), Some(model::CompactionTrigger::Manual)) {
+        super::push_system_message_with_severity(
+            app,
+            Some(SystemSeverity::Info),
+            "Session successfully compacted.",
+        );
+    }
+}

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -3,6 +3,7 @@
 
 mod api_retry;
 mod client;
+mod compaction;
 mod notices;
 mod rate_limit;
 mod retraction;
@@ -258,7 +259,6 @@ fn handle_session_update_event(app: &mut App, update: model::SessionUpdate) {
             | model::SessionUpdate::ToolCall(_)
             | model::SessionUpdate::ToolCallUpdate(_)
             | model::SessionUpdate::TranscriptRetraction(_)
-            | model::SessionUpdate::CompactionBoundary(_)
     );
     handle_session_update(app, update);
     if needs_history_retention {
@@ -270,7 +270,7 @@ fn handle_session_update_event(app: &mut App, update: model::SessionUpdate) {
 fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
     match update {
         model::SessionUpdate::AgentMessageChunk(chunk) => {
-            clear_compaction_state(app, true);
+            compaction::finish_inferred(app, true);
             streaming::handle_agent_message_chunk(app, chunk);
         }
         model::SessionUpdate::ToolCall(tc) => tool_calls::handle_tool_call(app, tc),
@@ -433,22 +433,13 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             handle_settings_parse_error(app, file.as_deref(), &path, &message);
         }
         model::SessionUpdate::SessionStatusUpdate(status) => {
-            let was_compacting = app.turn.is_compacting;
-            if matches!(status, model::SessionStatus::Compacting) {
-                app.turn.is_compacting = true;
-            } else {
-                clear_compaction_state(app, true);
-            }
-            if was_compacting && matches!(status, model::SessionStatus::Idle) {
-                crate::app::session_runtime::request_context_usage_refresh(app);
-            }
             tracing::debug!(
                 target: crate::logging::targets::APP_SESSION,
                 event_name = "session_status_applied",
                 message = "session status update applied",
                 outcome = "success",
                 session_status = ?status,
-                compacting = app.turn.is_compacting,
+                compacting = app.turn.compaction.is_active(),
             );
         }
         model::SessionUpdate::SystemNoticeUpdate { severity, message } => {
@@ -459,8 +450,8 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             };
             notices::emit_system_notice(app, severity, &message);
         }
-        model::SessionUpdate::CompactionBoundary(boundary) => {
-            rate_limit::handle_compaction_boundary_update(app, boundary);
+        model::SessionUpdate::CompactionUpdate(update) => {
+            compaction::handle_update(app, update);
         }
     }
 }
@@ -470,7 +461,7 @@ fn handle_runtime_session_state_update(app: &mut App, state: model::RuntimeSessi
     match state {
         model::RuntimeSessionState::Running => {
             if matches!(app.status, AppStatus::Ready | AppStatus::Thinking | AppStatus::Running)
-                && !app.turn.is_compacting
+                && !app.turn.compaction.is_active()
             {
                 app.status = AppStatus::Running;
             }
@@ -478,7 +469,7 @@ fn handle_runtime_session_state_update(app: &mut App, state: model::RuntimeSessi
         model::RuntimeSessionState::RequiresAction => {}
         model::RuntimeSessionState::Idle => {
             if matches!(app.status, AppStatus::Thinking | AppStatus::Running)
-                && !app.turn.is_compacting
+                && !app.turn.compaction.is_active()
                 && app.turn.pending_cancel_origin.is_none()
             {
                 app.status = AppStatus::Ready;
@@ -512,22 +503,6 @@ pub(crate) fn push_system_message_with_severity(
         None,
     ));
     app.enforce_history_retention_tracked();
-}
-
-pub(super) fn clear_compaction_state(app: &mut App, emit_manual_success: bool) {
-    if !app.turn.is_compacting && !app.turn.pending_compact_clear {
-        return;
-    }
-    let should_emit_success = emit_manual_success && app.turn.pending_compact_clear;
-    app.turn.pending_compact_clear = false;
-    app.turn.is_compacting = false;
-    if should_emit_success {
-        push_system_message_with_severity(
-            app,
-            Some(SystemSeverity::Info),
-            "Session successfully compacted.",
-        );
-    }
 }
 
 fn handle_config_option_update(app: &mut App, config: model::ConfigOptionUpdate) {

--- a/src/app/events/rate_limit.rs
+++ b/src/app/events/rate_limit.rs
@@ -167,23 +167,6 @@ pub(super) fn handle_rate_limit_update(app: &mut App, update: &model::RateLimitU
     }
 }
 
-pub(super) fn handle_compaction_boundary_update(
-    app: &mut App,
-    boundary: model::CompactionBoundary,
-) {
-    app.turn.is_compacting = true;
-    if matches!(boundary.trigger, model::CompactionTrigger::Manual) {
-        app.turn.pending_compact_clear = true;
-    }
-    app.session_runtime.session_usage.last_compaction_trigger = Some(boundary.trigger);
-    app.session_runtime.session_usage.last_compaction_pre_tokens = Some(boundary.pre_tokens);
-    tracing::debug!(
-        "CompactionBoundary: trigger={:?} pre_tokens={}",
-        boundary.trigger,
-        boundary.pre_tokens
-    );
-}
-
 #[cfg(test)]
 mod tests {
     use super::format_rate_limit_summary;

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -163,7 +163,7 @@ pub(super) fn handle_auth_required_event(
     app.session_runtime.login_hint = Some(LoginHint { method_name, method_description });
     app.bump_session_scope_epoch();
     app.clear_session_runtime_identity();
-    super::clear_compaction_state(app, false);
+    super::compaction::reset(app);
     app.session_runtime.last_rate_limit_update = None;
     app.turn.clear_cancel_state();
     app.session_runtime.account_info = None;
@@ -184,7 +184,7 @@ pub(super) fn handle_auth_required_event(
 pub(super) fn handle_connection_failed_event(app: &mut App, msg: &str) {
     app.bump_session_scope_epoch();
     app.clear_session_runtime_identity();
-    super::clear_compaction_state(app, false);
+    super::compaction::reset(app);
     app.turn.clear_cancel_state();
     app.session_runtime.last_rate_limit_update = None;
     app.session_runtime.account_info = None;
@@ -322,7 +322,7 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
     let session_id_for_log = session_id.to_string();
     let history_update_count = history_updates.len();
     let available_model_count = available_models.len();
-    super::clear_compaction_state(app, false);
+    super::compaction::reset(app);
     apply_session_cwd(app, cwd);
     app.sdk_inventory.available_models = available_models;
     reset_for_new_session(

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -46,7 +46,7 @@ fn reset_session_identity_state(
             .insert("model".to_owned(), serde_json::Value::String(requested_id));
     }
     app.session_runtime.login_hint = None;
-    super::clear_compaction_state(app, false);
+    super::compaction::reset(app);
     app.session_runtime.session_usage = super::super::SessionUsageState::default();
     app.sdk_inventory.clear_rewind_targets();
     app.status = super::super::AppStatus::Ready;
@@ -170,7 +170,7 @@ pub(super) fn load_resume_history(app: &mut App, history_updates: &[model::Sessi
     }
     app.finalize_turn_runtime_artifacts(model::ToolCallStatus::Failed);
     app.clear_active_turn_assistant();
-    super::clear_compaction_state(app, false);
+    super::compaction::reset(app);
     app.status = super::super::AppStatus::Ready;
     app.turn.clear_cancel_state();
     app.enforce_history_retention_tracked();

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -1503,24 +1503,38 @@ fn turn_complete_without_cancel_does_not_render_interrupted_hint() {
 }
 
 #[test]
-fn turn_complete_keeps_history_and_adds_compaction_success_after_manual_boundary() {
+fn explicit_manual_compaction_success_keeps_history_and_emits_once() {
     let mut app = make_test_app();
+    app.turn.compaction.begin_manual();
     app.transcript.messages.push(user_msg("/compact"));
     app.transcript
         .messages
         .push(assistant_msg(vec![MessageBlock::Text(TextBlock::from_complete("compacted"))]));
     handle_client_event(
         &mut app,
-        session_update(model::SessionUpdate::CompactionBoundary(model::CompactionBoundary {
-            trigger: model::CompactionTrigger::Manual,
-            pre_tokens: 123_456,
+        session_update(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Boundary(
+            model::CompactionBoundary {
+                trigger: model::CompactionTrigger::Manual,
+                pre_tokens: 123_456,
+                post_tokens: Some(20_000),
+                duration_ms: Some(1_500),
+            },
+        ))),
+    );
+    assert!(app.turn.compaction.is_active());
+
+    handle_client_event(
+        &mut app,
+        session_update(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Finished {
+            result: model::CompactionResult::Success,
+            error_code: None,
+            error: None,
         })),
     );
-    assert!(app.turn.pending_compact_clear);
 
     handle_client_event(&mut app, turn_complete(None));
 
-    assert!(!app.turn.pending_compact_clear);
+    assert!(!app.turn.compaction.is_active());
     assert_eq!(app.transcript.messages.len(), 3);
     let Some(ChatMessage { role: MessageRole::System(Some(SystemSeverity::Info)), blocks, .. }) =
         app.transcript.messages.last()
@@ -1538,9 +1552,66 @@ fn turn_complete_keeps_history_and_adds_compaction_success_after_manual_boundary
 }
 
 #[test]
+fn late_boundary_after_explicit_success_does_not_reopen_or_duplicate_manual_notice() {
+    let mut app = make_test_app();
+    app.turn.compaction.begin_manual();
+
+    handle_client_event(
+        &mut app,
+        session_update(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Started)),
+    );
+    handle_client_event(
+        &mut app,
+        session_update(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Finished {
+            result: model::CompactionResult::Success,
+            error_code: None,
+            error: None,
+        })),
+    );
+    handle_client_event(
+        &mut app,
+        session_update(model::SessionUpdate::SessionStatusUpdate(model::SessionStatus::Idle)),
+    );
+    handle_client_event(
+        &mut app,
+        session_update(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Boundary(
+            model::CompactionBoundary {
+                trigger: model::CompactionTrigger::Manual,
+                pre_tokens: 47_024,
+                post_tokens: Some(8_049),
+                duration_ms: Some(92_408),
+            },
+        ))),
+    );
+
+    assert!(!app.turn.compaction.is_active());
+    assert_eq!(app.session_runtime.session_usage.last_compaction_pre_tokens, Some(47_024));
+    assert_eq!(app.session_runtime.session_usage.last_compaction_post_tokens, Some(8_049));
+    assert_eq!(app.session_runtime.session_usage.last_compaction_duration_ms, Some(92_408));
+
+    handle_client_event(&mut app, turn_complete(None));
+
+    let success_notices = app
+        .transcript
+        .messages
+        .iter()
+        .filter(|message| {
+            matches!(message.role, MessageRole::System(Some(SystemSeverity::Info)))
+                && message.blocks.iter().any(|block| {
+                    matches!(
+                        block,
+                        MessageBlock::Text(text) if text.text == "Session successfully compacted."
+                    )
+                })
+        })
+        .count();
+    assert_eq!(success_notices, 1);
+}
+
+#[test]
 fn first_agent_chunk_clears_unconfirmed_compacting_without_success_message() {
     let mut app = make_test_app();
-    app.turn.is_compacting = true;
+    app.turn.compaction.begin();
 
     handle_client_event(
         &mut app,
@@ -1549,8 +1620,7 @@ fn first_agent_chunk_clears_unconfirmed_compacting_without_success_message() {
         ))),
     );
 
-    assert!(!app.turn.is_compacting);
-    assert!(!app.turn.pending_compact_clear);
+    assert!(!app.turn.compaction.is_active());
     assert!(app.transcript.messages.iter().all(|message| {
         !matches!(
             message,
@@ -1560,24 +1630,23 @@ fn first_agent_chunk_clears_unconfirmed_compacting_without_success_message() {
 }
 
 #[test]
-fn session_status_idle_does_not_emit_compaction_success_without_boundary() {
+fn generic_session_status_does_not_mutate_compaction() {
     let mut app = make_test_app();
-    app.turn.is_compacting = true;
+    app.turn.compaction.begin();
 
     handle_client_event(
         &mut app,
         session_update(model::SessionUpdate::SessionStatusUpdate(model::SessionStatus::Idle)),
     );
 
-    assert!(!app.turn.is_compacting);
-    assert!(!app.turn.pending_compact_clear);
+    assert!(app.turn.compaction.is_active());
     assert!(app.transcript.messages.is_empty());
 }
 
 #[test]
-fn turn_error_keeps_history_when_compact_pending() {
+fn turn_error_clears_manual_compaction_without_success_message() {
     let mut app = make_test_app();
-    app.turn.pending_compact_clear = true;
+    app.turn.compaction.begin_manual();
     app.transcript.messages.push(user_msg("/compact"));
 
     handle_client_event(
@@ -1590,19 +1659,10 @@ fn turn_error_keeps_history_when_compact_pending() {
         },
     );
 
-    assert!(!app.turn.pending_compact_clear);
+    assert!(!app.turn.compaction.is_active());
     assert!(matches!(app.status, AppStatus::Error));
-    assert_eq!(app.transcript.messages.len(), 3);
+    assert_eq!(app.transcript.messages.len(), 2);
     assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
-    let Some(ChatMessage { role: MessageRole::System(Some(SystemSeverity::Info)), blocks, .. }) =
-        app.transcript.messages.get(1)
-    else {
-        panic!("expected compaction success system message");
-    };
-    let Some(MessageBlock::Text(block)) = blocks.first() else {
-        panic!("expected text block");
-    };
-    assert_eq!(block.text, "Session successfully compacted.");
     let Some(ChatMessage { role: MessageRole::System(_), blocks, .. }) =
         app.transcript.messages.last()
     else {
@@ -1616,23 +1676,20 @@ fn turn_error_keeps_history_when_compact_pending() {
 }
 
 #[test]
-fn turn_cancel_keeps_manual_compaction_success_pending_until_exit() {
+fn turn_cancel_keeps_manual_compaction_active_until_exit() {
     let mut app = make_test_app();
-    app.turn.pending_compact_clear = true;
-    app.turn.is_compacting = true;
+    app.turn.compaction.begin_manual();
 
     handle_local_cancel_enqueued(&mut app);
 
-    assert!(app.turn.pending_compact_clear);
-    assert!(app.turn.is_compacting);
+    assert!(app.turn.compaction.is_active());
 }
 
 #[test]
-fn turn_error_after_cancel_keeps_compaction_success_before_interrupted_hint() {
+fn turn_error_after_cancel_clears_compaction_without_success() {
     let mut app = make_test_app();
     app.transcript.messages.push(user_msg("/compact"));
-    app.turn.pending_compact_clear = true;
-    app.turn.is_compacting = true;
+    app.turn.compaction.begin_manual();
 
     handle_local_cancel_enqueued(&mut app);
     handle_client_event(
@@ -1645,16 +1702,9 @@ fn turn_error_after_cancel_keeps_compaction_success_before_interrupted_hint() {
         },
     );
 
-    assert_eq!(app.transcript.messages.len(), 3);
-    assert!(matches!(
-        app.transcript.messages[1].role,
-        MessageRole::System(Some(SystemSeverity::Info))
-    ));
+    assert!(!app.turn.compaction.is_active());
+    assert_eq!(app.transcript.messages.len(), 2);
     let Some(MessageBlock::Text(block)) = app.transcript.messages[1].blocks.first() else {
-        panic!("expected text block");
-    };
-    assert_eq!(block.text, "Session successfully compacted.");
-    let Some(MessageBlock::Text(block)) = app.transcript.messages[2].blocks.first() else {
         panic!("expected text block");
     };
     assert_eq!(block.text, "Conversation interrupted. Tell the model how to proceed.");
@@ -1952,47 +2002,139 @@ fn fatal_event_clears_active_turn_runtime_tracking() {
 }
 
 #[test]
-fn compaction_boundary_enables_compacting_and_records_boundary() {
+fn manual_compaction_boundary_enriches_active_state_and_records_metrics() {
     let mut app = make_test_app();
-    assert!(!app.turn.is_compacting);
+    app.turn.compaction.begin_manual();
 
     handle_client_event(
         &mut app,
-        session_update(model::SessionUpdate::CompactionBoundary(model::CompactionBoundary {
-            trigger: model::CompactionTrigger::Manual,
-            pre_tokens: 123_456,
-        })),
+        session_update(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Boundary(
+            model::CompactionBoundary {
+                trigger: model::CompactionTrigger::Manual,
+                pre_tokens: 123_456,
+                post_tokens: Some(20_000),
+                duration_ms: Some(1_500),
+            },
+        ))),
     );
 
-    assert!(app.turn.is_compacting);
-    assert!(app.turn.pending_compact_clear);
+    assert!(app.turn.compaction.is_active());
     assert_eq!(
         app.session_runtime.session_usage.last_compaction_trigger,
         Some(model::CompactionTrigger::Manual)
     );
     assert_eq!(app.session_runtime.session_usage.last_compaction_pre_tokens, Some(123_456));
+    assert_eq!(app.session_runtime.session_usage.last_compaction_post_tokens, Some(20_000));
+    assert_eq!(app.session_runtime.session_usage.last_compaction_duration_ms, Some(1_500));
 }
 
 #[test]
-fn auto_compaction_boundary_sets_compacting_without_manual_success_pending() {
+fn auto_compaction_boundary_enriches_started_state_without_manual_success_pending() {
     let mut app = make_test_app();
-    assert!(!app.turn.is_compacting);
+    assert!(!app.turn.compaction.is_active());
 
     handle_client_event(
         &mut app,
-        session_update(model::SessionUpdate::CompactionBoundary(model::CompactionBoundary {
-            trigger: model::CompactionTrigger::Auto,
-            pre_tokens: 234_567,
-        })),
+        session_update(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Started)),
     );
 
-    assert!(app.turn.is_compacting);
-    assert!(!app.turn.pending_compact_clear);
+    handle_client_event(
+        &mut app,
+        session_update(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Boundary(
+            model::CompactionBoundary {
+                trigger: model::CompactionTrigger::Auto,
+                pre_tokens: 234_567,
+                post_tokens: None,
+                duration_ms: None,
+            },
+        ))),
+    );
+
+    assert!(app.turn.compaction.is_active());
     assert_eq!(
         app.session_runtime.session_usage.last_compaction_trigger,
         Some(model::CompactionTrigger::Auto)
     );
     assert_eq!(app.session_runtime.session_usage.last_compaction_pre_tokens, Some(234_567));
+}
+
+#[test]
+fn duplicate_compaction_updates_share_one_idempotent_lifecycle() {
+    let mut app = make_test_app();
+
+    for _ in 0..2 {
+        handle_client_event(
+            &mut app,
+            session_update(model::SessionUpdate::CompactionUpdate(
+                model::CompactionUpdate::Started,
+            )),
+        );
+    }
+    assert!(app.turn.compaction.is_active());
+
+    for _ in 0..2 {
+        handle_client_event(
+            &mut app,
+            session_update(model::SessionUpdate::CompactionUpdate(
+                model::CompactionUpdate::Finished {
+                    result: model::CompactionResult::Success,
+                    error_code: None,
+                    error: None,
+                },
+            )),
+        );
+    }
+
+    assert!(!app.turn.compaction.is_active());
+    assert!(app.transcript.messages.is_empty());
+}
+
+#[test]
+fn failed_compaction_clears_state_and_surfaces_sdk_error() {
+    let mut app = make_test_app();
+    app.turn.compaction.begin();
+
+    handle_client_event(
+        &mut app,
+        session_update(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Finished {
+            result: model::CompactionResult::Failed,
+            error_code: Some(model::CompactionFailureCode::Unknown),
+            error: Some("Prompt is too long".to_owned()),
+        })),
+    );
+
+    assert!(!app.turn.compaction.is_active());
+    let Some(MessageBlock::Text(block)) =
+        app.transcript.messages.last().and_then(|message| message.blocks.first())
+    else {
+        panic!("expected compaction failure message");
+    };
+    assert_eq!(block.text, "Context compaction failed: Prompt is too long");
+}
+
+#[test]
+fn too_few_groups_compaction_failure_is_actionable() {
+    let mut app = make_test_app();
+    app.turn.compaction.begin();
+
+    handle_client_event(
+        &mut app,
+        session_update(model::SessionUpdate::CompactionUpdate(model::CompactionUpdate::Finished {
+            result: model::CompactionResult::Failed,
+            error_code: Some(model::CompactionFailureCode::TooFewGroups),
+            error: Some("too_few_groups".to_owned()),
+        })),
+    );
+
+    let Some(MessageBlock::Text(block)) =
+        app.transcript.messages.last().and_then(|message| message.blocks.first())
+    else {
+        panic!("expected compaction failure message");
+    };
+    assert_eq!(
+        block.text,
+        "Context compaction cannot reduce a single oversized request because there are not enough earlier conversation turns to summarize. Start a new session and retry with a smaller request or a skill that loads less context."
+    );
 }
 
 #[test]

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -6,7 +6,7 @@ use super::super::{
     InvalidationLevel, MessageBlock, MessageRole, NoticeStage, SubagentPermissionContext,
     SystemSeverity, TextBlock, ToolCallInfo, ToolCallScope, UserDialogBlock,
 };
-use super::clear_compaction_state;
+use super::compaction;
 use super::rate_limit::{format_rate_limit_summary, rate_limit_notice_key};
 use crate::agent::error_handling::{TurnErrorClass, classify_turn_error, summarize_internal_error};
 use crate::agent::model;
@@ -443,7 +443,7 @@ fn begin_turn_exit(app: &mut App, emit_manual_compaction_success: bool) -> TurnE
         cancelled_requested: app.turn.pending_cancel_origin,
         show_interrupted_hint: matches!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual)),
     };
-    clear_compaction_state(app, emit_manual_compaction_success);
+    compaction::finish_inferred(app, emit_manual_compaction_success);
     app.turn.pending_cancel_origin = None;
     app.turn.cancelled_pending_hint = false;
     state
@@ -510,7 +510,7 @@ pub(super) fn handle_turn_error_event(
     api_error_status: Option<u16>,
     terminal_reason: Option<crate::agent::types::TerminalReason>,
 ) {
-    let exit = begin_turn_exit(app, true);
+    let exit = begin_turn_exit(app, false);
 
     if exit.cancelled_requested.is_some() {
         let summary = summarize_internal_error(msg);

--- a/src/app/input_submit.rs
+++ b/src/app/input_submit.rs
@@ -30,7 +30,7 @@ pub(super) fn submit_input(app: &mut App) {
         return;
     }
 
-    if app.turn.is_compacting {
+    if app.turn.compaction.is_active() {
         app.turn.pending_auto_submit_after_cancel = false;
         tracing::debug!(
             target: crate::logging::targets::APP_INPUT,
@@ -76,7 +76,7 @@ pub(super) fn submit_input(app: &mut App) {
 fn is_turn_busy(app: &App) -> bool {
     matches!(app.status, AppStatus::Thinking | AppStatus::Running)
         || app.turn.pending_cancel_origin.is_some()
-        || app.turn.is_compacting
+        || app.turn.compaction.is_active()
 }
 
 pub(super) fn request_cancel(app: &mut App, origin: CancelOrigin) -> Result<(), String> {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -67,17 +67,18 @@ pub use service_status_check::start_service_status_check;
 pub use settings::{AppSettings, UpdatePrompt};
 pub(crate) use state::MarkdownRenderKey;
 pub use state::{
-    App, AppStatus, AutocompleteKind, BlockCache, CacheMetrics, CancelOrigin, ChatMessage,
-    ChatMessageId, ChatRenderState, ComposerRenderState, ExtraUsage, HistoryOutputId,
-    ImageAttachmentBlock, IncrementalMarkdown, InlinePermission, InlineQuestion, InvalidationLevel,
-    LayoutInvalidation, LiveRegionRenderState, LoginHint, McpState, MessageBlock, MessageBlockId,
-    MessageRole, MessageUsage, ModeInfo, ModeState, NoticeBlock, NoticeDedupKey, NoticeStage,
-    PasteSessionState, PendingCommandAck, PostExitAction, RateLimitIncidentKey, RecentSessionInfo,
-    SelectionPoint, SessionPickerState, SessionUsageState, SubagentPermissionContext,
-    SystemSeverity, TerminalSize, TerminalSizeChange, TextBlock, TextBlockSpacing, ToolCallInfo,
-    ToolCallScope, TurnNoticeLocation, TurnNoticeRef, UpdatePromptAction, UpdatePromptState,
-    UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow, UserDialogBlock,
-    WelcomeBlock, hash_text_block_content, hash_welcome_block_content, is_execute_tool_name,
+    ActiveCompaction, App, AppStatus, AutocompleteKind, BlockCache, CacheMetrics, CancelOrigin,
+    ChatMessage, ChatMessageId, ChatRenderState, CompactionState, ComposerRenderState, ExtraUsage,
+    HistoryOutputId, ImageAttachmentBlock, IncrementalMarkdown, InlinePermission, InlineQuestion,
+    InvalidationLevel, LayoutInvalidation, LiveRegionRenderState, LoginHint, McpState,
+    MessageBlock, MessageBlockId, MessageRole, MessageUsage, ModeInfo, ModeState, NoticeBlock,
+    NoticeDedupKey, NoticeStage, PasteSessionState, PendingCommandAck, PostExitAction,
+    RateLimitIncidentKey, RecentSessionInfo, SelectionPoint, SessionPickerState, SessionUsageState,
+    SubagentPermissionContext, SystemSeverity, TerminalSize, TerminalSizeChange, TextBlock,
+    TextBlockSpacing, ToolCallInfo, ToolCallScope, TurnNoticeLocation, TurnNoticeRef,
+    UpdatePromptAction, UpdatePromptState, UsageSnapshot, UsageSourceKind, UsageSourceMode,
+    UsageState, UsageWindow, UserDialogBlock, WelcomeBlock, hash_text_block_content,
+    hash_welcome_block_content, is_execute_tool_name,
 };
 pub use trust::TrustSelection;
 pub use update_check::start_update_check;
@@ -257,7 +258,7 @@ async fn run_tui_loop(
                 | AppStatus::CommandPending
                 | AppStatus::Thinking
                 | AppStatus::Running
-        ) || app.turn.is_compacting;
+        ) || app.turn.compaction.is_active();
         if is_animating {
             advance_spinner_frame(app, Instant::now());
             tab_title::update_tab_title(&app.status, app.spinner_frame, &app.cwd);

--- a/src/app/session_runtime.rs
+++ b/src/app/session_runtime.rs
@@ -114,7 +114,8 @@ pub(crate) fn tick_context_usage_refresh(app: &mut App, now: Instant) {
 }
 
 fn context_usage_refresh_is_active(app: &App) -> bool {
-    matches!(app.status, AppStatus::Thinking | AppStatus::Running) || app.turn.is_compacting
+    matches!(app.status, AppStatus::Thinking | AppStatus::Running)
+        || app.turn.compaction.is_active()
 }
 
 pub(crate) fn request_status_snapshot_refresh(app: &mut App) {

--- a/src/app/slash/executors.rs
+++ b/src/app/slash/executors.rs
@@ -330,7 +330,7 @@ fn handle_compact_submit(app: &mut App, args: &[&str]) -> bool {
         return true;
     }
 
-    app.turn.is_compacting = true;
+    app.turn.compaction.begin_manual();
     false
 }
 

--- a/src/app/slash/tests.rs
+++ b/src/app/slash/tests.rs
@@ -1880,7 +1880,7 @@ fn compact_without_connection_is_handled_locally() {
 
     let consumed = try_handle_submit(&mut app, "/compact");
     assert!(consumed);
-    assert!(!app.turn.pending_compact_clear);
+    assert!(!app.turn.compaction.is_active());
     let Some(last) = app.transcript.messages.last() else {
         panic!("expected system message");
     };
@@ -1892,15 +1892,14 @@ fn compact_without_connection_is_handled_locally() {
 }
 
 #[test]
-fn compact_with_active_session_sets_compacting_without_success_pending() {
+fn compact_with_active_session_starts_manual_compaction() {
     let mut app = App::test_default();
     let _rx = attach_test_connection(&mut app);
     app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
 
     let consumed = try_handle_submit(&mut app, "/compact");
     assert!(!consumed);
-    assert!(!app.turn.pending_compact_clear);
-    assert!(app.turn.is_compacting);
+    assert!(app.turn.compaction.is_active());
 }
 
 #[test]

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -51,7 +51,7 @@ pub use tool_call_info::{
     InlinePermission, InlineQuestion, SubagentPermissionContext, ToolCallInfo, is_execute_tool_name,
 };
 pub use transcript::Transcript;
-pub use turn::TurnState;
+pub use turn::{ActiveCompaction, CompactionState, TurnState};
 pub use turn_notices::{NoticeStage, TurnNoticeLocation, TurnNoticeRef};
 pub use types::{
     AppStatus, CancelOrigin, ExtraUsage, HistoryRetentionPolicy, HistoryRetentionStats, LoginHint,

--- a/src/app/state/turn.rs
+++ b/src/app/state/turn.rs
@@ -3,13 +3,75 @@
 
 use super::prelude::*;
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum CompactionState {
+    #[default]
+    Idle,
+    Active(ActiveCompaction),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ActiveCompaction {
+    trigger: Option<model::CompactionTrigger>,
+    boundary: Option<model::CompactionBoundary>,
+}
+
+impl CompactionState {
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Active(_))
+    }
+
+    pub(crate) fn begin(&mut self) {
+        if matches!(self, Self::Idle) {
+            *self = Self::Active(ActiveCompaction::default());
+        }
+    }
+
+    pub(crate) fn begin_manual(&mut self) {
+        if matches!(self, Self::Idle) {
+            *self = Self::Active(ActiveCompaction {
+                trigger: Some(model::CompactionTrigger::Manual),
+                boundary: None,
+            });
+        }
+    }
+
+    pub(crate) fn apply_boundary(&mut self, boundary: model::CompactionBoundary) -> bool {
+        let Self::Active(active) = self else {
+            return false;
+        };
+        active.trigger = Some(boundary.trigger);
+        active.boundary = Some(boundary);
+        true
+    }
+
+    pub(crate) fn finish(&mut self) -> Option<ActiveCompaction> {
+        match std::mem::take(self) {
+            Self::Idle => None,
+            Self::Active(active) => Some(active),
+        }
+    }
+
+    pub(crate) fn reset(&mut self) {
+        *self = Self::Idle;
+    }
+}
+
+impl ActiveCompaction {
+    pub(crate) fn trigger(&self) -> Option<model::CompactionTrigger> {
+        self.trigger
+    }
+
+    pub(crate) fn boundary(&self) -> Option<model::CompactionBoundary> {
+        self.boundary
+    }
+}
+
 /// State scoped to the currently active turn: in-flight command tracking,
 /// cancellation bookkeeping, inline interactions, and turn-local notices.
 ///
 /// Everything here resets at turn or session boundaries; grouping it makes
 /// those reset contracts explicit instead of scattering them across `App`.
-// The bools are independent latches consumed at different turn-lifecycle
-// points, not an encodable state machine.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Default)]
 pub struct TurnState {
@@ -17,9 +79,8 @@ pub struct TurnState {
     pub pending_command_label: Option<String>,
     /// Ack marker required to clear `CommandPending` for strict completion semantics.
     pub pending_command_ack: Option<PendingCommandAck>,
-    /// When true, the current/next turn completion should clear local conversation history.
-    /// Set by `/compact` once the command is accepted for bridge forwarding.
-    pub pending_compact_clear: bool,
+    /// The single live lifecycle state for manual and automatic context compaction.
+    pub compaction: CompactionState,
     /// Tool call IDs with pending inline interactions, ordered by arrival.
     /// The first entry is the focused interaction that receives keyboard input.
     /// Up / Down arrow keys cycle focus through the list.
@@ -37,8 +98,6 @@ pub struct TurnState {
     /// IDs of root Task/Agent tool calls currently `InProgress`.
     /// Use `App::insert_active_task()`, `App::remove_active_task()`.
     pub active_task_ids: HashSet<String>,
-    /// True while the SDK reports active compaction.
-    pub is_compacting: bool,
     /// Turn-local inline/system notices that may upgrade in place during the active turn.
     pub notice_refs: Vec<TurnNoticeRef>,
 }
@@ -58,13 +117,12 @@ impl TurnState {
     pub fn reset_for_turn_exit(&mut self) {
         self.pending_command_label = None;
         self.pending_command_ack = None;
-        self.pending_compact_clear = false;
+        self.compaction.reset();
         self.pending_interaction_ids.clear();
         self.cancelled_pending_hint = false;
         self.pending_cancel_origin = None;
         self.assistant_message_idx = None;
         self.active_task_ids.clear();
-        self.is_compacting = false;
         self.notice_refs.clear();
     }
 

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -151,6 +151,8 @@ pub struct UsageState {
 pub struct SessionUsageState {
     pub last_compaction_trigger: Option<model::CompactionTrigger>,
     pub last_compaction_pre_tokens: Option<u64>,
+    pub last_compaction_post_tokens: Option<u64>,
+    pub last_compaction_duration_ms: Option<u64>,
     pub context_usage_percent: Option<u8>,
     pub context_usage_in_flight: bool,
     pub context_usage_refresh_pending: bool,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -232,7 +232,7 @@ fn plain_enter_preserves_single_line_draft_before_submit() {
 #[test]
 fn compaction_allows_drafting_but_blocks_submit() {
     let (mut app, mut rx) = app_with_connection();
-    app.turn.is_compacting = true;
+    app.turn.compaction.begin();
     app.input.set_text("draft");
 
     events::handle_terminal_event(
@@ -259,7 +259,7 @@ fn compaction_allows_drafting_but_blocks_submit() {
 #[test]
 fn compaction_allows_paste_drafting() {
     let (mut app, _rx) = app_with_connection();
-    app.turn.is_compacting = true;
+    app.turn.compaction.begin();
 
     events::handle_terminal_event(&mut app, Event::Paste(" pasted".into()));
 

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -47,7 +47,7 @@ fn build_key_help_items(app: &App) -> Vec<(String, String)> {
 
     let context = active_key_help_context(app);
     let mut items = keymap_help_rows(app, context);
-    if app.turn.is_compacting {
+    if app.turn.compaction.is_active() {
         items.push(("Status".to_owned(), "Compacting context".to_owned()));
     }
     items.push(("Mouse wheel".to_owned(), "Scroll chat".to_owned()));

--- a/src/ui/inline_chat_rows.rs
+++ b/src/ui/inline_chat_rows.rs
@@ -380,7 +380,7 @@ fn welcome_value_ready(value: &str) -> bool {
 }
 
 fn sync_runtime_indicator(app: &mut App) -> Option<AssistantRuntimeIndicator> {
-    if app.turn.is_compacting {
+    if app.turn.compaction.is_active() {
         app.chat_render.thinking_verb = None;
         return Some(AssistantRuntimeIndicator::Compacting);
     }
@@ -489,7 +489,7 @@ impl RenderedMessageRows {
 
 fn active_assistant_message_is_mutable(app: &App, msg_idx: usize) -> bool {
     app.active_turn_assistant_idx() == Some(msg_idx)
-        && (app.turn.is_compacting
+        && (app.turn.compaction.is_active()
             || matches!(app.status, AppStatus::Thinking | AppStatus::Running))
 }
 
@@ -954,7 +954,11 @@ fn render_assistant_rows(mut request: AssistantRowsRequest<'_>) -> RenderedMessa
         return RenderedMessageRows::empty();
     }
 
-    RenderedMessageRows::rendered(trim_trailing_blank_rows(rows), boundaries)
+    let mut rows = trim_trailing_blank_rows(rows);
+    if matches!(request.indicator, Some(AssistantRuntimeIndicator::Compacting)) {
+        rows.push(Line::default());
+    }
+    RenderedMessageRows::rendered(rows, boundaries)
 }
 
 fn assistant_text_trailing_gap(
@@ -1160,10 +1164,10 @@ fn append_assistant_indicator_rows(
     state: &AssistantInlineLayoutState,
     meta: AssistantIndicatorMeta,
 ) {
-    let line = match meta.indicator {
-        Some(AssistantRuntimeIndicator::Compacting) => compacting_line(meta.spinner.frame),
+    let indicator_lines = match meta.indicator {
+        Some(AssistantRuntimeIndicator::Compacting) => compacting_lines(meta.spinner.frame),
         Some(AssistantRuntimeIndicator::Thinking { verb }) => {
-            thinking_line(meta.spinner.frame, verb)
+            vec![thinking_line(meta.spinner.frame, verb)]
         }
         None => return,
     };
@@ -1179,7 +1183,7 @@ fn append_assistant_indicator_rows(
         start_row: boundary_start,
         commit_ready: false,
     });
-    rows.extend(wrap_lines_to_physical_rows(&[line], meta.width));
+    rows.extend(wrap_lines_to_physical_rows(&indicator_lines, meta.width));
 }
 
 fn spinner_state_for_live(frame: usize) -> SpinnerState {
@@ -1277,16 +1281,22 @@ fn thinking_line(frame: usize, verb: &str) -> Line<'static> {
     ))
 }
 
-fn compacting_line(frame: usize) -> Line<'static> {
+fn compacting_lines(frame: usize) -> Vec<Line<'static>> {
     const SPINNER_FRAMES: &[char] = &[
         '\u{280B}', '\u{2819}', '\u{2839}', '\u{2838}', '\u{283C}', '\u{2834}', '\u{2826}',
         '\u{2827}', '\u{2807}', '\u{280F}',
     ];
     let ch = SPINNER_FRAMES[frame % SPINNER_FRAMES.len()];
-    Line::from(ratatui::text::Span::styled(
-        format!("{ch} Compacting context..."),
-        Style::default().fg(theme::RUST_ORANGE),
-    ))
+    vec![
+        Line::from(ratatui::text::Span::styled(
+            format!("{ch} Compacting context..."),
+            Style::default().fg(theme::RUST_ORANGE),
+        )),
+        Line::from(ratatui::text::Span::styled(
+            "  └─ Keep drafting — sending resumes when compaction finishes.",
+            Style::default().fg(theme::DIM),
+        )),
+    ]
 }
 
 fn system_severity_color(severity: SystemSeverity) -> Color {
@@ -2089,6 +2099,35 @@ mod tests {
 
         assert_eq!(text.first().map(String::as_str), Some("Claude"));
         assert!(text.iter().any(|line| line.contains("Pondering...")));
+    }
+
+    #[test]
+    fn active_compaction_renders_one_assistant_owned_indicator() {
+        let mut app = App::test_default();
+        app.transcript.messages.push(assistant_message());
+        app.bind_active_turn_assistant(0);
+        app.turn.compaction.begin();
+
+        for width in [32, 120, 32] {
+            let serialized = serialize_all_rows_with_boundaries(&mut app, width);
+            let text = line_texts(serialized.rows());
+            let compact = compact_text(serialized.rows());
+
+            assert_eq!(text.first().map(String::as_str), Some("Claude"));
+            assert_eq!(compact.matches("Compactingcontext...").count(), 1);
+            assert!(compact.contains("└─Keepdrafting—sendingresumeswhencompactionfinishes."));
+            assert!(text.iter().any(|line| line.starts_with("  └─ Keep drafting")));
+            assert_eq!(text.last().map(String::as_str), Some(""));
+            assert_eq!(
+                serialized
+                    .segments()
+                    .iter()
+                    .filter(|segment| segment.kind == LiveRowBoundaryKind::AssistantIndicator)
+                    .count(),
+                1
+            );
+            assert!(app.transcript.messages[0].blocks.is_empty());
+        }
     }
 
     #[test]

--- a/src/ui/input_rows.rs
+++ b/src/ui/input_rows.rs
@@ -36,17 +36,6 @@ pub(crate) fn build_composer_hint_rows(app: &App) -> Vec<Line<'static>> {
         ]));
     }
 
-    if app.turn.is_compacting {
-        let spinner_ch = SPINNER_FRAMES[app.spinner_frame % SPINNER_FRAMES.len()];
-        rows.push(Line::from(vec![
-            Span::styled(format!("{spinner_ch} "), Style::default().fg(theme::DIM)),
-            Span::styled(
-                "Compacting session... you can draft, submit is paused.",
-                Style::default().fg(theme::DIM),
-            ),
-        ]));
-    }
-
     if autocomplete::is_active(app) {
         rows.extend(autocomplete::composer_hint_rows(app));
     } else if app.input.is_empty()
@@ -134,15 +123,13 @@ mod tests {
     }
 
     #[test]
-    fn build_composer_hint_rows_shows_compaction_draft_hint() {
+    fn build_composer_hint_rows_omits_compaction_status() {
         let mut app = App::test_default();
-        app.turn.is_compacting = true;
+        app.turn.compaction.begin();
 
         let rows = build_composer_hint_rows(&app);
 
-        assert_eq!(rows.len(), 1);
-        assert!(line_text(&rows[0]).contains("Compacting session"));
-        assert!(line_text(&rows[0]).contains("you can draft"));
+        assert!(rows.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Normalize Agent SDK compaction notifications into typed `started`, `boundary`, and `finished` updates.
- Replace independent Rust compaction flags with one centralized lifecycle state that tolerates duplicate and out-of-order SDK events.
- Render one assistant-owned compaction indicator with drafting guidance, block submission until completion, and surface actionable failures.
- Prevent late boundary metadata from reopening a completed compaction or emitting a second success notice.

## Why

Compaction was represented by separate SDK signals and Rust state flags, which allowed the TUI to show duplicate status information and made completion handling depend on event order. In observed Agent SDK traffic, an explicit successful result can arrive before its boundary metadata; the late boundary then reopened the completed manual lifecycle and caused a second success notification. Centralizing the lifecycle preserves boundary metrics while keeping rendering, submission gating, success, failure, cancellation, and reset behavior consistent.

Closes #

## Validation

- Automated: `cargo test --offline` (1,728 Rust unit tests plus integration and doc suites), `cargo clippy --all-targets --all-features --offline -- -D warnings`, `cargo check --offline`, `cargo fmt --all -- --check`, `npm test` (333 Agent SDK bridge tests), `npm run lint`, and `git diff --check`.
- Manual: Exercised `/compact` failure and success paths in the TUI; verified the expected too-few-messages failure, one active spinner, one success notice, late boundary handling as metadata-only, refreshed context usage, and graceful bridge shutdown with exit code 0.
- Screenshot/video (if UI changed): N/A; verified directly in the TUI and excluded diagnostic screenshots from the change.

## Notes

- Breaking changes: N/A
- Docs updated: `CHANGELOG.md`
- Governance/release impact: N/A
