### PR TITLE
chore(deps): bump @hono/node-server to 2.1.0 in both lockfiles

### DIFF
--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -403,26 +403,26 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -194,26 +194,26 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",


### PR DESCRIPTION
## Summary

<!-- What changed -->

Raises `@hono/node-server` from 1.19.14 to 2.1.0 in both `package-lock.json` and `agent-sdk/package-lock.json`, by first raising `@modelcontextprotocol/sdk` from 1.29.0 to 1.30.0.

`@hono/node-server` is a transitive dependency three levels deep:

```
@anthropic-ai/claude-agent-sdk@0.3.220
└─ @modelcontextprotocol/sdk        (peerDependency "^1.29.0")
   └─ @hono/node-server
```

MCP SDK 1.29.0 declared `"@hono/node-server": "^1.19.9"`, which semver-excludes the patched 2.0.5. Version 1.30.0 widens that to `"^1.19.9 || ^2.0.5"`, so the leaf can move. Both steps are required: widening the range alone leaves 1.19.14 installed.

Lockfile-only change; no `package.json` edits and no `overrides` introduced.

## Why

<!-- Why this change is needed -->

Resolves the two remaining open Dependabot security alerts:

- [Dependabot alert 13](https://github.com/srothgan/claude-code-rust/security/dependabot/13) — `agent-sdk/package-lock.json`
- [Dependabot alert 15](https://github.com/srothgan/claude-code-rust/security/dependabot/15) — `package-lock.json`

Both are [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9): path traversal in Hono's `serve-static` on Windows via an encoded backslash (`%5C`), patched in 2.0.5.

These are Dependabot alert numbers, not issue numbers, so they are linked explicitly rather than written as `#13` / `#15`.

Closes #

Supersedes #325, which bumped `@modelcontextprotocol/sdk` to 1.30.0 in `agent-sdk/` only and left `@hono/node-server` resolved at 1.19.14 — it widened the range without applying the fix, and did not touch the root lockfile.

## Validation

- Automated: `npm run build` clean; `npm test` 333/333 passing in `agent-sdk`. `npm audit` reports 0 vulnerabilities in both projects. On `main` the `Agent SDK / Check agent-sdk` job emits a non-blocking `exit code 1` audit annotation for this advisory; that annotation is absent on this branch.
- Manual: verified `npm ls @hono/node-server --all` resolves to 2.1.0 via `@modelcontextprotocol/sdk@1.30.0` in both trees; confirmed the diff touches only the two package entries and no other dependency.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A — `@hono/node-server` 2.x is a major bump, but it is transitive and reached only through the MCP SDK's HTTP transport. The bridge does not import `hono`, `serve-static`, or the HTTP/SSE transports, and runs over stdio.
- Docs updated: N/A — lockfile-only dependency change.
- Governance/release impact: N/A
