### PR TITLE
chore(release): publish version 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.3] - 2026-08-01 [Changes][v0.14.3]
+
 ### Features
 
 - **Installer download progress** (#312, @srothgan): Stream release downloads with reliable retries, fixed-width progress bars, and optional transfer diagnostics.
@@ -802,6 +804,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.14.3]: https://github.com/srothgan/claude-code-rust/compare/v0.14.2...v0.14.3
 [v0.14.2]: https://github.com/srothgan/claude-code-rust/compare/v0.14.1...v0.14.2
 [v0.14.1]: https://github.com/srothgan/claude-code-rust/compare/v0.14.0...v0.14.1
 [v0.14.0]: https://github.com/srothgan/claude-code-rust/compare/v0.13.4...v0.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rust",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.220"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Claude Code Rust - native Rust terminal interface for Claude Code",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary

- Prepare the repository for the `0.14.3` release.
- Synchronize the Cargo and npm package versions at `0.14.3`.
- Promote the current Unreleased changelog entries into the dated `0.14.3` section and add its comparison link.

## Why

The changes accumulated since `v0.14.2` are ready to be published as `v0.14.3`. The release metadata must use one consistent version so the automated release workflow can build and publish the matching artifacts.

Closes: N/A

## Validation

- Automated: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test`; `cargo check --offline`; Cargo/npm metadata consistency check; `git diff --check`.
- Manual: Reviewed the `main...release/0.14.3` diff and confirmed that only the release version metadata and changelog release markers changed.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: `CHANGELOG.md` now contains the `0.14.3` release section and comparison link.
- Governance/release impact: Merging the `Cargo.toml` version change into `main` triggers the automated release workflow for `v0.14.3`.
