### PR TITLE
feat(agent-sdk): migrate to 0.3.227

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **Claude Agent SDK 0.3.227 migration** (#338, @srothgan): Add guarded resume-at, structured usage, cross-session message provenance, and current SDK metadata support.
+
 ## [0.14.3] - 2026-08-01 [Changes][v0.14.3]
 
 ### Features

--- a/agent-sdk/package-lock.json
+++ b/agent-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.220"
+        "@anthropic-ai/claude-agent-sdk": "0.3.227"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.7",
@@ -22,22 +22,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
-      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.227.tgz",
+      "integrity": "sha512-jNw9vBjaqHwuLy93d02PSBmounWjzEyO2RKA7/PR+5ooewIH7ceYo40yxaW2rJnGvXvjpLiuk7ZXM6/TFHQ+qQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.227"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
-      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.227.tgz",
+      "integrity": "sha512-9iL2Q5QSLAVRgAZnXeSag6g2k9e7ZOHktYxL5LzTg05lbcYCeop4eVs7R8+qsJRIHtbGthA919hrnzkq1Ij9GQ==",
       "cpu": [
         "arm64"
       ],
@@ -59,9 +59,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
-      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.227.tgz",
+      "integrity": "sha512-GDdYKtv3wC0kLGS5wrxUf5Oq2hkKW0Nw/CyqcxHEnmeuc8istbQM6dveTK66ufPyI5Q7FiHxmo/kL7YLlFdvtw==",
       "cpu": [
         "x64"
       ],
@@ -72,9 +72,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
-      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.227.tgz",
+      "integrity": "sha512-/Ve9ZVcULeYP6kxaEBFEwCDPAJRl/9O38PgXcOSCYIott6H3IA+4nb51Ee0ljITeA52IPyEo7stbduIjiPsp+g==",
       "cpu": [
         "arm64"
       ],
@@ -88,9 +88,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
-      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.227.tgz",
+      "integrity": "sha512-21cruWs2wTVUYqpDn2z3SgG3fnDmf3tpH7iSw/V1NIrvaiiN+tFfeliIEvZPzLzT26048GEvK6GZcFG5k5mshQ==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
-      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.227.tgz",
+      "integrity": "sha512-eBSNIOauM5+crbIH/f8G1vgGMIMHVwh+NDH6esCRKdbRVvcnE4+urdVFSaKz0G7Ji8c6WGKLQYqrdrAVdPyODw==",
       "cpu": [
         "x64"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
-      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.227.tgz",
+      "integrity": "sha512-YfpJj8YVkzG2MhPOnc24NtErwWRpWYDNxc2Ig359kR4ZbfGKlmonKvkXceUQaeFXSh1LNUZAjsm2Y04XdBaUbQ==",
       "cpu": [
         "x64"
       ],
@@ -136,9 +136,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
-      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.227.tgz",
+      "integrity": "sha512-4vkR0Hn1TI6ypomZcpMTk7h8Wtk1iY59XDtpyk5bk7eMNxuNtlm8a4DX7OS00sn4/I3cUoDOhRpTVA4p7j5oxA==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +149,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
-      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.227.tgz",
+      "integrity": "sha512-iCEk00U8o8Y+0fsSCFbFGWGRokrfxo9kCwzBuKPjzvQEux06g7ps/O+Y0q9Nw/4iPCTXgUbekiSNcqg9CWaN9A==",
       "cpu": [
         "x64"
       ],

--- a/agent-sdk/package.json
+++ b/agent-sdk/package.json
@@ -20,7 +20,7 @@
     "node": ">=24"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.220"
+    "@anthropic-ai/claude-agent-sdk": "0.3.227"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.7",

--- a/agent-sdk/src/bridge.contract.test.ts
+++ b/agent-sdk/src/bridge.contract.test.ts
@@ -60,7 +60,9 @@ class SpawnedBridge {
 
     this.child.once("exit", (code) => {
       this.#exitCode = code;
-      this.#rejectWaiters(new Error(`bridge exited before next protocol event: ${code}`));
+      this.#rejectWaiters(
+        new Error(`bridge exited before next protocol event: ${code}`),
+      );
     });
   }
 
@@ -78,12 +80,16 @@ class SpawnedBridge {
       return Promise.resolve(queued);
     }
     if (this.#exitCode !== undefined) {
-      return Promise.reject(new Error(`bridge already exited: ${this.#exitCode}`));
+      return Promise.reject(
+        new Error(`bridge already exited: ${this.#exitCode}`),
+      );
     }
 
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
-        const index = this.#stdoutWaiters.findIndex((waiter) => waiter.resolve === resolve);
+        const index = this.#stdoutWaiters.findIndex(
+          (waiter) => waiter.resolve === resolve,
+        );
         if (index >= 0) {
           this.#stdoutWaiters.splice(index, 1);
         }
@@ -209,7 +215,10 @@ test("bridge process preserves request_id for unsupported commands", async () =>
 
     assertProtocolEvent(envelope, "connection_failed");
     assert.equal(envelope.request_id, "req-unsupported");
-    assert.match(String(envelope.message), /unsupported command: future_command/);
+    assert.match(
+      String(envelope.message),
+      /unsupported command: future_command/,
+    );
   } finally {
     await bridge.stop();
   }
@@ -256,8 +265,14 @@ test("bridge process reports actionable session initialization failure", async (
 
     assertProtocolEvent(envelope, "connection_failed");
     assert.equal(envelope.request_id, "req-create");
-    assert.match(String(envelope.message), /bridge command failed \(create_session\)/);
-    assert.match(String(envelope.message), /CLAUDE_CODE_EXECUTABLE does not exist/);
+    assert.match(
+      String(envelope.message),
+      /bridge command failed \(create_session\)/,
+    );
+    assert.match(
+      String(envelope.message),
+      /CLAUDE_CODE_EXECUTABLE does not exist/,
+    );
   } finally {
     await bridge.stop();
   }

--- a/agent-sdk/src/bridge.test.ts
+++ b/agent-sdk/src/bridge.test.ts
@@ -69,6 +69,7 @@ import {
   handleUserDialogResponse,
   closeSession,
   closeSessionsBeforeRegister,
+  commitDeferredSession,
   refreshCurrentModel,
   resolveCurrentModel,
   sessions,
@@ -78,20 +79,35 @@ import {
 } from "./bridge/session_lifecycle.js";
 import {
   classifyTurnErrorKind,
+  emitAuthRequired,
   setFastModeSnapshotIfChanged,
 } from "./bridge/error_classification.js";
 import {
   buildConnectBridgeEvent,
+  emitSessionResumeFailed,
+  emitSessionUpdate,
   replaceProtocolEventWriter,
+  writeEvent,
 } from "./bridge/events.js";
-import { emitToolCall, emitToolProgressUpdate, emitToolResultUpdate } from "./bridge/tool_calls.js";
+import {
+  emitToolCall,
+  emitToolProgressUpdate,
+  emitToolResultUpdate,
+} from "./bridge/tool_calls.js";
 import { linkTaskToolUse } from "./bridge/task_links.js";
 import { requestAskUserQuestionAnswers } from "./bridge/user_interaction.js";
-import { flushPendingWorkerShutdown, handleResultMessage } from "./bridge/message_handlers.js";
+import {
+  flushPendingWorkerShutdown,
+  handleResultMessage,
+} from "./bridge/message_handlers.js";
 import { dispatchCancelTurnCommand } from "./bridge/command_dispatch.js";
+import { normalizeStructuredUsage } from "./bridge/command_session_data.js";
+import { handleLifecycleCommand } from "./bridge/command_lifecycle.js";
 
 const BRIDGE_RUNTIME_PROCESS_NAME =
-  process.platform === "win32" ? "claude-rs-bridge-bun.exe" : "claude-rs-bridge-bun";
+  process.platform === "win32"
+    ? "claude-rs-bridge-bun.exe"
+    : "claude-rs-bridge-bun";
 const BRIDGE_RUNTIME_GUARD_PROMPT =
   `Do not terminate the Claude Rust bridge runtime process \`${BRIDGE_RUNTIME_PROCESS_NAME}\`; ` +
   "when cleaning up development servers, only stop processes by explicit PIDs you started in this session.";
@@ -100,7 +116,9 @@ const GERMAN_LANGUAGE_PROMPT =
   "Keep code, shell commands, file paths, API names, tool names, and raw error text unchanged unless the user explicitly asks for translation.";
 
 function makeSessionState(): SessionState {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   return {
     sessionId: "session-1",
     cwd: "C:/work",
@@ -133,6 +151,21 @@ function makeSessionState(): SessionState {
     authHintSent: false,
   };
 }
+
+test("session resume failures carry their operation identity", () => {
+  const events = captureBridgeEvents(() => {
+    emitSessionResumeFailed("source-session", "resume-at-1", "resume rejected");
+  });
+
+  assert.deepEqual(events, [
+    {
+      request_id: "resume-at-1",
+      event: "session_resume_failed",
+      session_id: "source-session",
+      message: "resume rejected",
+    },
+  ]);
+});
 
 test("closeSessionsBeforeRegister closes same-key stale session before replacement registration", async () => {
   sessions.clear();
@@ -193,9 +226,11 @@ test("closeAllSessions waits for tracked stale-session cleanup", async () => {
   });
   trackSessionCloseTask(cleanup);
 
-  const closePromise = closeAllSessions({ reason: "test_shutdown" }).then(() => {
-    closeResolved = true;
-  });
+  const closePromise = closeAllSessions({ reason: "test_shutdown" }).then(
+    () => {
+      closeResolved = true;
+    },
+  );
   await Promise.resolve();
   assert.equal(closeResolved, false);
 
@@ -242,7 +277,8 @@ test("closeSession cancels and awaits one coalesced MCP auth monitor per server"
 
 test("replacement handoff suppresses an old session's in-flight MCP monitor snapshot", async () => {
   const session = makeSessionState();
-  type SdkMcpServerStatus = import("@anthropic-ai/claude-agent-sdk").McpServerStatus;
+  type SdkMcpServerStatus =
+    import("@anthropic-ai/claude-agent-sdk").McpServerStatus;
   let resolveStatus!: (statuses: SdkMcpServerStatus[]) => void;
   let statusStarted!: () => void;
   const started = new Promise<void>((resolve) => {
@@ -266,7 +302,9 @@ test("replacement handoff suppresses an old session's in-flight MCP monitor snap
     });
     await started;
     beginSessionClose(session);
-    resolveStatus([{ name: "docs", status: "connected" } as SdkMcpServerStatus]);
+    resolveStatus([
+      { name: "docs", status: "connected" } as SdkMcpServerStatus,
+    ]);
     const result = await monitor;
     assert.equal(result.outcome, "cancelled");
     assert.equal(session.closing, true);
@@ -346,10 +384,13 @@ test("refreshSupportedModesForSession retains current mode before capability dat
 
   refreshSupportedModesForSession(session);
 
-  assert.deepEqual(
-    session.supportedModeIds,
-    ["default", "auto", "acceptEdits", "plan", "dontAsk"],
-  );
+  assert.deepEqual(session.supportedModeIds, [
+    "default",
+    "auto",
+    "acceptEdits",
+    "plan",
+    "dontAsk",
+  ]);
 });
 
 test("markModeUnavailableForSession prunes rejected runtime mode from session list", () => {
@@ -447,6 +488,35 @@ async function captureBridgeEventsAsync(
     });
 }
 
+test("resume-at validation failures use the correlated failure event", async () => {
+  const events = await captureBridgeEventsAsync(async () => {
+    await handleLifecycleCommand(
+      {
+        command: "resume_session_at",
+        session_id: "source-session",
+        target_user_message_id: " ",
+        launch_settings: {},
+      },
+      "resume-at-invalid",
+      undefined,
+      {
+        buildRewindConversationPlan: () => {
+          throw new Error("unexpected plan construction");
+        },
+      },
+    );
+  });
+
+  assert.deepEqual(events, [
+    {
+      request_id: "resume-at-invalid",
+      event: "session_resume_failed",
+      session_id: "source-session",
+      message: "resume target cannot be empty",
+    },
+  ]);
+});
+
 test("parseCommandEnvelope validates initialize command", () => {
   const parsed = parseCommandEnvelope(
     JSON.stringify({
@@ -503,6 +573,26 @@ test("parseCommandEnvelope validates resume_session command without cwd", () => 
     terminalProgressBarEnabled: true,
   });
   assert.equal(parsed.command.launch_settings.agent_progress_summaries, true);
+});
+
+test("parseCommandEnvelope validates resume_session_at independently from plain resume", () => {
+  const parsed = parseCommandEnvelope(
+    JSON.stringify({
+      request_id: "req-resume-at",
+      command: "resume_session_at",
+      session_id: "session-123",
+      target_user_message_id: "user-2",
+      launch_settings: {},
+    }),
+  );
+
+  assert.equal(parsed.requestId, "req-resume-at");
+  assert.deepEqual(parsed.command, {
+    command: "resume_session_at",
+    session_id: "session-123",
+    target_user_message_id: "user-2",
+    launch_settings: {},
+  });
 });
 
 test("parseCommandEnvelope validates rename_session command", () => {
@@ -690,7 +780,9 @@ test("parseCommandEnvelope rejects invalid latest MCP config fields", () => {
         JSON.stringify({
           command: "mcp_set_servers",
           session_id: "session-123",
-          servers: { bad: { type: "http", url: "https://mcp.example.com", timeout: 999 } },
+          servers: {
+            bad: { type: "http", url: "https://mcp.example.com", timeout: 999 },
+          },
         }),
       ),
     /mcp_set_servers\.servers\.bad\.timeout must be an integer >= 1000/,
@@ -720,7 +812,13 @@ test("parseCommandEnvelope rejects invalid latest MCP config fields", () => {
         JSON.stringify({
           command: "mcp_set_servers",
           session_id: "session-123",
-          servers: { bad: { type: "http", url: "https://mcp.example.com", always_load: "yes" } },
+          servers: {
+            bad: {
+              type: "http",
+              url: "https://mcp.example.com",
+              always_load: "yes",
+            },
+          },
         }),
       ),
     /mcp_set_servers\.servers\.bad\.always_load must be a boolean/,
@@ -975,7 +1073,11 @@ test("bridgeMcpConfigToSdk maps latest MCP fields to SDK casing", () => {
       always_load: true,
       tools: [
         { name: "search" },
-        { name: "write", permission_policy: "always_allow", org_max_permission: "blocked" },
+        {
+          name: "write",
+          permission_policy: "always_allow",
+          org_max_permission: "blocked",
+        },
       ],
     }),
     {
@@ -986,7 +1088,11 @@ test("bridgeMcpConfigToSdk maps latest MCP fields to SDK casing", () => {
       alwaysLoad: true,
       tools: [
         { name: "search" },
-        { name: "write", permission_policy: "always_allow", org_max_permission: "blocked" },
+        {
+          name: "write",
+          permission_policy: "always_allow",
+          org_max_permission: "blocked",
+        },
       ],
     },
   );
@@ -1005,9 +1111,15 @@ test("mapMcpServerStatus preserves latest MCP status config fields", () => {
       alwaysLoad: true,
       tools: [
         { name: "search" },
-        { name: "write", permission_policy: "always_deny", org_max_permission: "ask" },
+        {
+          name: "write",
+          permission_policy: "always_deny",
+          org_max_permission: "ask",
+        },
       ],
-    } as unknown as NonNullable<import("@anthropic-ai/claude-agent-sdk").McpServerStatus["config"]>,
+    } as unknown as NonNullable<
+      import("@anthropic-ai/claude-agent-sdk").McpServerStatus["config"]
+    >,
     tools: [],
   });
 
@@ -1020,7 +1132,11 @@ test("mapMcpServerStatus preserves latest MCP status config fields", () => {
     always_load: true,
     tools: [
       { name: "search" },
-      { name: "write", permission_policy: "always_deny", org_max_permission: "ask" },
+      {
+        name: "write",
+        permission_policy: "always_deny",
+        org_max_permission: "ask",
+      },
     ],
   });
 });
@@ -1029,7 +1145,9 @@ test("mapMcpServerStatusConfig maps unknown config types without throwing", () =
   const mapped = mapMcpServerStatusConfig({
     type: "future-transport",
     url: "future://server",
-  } as unknown as NonNullable<import("@anthropic-ai/claude-agent-sdk").McpServerStatus["config"]>);
+  } as unknown as NonNullable<
+    import("@anthropic-ai/claude-agent-sdk").McpServerStatus["config"]
+  >);
 
   assert.deepEqual(mapped, { type: "unknown", raw_type: "future-transport" });
 });
@@ -1209,6 +1327,106 @@ test("parseCommandEnvelope validates get_context_usage command", () => {
   });
 });
 
+test("parseCommandEnvelope validates get_usage command", () => {
+  const parsed = parseCommandEnvelope(
+    JSON.stringify({ command: "get_usage", session_id: "session-usage" }),
+  );
+
+  assert.deepEqual(parsed.command, {
+    command: "get_usage",
+    session_id: "session-usage",
+  });
+});
+
+test("normalizeStructuredUsage keeps stable fields and tolerates malformed optional data", () => {
+  const snapshot = normalizeStructuredUsage({
+    subscription_type: " max ",
+    rate_limits_available: true,
+    rate_limits: {
+      five_hour: { utilization: 125, resets_at: " 2026-08-12T10:00:00Z " },
+      seven_day: { utilization: "bad", resets_at: null },
+      seven_day_oauth_apps: { utilization: 18, resets_at: null },
+      model_scoped: [
+        {
+          display_name: " Fable ",
+          utilization: 33,
+          resets_at: "2026-08-18T10:00:00Z",
+        },
+        { display_name: "Broken", utilization: null, resets_at: null },
+      ],
+      extra_usage: {
+        is_enabled: true,
+        monthly_limit: 2_000,
+        used_credits: 375,
+        utilization: -4,
+        currency: " USD ",
+      },
+    },
+    session: {
+      total_cost_usd: 0.125,
+      total_api_duration_ms: 1_500,
+      total_duration_ms: 2_000,
+      total_lines_added: 12,
+      total_lines_removed: 3,
+      model_usage: { opus: {}, sonnet: {} },
+    },
+    behaviors: {
+      day: {
+        request_count: 4.9,
+        session_count: 2,
+        behaviors: [{ key: "long_context", pct: 25, count: 1 }],
+        agents: [{ name: "Explore", pct: 40 }],
+        skills: [{ name: "review", pct: 20 }],
+        plugins: [],
+        mcp_servers: [{ name: "github", pct: 10 }],
+      },
+      week: { request_count: -1, session_count: 3 },
+    },
+  });
+
+  assert.deepEqual(snapshot, {
+    subscription_type: "max",
+    rate_limits_available: true,
+    five_hour: { utilization: 100, resets_at: "2026-08-12T10:00:00Z" },
+    seven_day_oauth_apps: { utilization: 18 },
+    model_scoped: [
+      {
+        display_name: "Fable",
+        utilization: 33,
+        resets_at: "2026-08-18T10:00:00Z",
+      },
+    ],
+    extra_usage: {
+      monthly_limit: 2_000,
+      used_credits: 375,
+      utilization: 0,
+      currency: "USD",
+    },
+    session: {
+      total_cost_usd: 0.125,
+      total_api_duration_ms: 1_500,
+      total_duration_ms: 2_000,
+      total_lines_added: 12,
+      total_lines_removed: 3,
+      model_count: 2,
+    },
+    activity_day: {
+      request_count: 4,
+      session_count: 2,
+      behaviors: [{ key: "long_context", pct: 25, count: 1 }],
+      agents: [{ name: "Explore", pct: 40 }],
+      skills: [{ name: "review", pct: 20 }],
+      plugins: [],
+      mcp_servers: [{ name: "github", pct: 10 }],
+    },
+  });
+});
+
+test("normalizeStructuredUsage isolates an incompatible root as an empty snapshot", () => {
+  assert.deepEqual(normalizeStructuredUsage(null), {});
+  assert.deepEqual(normalizeStructuredUsage("not-an-object"), {});
+});
+
 test("parseCommandEnvelope validates get_rewind_targets command", () => {
   const parsed = parseCommandEnvelope(
     JSON.stringify({
@@ -1235,8 +1453,14 @@ test("mapRewindFilesResult preserves valid skipped link counts", () => {
     can_rewind: true,
     files_changed: ["src/main.rs"],
   });
-  assert.equal(mapRewindFilesResult({ ...base, skippedLinks: 0 }).skipped_links, 0);
-  assert.equal(mapRewindFilesResult({ ...base, skippedLinks: 2 }).skipped_links, 2);
+  assert.equal(
+    mapRewindFilesResult({ ...base, skippedLinks: 0 }).skipped_links,
+    0,
+  );
+  assert.equal(
+    mapRewindFilesResult({ ...base, skippedLinks: 2 }).skipped_links,
+    2,
+  );
 });
 
 test("mapRewindFilesResult drops malformed skipped link counts", () => {
@@ -1245,7 +1469,10 @@ test("mapRewindFilesResult drops malformed skipped link counts", () => {
     filesChanged: [],
   };
   for (const skippedLinks of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
-    assert.equal(mapRewindFilesResult({ ...base, skippedLinks }).skipped_links, undefined);
+    assert.equal(
+      mapRewindFilesResult({ ...base, skippedLinks }).skipped_links,
+      undefined,
+    );
   }
 });
 
@@ -1295,22 +1522,34 @@ test("rewindTargetsFromSessionMessages filters user text messages with UUIDs", (
     {
       type: "user",
       uuid: "user-1",
-      message: { role: "user", content: [{ type: "text", text: " first prompt\nline " }] },
+      message: {
+        role: "user",
+        content: [{ type: "text", text: " first prompt\nline " }],
+      },
     },
     {
       type: "assistant",
       uuid: "assistant-1",
-      message: { role: "assistant", content: [{ type: "text", text: "ignored" }] },
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "ignored" }],
+      },
     },
     {
       type: "user",
       uuid: "tool-result",
-      message: { role: "user", content: [{ type: "tool_result", content: "ignored" }] },
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: "ignored" }],
+      },
     },
     {
       type: "user",
       uuid: "user-2",
-      message: { role: "user", content: [{ type: "text", text: "second prompt" }] },
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "second prompt" }],
+      },
     },
   ] as unknown as SessionMessage[];
 
@@ -1321,6 +1560,7 @@ test("rewindTargetsFromSessionMessages filters user text messages with UUIDs", (
       input_text: "second prompt",
       index: 3,
       previous_assistant_uuid: "assistant-1",
+      resume_anchor_uuid: "tool-result",
     },
     {
       uuid: "user-1",
@@ -1331,7 +1571,7 @@ test("rewindTargetsFromSessionMessages filters user text messages with UUIDs", (
   ]);
 });
 
-test("buildRewindConversationPlan anchors at previous assistant message", () => {
+test("buildRewindConversationPlan anchors at the last kept chain entry", () => {
   const messages = [
     {
       type: "user",
@@ -1341,7 +1581,10 @@ test("buildRewindConversationPlan anchors at previous assistant message", () => 
     {
       type: "assistant",
       uuid: "assistant-1",
-      message: { role: "assistant", content: [{ type: "text", text: "reply" }] },
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "reply" }],
+      },
     },
     {
       type: "user",
@@ -1355,6 +1598,8 @@ test("buildRewindConversationPlan anchors at previous assistant message", () => 
   assert.ok(plan);
   assert.equal(plan.inputText, "second prompt");
   assert.equal(plan.previousAssistantUuid, "assistant-1");
+  assert.equal(plan.resumeSessionAtUuid, "assistant-1");
+  assert.equal(plan.resumeDropsTurnId, "user-2");
   assert.equal(plan.targetIndex, 2);
   assert.deepEqual(
     plan.retainedMessages.map((message) => message.uuid),
@@ -1373,7 +1618,10 @@ test("buildRewindConversationPlan treats first user message as fresh replacement
     {
       type: "assistant",
       uuid: "assistant-1",
-      message: { role: "assistant", content: [{ type: "text", text: "reply" }] },
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "reply" }],
+      },
     },
   ] as unknown as SessionMessage[];
 
@@ -1382,12 +1630,14 @@ test("buildRewindConversationPlan treats first user message as fresh replacement
   assert.ok(plan);
   assert.equal(plan.inputText, " first prompt\nline ");
   assert.equal(plan.previousAssistantUuid, undefined);
+  assert.equal(plan.resumeSessionAtUuid, undefined);
+  assert.equal(plan.resumeDropsTurnId, undefined);
   assert.equal(plan.targetIndex, 0);
   assert.deepEqual(plan.retainedMessages, []);
   assert.deepEqual(plan.resumeUpdates, []);
 });
 
-test("buildRewindConversationPlan rejects stale or inconsistent targets", () => {
+test("buildRewindConversationPlan accepts a queued prompt and rejects stale targets", () => {
   const messages = [
     {
       type: "user",
@@ -1402,7 +1652,109 @@ test("buildRewindConversationPlan rejects stale or inconsistent targets", () => 
   ] as unknown as SessionMessage[];
 
   assert.equal(buildRewindConversationPlan(messages, "missing-user"), null);
-  assert.equal(buildRewindConversationPlan(messages, "user-2"), null);
+  const queuedPromptPlan = buildRewindConversationPlan(messages, "user-2");
+  assert.ok(queuedPromptPlan);
+  assert.equal(queuedPromptPlan.resumeSessionAtUuid, "user-1");
+  assert.equal(queuedPromptPlan.resumeDropsTurnId, "user-2");
+});
+
+test("buildRewindConversationPlan leaves older truncation boundaries unguarded", () => {
+  const messages = [
+    {
+      type: "user",
+      uuid: "user-1",
+      message: { role: "user", content: "first prompt" },
+    },
+    {
+      type: "assistant",
+      uuid: "assistant-1",
+      message: { role: "assistant", content: "first response" },
+    },
+    {
+      type: "user",
+      uuid: "user-2",
+      message: { role: "user", content: "second prompt" },
+    },
+    {
+      type: "assistant",
+      uuid: "assistant-2",
+      message: { role: "assistant", content: "second response" },
+    },
+    {
+      type: "user",
+      uuid: "user-3",
+      message: { role: "user", content: "third prompt" },
+    },
+  ] as unknown as SessionMessage[];
+
+  const olderPlan = buildRewindConversationPlan(messages, "user-2");
+  const tailPlan = buildRewindConversationPlan(messages, "user-3");
+
+  assert.ok(olderPlan);
+  assert.equal(olderPlan.resumeSessionAtUuid, "assistant-1");
+  assert.equal(olderPlan.resumeDropsTurnId, undefined);
+  assert.ok(tailPlan);
+  assert.equal(tailPlan.resumeSessionAtUuid, "assistant-2");
+  assert.equal(tailPlan.resumeDropsTurnId, "user-3");
+});
+
+test("buildRewindConversationPlan anchors after kept turn attachments", () => {
+  const messages = [
+    {
+      type: "user",
+      uuid: "user-1",
+      message: { role: "user", content: "first prompt" },
+    },
+    {
+      type: "assistant",
+      uuid: "assistant-1",
+      message: { role: "assistant", content: "tool response" },
+    },
+    {
+      type: "system",
+      uuid: "structured-output-1",
+      subtype: "structured_output",
+      data: { result: "kept output" },
+    },
+    {
+      type: "user",
+      uuid: "user-2",
+      message: { role: "user", content: "second prompt" },
+    },
+  ] as unknown as SessionMessage[];
+
+  const plan = buildRewindConversationPlan(messages, "user-2");
+
+  assert.ok(plan);
+  assert.equal(plan.previousAssistantUuid, "assistant-1");
+  assert.equal(plan.resumeSessionAtUuid, "structured-output-1");
+  assert.equal(plan.resumeDropsTurnId, "user-2");
+});
+
+test("buildRewindConversationPlan rejects empty and duplicate chain UUIDs", () => {
+  const duplicate = [
+    { type: "user", uuid: "same", message: { role: "user", content: "first" } },
+    {
+      type: "assistant",
+      uuid: "same",
+      message: { role: "assistant", content: "reply" },
+    },
+  ] as unknown as SessionMessage[];
+  const empty = [
+    {
+      type: "user",
+      uuid: "user-1",
+      message: { role: "user", content: "first" },
+    },
+    {
+      type: "assistant",
+      uuid: " ",
+      message: { role: "assistant", content: "reply" },
+    },
+  ] as unknown as SessionMessage[];
+
+  assert.equal(buildRewindConversationPlan(duplicate, "same"), null);
+  assert.equal(buildRewindConversationPlan(empty, "user-1"), null);
 });
 
 test("staleMcpAuthCandidates selects previously connected servers that regressed to needs-auth", () => {
@@ -1459,7 +1811,8 @@ test("staleMcpAuthCandidates respects the revalidation cooldown", () => {
 });
 
 test("MCP connection history is isolated between sessions with the same server name", async () => {
-  type SdkMcpServerStatus = import("@anthropic-ai/claude-agent-sdk").McpServerStatus;
+  type SdkMcpServerStatus =
+    import("@anthropic-ai/claude-agent-sdk").McpServerStatus;
   const connected = {
     name: "docs",
     status: "connected",
@@ -1491,7 +1844,9 @@ test("MCP connection history is isolated between sessions with the same server n
 });
 
 test("buildSessionMutationOptions scopes rename requests to the session cwd", () => {
-  assert.deepEqual(buildSessionMutationOptions("C:/worktree"), { dir: "C:/worktree" });
+  assert.deepEqual(buildSessionMutationOptions("C:/worktree"), {
+    dir: "C:/worktree",
+  });
   assert.equal(buildSessionMutationOptions(undefined), undefined);
 });
 
@@ -1503,7 +1858,12 @@ test("canGenerateSessionTitle detects supported query objects", () => {
   } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
 
   assert.equal(canGenerateSessionTitle(query), true);
-  assert.equal(canGenerateSessionTitle({} as import("@anthropic-ai/claude-agent-sdk").Query), false);
+  assert.equal(
+    canGenerateSessionTitle(
+      {} as import("@anthropic-ai/claude-agent-sdk").Query,
+    ),
+    false,
+  );
 });
 
 test("generatePersistedSessionTitle calls sdk query with persist true", async () => {
@@ -1525,7 +1885,9 @@ test("generatePersistedSessionTitle calls sdk query with persist true", async ()
 });
 
 test("buildQueryOptions maps launch settings into sdk query options", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {
@@ -1566,7 +1928,8 @@ test("buildQueryOptions maps launch settings into sdk query options", () => {
     preset: "claude_code",
     append: `${BRIDGE_RUNTIME_GUARD_PROMPT} ${GERMAN_LANGUAGE_PROMPT}`,
   });
-  const _systemPrompt: NonNullable<Options["systemPrompt"]> = options.systemPrompt;
+  const _systemPrompt: NonNullable<Options["systemPrompt"]> =
+    options.systemPrompt;
   assert.ok(_systemPrompt);
   assert.equal(options.model, "haiku");
   assert.equal(options.permissionMode, "plan");
@@ -1576,7 +1939,7 @@ test("buildQueryOptions maps launch settings into sdk query options", () => {
   assert.equal(options.agentProgressSummaries, true);
   assert.equal(options.promptSuggestions, true);
   assert.equal(options.enableFileCheckpointing, true);
-  assert.deepEqual(options.disallowedTools, ["ProposeSkills"]);
+  assert.deepEqual(options.disallowedTools, ["ProposeSkills", "ProposeGoal"]);
   assert.equal(options.executable, "bun");
   assert.equal(options.sessionId, "session-1");
   assert.deepEqual(options.settingSources, ["user", "project", "local"]);
@@ -1586,11 +1949,15 @@ test("buildQueryOptions maps launch settings into sdk query options", () => {
 });
 
 test("buildQueryOptions includes resumeSessionAt when provided", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     resume: "session-1",
     resumeSessionAt: "assistant-1",
+    resumeDropsTurn: "user-2",
+    forkSession: true,
     launchSettings: {},
     provisionalSessionId: "session-1",
     input,
@@ -1602,11 +1969,15 @@ test("buildQueryOptions includes resumeSessionAt when provided", () => {
 
   assert.equal(options.resume, "session-1");
   assert.equal(options.resumeSessionAt, "assistant-1");
-  assert.equal("sessionId" in options, false);
+  assert.equal(options.resumeDropsTurn, "user-2");
+  assert.equal(options.forkSession, true);
+  assert.equal(options.sessionId, "session-1");
 });
 
 test("buildQueryOptions forwards settings and maps startup model and permission mode", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {
@@ -1646,7 +2017,9 @@ test("buildQueryOptions forwards settings and maps startup model and permission 
 });
 
 test("buildQueryOptions normalizes manual startup permission mode to default", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {
@@ -1666,7 +2039,9 @@ test("buildQueryOptions normalizes manual startup permission mode to default", (
 });
 
 test("buildQueryOptions trims startup model before passing sdk option", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {
@@ -1688,7 +2063,9 @@ test("buildQueryOptions trims startup model before passing sdk option", () => {
 });
 
 test("buildQueryOptions maps auto startup permission mode", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {
@@ -1709,7 +2086,9 @@ test("buildQueryOptions maps auto startup permission mode", () => {
 });
 
 test("buildQueryOptions enables dangerous skip flag for bypass permissions startup mode", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {
@@ -1731,7 +2110,9 @@ test("buildQueryOptions enables dangerous skip flag for bypass permissions start
 });
 
 test("buildQueryOptions omits optional startup overrides but keeps bridge guard prompt", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {},
@@ -1756,7 +2137,9 @@ test("buildQueryOptions omits optional startup overrides but keeps bridge guard 
 });
 
 test("buildQueryOptions disables feedback drafts without mutating launch settings", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const settings = {
     feedbackDrafts: "notify",
     spinnerTipsEnabled: true,
@@ -1785,7 +2168,11 @@ test("buildQueryOptions disables feedback drafts without mutating launch setting
 test("dispatchCancelTurnCommand interrupts the matching session query", async () => {
   let interruptCount = 0;
   let receiptReturned = false;
-  const slashErrors: Array<{ sessionId: string; message: string; requestId?: string }> = [];
+  const slashErrors: Array<{
+    sessionId: string;
+    message: string;
+    requestId?: string;
+  }> = [];
 
   await dispatchCancelTurnCommand(
     { command: "cancel_turn", session_id: "session-1" },
@@ -1816,7 +2203,11 @@ test("dispatchCancelTurnCommand interrupts the matching session query", async ()
 
 test("dispatchCancelTurnCommand emits slash error for unknown session", async () => {
   const interruptCount = 0;
-  const slashErrors: Array<{ sessionId: string; message: string; requestId?: string }> = [];
+  const slashErrors: Array<{
+    sessionId: string;
+    message: string;
+    requestId?: string;
+  }> = [];
 
   await dispatchCancelTurnCommand(
     { command: "cancel_turn", session_id: "missing-session" },
@@ -1844,12 +2235,20 @@ test("resolveClaudeCodeSpawnCommand remaps bare bun to the bridge runtime execut
 });
 
 test("resolveClaudeCodeSpawnCommand preserves commands with path separators", () => {
-  assert.equal(resolveClaudeCodeSpawnCommand("/opt/runtime/bun"), "/opt/runtime/bun");
-  assert.equal(resolveClaudeCodeSpawnCommand("C:\\runtime\\bun.exe"), "C:\\runtime\\bun.exe");
+  assert.equal(
+    resolveClaudeCodeSpawnCommand("/opt/runtime/bun"),
+    "/opt/runtime/bun",
+  );
+  assert.equal(
+    resolveClaudeCodeSpawnCommand("C:\\runtime\\bun.exe"),
+    "C:\\runtime\\bun.exe",
+  );
 });
 
 test("buildQueryOptions spawn hook remaps bare bun command", async () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {},
@@ -1885,7 +2284,9 @@ test("buildQueryOptions spawn hook remaps bare bun command", async () => {
 });
 
 test("buildQueryOptions forwards SDK-provided spawn env without passing top-level env", async () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {},
@@ -1936,7 +2337,9 @@ test("buildQueryOptions forwards SDK-provided spawn env without passing top-leve
 });
 
 test("buildQueryOptions makes sandbox fallback explicit when enabled", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {
@@ -1964,7 +2367,9 @@ test("buildQueryOptions makes sandbox fallback explicit when enabled", () => {
 });
 
 test("buildQueryOptions preserves explicit sandbox failIfUnavailable setting", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {
@@ -1993,7 +2398,9 @@ test("buildQueryOptions preserves explicit sandbox failIfUnavailable setting", (
 });
 
 test("buildQueryOptions preserves target sandbox network and filesystem fields", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {
@@ -2015,6 +2422,60 @@ test("buildQueryOptions preserves target sandbox network and filesystem fields",
   assert.deepEqual(options.settings?.sandbox, {
     network: { strictAllowlist: true },
     filesystem: { disabled: true },
+  });
+});
+
+test("buildQueryOptions preserves nested sandbox credential controls", () => {
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
+  const credentials = {
+    files: [
+      {
+        path: ".secrets/token",
+        mode: "mask",
+        extract: "token=(.+)",
+        onExtractNoMatch: "deny",
+        decode: "jwt",
+        maskClaims: ["sub"],
+        maskDuplicates: true,
+        injectHosts: ["api.example.test"],
+      },
+    ],
+    envVars: [
+      {
+        name: "API_TOKEN",
+        mode: "mask",
+        decode: "jwt",
+        maskClaims: ["sub"],
+        injectHosts: ["api.example.test"],
+      },
+    ],
+    allowPlaintextInject: false,
+    awsPairs: [
+      {
+        accessKeyIdVar: "AWS_ACCESS_KEY_ID",
+        secretAccessKeyVar: "AWS_SECRET_ACCESS_KEY",
+        sessionTokenVar: "AWS_SESSION_TOKEN",
+      },
+    ],
+    sigv4: { streaming: "deny", presigned: "passthrough", sigv4a: "deny" },
+  };
+  const options = buildQueryOptions({
+    cwd: "C:/work",
+    launchSettings: { settings: { sandbox: { enabled: true, credentials } } },
+    provisionalSessionId: "session-sandbox-credentials",
+    input,
+    canUseTool: async () => ({ behavior: "deny", message: "not used" }),
+    enableSdkDebug: false,
+    enableSpawnDebug: false,
+    sessionIdForLogs: () => "session-sandbox-credentials",
+  });
+
+  assert.deepEqual(options.settings?.sandbox, {
+    enabled: true,
+    failIfUnavailable: false,
+    credentials,
   });
 });
 
@@ -2085,7 +2546,10 @@ test("handleTaskSystemMessage falls back to description and last tool when progr
         content: [
           {
             type: "content",
-            content: { type: "text", text: "Inspecting auth code (last tool: Read)" },
+            content: {
+              type: "text",
+              text: "Inspecting auth code (last tool: Read)",
+            },
           },
         ],
       },
@@ -2164,7 +2628,10 @@ test("handleTaskSystemMessage keeps Agent completed notification provisional unt
         content: [
           {
             type: "content",
-            content: { type: "text", text: "Found the auth bug and prepared the fix" },
+            content: {
+              type: "text",
+              text: "Found the auth bug and prepared the fix",
+            },
           },
         ],
         task_metadata: {
@@ -2267,7 +2734,10 @@ test("handleTaskSystemMessage ignores lifecycle content for concrete output tool
   for (const toolCall of protectedTools) {
     const stored = session.toolCalls.get(toolCall.tool_call_id);
     assert.equal(stored?.status, "in_progress");
-    assert.equal(stored?.raw_output, `actual output for ${toolCall.tool_call_id}`);
+    assert.equal(
+      stored?.raw_output,
+      `actual output for ${toolCall.tool_call_id}`,
+    );
   }
 });
 
@@ -2292,7 +2762,9 @@ test("handleSdkMessage ignores tool_use_summary for Bash Read and Write tools", 
     handleSdkMessage(session, {
       type: "tool_use_summary",
       summary: "Show commits on this branch since diverging from main",
-      preceding_tool_use_ids: protectedTools.map((toolCall) => toolCall.tool_call_id),
+      preceding_tool_use_ids: protectedTools.map(
+        (toolCall) => toolCall.tool_call_id,
+      ),
       uuid: "message-summary",
       session_id: "session-1",
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
@@ -2309,7 +2781,9 @@ test("handleSdkMessage ignores tool_use_summary for Bash Read and Write tools", 
 
 test("handleSdkMessage applies tool_use_summary for summary-oriented tools", () => {
   const session = makeSessionState();
-  const toolCall = createToolCall("tool-agent", "Agent", { prompt: "Inspect auth flow" });
+  const toolCall = createToolCall("tool-agent", "Agent", {
+    prompt: "Inspect auth flow",
+  });
   session.toolCalls.set(toolCall.tool_call_id, toolCall);
 
   const events = captureBridgeEvents(() => {
@@ -2335,13 +2809,19 @@ test("handleSdkMessage applies tool_use_summary for summary-oriented tools", () 
         content: [
           {
             type: "content",
-            content: { type: "text", text: "Inspected auth flow and found the failing check" },
+            content: {
+              type: "text",
+              text: "Inspected auth flow and found the failing check",
+            },
           },
         ],
       },
     },
   });
-  assert.equal(session.toolCalls.get(toolCall.tool_call_id)?.raw_output, "Inspected auth flow and found the failing check");
+  assert.equal(
+    session.toolCalls.get(toolCall.tool_call_id)?.raw_output,
+    "Inspected auth flow and found the failing check",
+  );
 });
 
 test("handleSdkMessage suppresses ToolSearch bridge events without denying SDK use", () => {
@@ -2412,6 +2892,7 @@ test("handleSdkMessage emits transcript retraction for model_refusal_fallback", 
       direction: "retry",
       original_model: "claude-opus-4-1",
       fallback_model: "claude-sonnet-4-5",
+      scope: "local",
       request_id: "req-1",
       api_refusal_category: "cyber",
       api_refusal_explanation: "policy text",
@@ -2422,25 +2903,30 @@ test("handleSdkMessage emits transcript retraction for model_refusal_fallback", 
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "transcript_retraction",
-      message_uuids: ["assistant-old"],
-      reason: "model_refusal_fallback",
-      request_id: "req-1",
-      trigger: "refusal",
-      direction: "retry",
-      original_model: "claude-opus-4-1",
-      fallback_model: "claude-sonnet-4-5",
-      api_refusal_category: "cyber",
-      api_refusal_explanation: "policy text",
-      content: "Retried with fallback model",
-    },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "transcript_retraction",
+        message_uuids: ["assistant-old"],
+        reason: "model_refusal_fallback",
+        request_id: "req-1",
+        trigger: "refusal",
+        direction: "retry",
+        original_model: "claude-opus-4-1",
+        fallback_model: "claude-sonnet-4-5",
+        scope: "local",
+        api_refusal_category: "cyber",
+        api_refusal_explanation: "policy text",
+        content: "Retried with fallback model",
+      },
+    ],
+  );
   assert.equal(
     events.some(
       (event) =>
-        (event.update as Record<string, unknown> | undefined)?.type === "system_notice_update",
+        (event.update as Record<string, unknown> | undefined)?.type ===
+        "system_notice_update",
     ),
     false,
   );
@@ -2464,14 +2950,17 @@ test("handleSdkMessage emits warning notice for model_refusal_no_fallback with e
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "system_notice_update",
-      severity: "warning",
-      message:
-        "Could not continue with claude-opus-4-1: model refused the request and no fallback model is configured. Reason: policy text.",
-    },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "system_notice_update",
+        severity: "warning",
+        message:
+          "Could not continue with claude-opus-4-1: model refused the request and no fallback model is configured. Reason: policy text.",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage emits warning notice for model_refusal_no_fallback with category only", () => {
@@ -2489,14 +2978,17 @@ test("handleSdkMessage emits warning notice for model_refusal_no_fallback with c
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "system_notice_update",
-      severity: "warning",
-      message:
-        "Could not continue with claude-opus-4-1: model refused the request and no fallback model is configured. Refusal category: cyber.",
-    },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "system_notice_update",
+        severity: "warning",
+        message:
+          "Could not continue with claude-opus-4-1: model refused the request and no fallback model is configured. Refusal category: cyber.",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage emits warning notice for model_refusal_no_fallback with content detail", () => {
@@ -2514,14 +3006,17 @@ test("handleSdkMessage emits warning notice for model_refusal_no_fallback with c
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "system_notice_update",
-      severity: "warning",
-      message:
-        "Could not continue with claude-opus-4-1: model refused the request and no fallback model is configured. Refused by policy!",
-    },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "system_notice_update",
+        severity: "warning",
+        message:
+          "Could not continue with claude-opus-4-1: model refused the request and no fallback model is configured. Refused by policy!",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage emits readable model_refusal_no_fallback notice for empty metadata", () => {
@@ -2542,14 +3037,17 @@ test("handleSdkMessage emits readable model_refusal_no_fallback notice for empty
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "system_notice_update",
-      severity: "warning",
-      message:
-        "Could not continue with the selected model: model refused the request and no fallback model is configured.",
-    },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "system_notice_update",
+        severity: "warning",
+        message:
+          "Could not continue with the selected model: model refused the request and no fallback model is configured.",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage emits tolerant transcript retraction for model_fallback", () => {
@@ -2567,15 +3065,19 @@ test("handleSdkMessage emits tolerant transcript retraction for model_fallback",
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "transcript_retraction",
-      message_uuids: ["old-1", "old-2"],
-      reason: "model_fallback",
-      original_model: "claude-opus-4-1",
-      fallback_model: "claude-sonnet-4-5",
-    },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "transcript_retraction",
+        message_uuids: ["old-1", "old-2"],
+        reason: "model_fallback",
+        original_model: "claude-opus-4-1",
+        fallback_model: "claude-sonnet-4-5",
+        scope: "session",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage emits assistant supersedes before replacement content", () => {
@@ -2590,33 +3092,41 @@ test("handleSdkMessage emits assistant supersedes before replacement content", (
       message: {
         role: "assistant",
         content: [
-          { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "echo ok" } },
+          {
+            type: "tool_use",
+            id: "tool-1",
+            name: "Bash",
+            input: { command: "echo ok" },
+          },
         ],
       },
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "transcript_retraction",
-      message_uuids: ["assistant-old"],
-      reason: "assistant_supersedes",
-    },
-    {
-      type: "tool_call",
-      tool_call: {
-        tool_call_id: "tool-1",
-        title: "echo ok",
-        kind: "execute",
-        status: "in_progress",
-        source_message_uuid: "assistant-new",
-        content: [],
-        raw_input: { command: "echo ok" },
-        locations: [],
-        meta: { claudeCode: { toolName: "Bash", parentToolUseId: null } },
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "transcript_retraction",
+        message_uuids: ["assistant-old"],
+        reason: "assistant_supersedes",
       },
-    },
-  ]);
+      {
+        type: "tool_call",
+        tool_call: {
+          tool_call_id: "tool-1",
+          title: "echo ok",
+          kind: "execute",
+          status: "in_progress",
+          source_message_uuid: "assistant-new",
+          content: [],
+          raw_input: { command: "echo ok" },
+          locations: [],
+          meta: { claudeCode: { toolName: "Bash", parentToolUseId: null } },
+        },
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage propagates source UUIDs for stream text and tool results", () => {
@@ -2654,7 +3164,12 @@ test("handleSdkMessage propagates source UUIDs for stream text and tool results"
       message: {
         role: "user",
         content: [
-          { type: "tool_result", tool_use_id: "tool-1", content: "ok", is_error: false },
+          {
+            type: "tool_result",
+            tool_use_id: "tool-1",
+            content: "ok",
+            is_error: false,
+          },
         ],
       },
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
@@ -2690,7 +3205,9 @@ test("handleSdkMessage propagates source UUIDs for stream text and tool results"
           fields: {
             status: "completed",
             raw_output: "ok",
-            content: [{ type: "content", content: { type: "text", text: "ok" } }],
+            content: [
+              { type: "content", content: { type: "text", text: "ok" } },
+            ],
           },
         },
       },
@@ -2727,44 +3244,55 @@ test("handleSdkMessage refreshes Grep title when final assistant snapshot carrie
             type: "tool_use",
             id: "tool-grep",
             name: "Grep",
-            input: { pattern: "<rare string>", output_mode: "content", "-n": true },
+            input: {
+              pattern: "<rare string>",
+              output_mode: "content",
+              "-n": true,
+            },
           },
         ],
       },
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "tool_call",
-      tool_call: {
-        tool_call_id: "tool-grep",
-        title: "Grep",
-        kind: "search",
-        status: "in_progress",
-        source_message_uuid: "assistant-stream",
-        content: [],
-        raw_input: {},
-        locations: [],
-        meta: { claudeCode: { toolName: "Grep", parentToolUseId: null } },
-      },
-    },
-    {
-      type: "tool_call_update",
-      tool_call_update: {
-        tool_call_id: "tool-grep",
-        source_message_uuid: "assistant-final",
-        fields: {
-          title: "Grep <rare string> (content)",
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "tool_call",
+        tool_call: {
+          tool_call_id: "tool-grep",
+          title: "Grep",
           kind: "search",
           status: "in_progress",
-          raw_input: { pattern: "<rare string>", output_mode: "content", "-n": true },
+          source_message_uuid: "assistant-stream",
+          content: [],
+          raw_input: {},
           locations: [],
           meta: { claudeCode: { toolName: "Grep", parentToolUseId: null } },
         },
       },
-    },
-  ]);
+      {
+        type: "tool_call_update",
+        tool_call_update: {
+          tool_call_id: "tool-grep",
+          source_message_uuid: "assistant-final",
+          fields: {
+            title: "Grep <rare string> (content)",
+            kind: "search",
+            status: "in_progress",
+            raw_input: {
+              pattern: "<rare string>",
+              output_mode: "content",
+              "-n": true,
+            },
+            locations: [],
+            meta: { claudeCode: { toolName: "Grep", parentToolUseId: null } },
+          },
+        },
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage refreshes Agent title when final assistant snapshot carries input", () => {
@@ -2809,43 +3337,46 @@ test("handleSdkMessage refreshes Agent title when final assistant snapshot carri
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "tool_call",
-      tool_call: {
-        tool_call_id: "tool-agent",
-        title: "Agent",
-        kind: "think",
-        status: "in_progress",
-        source_message_uuid: "assistant-stream",
-        content: [],
-        raw_input: {},
-        locations: [],
-        meta: { claudeCode: { toolName: "Agent", parentToolUseId: null } },
-      },
-    },
-    {
-      type: "tool_call_update",
-      tool_call_update: {
-        tool_call_id: "tool-agent",
-        source_message_uuid: "assistant-final",
-        fields: {
-          title: "Agent: review-worker",
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "tool_call",
+        tool_call: {
+          tool_call_id: "tool-agent",
+          title: "Agent",
           kind: "think",
           status: "in_progress",
-          raw_input: {
-            description: "review changes",
-            prompt: "Review the branch",
-            name: "review-worker",
-            subagent_type: "general-purpose",
-            model: "opus",
-          },
+          source_message_uuid: "assistant-stream",
+          content: [],
+          raw_input: {},
           locations: [],
           meta: { claudeCode: { toolName: "Agent", parentToolUseId: null } },
         },
       },
-    },
-  ]);
+      {
+        type: "tool_call_update",
+        tool_call_update: {
+          tool_call_id: "tool-agent",
+          source_message_uuid: "assistant-final",
+          fields: {
+            title: "Agent: review-worker",
+            kind: "think",
+            status: "in_progress",
+            raw_input: {
+              description: "review changes",
+              prompt: "Review the branch",
+              name: "review-worker",
+              subagent_type: "general-purpose",
+              model: "opus",
+            },
+            locations: [],
+            meta: { claudeCode: { toolName: "Agent", parentToolUseId: null } },
+          },
+        },
+      },
+    ],
+  );
   assert.deepEqual(session.toolCalls.get("tool-agent")?.raw_input, {
     description: "review changes",
     prompt: "Review the branch",
@@ -3088,11 +3619,17 @@ test("Workflow task notifications finish the linked root tool", () => {
     const toolCall = session.toolCalls.get(`tool-workflow-${sdkStatus}`);
     assert.equal(toolCall?.status, expectedStatus);
     assert.equal(toolCall?.raw_output, `Workflow ${sdkStatus}`);
-    assert.equal(toolCall?.task_metadata?.output_file, `C:/tmp/workflow-${sdkStatus}.output`);
+    assert.equal(
+      toolCall?.task_metadata?.output_file,
+      `C:/tmp/workflow-${sdkStatus}.output`,
+    );
     assert.equal(toolCall?.task_metadata?.summary, `Workflow ${sdkStatus}`);
     assert.equal(toolCall?.task_metadata?.terminal_status, sdkStatus);
     assert.equal(session.taskToolUseIds.has(`workflow-${sdkStatus}`), false);
-    assert.equal(session.taskIdsByToolUseId.has(`tool-workflow-${sdkStatus}`), false);
+    assert.equal(
+      session.taskIdsByToolUseId.has(`tool-workflow-${sdkStatus}`),
+      false,
+    );
   }
 });
 
@@ -3111,18 +3648,29 @@ test("TaskCreate output emits task state and links lifecycle task id", () => {
     });
   });
 
-  const updates = events.map((event) => event.update as Record<string, unknown>);
-  assert.equal(updates.some((update) => update.type === "tool_call"), true);
+  const updates = events.map(
+    (event) => event.update as Record<string, unknown>,
+  );
+  assert.equal(
+    updates.some((update) => update.type === "tool_call"),
+    true,
+  );
   const toolResult = updates.find((update) => {
-    const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+    const toolCallUpdate = update.tool_call_update as
+      | Record<string, unknown>
+      | undefined;
     return toolCallUpdate?.tool_call_id === "tool-create";
   })?.tool_call_update as Record<string, unknown> | undefined;
-  const resultFields = toolResult?.fields as Record<string, unknown> | undefined;
+  const resultFields = toolResult?.fields as
+    | Record<string, unknown>
+    | undefined;
   assert.equal(resultFields?.status, "completed");
   assert.equal(Object.hasOwn(resultFields ?? {}, "content"), false);
   assert.equal(Object.hasOwn(resultFields ?? {}, "raw_output"), false);
 
-  const taskUpdate = updates.find((update) => update.type === "task_state_update");
+  const taskUpdate = updates.find(
+    (update) => update.type === "task_state_update",
+  );
   assert.deepEqual(taskUpdate, {
     type: "task_state_update",
     source: "task_create",
@@ -3187,9 +3735,13 @@ test("TaskCreate transcript toolUseResult object emits typed task state", () => 
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  const updates = events.map((event) => event.update as Record<string, unknown>);
+  const updates = events.map(
+    (event) => event.update as Record<string, unknown>,
+  );
   const result = updates.find((update) => {
-    const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+    const toolCallUpdate = update.tool_call_update as
+      | Record<string, unknown>
+      | undefined;
     return toolCallUpdate?.tool_call_id === "tool-create-transcript";
   })?.tool_call_update as Record<string, unknown> | undefined;
   const resultFields = result?.fields as Record<string, unknown> | undefined;
@@ -3197,24 +3749,27 @@ test("TaskCreate transcript toolUseResult object emits typed task state", () => 
   assert.equal(Object.hasOwn(resultFields ?? {}, "content"), false);
   assert.equal(Object.hasOwn(resultFields ?? {}, "raw_output"), false);
 
-  assert.deepEqual(updates.find((update) => update.type === "task_state_update"), {
-    type: "task_state_update",
-    source: "task_create",
-    tasks: [
-      {
-        task_id: "1",
-        subject: "Scaffold Next.js app",
-        description: "Run create-next-app",
-        active_form: "Scaffolding Next.js app",
-        status: "pending",
-        blocks: [],
-        blocked_by: [],
-        source_tool_call_id: "tool-create-transcript",
-      },
-    ],
-    removed_task_ids: [],
-    is_complete_snapshot: false,
-  });
+  assert.deepEqual(
+    updates.find((update) => update.type === "task_state_update"),
+    {
+      type: "task_state_update",
+      source: "task_create",
+      tasks: [
+        {
+          task_id: "1",
+          subject: "Scaffold Next.js app",
+          description: "Run create-next-app",
+          active_form: "Scaffolding Next.js app",
+          status: "pending",
+          blocks: [],
+          blocked_by: [],
+          source_tool_call_id: "tool-create-transcript",
+        },
+      ],
+      removed_task_ids: [],
+      is_complete_snapshot: false,
+    },
+  );
 });
 
 test("TodoWrite tool use remains generic and emits no plan or task state", () => {
@@ -3247,10 +3802,21 @@ test("TodoWrite tool use remains generic and emits no plan or task state", () =>
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  const updates = events.map((event) => event.update as Record<string, unknown>);
-  assert.equal(updates.some((update) => update.type === "tool_call"), true);
-  assert.equal(updates.some((update) => update.type === "plan"), false);
-  assert.equal(updates.some((update) => update.type === "task_state_update"), false);
+  const updates = events.map(
+    (event) => event.update as Record<string, unknown>,
+  );
+  assert.equal(
+    updates.some((update) => update.type === "tool_call"),
+    true,
+  );
+  assert.equal(
+    updates.some((update) => update.type === "plan"),
+    false,
+  );
+  assert.equal(
+    updates.some((update) => update.type === "task_state_update"),
+    false,
+  );
   assert.equal(session.tasksById.size, 0);
 });
 
@@ -3280,9 +3846,13 @@ test("TaskUpdate success patches one task by task id", () => {
     });
   });
 
-  const updates = events.map((event) => event.update as Record<string, unknown>);
+  const updates = events.map(
+    (event) => event.update as Record<string, unknown>,
+  );
   const result = updates.find((update) => {
-    const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+    const toolCallUpdate = update.tool_call_update as
+      | Record<string, unknown>
+      | undefined;
     return toolCallUpdate?.tool_call_id === "tool-update";
   })?.tool_call_update as Record<string, unknown> | undefined;
   const resultFields = result?.fields as Record<string, unknown> | undefined;
@@ -3331,8 +3901,13 @@ test("TaskUpdate title uses known subject when input only has task id", () => {
 
   const toolCall = events
     .map((event) => event.update as Record<string, unknown>)
-    .find((update) => update.type === "tool_call")?.tool_call as Record<string, unknown> | undefined;
-  assert.equal(toolCall?.title, "Update task: Scaffold Next.js app via create-next-app CLI");
+    .find((update) => update.type === "tool_call")?.tool_call as
+    | Record<string, unknown>
+    | undefined;
+  assert.equal(
+    toolCall?.title,
+    "Update task: Scaffold Next.js app via create-next-app CLI",
+  );
 });
 
 test("TaskOutput renders structured fields and deduplicates XML content without mutating task state", () => {
@@ -3371,15 +3946,18 @@ test("TaskOutput renders structured fields and deduplicates XML content without 
     );
   });
 
-  const updates = events.map((event) => event.update as Record<string, unknown>);
-  const toolCall = updates.find((update) => update.type === "tool_call")?.tool_call as
-    | Record<string, unknown>
-    | undefined;
+  const updates = events.map(
+    (event) => event.update as Record<string, unknown>,
+  );
+  const toolCall = updates.find((update) => update.type === "tool_call")
+    ?.tool_call as Record<string, unknown> | undefined;
   assert.equal(toolCall?.kind, "other");
   assert.equal(toolCall?.title, "Task output: Watch build");
 
   const result = updates.find((update) => {
-    const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+    const toolCallUpdate = update.tool_call_update as
+      | Record<string, unknown>
+      | undefined;
     return toolCallUpdate?.tool_call_id === "tool-output";
   })?.tool_call_update as Record<string, unknown> | undefined;
   const fields = result?.fields as Record<string, unknown> | undefined;
@@ -3394,12 +3972,16 @@ test("TaskOutput renders structured fields and deduplicates XML content without 
       },
     },
   ]);
-  const text = (((fields?.content as Array<Record<string, unknown>> | undefined)?.[0]?.content as
-    | Record<string, unknown>
-    | undefined)?.text ?? "") as string;
+  const text = ((
+    (fields?.content as Array<Record<string, unknown>> | undefined)?.[0]
+      ?.content as Record<string, unknown> | undefined
+  )?.text ?? "") as string;
   assert.equal(text.includes("<retrieval_status>"), false);
   assert.equal(text.includes("Task ID: task-1"), false);
-  assert.equal(updates.some((update) => update.type === "task_state_update"), false);
+  assert.equal(
+    updates.some((update) => update.type === "task_state_update"),
+    false,
+  );
   assert.equal(session.tasksById.get("task-1")?.status, "in_progress");
 });
 
@@ -3423,7 +4005,9 @@ test("TaskOutput parses XML leaf fields when structured result is unavailable", 
   const result = events
     .map((event) => event.update as Record<string, unknown>)
     .find((update) => {
-      const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+      const toolCallUpdate = update.tool_call_update as
+        | Record<string, unknown>
+        | undefined;
       return toolCallUpdate?.tool_call_id === "tool-output-xml";
     })?.tool_call_update as Record<string, unknown> | undefined;
   const fields = result?.fields as Record<string, unknown> | undefined;
@@ -3464,15 +4048,18 @@ test("TaskStop renders structured output and marks the task terminal", () => {
     });
   });
 
-  const updates = events.map((event) => event.update as Record<string, unknown>);
-  const toolCall = updates.find((update) => update.type === "tool_call")?.tool_call as
-    | Record<string, unknown>
-    | undefined;
+  const updates = events.map(
+    (event) => event.update as Record<string, unknown>,
+  );
+  const toolCall = updates.find((update) => update.type === "tool_call")
+    ?.tool_call as Record<string, unknown> | undefined;
   assert.equal(toolCall?.kind, "other");
   assert.equal(toolCall?.title, "Stop task: Watch build");
 
   const result = updates.find((update) => {
-    const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+    const toolCallUpdate = update.tool_call_update as
+      | Record<string, unknown>
+      | undefined;
     return toolCallUpdate?.tool_call_id === "tool-stop";
   })?.tool_call_update as Record<string, unknown> | undefined;
   const fields = result?.fields as Record<string, unknown> | undefined;
@@ -3488,27 +4075,30 @@ test("TaskStop renders structured output and marks the task terminal", () => {
     },
   ]);
 
-  assert.deepEqual(updates.find((update) => update.type === "task_state_update"), {
-    type: "task_state_update",
-    source: "task_lifecycle",
-    tasks: [
-      {
-        task_id: "task-1",
-        subject: "Watch build",
-        status: "completed",
-        blocks: [],
-        blocked_by: [],
-        metadata: {
-          terminal_status: "stopped",
-          task_type: "bash",
-          command: "npm run watch",
+  assert.deepEqual(
+    updates.find((update) => update.type === "task_state_update"),
+    {
+      type: "task_state_update",
+      source: "task_lifecycle",
+      tasks: [
+        {
+          task_id: "task-1",
+          subject: "Watch build",
+          status: "completed",
+          blocks: [],
+          blocked_by: [],
+          metadata: {
+            terminal_status: "stopped",
+            task_type: "bash",
+            command: "npm run watch",
+          },
+          source_tool_call_id: "tool-agent",
         },
-        source_tool_call_id: "tool-agent",
-      },
-    ],
-    removed_task_ids: [],
-    is_complete_snapshot: false,
-  });
+      ],
+      removed_task_ids: [],
+      is_complete_snapshot: false,
+    },
+  );
   assert.equal(session.taskToolUseIds.has("task-1"), false);
 });
 
@@ -3527,14 +4117,21 @@ test("TaskStop result for an already-gone task does not create stale task state"
     });
   });
 
-  const updates = events.map((event) => event.update as Record<string, unknown>);
+  const updates = events.map(
+    (event) => event.update as Record<string, unknown>,
+  );
   const result = updates.find((update) => {
-    const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+    const toolCallUpdate = update.tool_call_update as
+      | Record<string, unknown>
+      | undefined;
     return toolCallUpdate?.tool_call_id === "tool-stop-missing";
   })?.tool_call_update as Record<string, unknown> | undefined;
   const fields = result?.fields as Record<string, unknown> | undefined;
   assert.equal(fields?.status, "completed");
-  assert.equal(updates.some((update) => update.type === "task_state_update"), false);
+  assert.equal(
+    updates.some((update) => update.type === "task_state_update"),
+    false,
+  );
   assert.equal(session.tasksById.has("task-missing"), false);
 });
 
@@ -3562,16 +4159,22 @@ test("TaskUpdate in-progress result leaves activity rendering to app task state"
     });
   });
 
-  const updates = events.map((event) => event.update as Record<string, unknown>);
+  const updates = events.map(
+    (event) => event.update as Record<string, unknown>,
+  );
   const result = updates.find((update) => {
-    const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+    const toolCallUpdate = update.tool_call_update as
+      | Record<string, unknown>
+      | undefined;
     return toolCallUpdate?.tool_call_id === "tool-activity";
   })?.tool_call_update as Record<string, unknown> | undefined;
   const fields = result?.fields as Record<string, unknown> | undefined;
   assert.equal(fields?.status, "completed");
   assert.equal(Object.hasOwn(fields ?? {}, "raw_output"), false);
   assert.equal(Object.hasOwn(fields ?? {}, "content"), false);
-  const taskUpdate = updates.find((update) => update.type === "task_state_update");
+  const taskUpdate = updates.find(
+    (update) => update.type === "task_state_update",
+  );
   assert.deepEqual(taskUpdate, {
     type: "task_state_update",
     source: "task_update",
@@ -3616,7 +4219,9 @@ test("TaskUpdate in-progress result omits activity when none is known", () => {
   const result = events
     .map((event) => event.update as Record<string, unknown>)
     .find((update) => {
-      const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+      const toolCallUpdate = update.tool_call_update as
+        | Record<string, unknown>
+        | undefined;
       return toolCallUpdate?.tool_call_id === "tool-no-activity";
     })?.tool_call_update as Record<string, unknown> | undefined;
   const fields = result?.fields as Record<string, unknown> | undefined;
@@ -3648,22 +4253,31 @@ test("TaskUpdate deleted removes task without persisting deleted status", () => 
     });
   });
 
-  const updates = events.map((event) => event.update as Record<string, unknown>);
+  const updates = events.map(
+    (event) => event.update as Record<string, unknown>,
+  );
   const toolResult = updates.find((update) => {
-    const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+    const toolCallUpdate = update.tool_call_update as
+      | Record<string, unknown>
+      | undefined;
     return toolCallUpdate?.tool_call_id === "tool-delete";
   })?.tool_call_update as Record<string, unknown> | undefined;
-  const resultFields = toolResult?.fields as Record<string, unknown> | undefined;
+  const resultFields = toolResult?.fields as
+    | Record<string, unknown>
+    | undefined;
   assert.equal(resultFields?.status, "completed");
   assert.equal(Object.hasOwn(resultFields ?? {}, "raw_output"), false);
   assert.equal(Object.hasOwn(resultFields ?? {}, "content"), false);
-  assert.deepEqual(updates.find((update) => update.type === "task_state_update"), {
-    type: "task_state_update",
-    source: "task_update",
-    tasks: [],
-    removed_task_ids: ["task-1"],
-    is_complete_snapshot: false,
-  });
+  assert.deepEqual(
+    updates.find((update) => update.type === "task_state_update"),
+    {
+      type: "task_state_update",
+      source: "task_update",
+      tasks: [],
+      removed_task_ids: ["task-1"],
+      is_complete_snapshot: false,
+    },
+  );
   assert.equal(session.tasksById.has("task-1"), false);
 });
 
@@ -3691,13 +4305,23 @@ test("failed TaskUpdate output renders failure but does not mutate task state", 
     });
   });
 
-  const updates = events.map((event) => event.update as Record<string, unknown>);
-  assert.equal(updates.some((update) => update.type === "task_state_update"), false);
+  const updates = events.map(
+    (event) => event.update as Record<string, unknown>,
+  );
+  assert.equal(
+    updates.some((update) => update.type === "task_state_update"),
+    false,
+  );
   const toolResult = updates.find((update) => {
-    const toolCallUpdate = update.tool_call_update as Record<string, unknown> | undefined;
+    const toolCallUpdate = update.tool_call_update as
+      | Record<string, unknown>
+      | undefined;
     return toolCallUpdate?.tool_call_id === "tool-failed-update";
   })?.tool_call_update as Record<string, unknown> | undefined;
-  assert.equal((toolResult?.fields as Record<string, unknown> | undefined)?.status, "failed");
+  assert.equal(
+    (toolResult?.fields as Record<string, unknown> | undefined)?.status,
+    "failed",
+  );
   assert.equal(session.tasksById.get("task-1")?.status, "pending");
 });
 
@@ -3776,7 +4400,9 @@ test("TaskGet null emits removal or confirmed absence", () => {
   });
 
   assert.deepEqual(
-    events.map((event) => event.update as Record<string, unknown>).find((update) => update.type === "task_state_update"),
+    events
+      .map((event) => event.update as Record<string, unknown>)
+      .find((update) => update.type === "task_state_update"),
     {
       type: "task_state_update",
       source: "task_get",
@@ -3801,24 +4427,27 @@ test("handleTaskSystemMessage emits task state for unlinked task_updated message
     });
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "task_state_update",
-      source: "task_lifecycle",
-      tasks: [
-        {
-          task_id: "task-missing",
-          subject: "This should not be emitted",
-          description: "This should not be emitted",
-          status: "in_progress",
-          blocks: [],
-          blocked_by: [],
-        },
-      ],
-      removed_task_ids: [],
-      is_complete_snapshot: false,
-    },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "task_state_update",
+        source: "task_lifecycle",
+        tasks: [
+          {
+            task_id: "task-missing",
+            subject: "This should not be emitted",
+            description: "This should not be emitted",
+            status: "in_progress",
+            blocks: [],
+            blocked_by: [],
+          },
+        ],
+        removed_task_ids: [],
+        is_complete_snapshot: false,
+      },
+    ],
+  );
 });
 
 test("handleTaskSystemMessage maps stopped notifications to terminal task state", () => {
@@ -3841,29 +4470,32 @@ test("handleTaskSystemMessage maps stopped notifications to terminal task state"
     });
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "task_state_update",
-      source: "task_lifecycle",
-      tasks: [
-        {
-          task_id: "task-1",
-          subject: "Watch build",
-          description: "Stopped background watch",
-          status: "completed",
-          blocks: [],
-          blocked_by: [],
-          metadata: {
-            output_file: "C:/tmp/task-1.txt",
-            summary: "Stopped background watch",
-            terminal_status: "stopped",
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "task_state_update",
+        source: "task_lifecycle",
+        tasks: [
+          {
+            task_id: "task-1",
+            subject: "Watch build",
+            description: "Stopped background watch",
+            status: "completed",
+            blocks: [],
+            blocked_by: [],
+            metadata: {
+              output_file: "C:/tmp/task-1.txt",
+              summary: "Stopped background watch",
+              terminal_status: "stopped",
+            },
           },
-        },
-      ],
-      removed_task_ids: [],
-      is_complete_snapshot: false,
-    },
-  ]);
+        ],
+        removed_task_ids: [],
+        is_complete_snapshot: false,
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage emits MCP snapshot from init status payload", () => {
@@ -3924,7 +4556,10 @@ test("handleSdkMessage emits MCP snapshot from init status payload", () => {
 
 test("authority snapshots publish fast mode set during initialization", () => {
   const session = makeSessionState();
-  assert.equal(setFastModeSnapshotIfChanged(session, "on", "model_not_allowed"), true);
+  assert.equal(
+    setFastModeSnapshotIfChanged(session, "on", "model_not_allowed"),
+    true,
+  );
 
   for (const connectEvent of ["connected", "session_replaced"] as const) {
     session.connectEvent = connectEvent;
@@ -3954,7 +4589,8 @@ test("handleSdkMessage emits fast mode as a delta after authority exists", () =>
   const fastModeUpdates = events.filter(
     (event) =>
       event.event === "session_update" &&
-      (event.update as { type?: unknown } | undefined)?.type === "fast_mode_update",
+      (event.update as { type?: unknown } | undefined)?.type ===
+        "fast_mode_update",
   );
   assert.deepEqual(fastModeUpdates, [
     {
@@ -4010,8 +4646,12 @@ test("fast mode snapshots deduplicate state and reason together and clear stale 
     .filter((event) => event.event === "session_update")
     .map((event) => event.update as import("./types.js").SessionUpdate)
     .filter(
-      (update): update is Extract<import("./types.js").SessionUpdate, { type: "fast_mode_update" }> =>
-        update.type === "fast_mode_update",
+      (
+        update,
+      ): update is Extract<
+        import("./types.js").SessionUpdate,
+        { type: "fast_mode_update" }
+      > => update.type === "fast_mode_update",
     );
   assert.deepEqual(updates, [
     ...reasons.map((reason) => ({
@@ -4093,9 +4733,15 @@ test("handleSdkMessage correlates heartbeat progress to its existing parent tool
     },
   });
   assert.equal(session.toolCalls.size, 1);
-  assert.equal(session.toolCalls.get(parentToolCall.tool_call_id)?.status, "in_progress");
+  assert.equal(
+    session.toolCalls.get(parentToolCall.tool_call_id)?.status,
+    "in_progress",
+  );
   for (let heartbeat = 0; heartbeat < 3; heartbeat += 1) {
-    assert.equal(session.toolCalls.has(`tool-shell-parent-heartbeat-${heartbeat}`), false);
+    assert.equal(
+      session.toolCalls.has(`tool-shell-parent-heartbeat-${heartbeat}`),
+      false,
+    );
   }
 });
 
@@ -4174,9 +4820,13 @@ test("handleSdkMessage updates and clears subagent retry progress in place", () 
       },
     },
   });
-  assert.equal(session.toolCalls.get(toolCall.tool_call_id)?.status, "in_progress");
   assert.equal(
-    session.toolCalls.get(toolCall.tool_call_id)?.task_metadata?.subagent_retry?.state,
+    session.toolCalls.get(toolCall.tool_call_id)?.status,
+    "in_progress",
+  );
+  assert.equal(
+    session.toolCalls.get(toolCall.tool_call_id)?.task_metadata?.subagent_retry
+      ?.state,
     "waiting",
   );
 
@@ -4242,7 +4892,10 @@ test("handleSdkMessage ignores malformed subagent retry progress", () => {
   });
 
   assert.deepEqual(events, []);
-  assert.equal(session.toolCalls.get(toolCall.tool_call_id)?.task_metadata, undefined);
+  assert.equal(
+    session.toolCalls.get(toolCall.tool_call_id)?.task_metadata,
+    undefined,
+  );
 });
 
 test("emitToolResultUpdate clears active subagent retry metadata", () => {
@@ -4274,12 +4927,19 @@ test("emitToolResultUpdate clears active subagent retry metadata", () => {
   const update = events.at(-1)?.update as Record<string, unknown>;
   const toolCallUpdate = update.tool_call_update as Record<string, unknown>;
   const fields = toolCallUpdate.fields as Record<string, unknown>;
-  assert.deepEqual(fields.task_metadata, { subagent_retry: { state: "clear" } });
-  assert.equal(session.toolCalls.get(toolCall.tool_call_id)?.task_metadata?.subagent_retry, undefined);
+  assert.deepEqual(fields.task_metadata, {
+    subagent_retry: { state: "clear" },
+  });
+  assert.equal(
+    session.toolCalls.get(toolCall.tool_call_id)?.task_metadata?.subagent_retry,
+    undefined,
+  );
 });
 
 test("buildQueryOptions trims language before appending system prompt", () => {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: {
@@ -4302,7 +4962,10 @@ test("buildQueryOptions trims language before appending system prompt", () => {
 
 test("parseCommandEnvelope rejects missing required fields", () => {
   assert.throws(
-    () => parseCommandEnvelope(JSON.stringify({ command: "set_model", session_id: "s1" })),
+    () =>
+      parseCommandEnvelope(
+        JSON.stringify({ command: "set_model", session_id: "s1" }),
+      ),
     /set_model\.model must be a string/,
   );
 });
@@ -4410,7 +5073,9 @@ test("requestAskUserQuestionAnswers preserves previews and annotations in update
     status: "in_progress",
     content: [] as Array<import("./types.js").ToolCallContent>,
     locations: [] as Array<import("./types.js").ToolLocation>,
-    meta: { claudeCode: { toolName: "AskUserQuestion", parentToolUseId: null } },
+    meta: {
+      claudeCode: { toolName: "AskUserQuestion", parentToolUseId: null },
+    },
   };
 
   const events = await captureBridgeEventsAsync(async () => {
@@ -4482,14 +5147,17 @@ test("requestAskUserQuestionAnswers preserves previews and annotations in update
       },
       annotations: {
         "Pick deployment target": {
-          preview: "Deploy to staging first.\n\nDeploy to production after approval.",
+          preview:
+            "Deploy to staging first.\n\nDeploy to production after approval.",
           notes: "Roll out in both environments",
         },
       },
     });
   });
 
-  const questionEvent = events.find((event) => event.event === "question_request");
+  const questionEvent = events.find(
+    (event) => event.event === "question_request",
+  );
   assert.ok(questionEvent, "expected question request event");
   assert.deepEqual(questionEvent.request, {
     tool_call: {
@@ -4499,7 +5167,9 @@ test("requestAskUserQuestionAnswers preserves previews and annotations in update
       status: "in_progress",
       content: [],
       locations: [],
-      meta: { claudeCode: { toolName: "AskUserQuestion", parentToolUseId: null } },
+      meta: {
+        claudeCode: { toolName: "AskUserQuestion", parentToolUseId: null },
+      },
       raw_input: {
         prompt: {
           question: "Pick deployment target",
@@ -4548,13 +5218,26 @@ test("requestAskUserQuestionAnswers preserves previews and annotations in update
   });
 
   const completedQuestionUpdate = events
-    .map((event) => (event.event === "session_update" ? (event.update as Record<string, unknown>) : undefined))
+    .map((event) =>
+      event.event === "session_update"
+        ? (event.update as Record<string, unknown>)
+        : undefined,
+    )
     .find((update) => {
-      const toolCallUpdate = update?.tool_call_update as Record<string, unknown> | undefined;
-      const fields = toolCallUpdate?.fields as Record<string, unknown> | undefined;
-      return toolCallUpdate?.tool_call_id === "tool-question" && fields?.status === "completed";
+      const toolCallUpdate = update?.tool_call_update as
+        | Record<string, unknown>
+        | undefined;
+      const fields = toolCallUpdate?.fields as
+        | Record<string, unknown>
+        | undefined;
+      return (
+        toolCallUpdate?.tool_call_id === "tool-question" &&
+        fields?.status === "completed"
+      );
     })?.tool_call_update as Record<string, unknown> | undefined;
-  const completedFields = completedQuestionUpdate?.fields as Record<string, unknown> | undefined;
+  const completedFields = completedQuestionUpdate?.fields as
+    | Record<string, unknown>
+    | undefined;
   assert.deepEqual(completedFields?.raw_input, {
     questions: [
       {
@@ -4580,7 +5263,8 @@ test("requestAskUserQuestionAnswers preserves previews and annotations in update
     },
     annotations: {
       "Pick deployment target": {
-        preview: "Deploy to staging first.\n\nDeploy to production after approval.",
+        preview:
+          "Deploy to staging first.\n\nDeploy to production after approval.",
         notes: "Roll out in both environments",
       },
     },
@@ -4605,7 +5289,8 @@ test("requestAskUserQuestionAnswers preserves previews and annotations in update
           },
         ],
         annotation: {
-          preview: "Deploy to staging first.\n\nDeploy to production after approval.",
+          preview:
+            "Deploy to staging first.\n\nDeploy to production after approval.",
           notes: "Roll out in both environments",
         },
       },
@@ -4639,7 +5324,10 @@ test("normalizeToolKind maps known tool names", () => {
   assert.equal(normalizeToolKind("Agent"), "think");
   assert.equal(normalizeToolKind("EnterPlanMode"), "switch_mode");
   assert.equal(normalizeToolKind("ExitPlanMode"), "switch_mode");
-  assert.equal(normalizeToolKind("TodoWrite"), normalizeToolKind("FutureUnknownTool"));
+  assert.equal(
+    normalizeToolKind("TodoWrite"),
+    normalizeToolKind("FutureUnknownTool"),
+  );
 });
 
 test("isShellToolName recognizes only supported shell tools", () => {
@@ -4650,12 +5338,20 @@ test("isShellToolName recognizes only supported shell tools", () => {
 });
 
 test("shell tool titles use input command", () => {
-  assert.equal(createToolCall("tc-bash-title", "Bash", { command: "git status" }).title, "git status");
   assert.equal(
-    createToolCall("tc-powershell-title", "PowerShell", { command: "Get-ChildItem" }).title,
+    createToolCall("tc-bash-title", "Bash", { command: "git status" }).title,
+    "git status",
+  );
+  assert.equal(
+    createToolCall("tc-powershell-title", "PowerShell", {
+      command: "Get-ChildItem",
+    }).title,
     "Get-ChildItem",
   );
-  assert.equal(createToolCall("tc-powershell-empty", "PowerShell", {}).title, "Terminal");
+  assert.equal(
+    createToolCall("tc-powershell-empty", "PowerShell", {}).title,
+    "Terminal",
+  );
 });
 
 test("ReadMcpResourceDir titles include server and URI context", () => {
@@ -4742,9 +5438,21 @@ test("buildRateLimitUpdate normalizes SDK overage boolean spellings", () => {
     ["new spelling true", { overageInUse: true }, true],
     ["new spelling false", { overageInUse: false }, false],
     ["both spellings true", { isUsingOverage: true, overageInUse: true }, true],
-    ["both spellings false", { isUsingOverage: false, overageInUse: false }, false],
-    ["conflicting spellings prefer new true", { isUsingOverage: false, overageInUse: true }, true],
-    ["conflicting spellings prefer new false", { isUsingOverage: true, overageInUse: false }, false],
+    [
+      "both spellings false",
+      { isUsingOverage: false, overageInUse: false },
+      false,
+    ],
+    [
+      "conflicting spellings prefer new true",
+      { isUsingOverage: false, overageInUse: true },
+      true,
+    ],
+    [
+      "conflicting spellings prefer new false",
+      { isUsingOverage: true, overageInUse: false },
+      false,
+    ],
   ] as const;
 
   for (const [name, fields, expected] of cases) {
@@ -4767,10 +5475,13 @@ test("buildRateLimitUpdate rejects invalid payloads", () => {
     }),
     { type: "rate_limit_update", status: "rejected" },
   );
-  assert.deepEqual(buildRateLimitUpdate({ status: "rejected", errorCode: "other" }), {
-    type: "rate_limit_update",
-    status: "rejected",
-  });
+  assert.deepEqual(
+    buildRateLimitUpdate({ status: "rejected", errorCode: "other" }),
+    {
+      type: "rate_limit_update",
+      status: "rejected",
+    },
+  );
 });
 
 test("buildApiRetryUpdate maps SDK api_retry messages to wire shape", () => {
@@ -4875,10 +5586,13 @@ test("normalizeSettingsParseError accepts only SDK-shaped errors", () => {
       message: "Expected array",
     },
   );
-  assert.deepEqual(normalizeSettingsParseError({ path: "", message: "Invalid JSON" }), {
-    path: "",
-    message: "Invalid JSON",
-  });
+  assert.deepEqual(
+    normalizeSettingsParseError({ path: "", message: "Invalid JSON" }),
+    {
+      path: "",
+      message: "Invalid JSON",
+    },
+  );
   assert.equal(normalizeSettingsParseError({ path: "", message: "" }), null);
   assert.equal(normalizeSettingsParseError("Invalid JSON"), null);
 });
@@ -4922,7 +5636,10 @@ test("handleSdkMessage emits lifecycle compatibility session updates", () => {
   assert.deepEqual(
     events.map((event) => event.update),
     [
-      { type: "prompt_suggestion_update", suggestion: "Write tests for this change" },
+      {
+        type: "prompt_suggestion_update",
+        suggestion: "Write tests for this change",
+      },
       {
         type: "api_retry_update",
         attempt: 1,
@@ -5049,13 +5766,42 @@ test("handleSdkMessage rejects invalid compaction boundary counters", () => {
 });
 
 test("classifyTurnErrorKind prefers SDK assistant error codes", () => {
-  assert.equal(classifyTurnErrorKind("error_during_execution", [], "model_not_found"), "model_unavailable");
-  assert.equal(classifyTurnErrorKind("error_during_execution", [], "oauth_org_not_allowed"), "account_access");
-  assert.equal(classifyTurnErrorKind("error_during_execution", [], "overloaded"), "transient_service");
-  assert.equal(classifyTurnErrorKind("error_during_execution", [], "server_error"), "transient_service");
-  assert.equal(classifyTurnErrorKind("error_during_execution", [], "authentication_failed"), "auth_required");
-  assert.equal(classifyTurnErrorKind("error_during_execution", [], "billing_error"), "plan_limit");
-  assert.equal(classifyTurnErrorKind("error_during_execution", [], "rate_limit"), "plan_limit");
+  assert.equal(
+    classifyTurnErrorKind("error_during_execution", [], "model_not_found"),
+    "model_unavailable",
+  );
+  assert.equal(
+    classifyTurnErrorKind(
+      "error_during_execution",
+      [],
+      "oauth_org_not_allowed",
+    ),
+    "account_access",
+  );
+  assert.equal(
+    classifyTurnErrorKind("error_during_execution", [], "overloaded"),
+    "transient_service",
+  );
+  assert.equal(
+    classifyTurnErrorKind("error_during_execution", [], "server_error"),
+    "transient_service",
+  );
+  assert.equal(
+    classifyTurnErrorKind(
+      "error_during_execution",
+      [],
+      "authentication_failed",
+    ),
+    "auth_required",
+  );
+  assert.equal(
+    classifyTurnErrorKind("error_during_execution", [], "billing_error"),
+    "plan_limit",
+  );
+  assert.equal(
+    classifyTurnErrorKind("error_during_execution", [], "rate_limit"),
+    "plan_limit",
+  );
 });
 
 test("handleSdkMessage replaces available commands from commands_changed", () => {
@@ -5073,17 +5819,20 @@ test("handleSdkMessage replaces available commands from commands_changed", () =>
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "available_commands_update",
-      commands: [
-        { name: "/one", description: "First command", input_hint: "<value>" },
-        { name: "/two", description: "" },
-      ],
-      source: "commands_changed",
-      generation: 1,
-    },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "available_commands_update",
+        commands: [
+          { name: "/one", description: "First command", input_hint: "<value>" },
+          { name: "/two", description: "" },
+        ],
+        source: "commands_changed",
+        generation: 1,
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage accepts empty commands_changed replacement list", () => {
@@ -5098,14 +5847,17 @@ test("handleSdkMessage accepts empty commands_changed replacement list", () => {
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "available_commands_update",
-      commands: [],
-      source: "commands_changed",
-      generation: 1,
-    },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "available_commands_update",
+        commands: [],
+        source: "commands_changed",
+        generation: 1,
+      },
+    ],
+  );
 });
 
 test("available command registry blocks stale supportedCommands after dynamic updates", () => {
@@ -5163,13 +5915,17 @@ test("available command registry blocks stale supportedCommands after dynamic up
 test("commands_changed wins an actual supportedCommands bootstrap race", async () => {
   const session = makeSessionState();
   let resolveSupportedCommands:
-    | ((commands: import("@anthropic-ai/claude-agent-sdk").SlashCommand[]) => void)
+    | ((
+        commands: import("@anthropic-ai/claude-agent-sdk").SlashCommand[],
+      ) => void)
     | undefined;
   session.query = {
     supportedCommands: () =>
-      new Promise<import("@anthropic-ai/claude-agent-sdk").SlashCommand[]>((resolve) => {
-        resolveSupportedCommands = resolve;
-      }),
+      new Promise<import("@anthropic-ai/claude-agent-sdk").SlashCommand[]>(
+        (resolve) => {
+          resolveSupportedCommands = resolve;
+        },
+      ),
   } as unknown as import("@anthropic-ai/claude-agent-sdk").Query;
 
   captureBridgeEvents(() => {
@@ -5257,10 +6013,21 @@ test("handleSdkMessage emits system notices for notifications and plugin failure
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    { type: "system_notice_update", severity: "info", message: "Sync completed" },
-    { type: "system_notice_update", severity: "warning", message: "Plugin install failed acme: download failed" },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "system_notice_update",
+        severity: "info",
+        message: "Sync completed",
+      },
+      {
+        type: "system_notice_update",
+        severity: "warning",
+        message: "Plugin install failed acme: download failed",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage maps informational system messages to notices by level", () => {
@@ -5292,11 +6059,22 @@ test("handleSdkMessage maps informational system messages to notices by level", 
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    { type: "system_notice_update", severity: "info", message: "Sync ready" },
-    { type: "system_notice_update", severity: "info", message: "Suggestion: Try /compact" },
-    { type: "system_notice_update", severity: "warning", message: "Hook blocked continuation" },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      { type: "system_notice_update", severity: "info", message: "Sync ready" },
+      {
+        type: "system_notice_update",
+        severity: "info",
+        message: "Suggestion: Try /compact",
+      },
+      {
+        type: "system_notice_update",
+        severity: "warning",
+        message: "Hook blocked continuation",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage keeps informational info log-only unless continuation is prevented", () => {
@@ -5321,13 +6099,16 @@ test("handleSdkMessage keeps informational info log-only unless continuation is 
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "system_notice_update",
-      severity: "warning",
-      message: "Stop hook denied continuation",
-    },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "system_notice_update",
+        severity: "warning",
+        message: "Stop hook denied continuation",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage deduplicates informational messages by tool use, level, and content", () => {
@@ -5362,10 +6143,17 @@ test("handleSdkMessage deduplicates informational messages by tool use, level, a
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    { type: "system_notice_update", severity: "info", message: "Progress" },
-    { type: "system_notice_update", severity: "info", message: "Progress updated" },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      { type: "system_notice_update", severity: "info", message: "Progress" },
+      {
+        type: "system_notice_update",
+        severity: "info",
+        message: "Progress updated",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage does not deduplicate informational messages without a tool use id", () => {
@@ -5383,10 +6171,21 @@ test("handleSdkMessage does not deduplicate informational messages without a too
     }
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    { type: "system_notice_update", severity: "info", message: "Repeated global notice" },
-    { type: "system_notice_update", severity: "info", message: "Repeated global notice" },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "system_notice_update",
+        severity: "info",
+        message: "Repeated global notice",
+      },
+      {
+        type: "system_notice_update",
+        severity: "info",
+        message: "Repeated global notice",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage treats worker shutdown before connect as log-only", () => {
@@ -5420,13 +6219,16 @@ test("handleSdkMessage flushes connected worker shutdown only when stream ends",
     flushPendingWorkerShutdown(session);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "system_notice_update",
-      severity: "warning",
-      message: "Claude worker is shutting down: host_exit",
-    },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "system_notice_update",
+        severity: "warning",
+        message: "Claude worker is shutting down: host_exit",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage cancels pending worker shutdown after later SDK activity", () => {
@@ -5450,9 +6252,16 @@ test("handleSdkMessage cancels pending worker shutdown after later SDK activity"
     flushPendingWorkerShutdown(session);
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    { type: "system_notice_update", severity: "info", message: "Still running" },
-  ]);
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "system_notice_update",
+        severity: "info",
+        message: "Still running",
+      },
+    ],
+  );
 });
 
 test("handleSdkMessage ignores unknown future system subtypes", () => {
@@ -5477,7 +6286,11 @@ test("handleSdkMessage treats mirror errors as log-only diagnostics", () => {
       type: "system",
       subtype: "mirror_error",
       error: "append timed out",
-      key: { projectKey: "project", sessionId: "session-1", subpath: "subagents/agent-1" },
+      key: {
+        projectKey: "project",
+        sessionId: "session-1",
+        subpath: "subagents/agent-1",
+      },
       uuid: "message-mirror",
       session_id: "session-1",
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
@@ -5542,13 +6355,88 @@ test("handleSdkMessage accepts auto-continuation message origin without user out
   assert.deepEqual(events, []);
 });
 
+test("handleSdkMessage renders cross-session peer input with preserved provenance", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "user",
+      uuid: "peer-message-1",
+      session_id: "session-1",
+      parent_tool_use_id: null,
+      origin: {
+        kind: "peer",
+        from: "reported-route",
+        name: "Build session",
+        fromSession: "session-peer",
+        body: "Decoded peer message",
+        verifiedPeerPid: 4242,
+      },
+      message: {
+        role: "user",
+        content: "raw envelope that must not be rendered",
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.deepEqual(events, [
+    {
+      event: "session_update",
+      session_id: "session-1",
+      update: {
+        type: "external_message_update",
+        content: "Decoded peer message",
+        source_message_uuid: "peer-message-1",
+        origin: {
+          kind: "peer",
+          from: "reported-route",
+          name: "Build session",
+          from_session: "session-peer",
+          verified_peer_pid: 4242,
+        },
+      },
+    },
+  ]);
+});
+
+test("handleSdkMessage distinguishes peer-send task notifications from human prompts", () => {
+  const session = makeSessionState();
+  const events = captureBridgeEvents(() => {
+    handleSdkMessage(session, {
+      type: "user",
+      uuid: "task-peer-1",
+      session_id: "session-1",
+      parent_tool_use_id: null,
+      origin: { kind: "task-notification", subkind: "peer-send-message" },
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "Peer task body" }],
+      },
+    } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
+  });
+
+  assert.equal(events.length, 1);
+  assert.deepEqual(events[0]?.update, {
+    type: "external_message_update",
+    content: "Peer task body",
+    source_message_uuid: "task-peer-1",
+    origin: { kind: "task-notification", subkind: "peer-send-message" },
+  });
+});
+
 test("handleSdkMessage preserves assistant correlation metadata on tool calls", () => {
   const session = makeSessionState();
   const events = captureBridgeEvents(() => {
     handleSdkMessage(session, {
       type: "assistant",
       message: {
-        content: [{ type: "tool_use", id: "tool-1", name: "Bash", input: { command: "npm test" } }],
+        content: [
+          {
+            type: "tool_use",
+            id: "tool-1",
+            name: "Bash",
+            input: { command: "npm test" },
+          },
+        ],
       },
       parent_tool_use_id: null,
       request_id: "request-1",
@@ -5598,68 +6486,76 @@ test("handleTaskSystemMessage preserves task correlation metadata", () => {
     });
   });
 
-  assert.deepEqual(events.map((event) => event.update), [
-    {
-      type: "tool_call",
-      tool_call: {
-        tool_call_id: "tool-1",
-        title: "Agent",
-        kind: "think",
-        status: "pending",
-        content: [],
-        raw_input: {},
-        locations: [],
-        meta: { claudeCode: { toolName: "Agent", parentToolUseId: null } },
+  assert.deepEqual(
+    events.map((event) => event.update),
+    [
+      {
+        type: "tool_call",
+        tool_call: {
+          tool_call_id: "tool-1",
+          title: "Agent",
+          kind: "think",
+          status: "pending",
+          content: [],
+          raw_input: {},
+          locations: [],
+          meta: { claudeCode: { toolName: "Agent", parentToolUseId: null } },
+        },
       },
-    },
-    {
-      type: "task_state_update",
-      source: "task_lifecycle",
-      tasks: [
-        {
-          task_id: "task-1",
-          subject: "Validate the branch",
-          description: "Run checks",
-          status: "in_progress",
-          blocks: [],
-          blocked_by: [],
-          metadata: {
-            request_id: "request-1",
-            subagent_type: "tester",
-            task_description: "Validate the branch",
+      {
+        type: "task_state_update",
+        source: "task_lifecycle",
+        tasks: [
+          {
+            task_id: "task-1",
+            subject: "Validate the branch",
+            description: "Run checks",
+            status: "in_progress",
+            blocks: [],
+            blocked_by: [],
+            metadata: {
+              request_id: "request-1",
+              subagent_type: "tester",
+              task_description: "Validate the branch",
+            },
+            source_tool_call_id: "tool-1",
           },
-          source_tool_call_id: "tool-1",
-        },
-      ],
-      removed_task_ids: [],
-      is_complete_snapshot: false,
-    },
-    {
-      type: "tool_call_update",
-      tool_call_update: {
-        tool_call_id: "tool-1",
-        fields: {
-          status: "in_progress",
-        },
+        ],
+        removed_task_ids: [],
+        is_complete_snapshot: false,
       },
-    },
-    {
-      type: "tool_call_update",
-      tool_call_update: {
-        tool_call_id: "tool-1",
-        fields: {
-          status: "in_progress",
-          raw_output: "Run checks",
-          content: [{ type: "content", content: { type: "text", text: "Run checks" } }],
-          task_metadata: {
-            request_id: "request-1",
-            subagent_type: "tester",
-            task_description: "Validate the branch",
+      {
+        type: "tool_call_update",
+        tool_call_update: {
+          tool_call_id: "tool-1",
+          fields: {
+            status: "in_progress",
           },
         },
       },
-    },
-  ]);
+      {
+        type: "tool_call_update",
+        tool_call_update: {
+          tool_call_id: "tool-1",
+          fields: {
+            status: "in_progress",
+            raw_output: "Run checks",
+            content: [
+              {
+                type: "content",
+                content: { type: "text", text: "Run checks" },
+              },
+            ],
+            task_metadata: {
+              request_id: "request-1",
+              subagent_type: "tester",
+              task_description: "Validate the branch",
+            },
+          },
+        },
+      },
+    ],
+  );
 });
 
 test("parseCommandEnvelope validates set_effort command", () => {
@@ -5819,7 +6715,9 @@ test("applySessionFastMode applies live settings and decodes the SDK's sparse of
     state: "on",
     disabled_reason: "pending",
   });
-  assert.deepEqual(await applySessionFastMode(query, true), { state: "cooldown" });
+  assert.deepEqual(await applySessionFastMode(query, true), {
+    state: "cooldown",
+  });
   assert.deepEqual(await applySessionFastMode(query, false), { state: "off" });
   assert.deepEqual(await applySessionFastMode(query, false), { state: "off" });
   assert.deepEqual(calls, [
@@ -5986,7 +6884,10 @@ test("shouldEmitStartupAuthRequiredForAccount skips Claude OAuth hint for extern
     "anthropicGoogleCloud",
     "mantle",
   ] as const) {
-    assert.equal(shouldEmitStartupAuthRequiredForAccount({ apiProvider }), false);
+    assert.equal(
+      shouldEmitStartupAuthRequiredForAccount({ apiProvider }),
+      false,
+    );
   }
 });
 
@@ -6089,7 +6990,11 @@ test("permissionOptionsFromSuggestions uses session label when only session scop
   ]);
   assert.deepEqual(options, [
     { option_id: "allow_once", name: "Allow once", kind: "allow_once" },
-    { option_id: "allow_session", name: "Allow for session", kind: "allow_session" },
+    {
+      option_id: "allow_session",
+      name: "Allow for session",
+      kind: "allow_session",
+    },
     { option_id: "reject_once", name: "Deny", kind: "reject_once" },
   ]);
 });
@@ -6231,7 +7136,7 @@ test("looksLikeAuthRequired detects login hints", () => {
 });
 
 test("agent sdk version compatibility check matches pinned version", () => {
-  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.220");
+  assert.equal(resolveInstalledAgentSdkVersion(), "0.3.227");
   assert.equal(agentSdkVersionCompatibilityError(), undefined);
 });
 
@@ -6258,7 +7163,12 @@ test("mapSessionMessagesToUpdates maps message content blocks", () => {
         id: "msg-1",
         role: "assistant",
         content: [
-          { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "echo hello" } },
+          {
+            type: "tool_use",
+            id: "tool-1",
+            name: "Bash",
+            input: { command: "echo hello" },
+          },
           { type: "text", text: "Nested assistant final" },
         ],
         usage: {
@@ -6301,32 +7211,39 @@ test("mapSessionMessagesToUpdates maps message content blocks", () => {
   const userChunk = updates.find(
     (
       update,
-    ): update is Extract<import("./types.js").SessionUpdate, { type: "user_message_chunk" }> =>
-      update.type === "user_message_chunk",
+    ): update is Extract<
+      import("./types.js").SessionUpdate,
+      { type: "user_message_chunk" }
+    > => update.type === "user_message_chunk",
   );
   const agentChunk = updates.find(
     (
       update,
-    ): update is Extract<import("./types.js").SessionUpdate, { type: "agent_message_chunk" }> =>
-      update.type === "agent_message_chunk",
+    ): update is Extract<
+      import("./types.js").SessionUpdate,
+      { type: "agent_message_chunk" }
+    > => update.type === "agent_message_chunk",
   );
   const toolCall = updates.find(
-    (update): update is Extract<import("./types.js").SessionUpdate, { type: "tool_call" }> =>
-      update.type === "tool_call",
+    (
+      update,
+    ): update is Extract<
+      import("./types.js").SessionUpdate,
+      { type: "tool_call" }
+    > => update.type === "tool_call",
   );
   const toolCallUpdate = updates.find(
     (
       update,
-    ): update is Extract<import("./types.js").SessionUpdate, { type: "tool_call_update" }> =>
-      update.type === "tool_call_update",
+    ): update is Extract<
+      import("./types.js").SessionUpdate,
+      { type: "tool_call_update" }
+    > => update.type === "tool_call_update",
   );
   assert.equal(userChunk?.source_message_uuid, "u1");
   assert.equal(agentChunk?.source_message_uuid, "a1");
   assert.equal(toolCall?.tool_call.source_message_uuid, "a1");
-  assert.equal(
-    toolCallUpdate?.tool_call_update.source_message_uuid,
-    "u2",
-  );
+  assert.equal(toolCallUpdate?.tool_call_update.source_message_uuid, "u2");
 });
 
 test("mapSessionMessagesToUpdates suppresses ToolSearch history blocks", () => {
@@ -6346,7 +7263,12 @@ test("mapSessionMessagesToUpdates suppresses ToolSearch history blocks", () => {
             name: "ToolSearch",
             input: { query: "src/" },
           },
-          { type: "tool_use", id: "tool-bash", name: "Bash", input: { command: "echo ok" } },
+          {
+            type: "tool_use",
+            id: "tool-bash",
+            name: "Bash",
+            input: { command: "echo ok" },
+          },
         ],
       },
     },
@@ -6377,7 +7299,9 @@ test("mapSessionMessagesToUpdates suppresses ToolSearch history blocks", () => {
   ]);
 
   const toolCalls = updates.filter((update) => update.type === "tool_call");
-  const toolUpdates = updates.filter((update) => update.type === "tool_call_update");
+  const toolUpdates = updates.filter(
+    (update) => update.type === "tool_call_update",
+  );
 
   assert.deepEqual(
     toolCalls.map((update) => update.tool_call.tool_call_id),
@@ -6400,8 +7324,18 @@ test("mapSessionMessagesToUpdates preserves parallel tool results", () => {
       message: {
         role: "assistant",
         content: [
-          { type: "tool_use", id: "tool-a", name: "Bash", input: { command: "echo a" } },
-          { type: "tool_use", id: "tool-b", name: "Bash", input: { command: "echo b" } },
+          {
+            type: "tool_use",
+            id: "tool-a",
+            name: "Bash",
+            input: { command: "echo a" },
+          },
+          {
+            type: "tool_use",
+            id: "tool-b",
+            name: "Bash",
+            input: { command: "echo b" },
+          },
         ],
       },
     },
@@ -6432,7 +7366,9 @@ test("mapSessionMessagesToUpdates preserves parallel tool results", () => {
   ]);
 
   const toolCalls = updates.filter((update) => update.type === "tool_call");
-  const toolUpdates = updates.filter((update) => update.type === "tool_call_update");
+  const toolUpdates = updates.filter(
+    (update) => update.type === "tool_call_update",
+  );
 
   assert.deepEqual(
     toolCalls.map((update) => update.tool_call.tool_call_id),
@@ -6493,22 +7429,31 @@ test("handleSdkMessage correlates tool non-execution metadata by tool ID", () =>
         ...cases.map(([id, kind]) => ({
           id,
           non_execution_kind: kind,
-          ...(id === "tool-user-rejected" ? { user_feedback: "Please use a safer command." } : {}),
+          ...(id === "tool-user-rejected"
+            ? { user_feedback: "Please use a safer command." }
+            : {}),
         })),
       ].reverse(),
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
   });
 
   const updates = events
-    .map((event) => event.update as import("./types.js").SessionUpdate | undefined)
+    .map(
+      (event) => event.update as import("./types.js").SessionUpdate | undefined,
+    )
     .filter(
-      (update): update is Extract<import("./types.js").SessionUpdate, { type: "tool_call_update" }> =>
-        update?.type === "tool_call_update",
+      (
+        update,
+      ): update is Extract<
+        import("./types.js").SessionUpdate,
+        { type: "tool_call_update" }
+      > => update?.type === "tool_call_update",
     );
   assert.equal(updates.length, cases.length);
   for (const [id, kind, status] of cases) {
-    const fields = updates.find((update) => update.tool_call_update.tool_call_id === id)
-      ?.tool_call_update.fields;
+    const fields = updates.find(
+      (update) => update.tool_call_update.tool_call_id === id,
+    )?.tool_call_update.fields;
     assert.equal(fields?.status, status);
     assert.equal(fields?.raw_output, `raw output for ${id}`);
     assert.equal(fields?.output_metadata?.non_execution?.kind, kind);
@@ -6530,7 +7475,14 @@ test("handleSdkMessage ignores malformed and mismatched tool non-execution metad
       session_id: "session-1",
       message: {
         role: "assistant",
-        content: [{ type: "tool_use", id: "tool-ok", name: "Bash", input: { command: "echo ok" } }],
+        content: [
+          {
+            type: "tool_use",
+            id: "tool-ok",
+            name: "Bash",
+            input: { command: "echo ok" },
+          },
+        ],
       },
     } as unknown as import("@anthropic-ai/claude-agent-sdk").SDKMessage);
     handleSdkMessage(session, {
@@ -6539,7 +7491,14 @@ test("handleSdkMessage ignores malformed and mismatched tool non-execution metad
       session_id: "session-1",
       message: {
         role: "user",
-        content: [{ type: "tool_result", tool_use_id: "tool-ok", content: "ok", is_error: false }],
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool-ok",
+            content: "ok",
+            is_error: false,
+          },
+        ],
       },
       tool_result_meta: [
         null,
@@ -6552,7 +7511,9 @@ test("handleSdkMessage ignores malformed and mismatched tool non-execution metad
   });
 
   const update = events
-    .map((event) => event.update as import("./types.js").SessionUpdate | undefined)
+    .map(
+      (event) => event.update as import("./types.js").SessionUpdate | undefined,
+    )
     .find((candidate) => candidate?.type === "tool_call_update");
   assert.equal(update?.type, "tool_call_update");
   if (update?.type !== "tool_call_update") {
@@ -6573,7 +7534,12 @@ test("mapSessionMessagesToUpdates carries tool non-execution metadata from histo
       message: {
         role: "assistant",
         content: [
-          { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "echo ok" } },
+          {
+            type: "tool_use",
+            id: "tool-1",
+            name: "Bash",
+            input: { command: "echo ok" },
+          },
         ],
       },
     },
@@ -6604,16 +7570,21 @@ test("mapSessionMessagesToUpdates carries tool non-execution metadata from histo
     },
   ] as unknown as SessionMessage[]);
 
-  const update = updates.find((candidate) => candidate.type === "tool_call_update");
+  const update = updates.find(
+    (candidate) => candidate.type === "tool_call_update",
+  );
   assert.equal(update?.type, "tool_call_update");
   if (update?.type !== "tool_call_update") {
     throw new Error("expected tool update");
   }
   assert.equal(update.tool_call_update.fields.status, "killed");
-  assert.deepEqual(update.tool_call_update.fields.output_metadata?.non_execution, {
-    kind: "interrupted",
-    user_feedback: "Stopped intentionally.",
-  });
+  assert.deepEqual(
+    update.tool_call_update.fields.output_metadata?.non_execution,
+    {
+      kind: "interrupted",
+      user_feedback: "Stopped intentionally.",
+    },
+  );
 });
 
 test("mapSessionMessagesToUpdates maps task system records from resume history", () => {
@@ -6702,7 +7673,9 @@ test("mapSessionMessagesToUpdates maps task system records from resume history",
     },
   ]);
 
-  const taskUpdates = updates.filter((update) => update.type === "task_state_update");
+  const taskUpdates = updates.filter(
+    (update) => update.type === "task_state_update",
+  );
   assert.equal(taskUpdates.length, 4);
   assert.deepEqual(taskUpdates.at(1), {
     type: "task_state_update",
@@ -6872,7 +7845,8 @@ test("handleResultMessage preserves new SDK terminal reasons", () => {
 
     assert.equal(events.at(-1)?.event, "turn_complete");
     assert.equal(
-      (events.at(-1) as { terminal_reason?: string } | undefined)?.terminal_reason,
+      (events.at(-1) as { terminal_reason?: string } | undefined)
+        ?.terminal_reason,
       terminalReason,
     );
   }
@@ -6967,6 +7941,98 @@ test("handleResultMessage emits terminal reason on turn errors", () => {
   });
 });
 
+test("handleResultMessage captures resumeDropsTurn refusal before candidate commit", () => {
+  const session = makeSessionState();
+  session.connected = false;
+  session.deferConnect = true;
+  session.initializationReady = true;
+  session.resumeDropsTurn = "user-2";
+  const refusal =
+    "Resume rejected by --resume-drops-turn: unexpected queued message";
+
+  const events = captureBridgeEvents(() => {
+    handleResultMessage(session, {
+      type: "result",
+      subtype: "error_during_execution",
+      errors: [refusal],
+    });
+  });
+
+  assert.deepEqual(events, []);
+  assert.equal(session.initializationReady, false);
+  assert.equal(session.initializationError, refusal);
+});
+
+test("commitDeferredSession requires the guarded-resume validation fence", () => {
+  sessions.clear();
+  const session = makeSessionState();
+  session.connected = false;
+  session.deferConnect = true;
+  session.initializationReady = true;
+  session.resumeDropsTurn = "user-2";
+  sessions.set(session.sessionId, session);
+  try {
+    const events = captureBridgeEvents(() => {
+      assert.throws(
+        () => commitDeferredSession(session),
+        /not ready to commit/,
+      );
+    });
+    assert.deepEqual(events, []);
+    assert.equal(session.deferConnect, true);
+  } finally {
+    sessions.clear();
+  }
+});
+
+test("commitDeferredSession publishes connect before all buffered session-scoped and auth events", () => {
+  sessions.clear();
+  const session = makeSessionState();
+  session.connected = false;
+  session.deferConnect = true;
+  session.initializationReady = true;
+  session.resumeDropsTurn = "user-2";
+  session.resumeGuardFenceComplete = true;
+  sessions.set(session.sessionId, session);
+  try {
+    const events = captureBridgeEvents(() => {
+      emitSessionUpdate(session.sessionId, {
+        type: "session_status_update",
+        status: "idle",
+      });
+      writeEvent({
+        event: "runtime_reload_completed",
+        session_id: session.sessionId,
+      });
+      sessions.delete(session.sessionId);
+      session.sessionId = "session-committed";
+      sessions.set(session.sessionId, session);
+      emitAuthRequired(session, "Login is required");
+      commitDeferredSession(session);
+    });
+
+    assert.deepEqual(
+      events.map((event) => event.event),
+      [
+        "connected",
+        "session_update",
+        "runtime_reload_completed",
+        "auth_required",
+      ],
+    );
+    assert.deepEqual(
+      events.flatMap((event) =>
+        "session_id" in event ? [event.session_id] : [],
+      ),
+      ["session-committed", "session-committed", "session-committed"],
+    );
+    assert.equal(session.deferredBridgeEvents, undefined);
+    assert.equal(session.deferredAuthRequired, undefined);
+  } finally {
+    sessions.clear();
+  }
+});
+
 test("handleResultMessage emits typed turn error classifications for SDK assistant errors", () => {
   const cases = [
     ["model_not_found", "model_unavailable"],
@@ -7007,7 +8073,9 @@ test("handleResultMessage preserves target api error status shapes", () => {
         type: "result",
         subtype: "error_during_execution",
         errors: ["service overloaded"],
-        ...(apiErrorStatus !== undefined ? { api_error_status: apiErrorStatus } : {}),
+        ...(apiErrorStatus !== undefined
+          ? { api_error_status: apiErrorStatus }
+          : {}),
       });
     });
 
@@ -7018,7 +8086,9 @@ test("handleResultMessage preserves target api error status shapes", () => {
       error_kind: "transient_service",
       sdk_result_subtype: "error_during_execution",
       assistant_error: "overloaded",
-      ...(typeof apiErrorStatus === "number" ? { api_error_status: apiErrorStatus } : {}),
+      ...(typeof apiErrorStatus === "number"
+        ? { api_error_status: apiErrorStatus }
+        : {}),
     });
   }
 });
@@ -7434,7 +8504,9 @@ test("resolveCurrentModel keeps runtime version in short display while using cat
 });
 
 function userDialogHandlerForTest(): NonNullable<Options["onUserDialog"]> {
-  const input = new AsyncQueue<import("@anthropic-ai/claude-agent-sdk").SDKUserMessage>();
+  const input = new AsyncQueue<
+    import("@anthropic-ai/claude-agent-sdk").SDKUserMessage
+  >();
   const options = buildQueryOptions({
     cwd: "C:/work",
     launchSettings: { language: "English" },
@@ -7472,11 +8544,12 @@ test("onUserDialog round-trips a retry_fallback selection", async () => {
             guidanceText: "This request was declined.",
           },
         },
-        { signal: new AbortController().signal },
+        { signal: new AbortController().signal, requestId: "dialog-retry-1" },
       );
 
       const requestId = [...session.pendingUserDialogs.keys()][0];
       assert.ok(requestId, "expected a pending user dialog resolver");
+      assert.equal(requestId, "dialog-retry-1");
 
       handleUserDialogResponse({
         command: "user_dialog_response",
@@ -7491,7 +8564,9 @@ test("onUserDialog round-trips a retry_fallback selection", async () => {
       });
     });
 
-    const dialogEvent = events.find((event) => event.event === "user_dialog_request");
+    const dialogEvent = events.find(
+      (event) => event.event === "user_dialog_request",
+    );
     assert.ok(dialogEvent, "expected a user_dialog_request event");
     const request = dialogEvent.request as {
       dialog_kind: string;
@@ -7507,7 +8582,10 @@ test("onUserDialog round-trips a retry_fallback selection", async () => {
       ["retry_fallback", "edit_prompt"],
     );
     assert.equal(request.options[0].label, "Switch to claude-sonnet-4-6");
-    assert.equal(request.options[1].label, "Edit prompt and retry with claude-opus-4-8");
+    assert.equal(
+      request.options[1].label,
+      "Edit prompt and retry with claude-opus-4-8",
+    );
   } finally {
     sessions.delete("session-dialog");
   }
@@ -7520,9 +8598,12 @@ test("onUserDialog round-trips an edit_prompt selection", async () => {
     const resultPromise = handler(
       {
         dialogKind: "refusal_fallback_prompt",
-        payload: { originalModel: "claude-opus-4-8", fallbackModel: "claude-sonnet-4-6" },
+        payload: {
+          originalModel: "claude-opus-4-8",
+          fallbackModel: "claude-sonnet-4-6",
+        },
       },
-      { signal: new AbortController().signal },
+      { signal: new AbortController().signal, requestId: "dialog-edit-1" },
     );
 
     const requestId = [...session.pendingUserDialogs.keys()][0];
@@ -7533,7 +8614,10 @@ test("onUserDialog round-trips an edit_prompt selection", async () => {
       outcome: { outcome: "selected", option_id: "edit_prompt" },
     });
 
-    assert.deepEqual(await resultPromise, { behavior: "completed", result: "edit_prompt" });
+    assert.deepEqual(await resultPromise, {
+      behavior: "completed",
+      result: "edit_prompt",
+    });
   } finally {
     sessions.delete("session-dialog");
   }
@@ -7547,9 +8631,12 @@ test("onUserDialog cancels when the dialog is aborted", async () => {
     const resultPromise = handler(
       {
         dialogKind: "refusal_fallback_prompt",
-        payload: { originalModel: "claude-opus-4-8", fallbackModel: "claude-sonnet-4-6" },
+        payload: {
+          originalModel: "claude-opus-4-8",
+          fallbackModel: "claude-sonnet-4-6",
+        },
       },
-      { signal: controller.signal },
+      { signal: controller.signal, requestId: "dialog-abort-1" },
     );
 
     assert.equal(session.pendingUserDialogs.size, 1);
@@ -7569,7 +8656,7 @@ test("onUserDialog fails closed on an unknown dialog kind without emitting", asy
     const events = await captureBridgeEventsAsync(async () => {
       const result = await handler(
         { dialogKind: "some_future_dialog_kind", payload: { anything: true } },
-        { signal: new AbortController().signal },
+        { signal: new AbortController().signal, requestId: "dialog-unknown-1" },
       );
       assert.deepEqual(result, { behavior: "cancelled" });
     });
@@ -7591,9 +8678,15 @@ test("handleUserDialogResponse ignores a duplicate response for a resolved reque
     const resultPromise = handler(
       {
         dialogKind: "refusal_fallback_prompt",
-        payload: { originalModel: "claude-opus-4-8", fallbackModel: "claude-sonnet-4-6" },
+        payload: {
+          originalModel: "claude-opus-4-8",
+          fallbackModel: "claude-sonnet-4-6",
+        },
       },
-      { signal: new AbortController().signal },
+      {
+        signal: new AbortController().signal,
+        requestId: "dialog-duplicate-response-1",
+      },
     );
 
     const requestId = [...session.pendingUserDialogs.keys()][0];
@@ -7601,11 +8694,17 @@ test("handleUserDialogResponse ignores a duplicate response for a resolved reque
       command: "user_dialog_response" as const,
       session_id: "session-dialog",
       request_id: requestId,
-      outcome: { outcome: "selected" as const, option_id: "retry_fallback" as const },
+      outcome: {
+        outcome: "selected" as const,
+        option_id: "retry_fallback" as const,
+      },
     };
 
     handleUserDialogResponse(response);
-    assert.deepEqual(await resultPromise, { behavior: "completed", result: "retry_fallback" });
+    assert.deepEqual(await resultPromise, {
+      behavior: "completed",
+      result: "retry_fallback",
+    });
 
     // A replayed pending_user_dialog_requests entry with the same id must be a
     // no-op now that the resolver is gone.

--- a/agent-sdk/src/bridge.ts
+++ b/agent-sdk/src/bridge.ts
@@ -36,18 +36,31 @@ import {
   sessionById,
   createSession,
   closeAllSessions,
-  type PendingRewindResult,
+  closeSessionWithLogging,
+  detachSessionForClose,
+  awaitSessionInitialization,
+  commitDeferredSession,
   type SessionState,
 } from "./bridge/session_lifecycle.js";
 import { mapSessionMessagesToUpdates } from "./bridge/history.js";
-import { emitAvailableAgentsIfChanged, mapAvailableAgents } from "./bridge/agents.js";
-import { mapSdkSlashCommands, updateAvailableCommands } from "./bridge/available_commands.js";
+import {
+  emitAvailableAgentsIfChanged,
+  mapAvailableAgents,
+} from "./bridge/agents.js";
+import {
+  mapSdkSlashCommands,
+  updateAvailableCommands,
+} from "./bridge/available_commands.js";
 import {
   MCP_STALE_STATUS_REVALIDATION_COOLDOWN_MS,
   emitReconciledMcpSnapshotFromStatuses,
   staleMcpAuthCandidates,
 } from "./bridge/mcp.js";
-import { bridgeLogger, LOG_TARGETS, logBridgeCommandReceived } from "./bridge/logger.js";
+import {
+  bridgeLogger,
+  LOG_TARGETS,
+  logBridgeCommandReceived,
+} from "./bridge/logger.js";
 import { BridgeCommandScheduler } from "./bridge/command_scheduler.js";
 import { handleLifecycleCommand } from "./bridge/command_lifecycle.js";
 import { handleInteractionCommand } from "./bridge/command_interactions.js";
@@ -58,7 +71,10 @@ import { handleSessionDataCommand } from "./bridge/command_session_data.js";
 // Re-exports: all symbols that tests and external consumers import from bridge.js.
 export { AsyncQueue } from "./bridge/shared.js";
 export { asRecordOrNull } from "./bridge/shared.js";
-export { CACHE_SPLIT_POLICY, previewKilobyteLabel } from "./bridge/cache_policy.js";
+export {
+  CACHE_SPLIT_POLICY,
+  previewKilobyteLabel,
+} from "./bridge/cache_policy.js";
 export {
   buildToolResultFields,
   createToolCall,
@@ -83,7 +99,10 @@ export {
   mapSessionMessagesToUpdates,
   mapSdkSessions,
 } from "./bridge/history.js";
-export { handleSdkMessage, handleTaskSystemMessage } from "./bridge/message_handlers.js";
+export {
+  handleSdkMessage,
+  handleTaskSystemMessage,
+} from "./bridge/message_handlers.js";
 export { mapAvailableAgents } from "./bridge/agents.js";
 export {
   buildQueryOptions,
@@ -134,7 +153,9 @@ type UserTextParts = {
   inputText: string;
 };
 
-function userTextPartsFromSessionMessage(message: SessionMessage): UserTextParts | undefined {
+function userTextPartsFromSessionMessage(
+  message: SessionMessage,
+): UserTextParts | undefined {
   const record = message as unknown as Record<string, unknown>;
   if (record.type !== "user") {
     return undefined;
@@ -161,11 +182,17 @@ function userTextPartsFromSessionMessage(message: SessionMessage): UserTextParts
       textBlocks.push(blockRecord.text);
     }
   }
-  const firstText = textBlocks.map(normalizeRewindTargetText).find((text) => text.length > 0);
-  return firstText ? { firstText, inputText: textBlocks.join("\n").trim() } : undefined;
+  const firstText = textBlocks
+    .map(normalizeRewindTargetText)
+    .find((text) => text.length > 0);
+  return firstText
+    ? { firstText, inputText: textBlocks.join("\n").trim() }
+    : undefined;
 }
 
-export function rewindTargetsFromSessionMessages(messages: SessionMessage[]): RewindTarget[] {
+export function rewindTargetsFromSessionMessages(
+  messages: SessionMessage[],
+): RewindTarget[] {
   const targets: RewindTarget[] = [];
   let previousAssistantUuid: string | undefined;
 
@@ -180,29 +207,42 @@ export function rewindTargetsFromSessionMessages(messages: SessionMessage[]): Re
     if (!uuid || !textParts) {
       return;
     }
+    const plan = buildRewindConversationPlan(messages, uuid);
+    if (!plan) {
+      return;
+    }
     targets.push({
       uuid,
       first_text: textParts.firstText,
       input_text: textParts.inputText,
       index,
-      ...(previousAssistantUuid ? { previous_assistant_uuid: previousAssistantUuid } : {}),
+      ...(previousAssistantUuid
+        ? { previous_assistant_uuid: previousAssistantUuid }
+        : {}),
+      ...(plan.resumeSessionAtUuid
+        ? { resume_anchor_uuid: plan.resumeSessionAtUuid }
+        : {}),
     });
   });
 
   return targets.reverse();
 }
 
-type SessionTitleGeneratingQuery = import("@anthropic-ai/claude-agent-sdk").Query & {
-  generateSessionTitle: (
-    description: string,
-    options?: { persist?: boolean },
-  ) => Promise<string | null | undefined>;
-};
+type SessionTitleGeneratingQuery =
+  import("@anthropic-ai/claude-agent-sdk").Query & {
+    generateSessionTitle: (
+      description: string,
+      options?: { persist?: boolean },
+    ) => Promise<string | null | undefined>;
+  };
 
 export function canGenerateSessionTitle(
   query: import("@anthropic-ai/claude-agent-sdk").Query,
 ): query is SessionTitleGeneratingQuery {
-  return typeof (query as { generateSessionTitle?: unknown }).generateSessionTitle === "function";
+  return (
+    typeof (query as { generateSessionTitle?: unknown })
+      .generateSessionTitle === "function"
+  );
 }
 
 export async function generatePersistedSessionTitle(
@@ -212,7 +252,9 @@ export async function generatePersistedSessionTitle(
   if (!canGenerateSessionTitle(query)) {
     throw new Error("SDK query does not support generateSessionTitle");
   }
-  const title = await query.generateSessionTitle(description, { persist: true });
+  const title = await query.generateSessionTitle(description, {
+    persist: true,
+  });
   if (typeof title !== "string" || title.trim().length === 0) {
     throw new Error("SDK did not return a generated session title");
   }
@@ -242,12 +284,16 @@ export async function applySessionFastMode(
     result = await query.reinitialize();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`SDK accepted the fast-mode change but state verification failed: ${message}`);
+    throw new Error(
+      `SDK accepted the fast-mode change but state verification failed: ${message}`,
+    );
   }
 
   const state = parseFastModeState(result.fast_mode_state);
   if (state) {
-    const disabledReason = parseFastModeDisabledReason(result.fast_mode_disabled_reason);
+    const disabledReason = parseFastModeDisabledReason(
+      result.fast_mode_disabled_reason,
+    );
     return {
       state,
       ...(disabledReason ? { disabled_reason: disabledReason } : {}),
@@ -256,7 +302,9 @@ export async function applySessionFastMode(
   if (!enabled && result.fast_mode_state === undefined) {
     return { state: "off" };
   }
-  throw new Error("SDK accepted the fast-mode change but did not report its resulting state");
+  throw new Error(
+    "SDK accepted the fast-mode change but did not report its resulting state",
+  );
 }
 
 export function buildPromptUserMessage(
@@ -287,7 +335,10 @@ export async function applySessionAgent(
   await query.applyFlagSettings(settings);
 }
 
-export function emitEffortConfigOptionUpdate(sessionId: string, effort: EffortLevel): void {
+export function emitEffortConfigOptionUpdate(
+  sessionId: string,
+  effort: EffortLevel,
+): void {
   emitSessionUpdate(sessionId, {
     type: "config_option_update",
     option_id: "effortLevel",
@@ -295,7 +346,10 @@ export function emitEffortConfigOptionUpdate(sessionId: string, effort: EffortLe
   });
 }
 
-export function emitAgentConfigOptionUpdate(sessionId: string, agent: string | null): void {
+export function emitAgentConfigOptionUpdate(
+  sessionId: string,
+  agent: string | null,
+): void {
   emitSessionUpdate(sessionId, {
     type: "config_option_update",
     option_id: "agent",
@@ -303,14 +357,16 @@ export function emitAgentConfigOptionUpdate(sessionId: string, agent: string | n
   });
 }
 
-const EXPECTED_AGENT_SDK_VERSION = "0.3.220";
+const EXPECTED_AGENT_SDK_VERSION = "0.3.227";
 const require = createRequire(import.meta.url);
 
 export function resolveInstalledAgentSdkVersion(): string | undefined {
   try {
     const entryPath = require.resolve("@anthropic-ai/claude-agent-sdk");
     const packageJsonPath = join(dirname(entryPath), "package.json");
-    const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { version?: unknown };
+    const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      version?: unknown;
+    };
     return typeof pkg.version === "string" ? pkg.version : undefined;
   } catch {
     return undefined;
@@ -340,7 +396,11 @@ export async function handleReloadPluginsCommand(
 ): Promise<void> {
   try {
     const result = await session.query.reloadPlugins();
-    updateAvailableCommands(session, "reload_plugins", mapSdkSlashCommands(result.commands));
+    updateAvailableCommands(
+      session,
+      "reload_plugins",
+      mapSdkSlashCommands(result.commands),
+    );
     emitAvailableAgentsIfChanged(session, mapAvailableAgents(result.agents));
     await emitReconciledMcpSnapshotFromStatuses(
       session,
@@ -367,6 +427,8 @@ export async function handleReloadPluginsCommand(
 type ResolvedRewindTarget = {
   inputText: string;
   previousAssistantUuid?: string;
+  resumeSessionAtUuid?: string;
+  resumeDropsTurnId?: string;
   targetIndex: number;
   retainedMessages: SessionMessage[];
 };
@@ -379,8 +441,21 @@ function resolveRewindTarget(
   messages: SessionMessage[],
   targetUserMessageId: string,
 ): ResolvedRewindTarget | null {
+  const seenUuids = new Set<string>();
+  for (const message of messages) {
+    const uuid = (message as unknown as Record<string, unknown>).uuid;
+    if (
+      typeof uuid !== "string" ||
+      uuid.trim().length === 0 ||
+      seenUuids.has(uuid.trim())
+    ) {
+      return null;
+    }
+    seenUuids.add(uuid.trim());
+  }
+
   let previousAssistantUuid: string | undefined;
-  let textUserCountBeforeTarget = 0;
+  let previousTextUserIndex: number | undefined;
 
   for (let index = 0; index < messages.length; index += 1) {
     const message = messages[index];
@@ -396,22 +471,26 @@ function resolveRewindTarget(
       continue;
     }
     if (uuid === targetUserMessageId) {
-      if (!previousAssistantUuid && textUserCountBeforeTarget > 0) {
-        return null;
-      }
-      if (previousAssistantUuid) {
-        const anchorIndex = messages.findIndex((candidate) => {
-          const candidateRecord = candidate as unknown as Record<string, unknown>;
-          return candidateRecord.uuid === previousAssistantUuid;
-        });
-        if (anchorIndex < 0) {
+      const isLatestTextUser = !messages
+        .slice(index + 1)
+        .some((candidate) => userTextPartsFromSessionMessage(candidate) !== undefined);
+      if (previousTextUserIndex !== undefined) {
+        const anchorRecord = messages[index - 1] as unknown as Record<
+          string,
+          unknown
+        >;
+        const resumeSessionAtUuid =
+          typeof anchorRecord.uuid === "string" ? anchorRecord.uuid.trim() : "";
+        if (!resumeSessionAtUuid || index - 1 < previousTextUserIndex) {
           return null;
         }
         return {
           inputText: textParts.inputText,
           previousAssistantUuid,
+          resumeSessionAtUuid,
+          ...(isLatestTextUser ? { resumeDropsTurnId: uuid } : {}),
           targetIndex: index,
-          retainedMessages: messages.slice(0, anchorIndex + 1),
+          retainedMessages: messages.slice(0, index),
         };
       }
       return {
@@ -421,7 +500,7 @@ function resolveRewindTarget(
       };
     }
     if (uuid) {
-      textUserCountBeforeTarget += 1;
+      previousTextUserIndex = index;
     }
   }
 
@@ -442,7 +521,9 @@ export function buildRewindConversationPlan(
   };
 }
 
-export function mapRewindFilesResult(result: SdkRewindFilesResult): RewindFilesResult {
+export function mapRewindFilesResult(
+  result: SdkRewindFilesResult,
+): RewindFilesResult {
   const skippedLinks =
     Number.isFinite(result.skippedLinks) &&
     Number.isInteger(result.skippedLinks) &&
@@ -453,7 +534,9 @@ export function mapRewindFilesResult(result: SdkRewindFilesResult): RewindFilesR
     can_rewind: result.canRewind,
     ...(result.error ? { error: result.error } : {}),
     files_changed: result.filesChanged ?? [],
-    ...(result.insertions !== undefined ? { insertions: result.insertions } : {}),
+    ...(result.insertions !== undefined
+      ? { insertions: result.insertions }
+      : {}),
     ...(result.deletions !== undefined ? { deletions: result.deletions } : {}),
     ...(skippedLinks !== undefined ? { skipped_links: skippedLinks } : {}),
   };
@@ -471,7 +554,9 @@ async function rewindFiles(
       files_changed: [],
     };
   }
-  return mapRewindFilesResult(await session.query.rewindFiles(targetUserMessageId, { dryRun }));
+  return mapRewindFilesResult(
+    await session.query.rewindFiles(targetUserMessageId, { dryRun }),
+  );
 }
 
 function emitRewindResult(
@@ -508,18 +593,20 @@ function requestIdFromCommandLine(line: string): string | undefined {
   }
 }
 
-async function replaceConversationForRewind(
+async function prepareConversationRewindCandidate(
   command: Extract<BridgeCommand, { command: "rewind" }>,
   session: SessionState,
   targetUserMessageId: string,
   requestId: string | undefined,
-  pendingRewindResult?: PendingRewindResult,
-): Promise<void> {
+): Promise<SessionState> {
   const historyMessages = await getSessionMessages(command.session_id, {
     dir: session.cwd,
     includeSystemMessages: true,
   });
-  const resolved = buildRewindConversationPlan(historyMessages, targetUserMessageId);
+  const resolved = buildRewindConversationPlan(
+    historyMessages,
+    targetUserMessageId,
+  );
   if (!resolved) {
     bridgeLogger.warn({
       target: LOG_TARGETS.APP_SESSION,
@@ -558,75 +645,83 @@ async function replaceConversationForRewind(
     },
   });
 
-  if (!resolved.previousAssistantUuid) {
+  let candidate: SessionState | undefined;
+  try {
+    if (!resolved.resumeSessionAtUuid) {
+      bridgeLogger.info({
+        target: LOG_TARGETS.APP_SESSION,
+        eventName: "rewind_first_message_branch",
+        message:
+          "conversation rewind target is first user message; creating fresh replacement",
+        outcome: "start",
+        ...(requestId ? { requestId } : {}),
+        sessionId: session.sessionId,
+        fields: {
+          target_user_message_id: targetUserMessageId,
+          history_message_count: historyMessages.length,
+          stale_session_count: staleSessions.length,
+        },
+      });
+      candidate = await createSession({
+        cwd: session.cwd,
+        launchSettings: command.launch_settings,
+        connectEvent: "session_replaced",
+        requestId,
+        deferConnect: true,
+        restoredInput: resolved.inputText,
+        ...(staleSessions.length > 0
+          ? { sessionsToCloseAfterConnect: staleSessions }
+          : {}),
+      });
+    } else {
+      candidate = await createSession({
+        cwd: session.cwd,
+        resume: command.session_id,
+        resumeSessionAt: resolved.resumeSessionAtUuid,
+        resumeDropsTurn: resolved.resumeDropsTurnId,
+        forkSession: true,
+        launchSettings: command.launch_settings,
+        connectEvent: "session_replaced",
+        requestId,
+        deferConnect: true,
+        ...(resumeUpdates.length > 0 ? { resumeUpdates } : {}),
+        restoredInput: resolved.inputText,
+        ...(staleSessions.length > 0
+          ? { sessionsToCloseAfterConnect: staleSessions }
+          : {}),
+      });
+    }
+    await awaitSessionInitialization(candidate);
     bridgeLogger.info({
       target: LOG_TARGETS.APP_SESSION,
-      eventName: "rewind_first_message_branch",
-      message: "conversation rewind target is first user message; creating fresh replacement",
-      outcome: "start",
-      ...(requestId ? { requestId } : {}),
-      sessionId: session.sessionId,
-      fields: {
-        target_user_message_id: targetUserMessageId,
-        history_message_count: historyMessages.length,
-        stale_session_count: staleSessions.length,
-      },
-    });
-    await createSession({
-      cwd: session.cwd,
-      launchSettings: command.launch_settings,
-      connectEvent: "session_replaced",
-      requestId,
-      restoredInput: resolved.inputText,
-      ...(pendingRewindResult ? { pendingRewindResult } : {}),
-      ...(staleSessions.length > 0 ? { sessionsToCloseAfterConnect: staleSessions } : {}),
-    });
-    bridgeLogger.info({
-      target: LOG_TARGETS.APP_SESSION,
-      eventName: "rewind_replacement_created",
-      message: "conversation rewind replacement session created",
+      eventName: "rewind_candidate_validated",
+      message:
+        "conversation rewind candidate passed initialization and truncation validation",
       outcome: "success",
       ...(requestId ? { requestId } : {}),
+      sessionId: candidate.sessionId,
       fields: {
         target_user_message_id: targetUserMessageId,
-        resume_session_at: "<none>",
-        retained_message_count: 0,
-        retained_update_count: 0,
+        resume_session_at: resolved.resumeSessionAtUuid ?? "<none>",
+        resume_drops_turn: resolved.resumeSessionAtUuid
+          ? (resolved.resumeDropsTurnId ?? "<none>")
+          : "<none>",
+        retained_message_count: resolved.retainedMessages.length,
+        retained_update_count: resumeUpdates.length,
         stale_session_count: staleSessions.length,
       },
     });
-    return;
+    return candidate;
+  } catch (error) {
+    if (candidate) {
+      detachSessionForClose(candidate);
+      await closeSessionWithLogging(candidate, {
+        reason: "rewind_candidate_rejected",
+        requestId,
+      });
+    }
+    throw error;
   }
-
-  const sessionsToCloseAfterConnect = staleSessions.filter((stale) => stale !== session);
-  await createSession({
-    cwd: session.cwd,
-    resume: command.session_id,
-    resumeSessionAt: resolved.previousAssistantUuid,
-    launchSettings: command.launch_settings,
-    connectEvent: "session_replaced",
-    requestId,
-    sessionsToCloseBeforeRegister: [session],
-    ...(resumeUpdates.length > 0 ? { resumeUpdates } : {}),
-    restoredInput: resolved.inputText,
-    ...(pendingRewindResult ? { pendingRewindResult } : {}),
-    ...(sessionsToCloseAfterConnect.length > 0 ? { sessionsToCloseAfterConnect } : {}),
-  });
-  bridgeLogger.info({
-    target: LOG_TARGETS.APP_SESSION,
-    eventName: "rewind_replacement_created",
-    message: "conversation rewind replacement session created",
-    outcome: "success",
-    ...(requestId ? { requestId } : {}),
-    sessionId: command.session_id,
-    fields: {
-      target_user_message_id: targetUserMessageId,
-      resume_session_at: resolved.previousAssistantUuid,
-      retained_message_count: resolved.retainedMessages.length,
-      retained_update_count: resumeUpdates.length,
-      stale_session_count: staleSessions.length,
-    },
-  });
 }
 
 async function handleRewind(
@@ -635,7 +730,11 @@ async function handleRewind(
 ): Promise<void> {
   const session = sessionById(command.session_id);
   if (!session) {
-    slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
+    slashError(
+      command.session_id,
+      `unknown session: ${command.session_id}`,
+      requestId,
+    );
     return;
   }
   const targetUserMessageId = command.target_user_message_id.trim();
@@ -659,7 +758,13 @@ async function handleRewind(
 
   if (command.restore_mode === "conversation") {
     try {
-      await replaceConversationForRewind(command, session, targetUserMessageId, requestId);
+      const candidate = await prepareConversationRewindCandidate(
+        command,
+        session,
+        targetUserMessageId,
+        requestId,
+      );
+      commitDeferredSession(candidate);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       bridgeLogger.error({
@@ -675,25 +780,24 @@ async function handleRewind(
           error_message: message,
         },
       });
-      slashError(command.session_id, `failed to rewind conversation: ${message}`, requestId);
+      slashError(
+        command.session_id,
+        `failed to rewind conversation: ${message}`,
+        requestId,
+      );
     }
     return;
   }
 
-  let appliedFileResult: RewindFilesResult;
+  let dryRunResult: RewindFilesResult;
   try {
-    const dryRunResult = await rewindFiles(session, targetUserMessageId, true);
+    dryRunResult = await rewindFiles(session, targetUserMessageId, true);
     if (!dryRunResult.can_rewind) {
       slashError(
         command.session_id,
         dryRunResult.error ?? "failed to dry-run file rewind",
         requestId,
       );
-      return;
-    }
-    appliedFileResult = await rewindFiles(session, targetUserMessageId, false);
-    if (!appliedFileResult.can_rewind) {
-      slashError(command.session_id, appliedFileResult.error ?? "failed to restore code", requestId);
       return;
     }
   } catch (error) {
@@ -711,35 +815,62 @@ async function handleRewind(
         error_message: message,
       },
     });
-    slashError(command.session_id, `failed to restore code: ${message}`, requestId);
-    return;
-  }
-
-  if (command.restore_mode === "code") {
-    emitRewindResult(
-      session.sessionId,
-      command.restore_mode,
-      "success",
+    slashError(
+      command.session_id,
+      `failed to restore code: ${message}`,
       requestId,
-      appliedFileResult,
     );
     return;
   }
 
+  if (command.restore_mode === "code") {
+    try {
+      const appliedFileResult = await rewindFiles(
+        session,
+        targetUserMessageId,
+        false,
+      );
+      if (!appliedFileResult.can_rewind) {
+        slashError(
+          command.session_id,
+          appliedFileResult.error ?? "failed to restore code",
+          requestId,
+        );
+        return;
+      }
+      emitRewindResult(
+        session.sessionId,
+        command.restore_mode,
+        "success",
+        requestId,
+        appliedFileResult,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      slashError(
+        command.session_id,
+        `failed to restore code: ${message}`,
+        requestId,
+      );
+    }
+    return;
+  }
+
+  let candidate: SessionState;
   try {
-    await replaceConversationForRewind(command, session, targetUserMessageId, requestId, {
-      event: "rewind_result",
-      restore_mode: command.restore_mode,
-      status: "success",
-      file_result: appliedFileResult,
-    });
+    candidate = await prepareConversationRewindCandidate(
+      command,
+      session,
+      targetUserMessageId,
+      requestId,
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     bridgeLogger.error({
       target: LOG_TARGETS.APP_SESSION,
       eventName: "rewind_failed",
-      message: "conversation rewind failed after file restore",
-      outcome: "partial_failure",
+      message: "conversation candidate failed before file restore",
+      outcome: "failure",
       ...(requestId ? { requestId } : {}),
       sessionId: session.sessionId,
       fields: {
@@ -748,21 +879,85 @@ async function handleRewind(
         error_message: message,
       },
     });
+    slashError(
+      command.session_id,
+      `failed to validate conversation rewind: ${message}`,
+      requestId,
+    );
+    return;
+  }
+
+  let appliedFileResult: RewindFilesResult;
+  try {
+    appliedFileResult = await rewindFiles(session, targetUserMessageId, false);
+    if (!appliedFileResult.can_rewind) {
+      throw new Error(appliedFileResult.error ?? "failed to restore code");
+    }
+  } catch (error) {
+    detachSessionForClose(candidate);
+    await closeSessionWithLogging(candidate, {
+      reason: "rewind_file_apply_failed",
+      requestId,
+    });
+    const message = error instanceof Error ? error.message : String(error);
+    bridgeLogger.error({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "rewind_failed",
+      message: "file rewind failed after conversation candidate validation",
+      outcome: "failure",
+      ...(requestId ? { requestId } : {}),
+      sessionId: session.sessionId,
+      fields: {
+        target_user_message_id: targetUserMessageId,
+        restore_mode: command.restore_mode,
+        error_message: message,
+      },
+    });
+    slashError(
+      command.session_id,
+      `failed to restore code: ${message}`,
+      requestId,
+    );
+    return;
+  }
+
+  candidate.pendingRewindResult = {
+    event: "rewind_result",
+    restore_mode: command.restore_mode,
+    status: "success",
+    file_result: appliedFileResult,
+  };
+  try {
+    commitDeferredSession(candidate);
+  } catch (error) {
+    detachSessionForClose(candidate);
+    await closeSessionWithLogging(candidate, {
+      reason: "rewind_candidate_failed_after_file_apply",
+      requestId,
+    });
+    const message = error instanceof Error ? error.message : String(error);
     emitRewindResult(
       session.sessionId,
       command.restore_mode,
       "partial_failure",
       requestId,
       appliedFileResult,
-      `Code was restored, but the conversation could not be rewound: ${message}`,
+      `Code was restored, but the conversation candidate could not be committed: ${message}`,
     );
   }
 }
 
-async function handleCommand(command: BridgeCommand, requestId?: string): Promise<void> {
+async function handleCommand(
+  command: BridgeCommand,
+  requestId?: string,
+): Promise<void> {
   logBridgeCommandReceived(command, requestId);
   const sdkVersionError = agentSdkVersionCompatibilityError();
-  if (sdkVersionError && command.command !== "initialize" && command.command !== "shutdown") {
+  if (
+    sdkVersionError &&
+    command.command !== "initialize" &&
+    command.command !== "shutdown"
+  ) {
     bridgeLogger.error({
       target: LOG_TARGETS.BRIDGE_LIFECYCLE,
       eventName: "bridge_command_rejected",
@@ -782,9 +977,12 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
     case "initialize":
     case "create_session":
     case "resume_session":
+    case "resume_session_at":
     case "new_session":
     case "shutdown":
-      await handleLifecycleCommand(command, requestId, sdkVersionError);
+      await handleLifecycleCommand(command, requestId, sdkVersionError, {
+        buildRewindConversationPlan,
+      });
       return;
     case "prompt":
     case "cancel_turn":
@@ -808,6 +1006,7 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
     case "rename_session":
     case "get_status_snapshot":
     case "get_context_usage":
+    case "get_usage":
     case "get_rewind_targets":
     case "rewind":
       await handleSessionDataCommand(command, requestId, {
@@ -840,7 +1039,8 @@ async function handleCommand(command: BridgeCommand, requestId?: string): Promis
         outcome: "failure",
         ...(requestId ? { requestId } : {}),
         fields: {
-          bridge_command: (command as { command?: string }).command ?? "unknown",
+          bridge_command:
+            (command as { command?: string }).command ?? "unknown",
           reason: "unsupported_command",
         },
       });
@@ -943,6 +1143,9 @@ function main(): void {
   });
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   main();
 }

--- a/agent-sdk/src/bridge/account_metadata.ts
+++ b/agent-sdk/src/bridge/account_metadata.ts
@@ -23,10 +23,14 @@ const KNOWN_API_PROVIDERS = new Set<string>([
 ]);
 
 function trimmedString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
 }
 
-export function isKnownApiProvider(provider: string | undefined): provider is KnownApiProvider {
+export function isKnownApiProvider(
+  provider: string | undefined,
+): provider is KnownApiProvider {
   return provider !== undefined && KNOWN_API_PROVIDERS.has(provider);
 }
 
@@ -37,7 +41,9 @@ export function apiProviderIsExternal(provider: string | undefined): boolean {
 export function mapSdkAccountInfo(account: SdkAccountInfo): AccountInfo {
   const apiProvider = trimmedString(account.apiProvider);
   return {
-    ...(trimmedString(account.email) ? { email: trimmedString(account.email) } : {}),
+    ...(trimmedString(account.email)
+      ? { email: trimmedString(account.email) }
+      : {}),
     ...(trimmedString(account.organization)
       ? { organization: trimmedString(account.organization) }
       : {}),
@@ -54,7 +60,9 @@ export function mapSdkAccountInfo(account: SdkAccountInfo): AccountInfo {
   };
 }
 
-export function shouldEmitStartupAuthRequiredForAccount(account: SdkAccountInfo): boolean {
+export function shouldEmitStartupAuthRequiredForAccount(
+  account: SdkAccountInfo,
+): boolean {
   const provider = trimmedString(account.apiProvider);
   if (apiProviderIsExternal(provider)) {
     return false;

--- a/agent-sdk/src/bridge/agents.ts
+++ b/agent-sdk/src/bridge/agents.ts
@@ -28,14 +28,21 @@ export function mapAvailableAgents(value: unknown): AvailableAgent[] {
     if (!name) {
       continue;
     }
-    const description = typeof record.description === "string" ? record.description : "";
-    const model = typeof record.model === "string" && record.model.trim().length > 0 ? record.model : undefined;
+    const description =
+      typeof record.description === "string" ? record.description : "";
+    const model =
+      typeof record.model === "string" && record.model.trim().length > 0
+        ? record.model
+        : undefined;
     const existing = byName.get(name);
     if (!existing) {
       byName.set(name, { name, description, model });
       continue;
     }
-    if (existing.description.trim().length === 0 && description.trim().length > 0) {
+    if (
+      existing.description.trim().length === 0 &&
+      description.trim().length > 0
+    ) {
       existing.description = description;
     }
     if (!existing.model && model) {
@@ -61,13 +68,19 @@ export function mapAvailableAgentsFromNames(value: unknown): AvailableAgent[] {
   return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export function emitAvailableAgentsIfChanged(session: SessionState, agents: AvailableAgent[]): void {
+export function emitAvailableAgentsIfChanged(
+  session: SessionState,
+  agents: AvailableAgent[],
+): void {
   const signature = availableAgentsSignature(agents);
   if (session.lastAvailableAgentsSignature === signature) {
     return;
   }
   session.lastAvailableAgentsSignature = signature;
-  emitSessionUpdate(session.sessionId, { type: "available_agents_update", agents });
+  emitSessionUpdate(session.sessionId, {
+    type: "available_agents_update",
+    agents,
+  });
 }
 
 export function refreshAvailableAgents(session: SessionState): void {

--- a/agent-sdk/src/bridge/available_commands.ts
+++ b/agent-sdk/src/bridge/available_commands.ts
@@ -25,7 +25,11 @@ function isDynamicSource(source: AvailableCommandsSource): boolean {
 
 function commandSignature(commands: AvailableCommand[]): string {
   return JSON.stringify(
-    commands.map((command) => [command.name, command.description, command.input_hint ?? ""]),
+    commands.map((command) => [
+      command.name,
+      command.description,
+      command.input_hint ?? "",
+    ]),
   );
 }
 
@@ -72,7 +76,10 @@ function shouldAcceptAvailableCommandsSnapshot(
   }
   if (!current) {
     if (commands.length === 0) {
-      return { accept: false, reason: "empty bootstrap snapshot ignored before first command list" };
+      return {
+        accept: false,
+        reason: "empty bootstrap snapshot ignored before first command list",
+      };
     }
     return { accept: true, reason: "initial command snapshot" };
   }
@@ -91,7 +98,10 @@ function shouldAcceptAvailableCommandsSnapshot(
   if (commands.length === 0) {
     return { accept: false, reason: "empty bootstrap snapshot ignored" };
   }
-  return { accept: true, reason: "bootstrap refresh before dynamic command source" };
+  return {
+    accept: true,
+    reason: "bootstrap refresh before dynamic command source",
+  };
 }
 
 export function updateAvailableCommands(
@@ -99,7 +109,11 @@ export function updateAvailableCommands(
   source: AvailableCommandsSource,
   commands: AvailableCommand[],
 ): boolean {
-  const decision = shouldAcceptAvailableCommandsSnapshot(session, source, commands);
+  const decision = shouldAcceptAvailableCommandsSnapshot(
+    session,
+    source,
+    commands,
+  );
   const currentGeneration = session.availableCommands?.generation ?? 0;
   const nextGeneration = currentGeneration + 1;
   if (!decision.accept) {
@@ -114,7 +128,8 @@ export function updateAvailableCommands(
     return false;
   }
 
-  const dynamicSeen = session.availableCommands?.dynamicSeen === true || isDynamicSource(source);
+  const dynamicSeen =
+    session.availableCommands?.dynamicSeen === true || isDynamicSource(source);
   session.availableCommands = {
     generation: nextGeneration,
     source,
@@ -164,8 +179,10 @@ export function mapSdkSlashCommand(command: unknown): AvailableCommand | null {
   }
   return {
     name,
-    description: typeof record.description === "string" ? record.description : "",
-    input_hint: typeof record.argumentHint === "string" ? record.argumentHint : undefined,
+    description:
+      typeof record.description === "string" ? record.description : "",
+    input_hint:
+      typeof record.argumentHint === "string" ? record.argumentHint : undefined,
   };
 }
 

--- a/agent-sdk/src/bridge/cache_policy.ts
+++ b/agent-sdk/src/bridge/cache_policy.ts
@@ -10,7 +10,9 @@ export const CACHE_SPLIT_POLICY: Readonly<CacheSplitPolicy> = Object.freeze({
   previewLimitBytes: 2048,
 });
 
-export function previewKilobyteLabel(policy: Readonly<CacheSplitPolicy> = CACHE_SPLIT_POLICY): string {
+export function previewKilobyteLabel(
+  policy: Readonly<CacheSplitPolicy> = CACHE_SPLIT_POLICY,
+): string {
   const kb = policy.previewLimitBytes / 1024;
   return Number.isInteger(kb) ? `${kb}KB` : `${kb.toFixed(1)}KB`;
 }

--- a/agent-sdk/src/bridge/command_dispatch.ts
+++ b/agent-sdk/src/bridge/command_dispatch.ts
@@ -21,12 +21,18 @@ export async function dispatchCancelTurnCommand(
 ): Promise<void> {
   const session = deps.sessionById(command.session_id);
   if (!session) {
-    deps.slashError(command.session_id, `unknown session: ${command.session_id}`, deps.requestId);
+    deps.slashError(
+      command.session_id,
+      `unknown session: ${command.session_id}`,
+      deps.requestId,
+    );
     return;
   }
   const receipt = await session.query.interrupt();
   const stillQueued = Array.isArray(receipt?.still_queued)
-    ? receipt.still_queued.filter((entry): entry is string => typeof entry === "string")
+    ? receipt.still_queued.filter(
+        (entry): entry is string => typeof entry === "string",
+      )
     : [];
   if (stillQueued.length > 0) {
     bridgeLogger.info({

--- a/agent-sdk/src/bridge/command_lifecycle.ts
+++ b/agent-sdk/src/bridge/command_lifecycle.ts
@@ -5,6 +5,7 @@ import {
 import type { BridgeCommand } from "../types.js";
 import {
   currentSessionListOptions,
+  emitSessionResumeFailed,
   emitSessionsList,
   failConnection,
   setSessionListingDir,
@@ -14,10 +15,15 @@ import {
 import { mapSessionMessagesToUpdates } from "./history.js";
 import { bridgeLogger, LOG_TARGETS } from "./logger.js";
 import {
+  awaitSessionInitialization,
   closeAllSessions,
+  closeSessionWithLogging,
+  commitDeferredSession,
   createSession,
+  detachSessionForClose,
   sessions,
 } from "./session_lifecycle.js";
+import type { RewindConversationPlan } from "../bridge.js";
 
 type LifecycleCommand = Extract<
   BridgeCommand,
@@ -26,6 +32,7 @@ type LifecycleCommand = Extract<
       | "initialize"
       | "create_session"
       | "resume_session"
+      | "resume_session_at"
       | "new_session"
       | "shutdown";
   }
@@ -35,6 +42,12 @@ export async function handleLifecycleCommand(
   command: LifecycleCommand,
   requestId: string | undefined,
   sdkVersionError: string | undefined,
+  deps: {
+    buildRewindConversationPlan: (
+      messages: import("@anthropic-ai/claude-agent-sdk").SessionMessage[],
+      targetUserMessageId: string,
+    ) => RewindConversationPlan | null;
+  },
 ): Promise<void> {
   switch (command.command) {
     case "initialize":
@@ -46,11 +59,112 @@ export async function handleLifecycleCommand(
     case "resume_session":
       await resume(command, requestId);
       return;
+    case "resume_session_at":
+      await resumeAt(command, requestId, deps.buildRewindConversationPlan);
+      return;
     case "new_session":
       await replace(command, requestId);
       return;
     case "shutdown":
       await shutdown(requestId);
+  }
+}
+
+async function resumeAt(
+  command: Extract<LifecycleCommand, { command: "resume_session_at" }>,
+  requestId: string | undefined,
+  buildPlan: (
+    messages: import("@anthropic-ai/claude-agent-sdk").SessionMessage[],
+    targetUserMessageId: string,
+  ) => RewindConversationPlan | null,
+): Promise<void> {
+  if (!requestId) {
+    slashError(
+      command.session_id,
+      "resume before a selected message requires an operation id",
+    );
+    return;
+  }
+  const targetUserMessageId = command.target_user_message_id.trim();
+  if (!targetUserMessageId) {
+    emitSessionResumeFailed(
+      command.session_id,
+      requestId,
+      "resume target cannot be empty",
+    );
+    return;
+  }
+
+  let candidate: import("./session_lifecycle.js").SessionState | undefined;
+  try {
+    const sdkSessions = await listSessions(currentSessionListOptions());
+    const matched = sdkSessions.find(
+      (entry) => entry.sessionId === command.session_id,
+    );
+    if (!matched) {
+      emitSessionResumeFailed(
+        command.session_id,
+        requestId,
+        `unknown session: ${command.session_id}`,
+      );
+      return;
+    }
+    const cwd = matched.cwd ?? process.cwd();
+    setSessionListingDir(cwd);
+    const historyMessages = await getSessionMessages(command.session_id, {
+      dir: cwd,
+      includeSystemMessages: true,
+    });
+    const plan = buildPlan(historyMessages, targetUserMessageId);
+    if (!plan) {
+      throw new Error(
+        `stale or inconsistent resume target: ${targetUserMessageId}`,
+      );
+    }
+
+    const staleSessions = Array.from(sessions.values());
+    const connectEvent =
+      staleSessions.length > 0 ? "session_replaced" : "connected";
+    candidate = plan.resumeSessionAtUuid
+      ? await createSession({
+          cwd,
+          resume: command.session_id,
+          resumeSessionAt: plan.resumeSessionAtUuid,
+          resumeDropsTurn: plan.resumeDropsTurnId,
+          forkSession: true,
+          launchSettings: command.launch_settings,
+          connectEvent,
+          requestId,
+          deferConnect: true,
+          resumeUpdates: plan.resumeUpdates,
+          sessionsToCloseAfterConnect: staleSessions,
+        })
+      : await createSession({
+          cwd,
+          launchSettings: command.launch_settings,
+          connectEvent,
+          requestId,
+          deferConnect: true,
+          sessionsToCloseAfterConnect: staleSessions,
+        });
+
+    await awaitSessionInitialization(candidate);
+    commitDeferredSession(candidate);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (candidate) {
+      detachSessionForClose(candidate);
+      await closeSessionWithLogging(candidate, {
+        reason: "resume_at_candidate_rejected",
+        requestId,
+      });
+    }
+    const userMessage = message.startsWith(
+      "Resume rejected by --resume-drops-turn:",
+    )
+      ? "The session changed while you were selecting a message, so Claude Code refused to discard the newer turn. Reopen Resume and try again."
+      : `Failed to fork before selected message: ${message}`;
+    emitSessionResumeFailed(command.session_id, requestId, userMessage);
   }
 }
 
@@ -137,7 +251,9 @@ async function resume(
   });
   try {
     const sdkSessions = await listSessions(currentSessionListOptions());
-    const matched = sdkSessions.find((entry) => entry.sessionId === command.session_id);
+    const matched = sdkSessions.find(
+      (entry) => entry.sessionId === command.session_id,
+    );
     if (!matched) {
       bridgeLogger.warn({
         target: LOG_TARGETS.APP_SESSION,
@@ -148,7 +264,11 @@ async function resume(
         sessionId: command.session_id,
         fields: { reason: "unknown_session" },
       });
-      slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
+      slashError(
+        command.session_id,
+        `unknown session: ${command.session_id}`,
+        requestId,
+      );
       return;
     }
     setSessionListingDir(matched.cwd ?? process.cwd());
@@ -180,7 +300,9 @@ async function resume(
       ...(resumeUpdates.length > 0 ? { resumeUpdates } : {}),
       connectEvent: hadActiveSession ? "session_replaced" : "connected",
       requestId,
-      ...(hadActiveSession ? { sessionsToCloseAfterConnect: staleSessions } : {}),
+      ...(hadActiveSession
+        ? { sessionsToCloseAfterConnect: staleSessions }
+        : {}),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -193,7 +315,11 @@ async function resume(
       sessionId: command.session_id,
       fields: { error_message: message },
     });
-    slashError(command.session_id, `failed to resume session: ${message}`, requestId);
+    slashError(
+      command.session_id,
+      `failed to resume session: ${message}`,
+      requestId,
+    );
   }
 }
 

--- a/agent-sdk/src/bridge/command_mcp.ts
+++ b/agent-sdk/src/bridge/command_mcp.ts
@@ -31,7 +31,11 @@ export async function handleMcpCommand(
 ): Promise<void> {
   const session = sessionById(command.session_id);
   if (!session) {
-    slashError(command.session_id, `unknown session: ${command.session_id}`, requestId);
+    slashError(
+      command.session_id,
+      `unknown session: ${command.session_id}`,
+      requestId,
+    );
     return;
   }
   switch (command.command) {

--- a/agent-sdk/src/bridge/command_scheduler.test.ts
+++ b/agent-sdk/src/bridge/command_scheduler.test.ts
@@ -24,24 +24,35 @@ test("lifecycle commands complete in arrival order when the older operation is d
   const order: string[] = [];
   let authority = "";
 
-  const olderTask = scheduler.schedule(command("resume_session", "older"), async () => {
-    order.push("older:start");
-    await older.promise;
-    authority = "older";
-    order.push("older:end");
-  });
-  const newerTask = scheduler.schedule(command("resume_session", "newer"), async () => {
-    order.push("newer:start");
-    authority = "newer";
-    order.push("newer:end");
-  });
+  const olderTask = scheduler.schedule(
+    command("resume_session", "older"),
+    async () => {
+      order.push("older:start");
+      await older.promise;
+      authority = "older";
+      order.push("older:end");
+    },
+  );
+  const newerTask = scheduler.schedule(
+    command("resume_session", "newer"),
+    async () => {
+      order.push("newer:start");
+      authority = "newer";
+      order.push("newer:end");
+    },
+  );
 
   await Promise.resolve();
   assert.deepEqual(order, ["older:start"]);
   older.resolve();
   await Promise.all([olderTask, newerTask]);
 
-  assert.deepEqual(order, ["older:start", "older:end", "newer:start", "newer:end"]);
+  assert.deepEqual(order, [
+    "older:start",
+    "older:end",
+    "newer:start",
+    "newer:end",
+  ]);
   assert.equal(authority, "newer");
 });
 
@@ -67,7 +78,12 @@ test("new-session is an exclusive barrier between session operations", async () 
   sessionMutation.resolve();
   await Promise.all([before, replacement, after]);
 
-  assert.deepEqual(order, ["mutation:start", "mutation:end", "new-session", "prompt"]);
+  assert.deepEqual(order, [
+    "mutation:start",
+    "mutation:end",
+    "new-session",
+    "prompt",
+  ]);
 });
 
 test("commands are FIFO within a session and concurrent across sessions", async () => {
@@ -75,17 +91,26 @@ test("commands are FIFO within a session and concurrent across sessions", async 
   const firstSession = deferred();
   const order: string[] = [];
 
-  const first = scheduler.schedule(command("set_mode", "session-1"), async () => {
-    order.push("one:start");
-    await firstSession.promise;
-    order.push("one:end");
-  });
-  const sameSession = scheduler.schedule(command("set_effort", "session-1"), async () => {
-    order.push("one:next");
-  });
-  const otherSession = scheduler.schedule(command("set_model", "session-2"), async () => {
-    order.push("two");
-  });
+  const first = scheduler.schedule(
+    command("set_mode", "session-1"),
+    async () => {
+      order.push("one:start");
+      await firstSession.promise;
+      order.push("one:end");
+    },
+  );
+  const sameSession = scheduler.schedule(
+    command("set_effort", "session-1"),
+    async () => {
+      order.push("one:next");
+    },
+  );
+  const otherSession = scheduler.schedule(
+    command("set_model", "session-2"),
+    async () => {
+      order.push("two");
+    },
+  );
 
   await Promise.resolve();
   await Promise.resolve();
@@ -162,8 +187,16 @@ test("unblocking commands remain admitted while shutdown is queued", async () =>
   });
 
   await Promise.all([parent, reply, shutdown]);
-  assert.deepEqual(order, ["parent:start", "response", "parent:end", "shutdown"]);
-  assert.equal(scheduler.schedule(command("cancel_turn"), async () => undefined), undefined);
+  assert.deepEqual(order, [
+    "parent:start",
+    "response",
+    "parent:end",
+    "shutdown",
+  ]);
+  assert.equal(
+    scheduler.schedule(command("cancel_turn"), async () => undefined),
+    undefined,
+  );
 });
 
 test("a failed operation does not poison its scheduling lane", async () => {

--- a/agent-sdk/src/bridge/command_scheduler.ts
+++ b/agent-sdk/src/bridge/command_scheduler.ts
@@ -11,6 +11,7 @@ const LIFECYCLE_COMMANDS = new Set<BridgeCommand["command"]>([
   "initialize",
   "create_session",
   "resume_session",
+  "resume_session_at",
   "new_session",
   "rewind",
   "shutdown",
@@ -49,9 +50,13 @@ export class BridgeCommandScheduler {
   private lifecycleTail: Promise<void> | undefined;
   private readonly sessionTails = new Map<string, Promise<void>>();
   private readonly activeTasks = new Set<Promise<void>>();
-  private shutdownState: "accepting" | "queued" | "running" | "complete" = "accepting";
+  private shutdownState: "accepting" | "queued" | "running" | "complete" =
+    "accepting";
 
-  schedule(command: BridgeCommand, task: CommandTask): Promise<void> | undefined {
+  schedule(
+    command: BridgeCommand,
+    task: CommandTask,
+  ): Promise<void> | undefined {
     const lane = commandLane(command);
     if (!this.accepts(command, lane)) {
       return undefined;
@@ -115,7 +120,9 @@ export class BridgeCommandScheduler {
       dependencies.add(this.lifecycleTail);
     }
     const operation =
-      dependencies.size === 0 ? this.start(task) : Promise.all(dependencies).then(task);
+      dependencies.size === 0
+        ? this.start(task)
+        : Promise.all(dependencies).then(task);
     const tail = settle(operation);
     this.lifecycleTail = tail;
     void tail.then(() => {
@@ -136,7 +143,9 @@ export class BridgeCommandScheduler {
       dependencies.push(previousSessionTask);
     }
     const operation =
-      dependencies.length === 0 ? this.start(task) : Promise.all(dependencies).then(task);
+      dependencies.length === 0
+        ? this.start(task)
+        : Promise.all(dependencies).then(task);
     const tail = settle(operation);
     this.sessionTails.set(sessionId, tail);
     void tail.then(() => {

--- a/agent-sdk/src/bridge/command_session_control.ts
+++ b/agent-sdk/src/bridge/command_session_control.ts
@@ -1,9 +1,5 @@
 import type { Query, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
-import type {
-  BridgeCommand,
-  EffortLevel,
-  FastModeSnapshot,
-} from "../types.js";
+import type { BridgeCommand, EffortLevel, FastModeSnapshot } from "../types.js";
 import {
   buildModeState,
   markModeUnavailableForSession,
@@ -45,9 +41,18 @@ export type SessionControlCommandDeps = {
   ) => SDKUserMessage | undefined;
   applySessionEffort: (query: Query, effort: EffortLevel) => Promise<void>;
   applySessionAgent: (query: Query, agent: string | null) => Promise<void>;
-  applySessionFastMode: (query: Query, enabled: boolean) => Promise<FastModeSnapshot>;
-  emitEffortConfigOptionUpdate: (sessionId: string, effort: EffortLevel) => void;
-  emitAgentConfigOptionUpdate: (sessionId: string, agent: string | null) => void;
+  applySessionFastMode: (
+    query: Query,
+    enabled: boolean,
+  ) => Promise<FastModeSnapshot>;
+  emitEffortConfigOptionUpdate: (
+    sessionId: string,
+    effort: EffortLevel,
+  ) => void;
+  emitAgentConfigOptionUpdate: (
+    sessionId: string,
+    agent: string | null,
+  ) => void;
   handleReloadPluginsCommand: (
     session: SessionState,
     requestId?: string,
@@ -64,7 +69,11 @@ export async function handleSessionControlCommand(
       handlePrompt(command, requestId, deps);
       return;
     case "cancel_turn":
-      await dispatchCancelTurnCommand(command, { requestId, sessionById, slashError });
+      await dispatchCancelTurnCommand(command, {
+        requestId,
+        sessionById,
+        slashError,
+      });
       return;
     case "set_model":
       await setModel(command, requestId);
@@ -130,16 +139,18 @@ async function setModel(
     await session.query.setModel(command.model);
     session.requestedModelId = command.model;
     session.model = command.model;
-    const invalidatedResolvedRuntimeModel = shouldInvalidateResolvedRuntimeModel(
-      previousRequestedModel,
-      previousSessionModel,
-      command.model,
-    );
+    const invalidatedResolvedRuntimeModel =
+      shouldInvalidateResolvedRuntimeModel(
+        previousRequestedModel,
+        previousSessionModel,
+        command.model,
+      );
     if (invalidatedResolvedRuntimeModel) {
       session.resolvedRuntimeModelId = undefined;
     }
     const changed = refreshCurrentModel(session, true);
-    const forcedCurrentModelUpdate = !changed && emitCurrentModelUpdate(session);
+    const forcedCurrentModelUpdate =
+      !changed && emitCurrentModelUpdate(session);
     bridgeLogger.info({
       target: LOG_TARGETS.APP_SESSION,
       eventName: "set_model_succeeded",
@@ -184,7 +195,11 @@ async function setModel(
         previous_current_model: session.currentModel?.resolved_id,
       },
     });
-    slashError(command.session_id, `failed to set model: ${message}`, requestId);
+    slashError(
+      command.session_id,
+      `failed to set model: ${message}`,
+      requestId,
+    );
   }
 }
 
@@ -198,7 +213,11 @@ async function setMode(
   }
   const mode = toPermissionMode(command.mode);
   if (!mode) {
-    slashError(command.session_id, `unsupported mode: ${command.mode}`, requestId);
+    slashError(
+      command.session_id,
+      `unsupported mode: ${command.mode}`,
+      requestId,
+    );
     return;
   }
   try {
@@ -220,7 +239,11 @@ async function setMode(
         });
       }
     }
-    slashError(command.session_id, `failed to set mode to ${mode}: ${message}`, requestId);
+    slashError(
+      command.session_id,
+      `failed to set mode to ${mode}: ${message}`,
+      requestId,
+    );
   }
 }
 
@@ -238,7 +261,11 @@ async function setEffort(
     deps.emitEffortConfigOptionUpdate(session.sessionId, command.effort);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    slashError(command.session_id, `failed to set effort: ${message}`, requestId);
+    slashError(
+      command.session_id,
+      `failed to set effort: ${message}`,
+      requestId,
+    );
   }
 }
 
@@ -256,7 +283,11 @@ async function setAgent(
     deps.emitAgentConfigOptionUpdate(session.sessionId, command.agent);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    slashError(command.session_id, `failed to set agent: ${message}`, requestId);
+    slashError(
+      command.session_id,
+      `failed to set agent: ${message}`,
+      requestId,
+    );
   }
 }
 
@@ -282,7 +313,10 @@ async function setFastMode(
     },
   });
   try {
-    const snapshot = await deps.applySessionFastMode(session.query, command.enabled);
+    const snapshot = await deps.applySessionFastMode(
+      session.query,
+      command.enabled,
+    );
     const state = snapshot.state;
     session.fastModeState = state;
     session.fastModeDisabledReason = snapshot.disabled_reason;
@@ -292,7 +326,8 @@ async function setFastMode(
       bridgeLogger.warn({
         target: LOG_TARGETS.APP_SESSION,
         eventName: "set_fast_mode_mismatch",
-        message: "SDK reported a fast-mode state that did not match the request",
+        message:
+          "SDK reported a fast-mode state that did not match the request",
         outcome: "failure",
         sessionId: session.sessionId,
         requestId,
@@ -336,7 +371,11 @@ async function setFastMode(
         error_message: message,
       },
     });
-    slashError(command.session_id, `failed to set fast mode: ${message}`, requestId);
+    slashError(
+      command.session_id,
+      `failed to set fast mode: ${message}`,
+      requestId,
+    );
   }
 }
 
@@ -351,7 +390,10 @@ async function reloadPlugins(
   }
 }
 
-function requireSession(sessionId: string, requestId?: string): SessionState | null {
+function requireSession(
+  sessionId: string,
+  requestId?: string,
+): SessionState | null {
   const session = sessionById(sessionId);
   if (!session) {
     slashError(sessionId, `unknown session: ${sessionId}`, requestId);

--- a/agent-sdk/src/bridge/command_session_data.ts
+++ b/agent-sdk/src/bridge/command_session_data.ts
@@ -1,5 +1,6 @@
 import {
   getSessionMessages,
+  listSessions,
   renameSession,
 } from "@anthropic-ai/claude-agent-sdk";
 import type {
@@ -10,9 +11,19 @@ import type {
 import type {
   BridgeCommand,
   RewindTarget,
+  StructuredActivityWindow,
+  StructuredExtraUsage,
+  StructuredBehaviorAttribution,
+  StructuredModelUsageWindow,
+  StructuredNamedAttribution,
+  StructuredSessionUsage,
+  StructuredUsageSnapshot,
+  StructuredUsageWindow,
 } from "../types.js";
+import { asRecordOrNull } from "./shared.js";
 import { mapSdkAccountInfo } from "./account_metadata.js";
 import {
+  currentSessionListOptions,
   emitSessionsList,
   setSessionListingDir,
   slashError,
@@ -33,15 +44,23 @@ type SessionDataCommand = Extract<
       | "rename_session"
       | "get_status_snapshot"
       | "get_context_usage"
+      | "get_usage"
       | "get_rewind_targets"
       | "rewind";
   }
 >;
 
 export type SessionDataCommandDeps = {
-  generatePersistedSessionTitle: (query: Query, description: string) => Promise<string>;
-  buildSessionMutationOptions: (cwd?: string) => SessionMutationOptions | undefined;
-  rewindTargetsFromSessionMessages: (messages: SessionMessage[]) => RewindTarget[];
+  generatePersistedSessionTitle: (
+    query: Query,
+    description: string,
+  ) => Promise<string>;
+  buildSessionMutationOptions: (
+    cwd?: string,
+  ) => SessionMutationOptions | undefined;
+  rewindTargetsFromSessionMessages: (
+    messages: SessionMessage[],
+  ) => RewindTarget[];
   handleRewind: (
     command: Extract<BridgeCommand, { command: "rewind" }>,
     requestId?: string,
@@ -66,6 +85,9 @@ export async function handleSessionDataCommand(
     case "get_context_usage":
       await getContextUsage(command, requestId);
       return;
+    case "get_usage":
+      await getUsage(command, requestId);
+      return;
     case "get_rewind_targets":
       await getRewindTargets(command, requestId, deps);
       return;
@@ -84,12 +106,19 @@ async function generateTitle(
     return;
   }
   try {
-    await deps.generatePersistedSessionTitle(session.query, command.description);
+    await deps.generatePersistedSessionTitle(
+      session.query,
+      command.description,
+    );
     setSessionListingDir(session.cwd);
     await emitSessionsList(requestId);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    slashError(command.session_id, `failed to generate session title: ${message}`, requestId);
+    slashError(
+      command.session_id,
+      `failed to generate session title: ${message}`,
+      requestId,
+    );
   }
 }
 
@@ -112,7 +141,11 @@ async function rename(
     await emitSessionsList(requestId);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    slashError(command.session_id, `failed to rename session: ${message}`, requestId);
+    slashError(
+      command.session_id,
+      `failed to rename session: ${message}`,
+      requestId,
+    );
   }
 }
 
@@ -134,7 +167,8 @@ async function getStatusSnapshot(
       ...(requestId ? { requestId } : {}),
       sessionId: session.sessionId,
       fields: {
-        has_email: typeof account.email === "string" && account.email.trim().length > 0,
+        has_email:
+          typeof account.email === "string" && account.email.trim().length > 0,
         has_organization: account.organization !== undefined,
         subscription_type: account.subscriptionType,
         token_source: account.tokenSource,
@@ -179,7 +213,8 @@ async function getContextUsage(
       session.resolvedRuntimeModelId = usage.model.trim();
       refreshCurrentModel(session, true);
     }
-    const rawPercentage = typeof usage.percentage === "number" ? usage.percentage : undefined;
+    const rawPercentage =
+      typeof usage.percentage === "number" ? usage.percentage : undefined;
     const normalizedPercentage =
       rawPercentage === undefined || !Number.isFinite(rawPercentage)
         ? undefined
@@ -194,9 +229,14 @@ async function getContextUsage(
       fields: {
         raw_percentage: rawPercentage,
         normalized_percentage: normalizedPercentage,
-        total_tokens: typeof usage.totalTokens === "number" ? usage.totalTokens : undefined,
-        max_tokens: typeof usage.maxTokens === "number" ? usage.maxTokens : undefined,
-        raw_max_tokens: typeof usage.rawMaxTokens === "number" ? usage.rawMaxTokens : undefined,
+        total_tokens:
+          typeof usage.totalTokens === "number" ? usage.totalTokens : undefined,
+        max_tokens:
+          typeof usage.maxTokens === "number" ? usage.maxTokens : undefined,
+        raw_max_tokens:
+          typeof usage.rawMaxTokens === "number"
+            ? usage.rawMaxTokens
+            : undefined,
         model: typeof usage.model === "string" ? usage.model : undefined,
       },
     });
@@ -204,7 +244,9 @@ async function getContextUsage(
       {
         event: "context_usage",
         session_id: session.sessionId,
-        ...(normalizedPercentage !== undefined ? { percentage: normalizedPercentage } : {}),
+        ...(normalizedPercentage !== undefined
+          ? { percentage: normalizedPercentage }
+          : {}),
       },
       requestId,
     );
@@ -229,18 +271,271 @@ async function getContextUsage(
   }
 }
 
-async function getRewindTargets(
-  command: Extract<SessionDataCommand, { command: "get_rewind_targets" }>,
+function finiteNumber(
+  record: Record<string, unknown> | null,
+  key: string,
+): number | undefined {
+  const value = record?.[key];
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function structuredUsageWindow(
+  value: unknown,
+): StructuredUsageWindow | undefined {
+  const record = asRecordOrNull(value);
+  const utilization = finiteNumber(record, "utilization");
+  if (utilization === undefined) {
+    return undefined;
+  }
+  const resetsAt =
+    typeof record?.resets_at === "string" ? record.resets_at.trim() : "";
+  return {
+    utilization: Math.max(0, Math.min(100, utilization)),
+    ...(resetsAt ? { resets_at: resetsAt } : {}),
+  };
+}
+
+function structuredModelUsageWindows(
+  value: unknown,
+): StructuredModelUsageWindow[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((entry) => {
+    const record = asRecordOrNull(entry);
+    const displayName =
+      typeof record?.display_name === "string"
+        ? record.display_name.trim()
+        : "";
+    const window = structuredUsageWindow(record);
+    return displayName && window
+      ? [{ display_name: displayName, ...window }]
+      : [];
+  });
+}
+
+function structuredExtraUsage(
+  value: unknown,
+): StructuredExtraUsage | undefined {
+  const record = asRecordOrNull(value);
+  if (!record || record.is_enabled === false) {
+    return undefined;
+  }
+  const monthlyLimit = finiteNumber(record, "monthly_limit");
+  const usedCredits = finiteNumber(record, "used_credits");
+  const utilization = finiteNumber(record, "utilization");
+  const normalized: StructuredExtraUsage = {
+    ...(monthlyLimit !== undefined ? { monthly_limit: monthlyLimit } : {}),
+    ...(usedCredits !== undefined ? { used_credits: usedCredits } : {}),
+    ...(utilization !== undefined
+      ? { utilization: Math.max(0, Math.min(100, utilization)) }
+      : {}),
+    ...(typeof record.currency === "string" && record.currency.trim()
+      ? { currency: record.currency.trim() }
+      : {}),
+  };
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function structuredSessionUsage(
+  value: unknown,
+): StructuredSessionUsage | undefined {
+  const record = asRecordOrNull(value);
+  if (!record) {
+    return undefined;
+  }
+  const modelUsage = asRecordOrNull(record.model_usage);
+  const normalized: StructuredSessionUsage = {
+    ...(finiteNumber(record, "total_cost_usd") !== undefined
+      ? { total_cost_usd: finiteNumber(record, "total_cost_usd") }
+      : {}),
+    ...(finiteNumber(record, "total_api_duration_ms") !== undefined
+      ? { total_api_duration_ms: finiteNumber(record, "total_api_duration_ms") }
+      : {}),
+    ...(finiteNumber(record, "total_duration_ms") !== undefined
+      ? { total_duration_ms: finiteNumber(record, "total_duration_ms") }
+      : {}),
+    ...(finiteNumber(record, "total_lines_added") !== undefined
+      ? { total_lines_added: finiteNumber(record, "total_lines_added") }
+      : {}),
+    ...(finiteNumber(record, "total_lines_removed") !== undefined
+      ? { total_lines_removed: finiteNumber(record, "total_lines_removed") }
+      : {}),
+    ...(modelUsage ? { model_count: Object.keys(modelUsage).length } : {}),
+  };
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function structuredActivityWindow(
+  value: unknown,
+): StructuredActivityWindow | undefined {
+  const record = asRecordOrNull(value);
+  const requestCount = finiteNumber(record, "request_count");
+  const sessionCount = finiteNumber(record, "session_count");
+  if (
+    requestCount === undefined ||
+    sessionCount === undefined ||
+    requestCount < 0 ||
+    sessionCount < 0
+  ) {
+    return undefined;
+  }
+  return {
+    request_count: Math.trunc(requestCount),
+    session_count: Math.trunc(sessionCount),
+    behaviors: structuredBehaviorAttributions(record?.behaviors),
+    agents: structuredNamedAttributions(record?.agents),
+    skills: structuredNamedAttributions(record?.skills),
+    plugins: structuredNamedAttributions(record?.plugins),
+    mcp_servers: structuredNamedAttributions(record?.mcp_servers),
+  };
+}
+
+function structuredBehaviorAttributions(
+  value: unknown,
+): StructuredBehaviorAttribution[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((entry) => {
+    const record = asRecordOrNull(entry);
+    const key = typeof record?.key === "string" ? record.key.trim() : "";
+    const pct = finiteNumber(record, "pct");
+    const count = finiteNumber(record, "count");
+    if (!key || pct === undefined || count === undefined || count < 0) {
+      return [];
+    }
+    return [
+      { key, pct: Math.max(0, Math.min(100, pct)), count: Math.trunc(count) },
+    ];
+  });
+}
+
+function structuredNamedAttributions(
+  value: unknown,
+): StructuredNamedAttribution[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((entry) => {
+    const record = asRecordOrNull(entry);
+    const name = typeof record?.name === "string" ? record.name.trim() : "";
+    const pct = finiteNumber(record, "pct");
+    return name && pct !== undefined
+      ? [{ name, pct: Math.max(0, Math.min(100, pct)) }]
+      : [];
+  });
+}
+
+export function normalizeStructuredUsage(
+  value: unknown,
+): StructuredUsageSnapshot {
+  const root = asRecordOrNull(value);
+  const limits = asRecordOrNull(root?.rate_limits);
+  const behaviors = asRecordOrNull(root?.behaviors);
+  const fiveHour = structuredUsageWindow(limits?.five_hour);
+  const sevenDay = structuredUsageWindow(limits?.seven_day);
+  const sevenDayOauthApps = structuredUsageWindow(limits?.seven_day_oauth_apps);
+  const sevenDayOpus = structuredUsageWindow(limits?.seven_day_opus);
+  const sevenDaySonnet = structuredUsageWindow(limits?.seven_day_sonnet);
+  const modelScoped = structuredModelUsageWindows(limits?.model_scoped);
+  const extraUsage = structuredExtraUsage(limits?.extra_usage);
+  const session = structuredSessionUsage(root?.session);
+  const activityDay = structuredActivityWindow(behaviors?.day);
+  const activityWeek = structuredActivityWindow(behaviors?.week);
+  return {
+    ...(typeof root?.subscription_type === "string" &&
+    root.subscription_type.trim()
+      ? { subscription_type: root.subscription_type.trim() }
+      : {}),
+    ...(typeof root?.rate_limits_available === "boolean"
+      ? { rate_limits_available: root.rate_limits_available }
+      : {}),
+    ...(fiveHour ? { five_hour: fiveHour } : {}),
+    ...(sevenDay ? { seven_day: sevenDay } : {}),
+    ...(sevenDayOauthApps ? { seven_day_oauth_apps: sevenDayOauthApps } : {}),
+    ...(sevenDayOpus ? { seven_day_opus: sevenDayOpus } : {}),
+    ...(sevenDaySonnet ? { seven_day_sonnet: sevenDaySonnet } : {}),
+    ...(modelScoped.length > 0 ? { model_scoped: modelScoped } : {}),
+    ...(extraUsage ? { extra_usage: extraUsage } : {}),
+    ...(session ? { session } : {}),
+    ...(activityDay ? { activity_day: activityDay } : {}),
+    ...(activityWeek ? { activity_week: activityWeek } : {}),
+  };
+}
+
+async function getUsage(
+  command: Extract<SessionDataCommand, { command: "get_usage" }>,
   requestId: string | undefined,
-  deps: SessionDataCommandDeps,
 ): Promise<void> {
   const session = requireSession(command.session_id, requestId);
   if (!session) {
     return;
   }
   try {
+    const usageMethod = (
+      session.query as Query & {
+        usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET?: () => Promise<unknown>;
+      }
+    ).usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET;
+    if (typeof usageMethod !== "function") {
+      throw new Error("structured SDK usage is unavailable in this runtime");
+    }
+    const snapshot = normalizeStructuredUsage(
+      await usageMethod.call(session.query),
+    );
+    if (Object.keys(snapshot).length === 0) {
+      throw new Error(
+        "structured SDK usage returned an incompatible empty payload",
+      );
+    }
+    writeEvent(
+      { event: "usage_snapshot", session_id: session.sessionId, snapshot },
+      requestId,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    bridgeLogger.warn({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "structured_usage_failed",
+      message: "experimental structured SDK usage failed",
+      outcome: "fallback_required",
+      ...(requestId ? { requestId } : {}),
+      sessionId: session.sessionId,
+      fields: { error_message: message },
+    });
+    writeEvent(
+      {
+        event: "usage_snapshot",
+        session_id: session.sessionId,
+        error: message,
+      },
+      requestId,
+    );
+  }
+}
+
+async function getRewindTargets(
+  command: Extract<SessionDataCommand, { command: "get_rewind_targets" }>,
+  requestId: string | undefined,
+  deps: SessionDataCommandDeps,
+): Promise<void> {
+  const activeSession = sessionById(command.session_id);
+  try {
+    let cwd = activeSession?.cwd;
+    if (!cwd) {
+      const listedSession = (
+        await listSessions(currentSessionListOptions())
+      ).find((entry) => entry.sessionId === command.session_id);
+      if (!listedSession) {
+        throw new Error(`unknown session: ${command.session_id}`);
+      }
+      cwd = listedSession.cwd?.trim() || currentSessionListOptions().dir;
+    }
     const historyMessages = await getSessionMessages(command.session_id, {
-      dir: session.cwd,
+      ...(cwd ? { dir: cwd } : {}),
       includeSystemMessages: true,
     });
     const targets = deps.rewindTargetsFromSessionMessages(historyMessages);
@@ -250,7 +545,7 @@ async function getRewindTargets(
       message: "rewind targets loaded from session history",
       outcome: "success",
       ...(requestId ? { requestId } : {}),
-      sessionId: session.sessionId,
+      sessionId: command.session_id,
       fields: {
         history_message_count: historyMessages.length,
         target_count: targets.length,
@@ -259,7 +554,7 @@ async function getRewindTargets(
     writeEvent(
       {
         event: "rewind_targets",
-        session_id: session.sessionId,
+        session_id: command.session_id,
         targets,
       },
       requestId,
@@ -272,14 +567,25 @@ async function getRewindTargets(
       message: "failed to load rewind targets",
       outcome: "failure",
       ...(requestId ? { requestId } : {}),
-      sessionId: session.sessionId,
+      sessionId: command.session_id,
       fields: { error_message: message },
     });
-    slashError(command.session_id, `failed to load rewind targets: ${message}`, requestId);
+    writeEvent(
+      {
+        event: "rewind_targets",
+        session_id: command.session_id,
+        targets: [],
+        error: `failed to load rewind targets: ${message}`,
+      },
+      requestId,
+    );
   }
 }
 
-function requireSession(sessionId: string, requestId?: string): SessionState | null {
+function requireSession(
+  sessionId: string,
+  requestId?: string,
+): SessionState | null {
   const session = sessionById(sessionId);
   if (!session) {
     slashError(sessionId, `unknown session: ${sessionId}`, requestId);

--- a/agent-sdk/src/bridge/commands.ts
+++ b/agent-sdk/src/bridge/commands.ts
@@ -29,11 +29,27 @@ const MODE_NAMES: Record<PermissionMode, string> = {
 
 const MODE_OPTIONS: ModeInfo[] = [
   { id: "default", name: "Default", description: "Standard permission flow" },
-  { id: "auto", name: "Auto", description: "Model-classified permission approvals" },
-  { id: "acceptEdits", name: "Accept Edits", description: "Auto-approve edit operations" },
+  {
+    id: "auto",
+    name: "Auto",
+    description: "Model-classified permission approvals",
+  },
+  {
+    id: "acceptEdits",
+    name: "Accept Edits",
+    description: "Auto-approve edit operations",
+  },
   { id: "plan", name: "Plan", description: "No tool execution" },
-  { id: "dontAsk", name: "Don't Ask", description: "Reject non-approved tools" },
-  { id: "bypassPermissions", name: "Bypass Permissions", description: "Auto-approve all tools" },
+  {
+    id: "dontAsk",
+    name: "Don't Ask",
+    description: "Reject non-approved tools",
+  },
+  {
+    id: "bypassPermissions",
+    name: "Bypass Permissions",
+    description: "Auto-approve all tools",
+  },
 ];
 
 const BASE_SUPPORTED_MODE_IDS: PermissionMode[] = [
@@ -49,17 +65,19 @@ function currentModelSupportsAutoMode(session: SessionState): boolean {
 }
 
 function modeInfoForId(mode: PermissionMode): ModeInfo {
-  return MODE_OPTIONS.find((entry) => entry.id === mode) ?? {
-    id: mode,
-    name: MODE_NAMES[mode],
-  };
+  return (
+    MODE_OPTIONS.find((entry) => entry.id === mode) ?? {
+      id: mode,
+      name: MODE_NAMES[mode],
+    }
+  );
 }
 
 function uniqueModeIds(modeIds: PermissionMode[]): PermissionMode[] {
   const unique = new Set(modeIds);
-  const ordered = MODE_OPTIONS.map((entry) => entry.id as PermissionMode).filter((mode) =>
-    unique.has(mode),
-  );
+  const ordered = MODE_OPTIONS.map(
+    (entry) => entry.id as PermissionMode,
+  ).filter((mode) => unique.has(mode));
   const extras = Array.from(unique).filter((mode) => !ordered.includes(mode));
   return [...ordered, ...extras];
 }
@@ -81,7 +99,9 @@ function computedSupportedModeIds(session: SessionState): PermissionMode[] {
 export function refreshSupportedModesForSession(session: SessionState): void {
   const computed = computedSupportedModeIds(session);
   session.supportedModeIds = computed.filter(
-    (mode) => mode === session.mode || !session.runtimeUnavailableModeIds.includes(mode),
+    (mode) =>
+      mode === session.mode ||
+      !session.runtimeUnavailableModeIds.includes(mode),
   );
 }
 
@@ -92,7 +112,10 @@ export function markModeUnavailableForSession(
   if (session.runtimeUnavailableModeIds.includes(mode)) {
     return false;
   }
-  session.runtimeUnavailableModeIds = [...session.runtimeUnavailableModeIds, mode];
+  session.runtimeUnavailableModeIds = [
+    ...session.runtimeUnavailableModeIds,
+    mode,
+  ];
   refreshSupportedModesForSession(session);
   return true;
 }
@@ -119,7 +142,11 @@ function asRecord(value: unknown, context: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function expectString(record: Record<string, unknown>, key: string, context: string): string {
+function expectString(
+  record: Record<string, unknown>,
+  key: string,
+  context: string,
+): string {
   const value = record[key];
   if (typeof value !== "string") {
     throw new Error(`${context}.${key} must be a string`);
@@ -140,7 +167,9 @@ function expectEffortLevel(
     value !== "xhigh" &&
     value !== "max"
   ) {
-    throw new Error(`${context}.${key} must be one of low, medium, high, xhigh, max`);
+    throw new Error(
+      `${context}.${key} must be one of low, medium, high, xhigh, max`,
+    );
   }
   return value;
 }
@@ -187,7 +216,10 @@ function optionalString(
   return value;
 }
 
-function optionalMetadata(record: Record<string, unknown>, key: string): Record<string, Json> {
+function optionalMetadata(
+  record: Record<string, unknown>,
+  key: string,
+): Record<string, Json> {
   const value = record[key];
   if (value === undefined || value === null) {
     return {};
@@ -297,14 +329,23 @@ function expectRefusalFallbackPromptChoice(
 ): RefusalFallbackPromptChoice {
   const value = expectString(record, key, context);
   if (value !== "retry_fallback" && value !== "edit_prompt") {
-    throw new Error(`${context}.${key} must be 'retry_fallback' or 'edit_prompt'`);
+    throw new Error(
+      `${context}.${key} must be 'retry_fallback' or 'edit_prompt'`,
+    );
   }
   return value;
 }
 
-export function parseCommandEnvelope(line: string): { requestId?: string; command: BridgeCommand } {
-  const raw = asRecord(JSON.parse(line) as BridgeCommandEnvelope, "command envelope");
-  const requestId = typeof raw.request_id === "string" ? raw.request_id : undefined;
+export function parseCommandEnvelope(line: string): {
+  requestId?: string;
+  command: BridgeCommand;
+} {
+  const raw = asRecord(
+    JSON.parse(line) as BridgeCommandEnvelope,
+    "command envelope",
+  );
+  const requestId =
+    typeof raw.request_id === "string" ? raw.request_id : undefined;
   const commandName = expectString(raw, "command", "command envelope");
 
   const command: BridgeCommand = (() => {
@@ -320,21 +361,48 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
           command: "create_session",
           cwd: expectString(raw, "cwd", "create_session"),
           resume: optionalString(raw, "resume", "create_session"),
-          launch_settings: optionalLaunchSettings(raw, "launch_settings", "create_session"),
+          launch_settings: optionalLaunchSettings(
+            raw,
+            "launch_settings",
+            "create_session",
+          ),
           metadata: optionalMetadata(raw, "metadata"),
         };
       case "resume_session":
         return {
           command: "resume_session",
           session_id: expectString(raw, "session_id", "resume_session"),
-          launch_settings: optionalLaunchSettings(raw, "launch_settings", "resume_session"),
+          launch_settings: optionalLaunchSettings(
+            raw,
+            "launch_settings",
+            "resume_session",
+          ),
           metadata: optionalMetadata(raw, "metadata"),
+        };
+      case "resume_session_at":
+        return {
+          command: "resume_session_at",
+          session_id: expectString(raw, "session_id", "resume_session_at"),
+          target_user_message_id: expectString(
+            raw,
+            "target_user_message_id",
+            "resume_session_at",
+          ),
+          launch_settings: optionalLaunchSettings(
+            raw,
+            "launch_settings",
+            "resume_session_at",
+          ),
         };
       case "new_session":
         return {
           command: "new_session",
           cwd: expectString(raw, "cwd", "new_session"),
-          launch_settings: optionalLaunchSettings(raw, "launch_settings", "new_session"),
+          launch_settings: optionalLaunchSettings(
+            raw,
+            "launch_settings",
+            "new_session",
+          ),
         };
       case "prompt":
         return {
@@ -381,7 +449,11 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
         return {
           command: "generate_session_title",
           session_id: expectString(raw, "session_id", "generate_session_title"),
-          description: expectString(raw, "description", "generate_session_title"),
+          description: expectString(
+            raw,
+            "description",
+            "generate_session_title",
+          ),
         };
       case "rename_session":
         return {
@@ -399,6 +471,11 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
           command: "get_context_usage",
           session_id: expectString(raw, "session_id", "get_context_usage"),
         };
+      case "get_usage":
+        return {
+          command: "get_usage",
+          session_id: expectString(raw, "session_id", "get_usage"),
+        };
       case "get_rewind_targets":
         return {
           command: "get_rewind_targets",
@@ -414,7 +491,11 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
             "rewind",
           ),
           restore_mode: expectRewindRestoreMode(raw, "restore_mode", "rewind"),
-          launch_settings: optionalLaunchSettings(raw, "launch_settings", "rewind"),
+          launch_settings: optionalLaunchSettings(
+            raw,
+            "launch_settings",
+            "rewind",
+          ),
         };
       case "reload_plugins":
         return {
@@ -445,33 +526,56 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
         return {
           command: "mcp_set_servers",
           session_id: expectString(raw, "session_id", "mcp_set_servers"),
-          servers: parseMcpServersRecord(raw.servers ?? {}, "mcp_set_servers.servers"),
+          servers: parseMcpServersRecord(
+            raw.servers ?? {},
+            "mcp_set_servers.servers",
+          ),
         };
       case "permission_response": {
         const outcome = asRecord(raw.outcome, "permission_response.outcome");
-        const outcomeType = expectString(outcome, "outcome", "permission_response.outcome");
+        const outcomeType = expectString(
+          outcome,
+          "outcome",
+          "permission_response.outcome",
+        );
         if (outcomeType !== "selected" && outcomeType !== "cancelled") {
-          throw new Error("permission_response.outcome.outcome must be 'selected' or 'cancelled'");
+          throw new Error(
+            "permission_response.outcome.outcome must be 'selected' or 'cancelled'",
+          );
         }
         const parsedOutcome: PermissionOutcome =
           outcomeType === "selected"
             ? {
                 outcome: "selected",
-                option_id: expectString(outcome, "option_id", "permission_response.outcome"),
+                option_id: expectString(
+                  outcome,
+                  "option_id",
+                  "permission_response.outcome",
+                ),
               }
             : { outcome: "cancelled" };
         return {
           command: "permission_response",
           session_id: expectString(raw, "session_id", "permission_response"),
-          tool_call_id: expectString(raw, "tool_call_id", "permission_response"),
+          tool_call_id: expectString(
+            raw,
+            "tool_call_id",
+            "permission_response",
+          ),
           outcome: parsedOutcome,
         };
       }
       case "question_response": {
         const outcome = asRecord(raw.outcome, "question_response.outcome");
-        const outcomeType = expectString(outcome, "outcome", "question_response.outcome");
+        const outcomeType = expectString(
+          outcome,
+          "outcome",
+          "question_response.outcome",
+        );
         if (outcomeType !== "answered" && outcomeType !== "cancelled") {
-          throw new Error("question_response.outcome.outcome must be 'answered' or 'cancelled'");
+          throw new Error(
+            "question_response.outcome.outcome must be 'answered' or 'cancelled'",
+          );
         }
         const parsedOutcome: QuestionOutcome =
           outcomeType === "answered"
@@ -482,9 +586,12 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
                   "selected_option_ids",
                   "question_response.outcome",
                 ),
-                ...(outcome.annotation === undefined || outcome.annotation === null
+                ...(outcome.annotation === undefined ||
+                outcome.annotation === null
                   ? {}
-                  : { annotation: parseQuestionAnnotation(outcome.annotation) }),
+                  : {
+                      annotation: parseQuestionAnnotation(outcome.annotation),
+                    }),
               }
             : { outcome: "cancelled" };
         return {
@@ -496,9 +603,15 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
       }
       case "user_dialog_response": {
         const outcome = asRecord(raw.outcome, "user_dialog_response.outcome");
-        const outcomeType = expectString(outcome, "outcome", "user_dialog_response.outcome");
+        const outcomeType = expectString(
+          outcome,
+          "outcome",
+          "user_dialog_response.outcome",
+        );
         if (outcomeType !== "selected" && outcomeType !== "cancelled") {
-          throw new Error("user_dialog_response.outcome.outcome must be 'selected' or 'cancelled'");
+          throw new Error(
+            "user_dialog_response.outcome.outcome must be 'selected' or 'cancelled'",
+          );
         }
         const parsedOutcome: UserDialogOutcome =
           outcomeType === "selected"
@@ -527,9 +640,19 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
             "elicitation_request_id",
             "elicitation_response",
           ),
-          action: expectElicitationAction(raw, "action", "elicitation_response"),
+          action: expectElicitationAction(
+            raw,
+            "action",
+            "elicitation_response",
+          ),
           ...(optionalJsonObject(raw, "content", "elicitation_response")
-            ? { content: optionalJsonObject(raw, "content", "elicitation_response") }
+            ? {
+                content: optionalJsonObject(
+                  raw,
+                  "content",
+                  "elicitation_response",
+                ),
+              }
             : {}),
         };
       case "mcp_authenticate":
@@ -548,8 +671,16 @@ export function parseCommandEnvelope(line: string): { requestId?: string; comman
         return {
           command: "mcp_oauth_callback_url",
           session_id: expectString(raw, "session_id", "mcp_oauth_callback_url"),
-          server_name: expectString(raw, "server_name", "mcp_oauth_callback_url"),
-          callback_url: expectString(raw, "callback_url", "mcp_oauth_callback_url"),
+          server_name: expectString(
+            raw,
+            "server_name",
+            "mcp_oauth_callback_url",
+          ),
+          callback_url: expectString(
+            raw,
+            "callback_url",
+            "mcp_oauth_callback_url",
+          ),
         };
       case "shutdown":
         return { command: "shutdown" };
@@ -578,10 +709,21 @@ function expectStringArray(
   });
 }
 
-function parseQuestionAnnotation(value: unknown): { preview?: string; notes?: string } {
+function parseQuestionAnnotation(value: unknown): {
+  preview?: string;
+  notes?: string;
+} {
   const record = asRecord(value, "question_response.outcome.annotation");
-  const preview = optionalString(record, "preview", "question_response.outcome.annotation");
-  const notes = optionalString(record, "notes", "question_response.outcome.annotation");
+  const preview = optionalString(
+    record,
+    "preview",
+    "question_response.outcome.annotation",
+  );
+  const notes = optionalString(
+    record,
+    "notes",
+    "question_response.outcome.annotation",
+  );
   return {
     ...(preview !== undefined ? { preview } : {}),
     ...(notes !== undefined ? { notes } : {}),
@@ -605,7 +747,10 @@ export function toPermissionMode(mode: string): PermissionMode | null {
   return null;
 }
 
-export function buildModeState(session: SessionState, mode: PermissionMode): ModeState {
+export function buildModeState(
+  session: SessionState,
+  mode: PermissionMode,
+): ModeState {
   return {
     current_mode_id: mode,
     current_mode_name: MODE_NAMES[mode],

--- a/agent-sdk/src/bridge/error_classification.ts
+++ b/agent-sdk/src/bridge/error_classification.ts
@@ -3,9 +3,16 @@ import { looksLikeAuthRequired } from "./auth.js";
 import { writeEvent } from "./events.js";
 import { emitSessionUpdate } from "./events.js";
 import type { SessionState } from "./session_lifecycle.js";
-import { parseFastModeDisabledReason, parseFastModeState } from "./state_parsing.js";
+import {
+  parseFastModeDisabledReason,
+  parseFastModeState,
+} from "./state_parsing.js";
 
 export function emitAuthRequired(session: SessionState, detail?: string): void {
+  if (session.deferConnect) {
+    session.deferredAuthRequired = detail ? { detail } : {};
+    return;
+  }
   if (session.authHintSent) {
     return;
   }

--- a/agent-sdk/src/bridge/events.ts
+++ b/agent-sdk/src/bridge/events.ts
@@ -1,12 +1,21 @@
-import { listSessions, type ListSessionsOptions } from "@anthropic-ai/claude-agent-sdk";
+import {
+  listSessions,
+  type ListSessionsOptions,
+} from "@anthropic-ai/claude-agent-sdk";
 import { writeSync } from "node:fs";
-import type { BridgeEvent, BridgeEventEnvelope, McpOperationError, SessionUpdate } from "../types.js";
+import type {
+  BridgeEvent,
+  BridgeEventEnvelope,
+  McpOperationError,
+  SessionUpdate,
+} from "../types.js";
 import { buildModeState } from "./commands.js";
 import { mapSdkSessions } from "./history.js";
 import { bridgeLogger, LOG_TARGETS, logBridgeEventSent } from "./logger.js";
 import {
   detachSessionForClose,
   resolveCurrentModel,
+  sessionById,
   trackSessionCloseTask,
   type SessionState,
 } from "./session_lifecycle.js";
@@ -34,7 +43,9 @@ function writeProtocolEventToStdout(line: string): void {
 
 let protocolEventWriter: ProtocolEventWriter = writeProtocolEventToStdout;
 
-export function replaceProtocolEventWriter(writer: ProtocolEventWriter): () => void {
+export function replaceProtocolEventWriter(
+  writer: ProtocolEventWriter,
+): () => void {
   const previous = protocolEventWriter;
   protocolEventWriter = writer;
   return () => {
@@ -60,6 +71,23 @@ export function currentSessionListOptions(): ListSessionsOptions {
 }
 
 export function writeEvent(event: BridgeEvent, requestId?: string): void {
+  if (
+    "session_id" in event &&
+    event.event !== "connected" &&
+    event.event !== "session_replaced"
+  ) {
+    const session = sessionById(event.session_id);
+    if (session?.deferConnect) {
+      const events = session.deferredBridgeEvents ?? [];
+      events.push({ event, ...(requestId ? { requestId } : {}) });
+      session.deferredBridgeEvents = events;
+      return;
+    }
+  }
+  writeEventNow(event, requestId);
+}
+
+function writeEventNow(event: BridgeEvent, requestId?: string): void {
   const envelope: BridgeEventEnvelope = {
     ...(requestId ? { request_id: requestId } : {}),
     ...event,
@@ -73,12 +101,40 @@ export function failConnection(message: string, requestId?: string): void {
   writeEvent({ event: "connection_failed", message }, requestId);
 }
 
-export function slashError(sessionId: string, message: string, requestId?: string): void {
-  writeEvent({ event: "slash_error", session_id: sessionId, message }, requestId);
+export function slashError(
+  sessionId: string,
+  message: string,
+  requestId?: string,
+): void {
+  writeEvent(
+    { event: "slash_error", session_id: sessionId, message },
+    requestId,
+  );
 }
 
-export function emitRuntimeReloadCompleted(sessionId: string, requestId?: string): void {
-  writeEvent({ event: "runtime_reload_completed", session_id: sessionId }, requestId);
+export function emitSessionResumeFailed(
+  sessionId: string,
+  operationId: string,
+  message: string,
+): void {
+  writeEventNow(
+    {
+      event: "session_resume_failed",
+      session_id: sessionId,
+      message,
+    },
+    operationId,
+  );
+}
+
+export function emitRuntimeReloadCompleted(
+  sessionId: string,
+  requestId?: string,
+): void {
+  writeEvent(
+    { event: "runtime_reload_completed", session_id: sessionId },
+    requestId,
+  );
 }
 
 export function emitRuntimeReloadFailed(
@@ -86,7 +142,10 @@ export function emitRuntimeReloadFailed(
   message: string,
   requestId?: string,
 ): void {
-  writeEvent({ event: "runtime_reload_failed", session_id: sessionId, message }, requestId);
+  writeEvent(
+    { event: "runtime_reload_failed", session_id: sessionId, message },
+    requestId,
+  );
 }
 
 export function emitMcpOperationError(
@@ -94,10 +153,16 @@ export function emitMcpOperationError(
   error: McpOperationError,
   requestId?: string,
 ): void {
-  writeEvent({ event: "mcp_operation_error", session_id: sessionId, error }, requestId);
+  writeEvent(
+    { event: "mcp_operation_error", session_id: sessionId, error },
+    requestId,
+  );
 }
 
-export function emitSessionUpdate(sessionId: string, update: SessionUpdate): void {
+export function emitSessionUpdate(
+  sessionId: string,
+  update: SessionUpdate,
+): void {
   writeEvent({ event: "session_update", session_id: sessionId, update });
 }
 
@@ -203,8 +268,12 @@ export function buildConnectBridgeEvent(
         ...(session.fastModeDisabledReason
           ? { fast_mode_disabled_reason: session.fastModeDisabledReason }
           : {}),
-        ...(historyUpdates && historyUpdates.length > 0 ? { history_updates: historyUpdates } : {}),
-        ...(session.restoredInput !== undefined ? { restored_input: session.restoredInput } : {}),
+        ...(historyUpdates && historyUpdates.length > 0
+          ? { history_updates: historyUpdates }
+          : {}),
+        ...(session.restoredInput !== undefined
+          ? { restored_input: session.restoredInput }
+          : {}),
       }
     : {
         event: "connected",
@@ -217,7 +286,9 @@ export function buildConnectBridgeEvent(
         ...(session.fastModeDisabledReason
           ? { fast_mode_disabled_reason: session.fastModeDisabledReason }
           : {}),
-        ...(historyUpdates && historyUpdates.length > 0 ? { history_updates: historyUpdates } : {}),
+        ...(historyUpdates && historyUpdates.length > 0
+          ? { history_updates: historyUpdates }
+          : {}),
       };
 }
 
@@ -228,8 +299,14 @@ function logConnectEventEmission(
 ): void {
   bridgeLogger.info({
     target: LOG_TARGETS.APP_SESSION,
-    eventName: eventName === "session_replaced" ? "session_replaced_emitted" : "session_connected_emitted",
-    message: eventName === "session_replaced" ? "session replaced event emitted" : "session connected event emitted",
+    eventName:
+      eventName === "session_replaced"
+        ? "session_replaced_emitted"
+        : "session_connected_emitted",
+    message:
+      eventName === "session_replaced"
+        ? "session replaced event emitted"
+        : "session connected event emitted",
     outcome: "success",
     ...(requestId ? { requestId } : {}),
     sessionId: session.sessionId,
@@ -252,7 +329,11 @@ export function emitConnectEvent(session: SessionState): void {
     }
   }
   const bridgeEvent = buildConnectBridgeEvent(session, session.connectEvent);
-  logConnectEventEmission(session, session.connectEvent, session.connectRequestId);
+  logConnectEventEmission(
+    session,
+    session.connectEvent,
+    session.connectRequestId,
+  );
   writeEvent(bridgeEvent, session.connectRequestId);
   if (session.pendingRewindResult) {
     writeEvent(
@@ -264,6 +345,16 @@ export function emitConnectEvent(session: SessionState): void {
   session.connectRequestId = undefined;
   session.connected = true;
   session.authHintSent = false;
+  const deferredBridgeEvents = session.deferredBridgeEvents;
+  session.deferredBridgeEvents = undefined;
+  if (deferredBridgeEvents) {
+    for (const deferred of deferredBridgeEvents) {
+      writeEventNow(
+        { ...deferred.event, session_id: session.sessionId } as BridgeEvent,
+        deferred.requestId,
+      );
+    }
+  }
   session.resumeUpdates = undefined;
   session.restoredInput = undefined;
 
@@ -286,12 +377,18 @@ export function emitConnectEvent(session: SessionState): void {
   trackSessionCloseTask(closeTask);
 }
 
-export function emitSessionReplacedEvent(session: SessionState, requestId?: string): void {
+export function emitSessionReplacedEvent(
+  session: SessionState,
+  requestId?: string,
+): void {
   const bridgeEvent = buildConnectBridgeEvent(session, "session_replaced");
   logConnectEventEmission(session, "session_replaced", requestId);
   writeEvent(bridgeEvent, requestId);
   if (session.pendingRewindResult) {
-    writeEvent({ ...session.pendingRewindResult, session_id: session.sessionId }, requestId);
+    writeEvent(
+      { ...session.pendingRewindResult, session_id: session.sessionId },
+      requestId,
+    );
     session.pendingRewindResult = undefined;
   }
   session.resumeUpdates = undefined;

--- a/agent-sdk/src/bridge/history.ts
+++ b/agent-sdk/src/bridge/history.ts
@@ -1,5 +1,15 @@
-import type { SDKSessionInfo, SessionMessage } from "@anthropic-ai/claude-agent-sdk";
-import type { Json, SessionListEntry, SessionUpdate, TaskItem, TaskStatus, ToolCall } from "../types.js";
+import type {
+  SDKSessionInfo,
+  SessionMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import type {
+  Json,
+  SessionListEntry,
+  SessionUpdate,
+  TaskItem,
+  TaskStatus,
+  ToolCall,
+} from "../types.js";
 import { asRecordOrNull } from "./shared.js";
 import {
   applyToolNonExecutionMetadata,
@@ -91,7 +101,10 @@ function taskSystemMetadata(
   patch: Record<string, unknown> | undefined,
 ): Record<string, Json> | undefined {
   const metadata: Record<string, Json> = {};
-  const copyValue = (from: Record<string, unknown> | undefined, key: string): void => {
+  const copyValue = (
+    from: Record<string, unknown> | undefined,
+    key: string,
+  ): void => {
     if (!from || !Object.hasOwn(from, key)) {
       return;
     }
@@ -118,7 +131,8 @@ function taskSystemMetadata(
     copyValue(msg, key);
     copyValue(patch, key);
   }
-  const terminalStatus = nonEmptyTrimmed(msg.status) ?? nonEmptyTrimmed(patch?.status);
+  const terminalStatus =
+    nonEmptyTrimmed(msg.status) ?? nonEmptyTrimmed(patch?.status);
   if (
     terminalStatus === "completed" ||
     terminalStatus === "failed" ||
@@ -160,12 +174,15 @@ function pushResumeTaskSystemUpdate(
   const status =
     normalizeLifecycleTaskStatus(msg.status) ??
     normalizeLifecycleTaskStatus(patch?.status) ??
-    (subtype === "task_started" || subtype === "task_progress" ? "in_progress" : undefined);
+    (subtype === "task_started" || subtype === "task_progress"
+      ? "in_progress"
+      : undefined);
   const description =
     nonEmptyTrimmed(patch?.description) ??
     nonEmptyTrimmed(msg.description) ??
     nonEmptyTrimmed(msg.summary);
-  const activeForm = nonEmptyTrimmed(patch?.activeForm) ?? nonEmptyTrimmed(patch?.active_form);
+  const activeForm =
+    nonEmptyTrimmed(patch?.activeForm) ?? nonEmptyTrimmed(patch?.active_form);
   const subject =
     nonEmptyTrimmed(patch?.subject) ??
     nonEmptyTrimmed(msg.subject) ??
@@ -174,20 +191,34 @@ function pushResumeTaskSystemUpdate(
     nonEmptyTrimmed(msg.task_description) ??
     description ??
     taskId;
-  const metadata = mergeTaskMetadata(existing?.metadata, taskSystemMetadata(msg, patch));
-  const sourceToolCallId = taskToolUseIds.get(taskId) ?? existing?.source_tool_call_id;
+  const metadata = mergeTaskMetadata(
+    existing?.metadata,
+    taskSystemMetadata(msg, patch),
+  );
+  const sourceToolCallId =
+    taskToolUseIds.get(taskId) ?? existing?.source_tool_call_id;
 
   const task: TaskItem = {
     task_id: taskId,
     subject,
-    ...(description !== undefined ? { description } : existing?.description !== undefined ? { description: existing.description } : {}),
-    ...(activeForm !== undefined ? { active_form: activeForm } : existing?.active_form !== undefined ? { active_form: existing.active_form } : {}),
+    ...(description !== undefined
+      ? { description }
+      : existing?.description !== undefined
+        ? { description: existing.description }
+        : {}),
+    ...(activeForm !== undefined
+      ? { active_form: activeForm }
+      : existing?.active_form !== undefined
+        ? { active_form: existing.active_form }
+        : {}),
     status: status ?? existing?.status ?? "pending",
     ...(existing?.owner !== undefined ? { owner: existing.owner } : {}),
     blocks: existing ? [...existing.blocks] : [],
     blocked_by: existing ? [...existing.blocked_by] : [],
     ...(metadata !== undefined ? { metadata } : {}),
-    ...(sourceToolCallId !== undefined ? { source_tool_call_id: sourceToolCallId } : {}),
+    ...(sourceToolCallId !== undefined
+      ? { source_tool_call_id: sourceToolCallId }
+      : {}),
   };
   tasksById.set(taskId, task);
   updates.push({
@@ -258,15 +289,22 @@ function pushResumeToolResult(
   toolCalls: Map<string, ToolCall>,
   hiddenToolUseIds: Set<string>,
   block: Record<string, unknown>,
-  nonExecutionByToolUseId: Map<string, import("../types.js").ToolNonExecutionMetadata>,
+  nonExecutionByToolUseId: Map<
+    string,
+    import("../types.js").ToolNonExecutionMetadata
+  >,
   sourceMessageUuid?: string,
 ): void {
-  const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
+  const toolUseId =
+    typeof block.tool_use_id === "string" ? block.tool_use_id : "";
   if (!toolUseId) {
     return;
   }
   const blockType = typeof block.type === "string" ? block.type : "";
-  if (isToolSearchToolResultType(blockType) || hiddenToolUseIds.has(toolUseId)) {
+  if (
+    isToolSearchToolResultType(blockType) ||
+    hiddenToolUseIds.has(toolUseId)
+  ) {
     hiddenToolUseIds.add(toolUseId);
     return;
   }
@@ -314,13 +352,22 @@ export function mapSdkSessionInfo(info: SDKSessionInfo): SessionListEntry {
     last_modified_ms: info.lastModified,
     file_size_bytes: info.fileSize ?? 0,
     ...(nonEmptyTrimmed(info.cwd) ? { cwd: info.cwd?.trim() } : {}),
-    ...(nonEmptyTrimmed(info.gitBranch) ? { git_branch: info.gitBranch?.trim() } : {}),
-    ...(nonEmptyTrimmed(info.customTitle) ? { custom_title: info.customTitle?.trim() } : {}),
-    ...(nonEmptyTrimmed(info.firstPrompt) ? { first_prompt: info.firstPrompt?.trim() } : {}),
+    ...(nonEmptyTrimmed(info.gitBranch)
+      ? { git_branch: info.gitBranch?.trim() }
+      : {}),
+    ...(nonEmptyTrimmed(info.customTitle)
+      ? { custom_title: info.customTitle?.trim() }
+      : {}),
+    ...(nonEmptyTrimmed(info.firstPrompt)
+      ? { first_prompt: info.firstPrompt?.trim() }
+      : {}),
   };
 }
 
-export function mapSdkSessions(infos: SDKSessionInfo[], limit = 50): SessionListEntry[] {
+export function mapSdkSessions(
+  infos: SDKSessionInfo[],
+  limit = 50,
+): SessionListEntry[] {
   const sorted = [...infos].sort((a, b) => b.lastModified - a.lastModified);
   const entries: SessionListEntry[] = [];
   const seen = new Set<string>();
@@ -337,7 +384,9 @@ export function mapSdkSessions(infos: SDKSessionInfo[], limit = 50): SessionList
   return entries;
 }
 
-export function mapSessionMessagesToUpdates(messages: SessionMessage[]): SessionUpdate[] {
+export function mapSessionMessagesToUpdates(
+  messages: SessionMessage[],
+): SessionUpdate[] {
   const updates: SessionUpdate[] = [];
   const toolCalls = new Map<string, ToolCall>();
   const hiddenToolUseIds = new Set<string>();
@@ -346,11 +395,19 @@ export function mapSessionMessagesToUpdates(messages: SessionMessage[]): Session
 
   for (const entry of messages) {
     const fallbackRole = entry.type === "assistant" ? "assistant" : "user";
-    const entrySourceMessageUuid = typeof entry.uuid === "string" ? entry.uuid : undefined;
+    const entrySourceMessageUuid =
+      typeof entry.uuid === "string" ? entry.uuid : undefined;
     const candidates = messageCandidates(entry.message);
     if (entry.type === "system") {
       for (const message of candidates) {
-        if (pushResumeTaskSystemUpdate(updates, tasksById, taskToolUseIds, message)) {
+        if (
+          pushResumeTaskSystemUpdate(
+            updates,
+            tasksById,
+            taskToolUseIds,
+            message,
+          )
+        ) {
           break;
         }
       }
@@ -358,9 +415,14 @@ export function mapSessionMessagesToUpdates(messages: SessionMessage[]): Session
     }
     for (const message of candidates) {
       const sourceMessageUuid =
-        typeof message.uuid === "string" ? message.uuid : entrySourceMessageUuid;
+        typeof message.uuid === "string"
+          ? message.uuid
+          : entrySourceMessageUuid;
       const roleCandidate = message.role;
-      const role = roleCandidate === "assistant" || roleCandidate === "user" ? roleCandidate : fallbackRole;
+      const role =
+        roleCandidate === "assistant" || roleCandidate === "user"
+          ? roleCandidate
+          : fallbackRole;
       const parentToolUseId =
         typeof entry.parent_tool_use_id === "string"
           ? entry.parent_tool_use_id

--- a/agent-sdk/src/bridge/logger.ts
+++ b/agent-sdk/src/bridge/logger.ts
@@ -47,11 +47,15 @@ type DiagnosticEvent = {
   fields?: DiagnosticFields;
 };
 
-function definedFields(fields?: DiagnosticFields): DiagnosticFields | undefined {
+function definedFields(
+  fields?: DiagnosticFields,
+): DiagnosticFields | undefined {
   if (!fields) {
     return undefined;
   }
-  const entries = Object.entries(fields).filter(([, value]) => value !== undefined);
+  const entries = Object.entries(fields).filter(
+    ([, value]) => value !== undefined,
+  );
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
@@ -74,7 +78,9 @@ function writeDiagnostic(level: LogLevel, event: DiagnosticEvent): void {
     ...(event.terminalId ? { terminal_id: event.terminalId } : {}),
     ...(event.errorKind ? { error_kind: event.errorKind } : {}),
     ...(event.errorCode ? { error_code: event.errorCode } : {}),
-    ...(event.durationMs !== undefined ? { duration_ms: event.durationMs } : {}),
+    ...(event.durationMs !== undefined
+      ? { duration_ms: event.durationMs }
+      : {}),
     ...(event.count !== undefined ? { count: event.count } : {}),
     ...(event.sizeBytes !== undefined ? { size_bytes: event.sizeBytes } : {}),
   };
@@ -92,6 +98,7 @@ function previewText(value: string, limit: number): string {
 function commandSessionId(command: BridgeCommand): string | undefined {
   switch (command.command) {
     case "resume_session":
+    case "resume_session_at":
     case "prompt":
     case "cancel_turn":
     case "set_model":
@@ -104,6 +111,7 @@ function commandSessionId(command: BridgeCommand): string | undefined {
     case "elicitation_response":
     case "get_status_snapshot":
     case "get_context_usage":
+    case "get_usage":
     case "get_rewind_targets":
     case "rewind":
     case "reload_plugins":
@@ -132,6 +140,7 @@ function commandToolCallId(command: BridgeCommand): string | undefined {
     case "initialize":
     case "create_session":
     case "resume_session":
+    case "resume_session_at":
     case "prompt":
     case "cancel_turn":
     case "set_model":
@@ -143,6 +152,7 @@ function commandToolCallId(command: BridgeCommand): string | undefined {
     case "elicitation_response":
     case "get_status_snapshot":
     case "get_context_usage":
+    case "get_usage":
     case "get_rewind_targets":
     case "rewind":
     case "reload_plugins":
@@ -167,6 +177,7 @@ function eventToolCallId(event: BridgeEvent): string | undefined {
     case "auth_required":
     case "connection_failed":
     case "session_update":
+    case "user_dialog_request":
     case "elicitation_request":
     case "elicitation_complete":
     case "mcp_auth_redirect":
@@ -175,6 +186,7 @@ function eventToolCallId(event: BridgeEvent): string | undefined {
     case "turn_complete":
     case "turn_error":
     case "slash_error":
+    case "session_resume_failed":
     case "runtime_reload_completed":
     case "runtime_reload_failed":
     case "session_replaced":
@@ -182,6 +194,7 @@ function eventToolCallId(event: BridgeEvent): string | undefined {
     case "sessions_listed":
     case "status_snapshot":
     case "context_usage":
+    case "usage_snapshot":
     case "rewind_targets":
     case "rewind_result":
     case "mcp_snapshot":
@@ -194,6 +207,7 @@ function protocolCommandLevel(command: BridgeCommand): LogLevel {
     case "initialize":
     case "create_session":
     case "resume_session":
+    case "resume_session_at":
     case "new_session":
     case "shutdown":
       return "info";
@@ -214,6 +228,7 @@ function protocolEventLevel(event: BridgeEvent): LogLevel {
     case "mcp_operation_error":
     case "turn_error":
     case "slash_error":
+    case "session_resume_failed":
     case "runtime_reload_failed":
       return "warn";
     case "session_update":
@@ -228,6 +243,7 @@ function protocolEventLevel(event: BridgeEvent): LogLevel {
     case "sessions_listed":
     case "status_snapshot":
     case "context_usage":
+    case "usage_snapshot":
     case "rewind_targets":
     case "rewind_result":
     case "runtime_reload_completed":
@@ -286,15 +302,22 @@ export function logSdkStderrLine(line: string, sessionId?: string): void {
   });
 }
 
-export function logBridgeCommandReceived(command: BridgeCommand, requestId?: string): void {
+export function logBridgeCommandReceived(
+  command: BridgeCommand,
+  requestId?: string,
+): void {
   writeDiagnostic(protocolCommandLevel(command), {
     target: LOG_TARGETS.BRIDGE_PROTOCOL,
     eventName: "bridge_command_received",
     message: "bridge command received",
     outcome: "success",
     ...(requestId ? { requestId } : {}),
-    ...(commandSessionId(command) ? { sessionId: commandSessionId(command) } : {}),
-    ...(commandToolCallId(command) ? { toolCallId: commandToolCallId(command) } : {}),
+    ...(commandSessionId(command)
+      ? { sessionId: commandSessionId(command) }
+      : {}),
+    ...(commandToolCallId(command)
+      ? { toolCallId: commandToolCallId(command) }
+      : {}),
     fields: { bridge_command: command.command },
   });
 }

--- a/agent-sdk/src/bridge/mcp.ts
+++ b/agent-sdk/src/bridge/mcp.ts
@@ -25,7 +25,8 @@ import {
 } from "./mcp_monitor.js";
 import type { SessionState } from "./session_lifecycle.js";
 
-type SdkMcpServerStatus = import("@anthropic-ai/claude-agent-sdk").McpServerStatus;
+type SdkMcpServerStatus =
+  import("@anthropic-ai/claude-agent-sdk").McpServerStatus;
 
 export const MCP_STALE_STATUS_REVALIDATION_COOLDOWN_MS = 30_000;
 
@@ -78,10 +79,14 @@ function mapMcpSetServersResult(result: unknown): McpSetServersResult {
     ? record.added.filter((value): value is string => typeof value === "string")
     : [];
   const removed = Array.isArray(record.removed)
-    ? record.removed.filter((value): value is string => typeof value === "string")
+    ? record.removed.filter(
+        (value): value is string => typeof value === "string",
+      )
     : [];
   const errors =
-    record.errors && typeof record.errors === "object" && !Array.isArray(record.errors)
+    record.errors &&
+    typeof record.errors === "object" &&
+    !Array.isArray(record.errors)
       ? Object.fromEntries(
           Object.entries(record.errors as Record<string, unknown>).filter(
             (entry): entry is [string, string] => typeof entry[1] === "string",
@@ -153,11 +158,17 @@ function emitMcpSnapshotFromMappedStatuses(
   requestId?: string,
 ): McpServerStatus[] {
   rememberKnownConnectedMcpServers(session, mapped);
-  logMcpSuccess("mcp_snapshot_emitted", "MCP snapshot emitted", session.sessionId, requestId, {
-    source,
-    server_count: mapped.length,
-    servers: summarizeMcpServersForDiagnostics(mapped),
-  });
+  logMcpSuccess(
+    "mcp_snapshot_emitted",
+    "MCP snapshot emitted",
+    session.sessionId,
+    requestId,
+    {
+      source,
+      server_count: mapped.length,
+      servers: summarizeMcpServersForDiagnostics(mapped),
+    },
+  );
   writeEvent(
     {
       event: "mcp_snapshot",
@@ -203,13 +214,18 @@ function rememberKnownConnectedMcpServers(
   }
 }
 
-function forgetKnownConnectedMcpServer(session: SessionState, serverName: string): void {
+function forgetKnownConnectedMcpServer(
+  session: SessionState,
+  serverName: string,
+): void {
   session.knownConnectedMcpServers.delete(serverName);
 }
 
 type McpMonitorActivityCheck = () => boolean;
 
-async function loadReconciledMcpStatuses(session: SessionState): Promise<McpServerStatus[]>;
+async function loadReconciledMcpStatuses(
+  session: SessionState,
+): Promise<McpServerStatus[]>;
 async function loadReconciledMcpStatuses(
   session: SessionState,
   isActive: McpMonitorActivityCheck,
@@ -300,7 +316,9 @@ async function reconcileSuspiciousMcpStatuses(
   return isActive() ? refreshed.map(mapMcpServerStatus) : undefined;
 }
 
-function shouldKeepMonitoringMcpAuth(server: McpServerStatus | undefined): boolean {
+function shouldKeepMonitoringMcpAuth(
+  server: McpServerStatus | undefined,
+): boolean {
   return server?.status === "needs-auth" || server?.status === "pending";
 }
 
@@ -409,9 +427,15 @@ export async function handleMcpReconnectCommand(
 ): Promise<void> {
   try {
     await session.query.reconnectMcpServer(command.server_name);
-    logMcpSuccess("mcp_reconnect_completed", "MCP reconnect completed", command.session_id, requestId, {
-      server_name: command.server_name,
-    });
+    logMcpSuccess(
+      "mcp_reconnect_completed",
+      "MCP reconnect completed",
+      command.session_id,
+      requestId,
+      {
+        server_name: command.server_name,
+      },
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logMcpFailure(
@@ -456,7 +480,13 @@ export async function handleMcpToggleCommand(
       requestId,
       { server_name: command.server_name, enabled: command.enabled },
     );
-    emitMcpCommandError(command.session_id, "toggle", message, requestId, command.server_name);
+    emitMcpCommandError(
+      command.session_id,
+      "toggle",
+      message,
+      requestId,
+      command.server_name,
+    );
   }
 }
 
@@ -505,7 +535,11 @@ export async function handleMcpSetServersCommand(
       { operation: "set-servers", message },
       requestId,
     );
-    slashError(command.session_id, `failed to set MCP servers: ${message}`, requestId);
+    slashError(
+      command.session_id,
+      `failed to set MCP servers: ${message}`,
+      requestId,
+    );
   }
 }
 
@@ -515,14 +549,20 @@ export async function handleMcpAuthenticateCommand(
   requestId?: string,
 ): Promise<void> {
   try {
-    const redirect = await authenticateMcpServer(session.query, command.server_name);
+    const redirect = await authenticateMcpServer(
+      session.query,
+      command.server_name,
+    );
     if (redirect) {
       logMcpSuccess(
         "mcp_auth_redirect_emitted",
         "MCP auth redirect emitted",
         command.session_id,
         requestId,
-        { server_name: command.server_name, requires_user_action: redirect.requires_user_action },
+        {
+          server_name: command.server_name,
+          requires_user_action: redirect.requires_user_action,
+        },
       );
       writeEvent(
         {
@@ -571,9 +611,15 @@ export async function handleMcpClearAuthCommand(
     await clearMcpServerAuth(session.query, command.server_name);
     forgetKnownConnectedMcpServer(session, command.server_name);
     session.mcpStatusRevalidatedAt.delete(command.server_name);
-    logMcpSuccess("mcp_clear_auth_completed", "MCP auth cleared", command.session_id, requestId, {
-      server_name: command.server_name,
-    });
+    logMcpSuccess(
+      "mcp_clear_auth_completed",
+      "MCP auth cleared",
+      command.session_id,
+      requestId,
+      {
+        server_name: command.server_name,
+      },
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logMcpFailure(
@@ -600,7 +646,11 @@ export async function handleMcpOauthCallbackUrlCommand(
   requestId?: string,
 ): Promise<void> {
   try {
-    await submitMcpOAuthCallbackUrl(session.query, command.server_name, command.callback_url);
+    await submitMcpOAuthCallbackUrl(
+      session.query,
+      command.server_name,
+      command.callback_url,
+    );
     logMcpSuccess(
       "mcp_oauth_callback_completed",
       "MCP OAuth callback URL submitted",

--- a/agent-sdk/src/bridge/mcp_auth_adapter.test.ts
+++ b/agent-sdk/src/bridge/mcp_auth_adapter.test.ts
@@ -46,7 +46,10 @@ test("MCP auth adapter preserves receiver and forwards exact arguments", async (
       callbackUrl: string,
     ) {
       assert.equal(this.marker, "query");
-      calls.push({ method: "submit_callback", args: [serverName, callbackUrl] });
+      calls.push({
+        method: "submit_callback",
+        args: [serverName, callbackUrl],
+      });
     },
   };
 
@@ -56,7 +59,11 @@ test("MCP auth adapter preserves receiver and forwards exact arguments", async (
     requires_user_action: true,
   });
   await clearMcpServerAuth(query, "docs");
-  await submitMcpOAuthCallbackUrl(query, "docs", "https://callback.example.test/code");
+  await submitMcpOAuthCallbackUrl(
+    query,
+    "docs",
+    "https://callback.example.test/code",
+  );
 
   assert.deepEqual(calls, [
     { method: "authenticate", args: ["docs"] },
@@ -108,11 +115,18 @@ test("MCP auth adapter rejects missing methods and incompatible responses", asyn
   );
 });
 
-function installedRuntimeMethodSource(source: string, methodName: string): string {
+function installedRuntimeMethodSource(
+  source: string,
+  methodName: string,
+): string {
   const start = source.indexOf(`async ${methodName}(`);
   assert.notEqual(start, -1, `installed SDK runtime is missing ${methodName}`);
   const end = source.indexOf("}async ", start);
-  assert.notEqual(end, -1, `could not isolate installed SDK runtime method ${methodName}`);
+  assert.notEqual(
+    end,
+    -1,
+    `could not isolate installed SDK runtime method ${methodName}`,
+  );
   return source.slice(start, end + 1);
 }
 
@@ -132,7 +146,10 @@ test("pinned SDK runtime retains the MCP auth control-request contract", async (
   assert.match(clearAuth, /serverName:/);
   assert.match(clearAuth, /\.response/);
 
-  const submitCallback = installedRuntimeMethodSource(source, "mcpSubmitOAuthCallbackUrl");
+  const submitCallback = installedRuntimeMethodSource(
+    source,
+    "mcpSubmitOAuthCallbackUrl",
+  );
   assert.match(submitCallback, /subtype:"mcp_oauth_callback_url"/);
   assert.match(submitCallback, /serverName:/);
   assert.match(submitCallback, /callbackUrl:/);

--- a/agent-sdk/src/bridge/mcp_auth_adapter.ts
+++ b/agent-sdk/src/bridge/mcp_auth_adapter.ts
@@ -8,7 +8,10 @@ const MCP_AUTH_METHODS = {
   submit_oauth_callback_url: "mcpSubmitOAuthCallbackUrl",
 } as const;
 
-function runtimeMethod(query: unknown, methodName: string): RuntimeMethod | undefined {
+function runtimeMethod(
+  query: unknown,
+  methodName: string,
+): RuntimeMethod | undefined {
   if ((!query || typeof query !== "object") && typeof query !== "function") {
     return undefined;
   }
@@ -16,7 +19,10 @@ function runtimeMethod(query: unknown, methodName: string): RuntimeMethod | unde
   return typeof method === "function" ? (method as RuntimeMethod) : undefined;
 }
 
-function requiredRuntimeMethod(query: unknown, methodName: string): RuntimeMethod {
+function requiredRuntimeMethod(
+  query: unknown,
+  methodName: string,
+): RuntimeMethod {
   const method = runtimeMethod(query, methodName);
   if (!method) {
     throw new Error(`installed SDK does not support ${methodName}`);
@@ -35,19 +41,26 @@ async function invokeRuntimeMethod(
 
 export function detectMcpAuthCapabilities(query: unknown): McpAuthCapabilities {
   return {
-    authenticate: runtimeMethod(query, MCP_AUTH_METHODS.authenticate) !== undefined,
+    authenticate:
+      runtimeMethod(query, MCP_AUTH_METHODS.authenticate) !== undefined,
     clear_auth: runtimeMethod(query, MCP_AUTH_METHODS.clear_auth) !== undefined,
     submit_oauth_callback_url:
-      runtimeMethod(query, MCP_AUTH_METHODS.submit_oauth_callback_url) !== undefined,
+      runtimeMethod(query, MCP_AUTH_METHODS.submit_oauth_callback_url) !==
+      undefined,
   };
 }
 
-function parseMcpAuthRedirect(serverName: string, value: unknown): McpAuthRedirect | null {
+function parseMcpAuthRedirect(
+  serverName: string,
+  value: unknown,
+): McpAuthRedirect | null {
   if (value === undefined || value === null) {
     return null;
   }
   if (typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("installed SDK returned an invalid mcpAuthenticate response");
+    throw new Error(
+      "installed SDK returned an invalid mcpAuthenticate response",
+    );
   }
 
   const authUrl = Reflect.get(value, "authUrl");
@@ -55,12 +68,19 @@ function parseMcpAuthRedirect(serverName: string, value: unknown): McpAuthRedire
     return null;
   }
   if (typeof authUrl !== "string" || authUrl.trim().length === 0) {
-    throw new Error("installed SDK returned an invalid mcpAuthenticate authUrl");
+    throw new Error(
+      "installed SDK returned an invalid mcpAuthenticate authUrl",
+    );
   }
 
   const requiresUserAction = Reflect.get(value, "requiresUserAction");
-  if (requiresUserAction !== undefined && typeof requiresUserAction !== "boolean") {
-    throw new Error("installed SDK returned an invalid mcpAuthenticate requiresUserAction");
+  if (
+    requiresUserAction !== undefined &&
+    typeof requiresUserAction !== "boolean"
+  ) {
+    throw new Error(
+      "installed SDK returned an invalid mcpAuthenticate requiresUserAction",
+    );
   }
 
   return {
@@ -74,11 +94,18 @@ export async function authenticateMcpServer(
   query: unknown,
   serverName: string,
 ): Promise<McpAuthRedirect | null> {
-  const result = await invokeRuntimeMethod(query, MCP_AUTH_METHODS.authenticate, [serverName]);
+  const result = await invokeRuntimeMethod(
+    query,
+    MCP_AUTH_METHODS.authenticate,
+    [serverName],
+  );
   return parseMcpAuthRedirect(serverName, result);
 }
 
-export async function clearMcpServerAuth(query: unknown, serverName: string): Promise<void> {
+export async function clearMcpServerAuth(
+  query: unknown,
+  serverName: string,
+): Promise<void> {
   await invokeRuntimeMethod(query, MCP_AUTH_METHODS.clear_auth, [serverName]);
 }
 

--- a/agent-sdk/src/bridge/mcp_metadata.ts
+++ b/agent-sdk/src/bridge/mcp_metadata.ts
@@ -8,8 +8,10 @@ import type {
 } from "../types.js";
 import { bridgeLogger, LOG_TARGETS } from "./logger.js";
 
-type SdkMcpServerConfig = import("@anthropic-ai/claude-agent-sdk").McpServerConfig;
-type SdkMcpServerStatus = import("@anthropic-ai/claude-agent-sdk").McpServerStatus;
+type SdkMcpServerConfig =
+  import("@anthropic-ai/claude-agent-sdk").McpServerConfig;
+type SdkMcpServerStatus =
+  import("@anthropic-ai/claude-agent-sdk").McpServerStatus;
 type SdkMcpServerStatusConfig = NonNullable<SdkMcpServerStatus["config"]>;
 
 type McpServerDiagnosticSummary = {
@@ -54,7 +56,10 @@ function optionalStringArray(
   if (value === undefined) {
     return undefined;
   }
-  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+  if (
+    !Array.isArray(value) ||
+    !value.every((entry) => typeof entry === "string")
+  ) {
     throw new Error(`${context}.${key} must be an array of strings`);
   }
   return value;
@@ -86,7 +91,12 @@ function optionalTimeout(
   if (value === undefined) {
     return undefined;
   }
-  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 1000) {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 1000
+  ) {
     throw new Error(`${context}.timeout must be an integer >= 1000`);
   }
   return value;
@@ -100,7 +110,12 @@ function optionalRequestTimeoutMs(
   if (value === undefined) {
     return undefined;
   }
-  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 1000) {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 1000
+  ) {
     throw new Error(`${context}.request_timeout_ms must be an integer >= 1000`);
   }
   return value;
@@ -140,15 +155,28 @@ function optionalToolPolicies(
     const policy: McpServerToolPolicy = { name };
     const permissionPolicy = item.permission_policy;
     if (permissionPolicy !== undefined) {
-      if (typeof permissionPolicy !== "string" || !TOOL_PERMISSION_POLICIES.has(permissionPolicy as McpServerToolPermissionPolicy)) {
-        throw new Error(`${context}.tools[${index}].permission_policy must be one of always_allow, always_ask, always_deny`);
+      if (
+        typeof permissionPolicy !== "string" ||
+        !TOOL_PERMISSION_POLICIES.has(
+          permissionPolicy as McpServerToolPermissionPolicy,
+        )
+      ) {
+        throw new Error(
+          `${context}.tools[${index}].permission_policy must be one of always_allow, always_ask, always_deny`,
+        );
       }
-      policy.permission_policy = permissionPolicy as McpServerToolPermissionPolicy;
+      policy.permission_policy =
+        permissionPolicy as McpServerToolPermissionPolicy;
     }
     const orgMaxPermission = item.org_max_permission;
     if (orgMaxPermission !== undefined) {
-      if (typeof orgMaxPermission !== "string" || !ORG_MAX_PERMISSIONS.has(orgMaxPermission as McpServerOrgMaxPermission)) {
-        throw new Error(`${context}.tools[${index}].org_max_permission must be one of allow, ask, blocked`);
+      if (
+        typeof orgMaxPermission !== "string" ||
+        !ORG_MAX_PERMISSIONS.has(orgMaxPermission as McpServerOrgMaxPermission)
+      ) {
+        throw new Error(
+          `${context}.tools[${index}].org_max_permission must be one of allow, ask, blocked`,
+        );
       }
       policy.org_max_permission = orgMaxPermission as McpServerOrgMaxPermission;
     }
@@ -156,7 +184,10 @@ function optionalToolPolicies(
   });
 }
 
-export function parseMcpServerConfig(value: unknown, context: string): McpServerConfig {
+export function parseMcpServerConfig(
+  value: unknown,
+  context: string,
+): McpServerConfig {
   const record = asRecord(value, context);
   const rawType = record.type;
   const type = rawType === undefined ? "stdio" : rawType;
@@ -171,7 +202,9 @@ export function parseMcpServerConfig(value: unknown, context: string): McpServer
   switch (type) {
     case "stdio": {
       if (record.tools !== undefined) {
-        throw new Error(`${context}.tools is only supported for http and sse MCP servers`);
+        throw new Error(
+          `${context}.tools is only supported for http and sse MCP servers`,
+        );
       }
       const command = record.command;
       if (typeof command !== "string") {
@@ -180,10 +213,16 @@ export function parseMcpServerConfig(value: unknown, context: string): McpServer
       return {
         type,
         command,
-        ...(optionalStringArray(record, "args", context) ? { args: optionalStringArray(record, "args", context) } : {}),
-        ...(optionalStringMap(record, "env", context) ? { env: optionalStringMap(record, "env", context) } : {}),
+        ...(optionalStringArray(record, "args", context)
+          ? { args: optionalStringArray(record, "args", context) }
+          : {}),
+        ...(optionalStringMap(record, "env", context)
+          ? { env: optionalStringMap(record, "env", context) }
+          : {}),
         ...(timeout === undefined ? {} : { timeout }),
-        ...(requestTimeoutMs === undefined ? {} : { request_timeout_ms: requestTimeoutMs }),
+        ...(requestTimeoutMs === undefined
+          ? {}
+          : { request_timeout_ms: requestTimeoutMs }),
         ...(alwaysLoad === undefined ? {} : { always_load: alwaysLoad }),
       };
     }
@@ -197,10 +236,14 @@ export function parseMcpServerConfig(value: unknown, context: string): McpServer
       return {
         type,
         url,
-        ...(optionalStringMap(record, "headers", context) ? { headers: optionalStringMap(record, "headers", context) } : {}),
+        ...(optionalStringMap(record, "headers", context)
+          ? { headers: optionalStringMap(record, "headers", context) }
+          : {}),
         ...(tools === undefined ? {} : { tools }),
         ...(timeout === undefined ? {} : { timeout }),
-        ...(requestTimeoutMs === undefined ? {} : { request_timeout_ms: requestTimeoutMs }),
+        ...(requestTimeoutMs === undefined
+          ? {}
+          : { request_timeout_ms: requestTimeoutMs }),
         ...(alwaysLoad === undefined ? {} : { always_load: alwaysLoad }),
       };
     }
@@ -215,23 +258,38 @@ export function parseMcpServersRecord(
 ): Record<string, McpServerConfig> {
   const record = asRecord(value, context);
   return Object.fromEntries(
-    Object.entries(record).map(([key, entry]) => [key, parseMcpServerConfig(entry, `${context}.${key}`)]),
+    Object.entries(record).map(([key, entry]) => [
+      key,
+      parseMcpServerConfig(entry, `${context}.${key}`),
+    ]),
   );
 }
 
-function toSdkToolPolicies(tools?: McpServerToolPolicy[]): import("@anthropic-ai/claude-agent-sdk").McpServerToolPolicy[] | undefined {
+function toSdkToolPolicies(
+  tools?: McpServerToolPolicy[],
+): import("@anthropic-ai/claude-agent-sdk").McpServerToolPolicy[] | undefined {
   return tools?.map((tool) => ({
     name: tool.name,
-    ...(tool.permission_policy === undefined ? {} : { permission_policy: tool.permission_policy }),
-    ...(tool.org_max_permission === undefined ? {} : { org_max_permission: tool.org_max_permission }),
+    ...(tool.permission_policy === undefined
+      ? {}
+      : { permission_policy: tool.permission_policy }),
+    ...(tool.org_max_permission === undefined
+      ? {}
+      : { org_max_permission: tool.org_max_permission }),
   }));
 }
 
-function sdkRequestTimeoutConfig(config: { request_timeout_ms?: number }): { requestTimeoutMs?: number } {
-  return config.request_timeout_ms === undefined ? {} : { requestTimeoutMs: config.request_timeout_ms };
+function sdkRequestTimeoutConfig(config: { request_timeout_ms?: number }): {
+  requestTimeoutMs?: number;
+} {
+  return config.request_timeout_ms === undefined
+    ? {}
+    : { requestTimeoutMs: config.request_timeout_ms };
 }
 
-export function bridgeMcpConfigToSdk(config: McpServerConfig): SdkMcpServerConfig {
+export function bridgeMcpConfigToSdk(
+  config: McpServerConfig,
+): SdkMcpServerConfig {
   switch (config.type) {
     case "stdio":
       return {
@@ -241,7 +299,9 @@ export function bridgeMcpConfigToSdk(config: McpServerConfig): SdkMcpServerConfi
         ...(config.env ? { env: config.env } : {}),
         ...(config.timeout === undefined ? {} : { timeout: config.timeout }),
         ...sdkRequestTimeoutConfig(config),
-        ...(config.always_load === undefined ? {} : { alwaysLoad: config.always_load }),
+        ...(config.always_load === undefined
+          ? {}
+          : { alwaysLoad: config.always_load }),
       };
     case "sse":
       return {
@@ -251,7 +311,9 @@ export function bridgeMcpConfigToSdk(config: McpServerConfig): SdkMcpServerConfi
         ...(config.tools ? { tools: toSdkToolPolicies(config.tools) } : {}),
         ...(config.timeout === undefined ? {} : { timeout: config.timeout }),
         ...sdkRequestTimeoutConfig(config),
-        ...(config.always_load === undefined ? {} : { alwaysLoad: config.always_load }),
+        ...(config.always_load === undefined
+          ? {}
+          : { alwaysLoad: config.always_load }),
       };
     case "http":
       return {
@@ -261,7 +323,9 @@ export function bridgeMcpConfigToSdk(config: McpServerConfig): SdkMcpServerConfi
         ...(config.tools ? { tools: toSdkToolPolicies(config.tools) } : {}),
         ...(config.timeout === undefined ? {} : { timeout: config.timeout }),
         ...sdkRequestTimeoutConfig(config),
-        ...(config.always_load === undefined ? {} : { alwaysLoad: config.always_load }),
+        ...(config.always_load === undefined
+          ? {}
+          : { alwaysLoad: config.always_load }),
       };
   }
 }
@@ -270,7 +334,10 @@ export function bridgeMcpServersToSdk(
   servers: Record<string, McpServerConfig>,
 ): Record<string, SdkMcpServerConfig> {
   return Object.fromEntries(
-    Object.entries(servers).map(([name, config]) => [name, bridgeMcpConfigToSdk(config)]),
+    Object.entries(servers).map(([name, config]) => [
+      name,
+      bridgeMcpConfigToSdk(config),
+    ]),
   );
 }
 
@@ -289,23 +356,37 @@ function mapSdkToolPolicies(tools: unknown): McpServerToolPolicy[] | undefined {
       }
       const policy: McpServerToolPolicy = { name: raw.name };
       if (raw.permission_policy !== undefined) {
-        if (typeof raw.permission_policy !== "string" || !TOOL_PERMISSION_POLICIES.has(raw.permission_policy as McpServerToolPermissionPolicy)) {
+        if (
+          typeof raw.permission_policy !== "string" ||
+          !TOOL_PERMISSION_POLICIES.has(
+            raw.permission_policy as McpServerToolPermissionPolicy,
+          )
+        ) {
           return null;
         }
-        policy.permission_policy = raw.permission_policy as McpServerToolPermissionPolicy;
+        policy.permission_policy =
+          raw.permission_policy as McpServerToolPermissionPolicy;
       }
       if (raw.org_max_permission !== undefined) {
-        if (typeof raw.org_max_permission !== "string" || !ORG_MAX_PERMISSIONS.has(raw.org_max_permission as McpServerOrgMaxPermission)) {
+        if (
+          typeof raw.org_max_permission !== "string" ||
+          !ORG_MAX_PERMISSIONS.has(
+            raw.org_max_permission as McpServerOrgMaxPermission,
+          )
+        ) {
           return null;
         }
-        policy.org_max_permission = raw.org_max_permission as McpServerOrgMaxPermission;
+        policy.org_max_permission =
+          raw.org_max_permission as McpServerOrgMaxPermission;
       }
       return policy;
     })
     .filter((tool): tool is McpServerToolPolicy => tool !== null);
 }
 
-export function mapMcpServerStatus(status: SdkMcpServerStatus): McpServerStatus {
+export function mapMcpServerStatus(
+  status: SdkMcpServerStatus,
+): McpServerStatus {
   return {
     name: status.name,
     status: status.status,
@@ -318,7 +399,9 @@ export function mapMcpServerStatus(status: SdkMcpServerStatus): McpServerStatus 
         }
       : {}),
     ...(status.error ? { error: status.error } : {}),
-    ...(status.config ? { config: mapMcpServerStatusConfig(status.config) } : {}),
+    ...(status.config
+      ? { config: mapMcpServerStatusConfig(status.config) }
+      : {}),
     ...(status.scope ? { scope: status.scope } : {}),
     tools: Array.isArray(status.tools)
       ? status.tools.map((tool) => ({
@@ -350,22 +433,32 @@ function sdkRequestTimeoutMs(config: unknown): number | undefined {
   }
   const raw = config as Record<string, unknown>;
   const value = raw.requestTimeoutMs ?? raw.request_timeout_ms;
-  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value)
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value)
     ? value
     : undefined;
 }
 
-export function mapMcpServerStatusConfig(config: SdkMcpServerStatusConfig): McpServerStatusConfig {
+export function mapMcpServerStatusConfig(
+  config: SdkMcpServerStatusConfig,
+): McpServerStatusConfig {
   switch (config.type) {
     case "stdio":
       return {
         type: "stdio",
         command: config.command,
-        ...(Array.isArray(config.args) && config.args.length > 0 ? { args: config.args } : {}),
+        ...(Array.isArray(config.args) && config.args.length > 0
+          ? { args: config.args }
+          : {}),
         ...(config.env ? { env: config.env } : {}),
         ...(config.timeout === undefined ? {} : { timeout: config.timeout }),
-        ...(sdkRequestTimeoutMs(config) === undefined ? {} : { request_timeout_ms: sdkRequestTimeoutMs(config) }),
-        ...(config.alwaysLoad === undefined ? {} : { always_load: config.alwaysLoad }),
+        ...(sdkRequestTimeoutMs(config) === undefined
+          ? {}
+          : { request_timeout_ms: sdkRequestTimeoutMs(config) }),
+        ...(config.alwaysLoad === undefined
+          ? {}
+          : { always_load: config.alwaysLoad }),
       };
     case "sse": {
       const tools = mapSdkToolPolicies(config.tools);
@@ -375,8 +468,12 @@ export function mapMcpServerStatusConfig(config: SdkMcpServerStatusConfig): McpS
         ...(config.headers ? { headers: config.headers } : {}),
         ...(tools === undefined ? {} : { tools }),
         ...(config.timeout === undefined ? {} : { timeout: config.timeout }),
-        ...(sdkRequestTimeoutMs(config) === undefined ? {} : { request_timeout_ms: sdkRequestTimeoutMs(config) }),
-        ...(config.alwaysLoad === undefined ? {} : { always_load: config.alwaysLoad }),
+        ...(sdkRequestTimeoutMs(config) === undefined
+          ? {}
+          : { request_timeout_ms: sdkRequestTimeoutMs(config) }),
+        ...(config.alwaysLoad === undefined
+          ? {}
+          : { always_load: config.alwaysLoad }),
       };
     }
     case "http": {
@@ -387,8 +484,12 @@ export function mapMcpServerStatusConfig(config: SdkMcpServerStatusConfig): McpS
         ...(config.headers ? { headers: config.headers } : {}),
         ...(tools === undefined ? {} : { tools }),
         ...(config.timeout === undefined ? {} : { timeout: config.timeout }),
-        ...(sdkRequestTimeoutMs(config) === undefined ? {} : { request_timeout_ms: sdkRequestTimeoutMs(config) }),
-        ...(config.alwaysLoad === undefined ? {} : { always_load: config.alwaysLoad }),
+        ...(sdkRequestTimeoutMs(config) === undefined
+          ? {}
+          : { request_timeout_ms: sdkRequestTimeoutMs(config) }),
+        ...(config.alwaysLoad === undefined
+          ? {}
+          : { always_load: config.alwaysLoad }),
       };
     }
     case "sdk":
@@ -418,7 +519,9 @@ export function mapMcpServerStatusConfig(config: SdkMcpServerStatusConfig): McpS
   }
 }
 
-function mcpStatusConfigDiagnostics(config: McpServerStatusConfig | undefined): {
+function mcpStatusConfigDiagnostics(
+  config: McpServerStatusConfig | undefined,
+): {
   config_type: string;
   timeout_ms?: number;
   request_timeout_ms?: number;
@@ -437,8 +540,12 @@ function mcpStatusConfigDiagnostics(config: McpServerStatusConfig | undefined): 
       return {
         config_type: "stdio",
         ...(config.timeout === undefined ? {} : { timeout_ms: config.timeout }),
-        ...(config.request_timeout_ms === undefined ? {} : { request_timeout_ms: config.request_timeout_ms }),
-        ...(config.always_load === undefined ? {} : { always_load: config.always_load }),
+        ...(config.request_timeout_ms === undefined
+          ? {}
+          : { request_timeout_ms: config.request_timeout_ms }),
+        ...(config.always_load === undefined
+          ? {}
+          : { always_load: config.always_load }),
         configured_tool_policy_count: 0,
       };
     case "sse":
@@ -446,8 +553,12 @@ function mcpStatusConfigDiagnostics(config: McpServerStatusConfig | undefined): 
       return {
         config_type: config.type,
         ...(config.timeout === undefined ? {} : { timeout_ms: config.timeout }),
-        ...(config.request_timeout_ms === undefined ? {} : { request_timeout_ms: config.request_timeout_ms }),
-        ...(config.always_load === undefined ? {} : { always_load: config.always_load }),
+        ...(config.request_timeout_ms === undefined
+          ? {}
+          : { request_timeout_ms: config.request_timeout_ms }),
+        ...(config.always_load === undefined
+          ? {}
+          : { always_load: config.always_load }),
         configured_tool_policy_count: config.tools?.length ?? 0,
       };
     case "sdk":
@@ -479,9 +590,15 @@ export function summarizeMcpServersForDiagnostics(
       status: server.status,
       config_type: config.config_type,
       ...(server.scope ? { scope: server.scope } : {}),
-      ...(config.timeout_ms === undefined ? {} : { timeout_ms: config.timeout_ms }),
-      ...(config.request_timeout_ms === undefined ? {} : { request_timeout_ms: config.request_timeout_ms }),
-      ...(config.always_load === undefined ? {} : { always_load: config.always_load }),
+      ...(config.timeout_ms === undefined
+        ? {}
+        : { timeout_ms: config.timeout_ms }),
+      ...(config.request_timeout_ms === undefined
+        ? {}
+        : { request_timeout_ms: config.request_timeout_ms }),
+      ...(config.always_load === undefined
+        ? {}
+        : { always_load: config.always_load }),
       tool_count: server.tools.length,
       configured_tool_policy_count: config.configured_tool_policy_count,
       has_error: typeof server.error === "string" && server.error.length > 0,

--- a/agent-sdk/src/bridge/mcp_monitor.ts
+++ b/agent-sdk/src/bridge/mcp_monitor.ts
@@ -33,7 +33,10 @@ const DEFAULT_MAX_ATTEMPTS = 24;
 const DEFAULT_INITIAL_DELAY_MS = 1_000;
 const DEFAULT_MAX_DELAY_MS = 10_000;
 
-async function abortableDelay(delayMs: number, signal: AbortSignal): Promise<void> {
+async function abortableDelay(
+  delayMs: number,
+  signal: AbortSignal,
+): Promise<void> {
   await delay(delayMs, undefined, { signal, ref: false });
 }
 
@@ -61,7 +64,12 @@ export async function runMcpAuthMonitor({
       }
       lastError = errorMessage(error);
       if (attempt === maxAttempts) {
-        return { outcome: "exhausted", attempts: attempt, reason: "error", lastError };
+        return {
+          outcome: "exhausted",
+          attempts: attempt,
+          reason: "error",
+          lastError,
+        };
       }
       nextDelayMs = Math.min(nextDelayMs * 2, maxDelayMs);
       continue;

--- a/agent-sdk/src/bridge/message_handlers.ts
+++ b/agent-sdk/src/bridge/message_handlers.ts
@@ -1,6 +1,7 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type {
   BridgeCommand,
+  SessionUpdate,
   SystemNoticeSeverity,
   TaskMetadata,
   TerminalReason,
@@ -8,7 +9,11 @@ import type {
   ToolCallUpdateFields,
 } from "../types.js";
 import { asRecordOrNull } from "./shared.js";
-import { toPermissionMode, buildModeState, refreshSupportedModesForSession } from "./commands.js";
+import {
+  toPermissionMode,
+  buildModeState,
+  refreshSupportedModesForSession,
+} from "./commands.js";
 import {
   writeEvent,
   emitSessionUpdate,
@@ -37,7 +42,10 @@ import {
   taskUpdatedFields,
   type ToolCorrelationMetadata,
 } from "./tool_calls.js";
-import { applyBackgroundTasksChanged, applyTaskLifecycleState } from "./tasks.js";
+import {
+  applyBackgroundTasksChanged,
+  applyTaskLifecycleState,
+} from "./tasks.js";
 import { linkTaskToolUse, unlinkTaskToolUse } from "./task_links.js";
 import {
   emitAuthRequired,
@@ -46,7 +54,11 @@ import {
   emitFastModeUpdateIfChanged,
   setFastModeSnapshotIfChanged,
 } from "./error_classification.js";
-import { mapAvailableAgentsFromNames, emitAvailableAgentsIfChanged, refreshAvailableAgents } from "./agents.js";
+import {
+  mapAvailableAgentsFromNames,
+  emitAvailableAgentsIfChanged,
+  refreshAvailableAgents,
+} from "./agents.js";
 import {
   mapInitSlashCommands,
   mapSdkSlashCommands,
@@ -64,11 +76,17 @@ import {
 } from "./state_parsing.js";
 import { looksLikeAuthRequired } from "./auth.js";
 import type { SessionState } from "./session_lifecycle.js";
-import { emitCurrentModelUpdate, refreshCurrentModel, updateSessionId } from "./session_lifecycle.js";
+import {
+  emitCurrentModelUpdate,
+  refreshCurrentModel,
+  updateSessionId,
+} from "./session_lifecycle.js";
 import { bridgeLogger, LOG_TARGETS } from "./logger.js";
 import { emitMcpSnapshotFromStatuses } from "./mcp.js";
 
-export function textFromPrompt(command: Extract<BridgeCommand, { command: "prompt" }>): string {
+export function textFromPrompt(
+  command: Extract<BridgeCommand, { command: "prompt" }>,
+): string {
   const chunks = command.chunks ?? [];
   return chunks
     .map((chunk) => {
@@ -91,7 +109,11 @@ const SUPPORTED_IMAGE_MIME_TYPES = new Set([
   "image/webp",
 ]);
 
-type SupportedImageMimeType = "image/png" | "image/jpeg" | "image/gif" | "image/webp";
+type SupportedImageMimeType =
+  | "image/png"
+  | "image/jpeg"
+  | "image/gif"
+  | "image/webp";
 
 type PromptContentBlock =
   | { type: "text"; text: string }
@@ -104,30 +126,59 @@ type PromptContentBlock =
       };
     };
 
-function sdkCorrelationMetadata(msg: Record<string, unknown>): ToolCorrelationMetadata {
+function sdkCorrelationMetadata(
+  msg: Record<string, unknown>,
+): ToolCorrelationMetadata {
   return {
     requestId: typeof msg.request_id === "string" ? msg.request_id : undefined,
-    subagentType: typeof msg.subagent_type === "string" ? msg.subagent_type : undefined,
-    taskDescription: typeof msg.task_description === "string" ? msg.task_description : undefined,
-    parentAgentId: typeof msg.parent_agent_id === "string" ? msg.parent_agent_id : undefined,
+    subagentType:
+      typeof msg.subagent_type === "string" ? msg.subagent_type : undefined,
+    taskDescription:
+      typeof msg.task_description === "string"
+        ? msg.task_description
+        : undefined,
+    parentAgentId:
+      typeof msg.parent_agent_id === "string" ? msg.parent_agent_id : undefined,
   };
 }
 
-function sdkTaskMetadata(msg: Record<string, unknown>): TaskMetadata | undefined {
+function sdkTaskMetadata(
+  msg: Record<string, unknown>,
+): TaskMetadata | undefined {
   const metadata = sdkCorrelationMetadata(msg);
-  const taskType = typeof msg.task_type === "string" && msg.task_type.length > 0 ? msg.task_type : undefined;
+  const taskType =
+    typeof msg.task_type === "string" && msg.task_type.length > 0
+      ? msg.task_type
+      : undefined;
   const workflowName =
-    typeof msg.workflow_name === "string" && msg.workflow_name.length > 0 ? msg.workflow_name : undefined;
-  const prompt = typeof msg.prompt === "string" && msg.prompt.length > 0 ? msg.prompt : undefined;
-  const outputFile = typeof msg.output_file === "string" && msg.output_file.length > 0 ? msg.output_file : undefined;
-  const status = typeof msg.status === "string" && msg.status.length > 0 ? msg.status : undefined;
+    typeof msg.workflow_name === "string" && msg.workflow_name.length > 0
+      ? msg.workflow_name
+      : undefined;
+  const prompt =
+    typeof msg.prompt === "string" && msg.prompt.length > 0
+      ? msg.prompt
+      : undefined;
+  const outputFile =
+    typeof msg.output_file === "string" && msg.output_file.length > 0
+      ? msg.output_file
+      : undefined;
+  const status =
+    typeof msg.status === "string" && msg.status.length > 0
+      ? msg.status
+      : undefined;
   const summary =
-    status && typeof msg.summary === "string" && msg.summary.length > 0 ? msg.summary : undefined;
+    status && typeof msg.summary === "string" && msg.summary.length > 0
+      ? msg.summary
+      : undefined;
   const taskMetadata: TaskMetadata = {
     ...(metadata.requestId ? { request_id: metadata.requestId } : {}),
     ...(metadata.subagentType ? { subagent_type: metadata.subagentType } : {}),
-    ...(metadata.taskDescription ? { task_description: metadata.taskDescription } : {}),
-    ...(metadata.parentAgentId ? { parent_agent_id: metadata.parentAgentId } : {}),
+    ...(metadata.taskDescription
+      ? { task_description: metadata.taskDescription }
+      : {}),
+    ...(metadata.parentAgentId
+      ? { parent_agent_id: metadata.parentAgentId }
+      : {}),
     ...(taskType ? { task_type: taskType } : {}),
     ...(workflowName ? { workflow_name: workflowName } : {}),
     ...(prompt ? { prompt } : {}),
@@ -139,12 +190,79 @@ function sdkTaskMetadata(msg: Record<string, unknown>): TaskMetadata | undefined
   return Object.keys(taskMetadata).length > 0 ? taskMetadata : undefined;
 }
 
-function sdkMessageOriginKind(msg: Record<string, unknown>): string | undefined {
-  const origin = msg.origin && typeof msg.origin === "object" ? (msg.origin as Record<string, unknown>) : null;
+function sdkMessageOriginKind(
+  msg: Record<string, unknown>,
+): string | undefined {
+  const origin =
+    msg.origin && typeof msg.origin === "object"
+      ? (msg.origin as Record<string, unknown>)
+      : null;
   return typeof origin?.kind === "string" ? origin.kind : undefined;
 }
 
-function logSdkMessageOrigin(session: SessionState, msg: Record<string, unknown>): void {
+function externalMessageUpdateFromSdkUser(
+  msg: Record<string, unknown>,
+): Extract<SessionUpdate, { type: "external_message_update" }> | undefined {
+  const origin = asRecordOrNull(msg.origin);
+  if (!origin) {
+    return undefined;
+  }
+  const kind = typeof origin?.kind === "string" ? origin.kind : undefined;
+  if (kind !== "peer" && kind !== "task-notification") {
+    return undefined;
+  }
+  const payload = asRecordOrNull(msg.message);
+  const content = payload?.content;
+  const contentText =
+    typeof content === "string"
+      ? content
+      : Array.isArray(content)
+        ? content
+            .flatMap((block) => {
+              const record = asRecordOrNull(block);
+              return record?.type === "text" && typeof record.text === "string"
+                ? [record.text]
+                : [];
+            })
+            .join("\n")
+        : "";
+  const text = typeof origin.body === "string" ? origin.body : contentText;
+  if (!text.trim()) {
+    return undefined;
+  }
+  return {
+    type: "external_message_update",
+    content: text,
+    ...(sourceMessageUuid(msg)
+      ? { source_message_uuid: sourceMessageUuid(msg) }
+      : {}),
+    origin: {
+      kind,
+      ...(typeof origin.subkind === "string"
+        ? { subkind: origin.subkind }
+        : {}),
+      ...(typeof origin.from === "string" ? { from: origin.from } : {}),
+      ...(typeof origin.name === "string" ? { name: origin.name } : {}),
+      ...(typeof origin.fromSession === "string"
+        ? { from_session: origin.fromSession }
+        : {}),
+      ...(typeof origin.senderTaskId === "string"
+        ? { sender_task_id: origin.senderTaskId }
+        : {}),
+      ...(typeof origin.verifiedPeerPid === "number" &&
+      Number.isSafeInteger(origin.verifiedPeerPid) &&
+      origin.verifiedPeerPid >= 0
+        ? { verified_peer_pid: origin.verifiedPeerPid }
+        : {}),
+    },
+  };
+}
+
+function logSdkMessageOrigin(
+  session: SessionState,
+  msg: Record<string, unknown>,
+): void {
+  const origin = asRecordOrNull(msg.origin);
   const originKind = sdkMessageOriginKind(msg);
   if (!originKind) {
     return;
@@ -158,6 +276,20 @@ function logSdkMessageOrigin(session: SessionState, msg: Record<string, unknown>
     fields: {
       message_type: typeof msg.type === "string" ? msg.type : undefined,
       origin_kind: originKind,
+      origin_subkind:
+        typeof origin?.subkind === "string" ? origin.subkind : undefined,
+      origin_from_session:
+        typeof origin?.fromSession === "string"
+          ? origin.fromSession
+          : undefined,
+      origin_sender_task_id:
+        typeof origin?.senderTaskId === "string"
+          ? origin.senderTaskId
+          : undefined,
+      origin_verified_peer_pid:
+        typeof origin?.verifiedPeerPid === "number"
+          ? origin.verifiedPeerPid
+          : undefined,
     },
   });
 }
@@ -171,7 +303,11 @@ function emitSystemNoticeUpdate(
   if (!trimmed) {
     return;
   }
-  emitSessionUpdate(session.sessionId, { type: "system_notice_update", severity, message: trimmed });
+  emitSessionUpdate(session.sessionId, {
+    type: "system_notice_update",
+    severity,
+    message: trimmed,
+  });
 }
 
 const MAX_INFORMATIONAL_DEDUP_KEYS = 256;
@@ -200,7 +336,10 @@ function shouldEmitInformationalMessage(
   return true;
 }
 
-function handleInformationalSystemMessage(session: SessionState, msg: Record<string, unknown>): void {
+function handleInformationalSystemMessage(
+  session: SessionState,
+  msg: Record<string, unknown>,
+): void {
   const content = typeof msg.content === "string" ? msg.content.trim() : "";
   if (!content) {
     return;
@@ -241,7 +380,10 @@ function handleInformationalSystemMessage(session: SessionState, msg: Record<str
   }
 }
 
-function trimmedStringField(msg: Record<string, unknown>, field: string): string | undefined {
+function trimmedStringField(
+  msg: Record<string, unknown>,
+  field: string,
+): string | undefined {
   const value = msg[field];
   if (typeof value !== "string") {
     return undefined;
@@ -259,7 +401,8 @@ function ensureSentencePunctuation(value: string): string {
 }
 
 function modelRefusalNoFallbackMessage(msg: Record<string, unknown>): string {
-  const model = trimmedStringField(msg, "original_model") ?? "the selected model";
+  const model =
+    trimmedStringField(msg, "original_model") ?? "the selected model";
   const base = `Could not continue with ${model}: model refused the request and no fallback model is configured.`;
   const explanation = trimmedStringField(msg, "api_refusal_explanation");
   const category = trimmedStringField(msg, "api_refusal_category");
@@ -273,7 +416,10 @@ function modelRefusalNoFallbackMessage(msg: Record<string, unknown>): string {
   return detailSentence ? `${base} ${detailSentence}` : base;
 }
 
-function handleModelRefusalNoFallbackMessage(session: SessionState, msg: Record<string, unknown>): void {
+function handleModelRefusalNoFallbackMessage(
+  session: SessionState,
+  msg: Record<string, unknown>,
+): void {
   const message = modelRefusalNoFallbackMessage(msg);
   emitSystemNoticeUpdate(session, "warning", message);
   bridgeLogger.info({
@@ -286,10 +432,14 @@ function handleModelRefusalNoFallbackMessage(session: SessionState, msg: Record<
     fields: {
       original_model: trimmedStringField(msg, "original_model"),
       api_refusal_category: trimmedStringField(msg, "api_refusal_category"),
-      refused_user_message_uuid: trimmedStringField(msg, "refused_user_message_uuid"),
+      refused_user_message_uuid: trimmedStringField(
+        msg,
+        "refused_user_message_uuid",
+      ),
       sdk_message_uuid: trimmedStringField(msg, "uuid"),
       sdk_message_session_id: trimmedStringField(msg, "session_id"),
-      has_api_refusal_explanation: trimmedStringField(msg, "api_refusal_explanation") !== undefined,
+      has_api_refusal_explanation:
+        trimmedStringField(msg, "api_refusal_explanation") !== undefined,
       has_content: trimmedStringField(msg, "content") !== undefined,
     },
   });
@@ -297,7 +447,9 @@ function handleModelRefusalNoFallbackMessage(session: SessionState, msg: Record<
 
 function workerShutdownMessage(reason: string): string {
   const trimmed = reason.trim();
-  return trimmed ? `Claude worker is shutting down: ${trimmed}` : "Claude worker is shutting down.";
+  return trimmed
+    ? `Claude worker is shutting down: ${trimmed}`
+    : "Claude worker is shutting down.";
 }
 
 function handleWorkerShuttingDownSystemMessage(
@@ -347,7 +499,11 @@ export function flushPendingWorkerShutdown(session: SessionState): void {
   if (!session.connected) {
     return;
   }
-  emitSystemNoticeUpdate(session, "warning", workerShutdownMessage(pending.reason));
+  emitSystemNoticeUpdate(
+    session,
+    "warning",
+    workerShutdownMessage(pending.reason),
+  );
 }
 
 function notificationSeverity(priority: unknown): SystemNoticeSeverity {
@@ -385,10 +541,13 @@ export function contentFromPrompt(
       }
     } else if (chunk.kind === "image") {
       const val =
-        chunk.value && typeof chunk.value === "object" ? (chunk.value as Record<string, unknown>) : null;
+        chunk.value && typeof chunk.value === "object"
+          ? (chunk.value as Record<string, unknown>)
+          : null;
       if (!val) continue;
       const data = typeof val.data === "string" ? val.data : "";
-      const mimeType = typeof val.mime_type === "string" ? val.mime_type : "image/png";
+      const mimeType =
+        typeof val.mime_type === "string" ? val.mime_type : "image/png";
       if (!SUPPORTED_IMAGE_MIME_TYPES.has(mimeType)) {
         bridgeLogger.warn({
           target: LOG_TARGETS.BRIDGE_PROTOCOL,
@@ -439,7 +598,8 @@ export function handleTaskSystemMessage(
   }
 
   const taskId = typeof msg.task_id === "string" ? msg.task_id : "";
-  const explicitToolUseId = typeof msg.tool_use_id === "string" ? msg.tool_use_id : "";
+  const explicitToolUseId =
+    typeof msg.tool_use_id === "string" ? msg.tool_use_id : "";
   const messageTaskMetadata = sdkTaskMetadata(msg);
   if (taskId && explicitToolUseId) {
     linkTaskToolUse(session, taskId, explicitToolUseId);
@@ -458,9 +618,11 @@ export function handleTaskSystemMessage(
       explicit_tool_use_id: explicitToolUseId || undefined,
       resolved_tool_use_id: toolUseId || undefined,
       task_status: typeof msg.status === "string" ? msg.status : undefined,
-      has_description: typeof msg.description === "string" && msg.description.length > 0,
+      has_description:
+        typeof msg.description === "string" && msg.description.length > 0,
       has_summary: typeof msg.summary === "string" && msg.summary.length > 0,
-      last_tool_name: typeof msg.last_tool_name === "string" ? msg.last_tool_name : undefined,
+      last_tool_name:
+        typeof msg.last_tool_name === "string" ? msg.last_tool_name : undefined,
     },
   });
   if (subtype === "task_updated") {
@@ -505,26 +667,29 @@ export function handleTaskSystemMessage(
   }
   applyTaskLifecycleState(session, subtype, msg);
   if (toolCall.status === "pending") {
-    emitToolCallUpdate(session, toolUseId, { status: "in_progress" }, "progress");
+    emitToolCallUpdate(
+      session,
+      toolUseId,
+      { status: "in_progress" },
+      "progress",
+    );
   }
 
   if (subtype === "task_started") {
-    const description = typeof msg.description === "string" ? msg.description : "";
+    const description =
+      typeof msg.description === "string" ? msg.description : "";
     if (!description) {
       return true;
     }
     const fields: ToolCallUpdateFields = {
       status: "in_progress",
       raw_output: description,
-      content: [{ type: "content", content: { type: "text", text: description } }],
+      content: [
+        { type: "content", content: { type: "text", text: description } },
+      ],
       ...(messageTaskMetadata ? { task_metadata: messageTaskMetadata } : {}),
     };
-    emitToolCallUpdate(
-      session,
-      toolUseId,
-      fields,
-      "task_started",
-    );
+    emitToolCallUpdate(session, toolUseId, fields, "task_started");
     return true;
   }
 
@@ -539,19 +704,17 @@ export function handleTaskSystemMessage(
       content: [{ type: "content", content: { type: "text", text: progress } }],
       ...(messageTaskMetadata ? { task_metadata: messageTaskMetadata } : {}),
     };
-    emitToolCallUpdate(
-      session,
-      toolUseId,
-      fields,
-      "task_progress",
-    );
+    emitToolCallUpdate(session, toolUseId, fields, "task_progress");
     return true;
   }
 
   if (subtype === "task_updated") {
     const fields = taskUpdatedFields(msg);
     if (messageTaskMetadata) {
-      fields.task_metadata = { ...(fields.task_metadata ?? {}), ...messageTaskMetadata };
+      fields.task_metadata = {
+        ...(fields.task_metadata ?? {}),
+        ...messageTaskMetadata,
+      };
     }
     if (Object.keys(fields).length === 0) {
       return true;
@@ -580,15 +743,25 @@ export function handleTaskSystemMessage(
 
   const status = typeof msg.status === "string" ? msg.status : "";
   const summary = typeof msg.summary === "string" ? msg.summary : "";
-  const finalStatus = status === "completed" ? "completed" : status === "stopped" ? "killed" : "failed";
-  const deferCompletion = finalStatus === "completed" && defersTaskNotificationCompletion(toolCall);
-  const fields: ToolCallUpdateFields = deferCompletion ? {} : { status: finalStatus };
+  const finalStatus =
+    status === "completed"
+      ? "completed"
+      : status === "stopped"
+        ? "killed"
+        : "failed";
+  const deferCompletion =
+    finalStatus === "completed" && defersTaskNotificationCompletion(toolCall);
+  const fields: ToolCallUpdateFields = deferCompletion
+    ? {}
+    : { status: finalStatus };
   if (messageTaskMetadata) {
     fields.task_metadata = messageTaskMetadata;
   }
   if (summary) {
     fields.raw_output = summary;
-    fields.content = [{ type: "content", content: { type: "text", text: summary } }];
+    fields.content = [
+      { type: "content", content: { type: "text", text: summary } },
+    ];
   }
   if (Object.keys(fields).length > 0) {
     emitToolCallUpdate(session, toolUseId, fields, "task_notification");
@@ -606,12 +779,18 @@ type ContentBlockLinkage = {
   sourceMessageUuid?: string;
 };
 
-function stringField(msg: Record<string, unknown>, field: string): string | undefined {
+function stringField(
+  msg: Record<string, unknown>,
+  field: string,
+): string | undefined {
   const value = msg[field];
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-function nullableStringField(msg: Record<string, unknown>, field: string): string | undefined {
+function nullableStringField(
+  msg: Record<string, unknown>,
+  field: string,
+): string | undefined {
   const value = msg[field];
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
@@ -656,10 +835,19 @@ function emitTranscriptRetraction(
     ...(metadata.requestId ? { request_id: metadata.requestId } : {}),
     ...(metadata.trigger ? { trigger: metadata.trigger } : {}),
     ...(metadata.direction ? { direction: metadata.direction } : {}),
-    ...(metadata.originalModel ? { original_model: metadata.originalModel } : {}),
-    ...(metadata.fallbackModel ? { fallback_model: metadata.fallbackModel } : {}),
-    ...(metadata.apiRefusalCategory ? { api_refusal_category: metadata.apiRefusalCategory } : {}),
-    ...(metadata.apiRefusalExplanation ? { api_refusal_explanation: metadata.apiRefusalExplanation } : {}),
+    ...(metadata.originalModel
+      ? { original_model: metadata.originalModel }
+      : {}),
+    ...(metadata.fallbackModel
+      ? { fallback_model: metadata.fallbackModel }
+      : {}),
+    ...(metadata.scope ? { scope: metadata.scope } : {}),
+    ...(metadata.apiRefusalCategory
+      ? { api_refusal_category: metadata.apiRefusalCategory }
+      : {}),
+    ...(metadata.apiRefusalExplanation
+      ? { api_refusal_explanation: metadata.apiRefusalExplanation }
+      : {}),
     ...(metadata.content ? { content: metadata.content } : {}),
   });
   return true;
@@ -682,11 +870,17 @@ function handleFallbackRetractionMessage(
     direction: stringField(msg, "direction"),
     originalModel: stringField(msg, "original_model"),
     fallbackModel: stringField(msg, "fallback_model"),
+    scope: stringField(msg, "scope") ?? "session",
     apiRefusalCategory: nullableStringField(msg, "api_refusal_category"),
     apiRefusalExplanation: nullableStringField(msg, "api_refusal_explanation"),
     content: stringField(msg, "content"),
   };
-  const emitted = emitTranscriptRetraction(session, messageUuids, reason, metadata);
+  const emitted = emitTranscriptRetraction(
+    session,
+    messageUuids,
+    reason,
+    metadata,
+  );
   bridgeLogger.info({
     target: LOG_TARGETS.APP_SESSION,
     eventName: "sdk_model_fallback_received",
@@ -701,6 +895,7 @@ function handleFallbackRetractionMessage(
       direction: metadata.direction,
       original_model: metadata.originalModel,
       fallback_model: metadata.fallbackModel,
+      scope: metadata.scope,
       api_refusal_category: metadata.apiRefusalCategory,
       has_api_refusal_explanation: metadata.apiRefusalExplanation !== undefined,
       has_content: metadata.content !== undefined,
@@ -762,7 +957,11 @@ function hideToolUse(session: SessionState, toolUseId: string): void {
   }
 }
 
-function isHiddenToolUse(session: SessionState, toolUseId: string, toolName: string): boolean {
+function isHiddenToolUse(
+  session: SessionState,
+  toolUseId: string,
+  toolName: string,
+): boolean {
   if (!toolUseId) {
     return false;
   }
@@ -773,7 +972,11 @@ function isHiddenToolUse(session: SessionState, toolUseId: string, toolName: str
   return session.hiddenToolUseIds.has(toolUseId);
 }
 
-function isHiddenToolResult(session: SessionState, toolUseId: string, blockType: string): boolean {
+function isHiddenToolResult(
+  session: SessionState,
+  toolUseId: string,
+  blockType: string,
+): boolean {
   if (!toolUseId) {
     return false;
   }
@@ -797,7 +1000,9 @@ export function handleContentBlock(
       emitSessionUpdate(session.sessionId, {
         type: "agent_message_chunk",
         content: { type: "text", text },
-        ...(linkage?.sourceMessageUuid ? { source_message_uuid: linkage.sourceMessageUuid } : {}),
+        ...(linkage?.sourceMessageUuid
+          ? { source_message_uuid: linkage.sourceMessageUuid }
+          : {}),
       });
     }
     return;
@@ -809,17 +1014,25 @@ export function handleContentBlock(
       emitSessionUpdate(session.sessionId, {
         type: "agent_thought_chunk",
         content: { type: "text", text },
-        ...(linkage?.sourceMessageUuid ? { source_message_uuid: linkage.sourceMessageUuid } : {}),
+        ...(linkage?.sourceMessageUuid
+          ? { source_message_uuid: linkage.sourceMessageUuid }
+          : {}),
       });
     }
     return;
   }
 
-  if (blockType === "tool_use" || blockType === "server_tool_use" || blockType === "mcp_tool_use") {
+  if (
+    blockType === "tool_use" ||
+    blockType === "server_tool_use" ||
+    blockType === "mcp_tool_use"
+  ) {
     const toolUseId = typeof block.id === "string" ? block.id : "";
     const name = typeof block.name === "string" ? block.name : "Tool";
     const input =
-      block.input && typeof block.input === "object" ? (block.input as Record<string, unknown>) : {};
+      block.input && typeof block.input === "object"
+        ? (block.input as Record<string, unknown>)
+        : {};
     if (!toolUseId) {
       return;
     }
@@ -840,7 +1053,8 @@ export function handleContentBlock(
   }
 
   if (TOOL_RESULT_TYPES.has(blockType)) {
-    const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
+    const toolUseId =
+      typeof block.tool_use_id === "string" ? block.tool_use_id : "";
     if (!toolUseId) {
       return;
     }
@@ -849,7 +1063,14 @@ export function handleContentBlock(
     }
     logContentBlockLinkage(session, blockType, toolUseId, undefined, linkage);
     const isError = Boolean(block.is_error);
-    emitToolResultUpdate(session, toolUseId, isError, block.content, block, linkage?.sourceMessageUuid);
+    emitToolResultUpdate(
+      session,
+      toolUseId,
+      isError,
+      block.content,
+      block,
+      linkage?.sourceMessageUuid,
+    );
   }
 }
 
@@ -863,11 +1084,15 @@ export function handleStreamEvent(
 
   if (eventType === "content_block_start") {
     if (event.content_block && typeof event.content_block === "object") {
-      handleContentBlock(session, event.content_block as Record<string, unknown>, {
-        source: "stream_event",
-        parentToolUseId,
-        sourceMessageUuid,
-      });
+      handleContentBlock(
+        session,
+        event.content_block as Record<string, unknown>,
+        {
+          source: "stream_event",
+          parentToolUseId,
+          sourceMessageUuid,
+        },
+      );
     }
     return;
   }
@@ -884,7 +1109,9 @@ export function handleStreamEvent(
         emitSessionUpdate(session.sessionId, {
           type: "agent_message_chunk",
           content: { type: "text", text },
-          ...(sourceMessageUuid ? { source_message_uuid: sourceMessageUuid } : {}),
+          ...(sourceMessageUuid
+            ? { source_message_uuid: sourceMessageUuid }
+            : {}),
         });
       }
     } else if (deltaType === "thinking_delta") {
@@ -893,14 +1120,19 @@ export function handleStreamEvent(
         emitSessionUpdate(session.sessionId, {
           type: "agent_thought_chunk",
           content: { type: "text", text },
-          ...(sourceMessageUuid ? { source_message_uuid: sourceMessageUuid } : {}),
+          ...(sourceMessageUuid
+            ? { source_message_uuid: sourceMessageUuid }
+            : {}),
         });
       }
     }
   }
 }
 
-export function handleAssistantMessage(session: SessionState, message: Record<string, unknown>): void {
+export function handleAssistantMessage(
+  session: SessionState,
+  message: Record<string, unknown>,
+): void {
   const assistantMessageUuid = sourceMessageUuid(message);
   emitTranscriptRetraction(
     session,
@@ -920,13 +1152,16 @@ export function handleAssistantMessage(session: SessionState, message: Record<st
   if (!messageObject) {
     return;
   }
-  const content = Array.isArray(messageObject.content) ? messageObject.content : [];
+  const content = Array.isArray(messageObject.content)
+    ? messageObject.content
+    : [];
   for (const block of content) {
     if (!block || typeof block !== "object") {
       continue;
     }
     const blockRecord = block as Record<string, unknown>;
-    const blockType = typeof blockRecord.type === "string" ? blockRecord.type : "";
+    const blockType =
+      typeof blockRecord.type === "string" ? blockRecord.type : "";
     if (
       blockType === "tool_use" ||
       blockType === "server_tool_use" ||
@@ -934,7 +1169,9 @@ export function handleAssistantMessage(session: SessionState, message: Record<st
       TOOL_RESULT_TYPES.has(blockType)
     ) {
       const parentToolUseId =
-        typeof message.parent_tool_use_id === "string" ? message.parent_tool_use_id : undefined;
+        typeof message.parent_tool_use_id === "string"
+          ? message.parent_tool_use_id
+          : undefined;
       handleContentBlock(session, blockRecord, {
         source: "assistant",
         parentToolUseId,
@@ -955,7 +1192,10 @@ function messageToolUseResult(message: Record<string, unknown>): unknown {
   return undefined;
 }
 
-export function handleUserToolResultBlocks(session: SessionState, message: Record<string, unknown>): boolean {
+export function handleUserToolResultBlocks(
+  session: SessionState,
+  message: Record<string, unknown>,
+): boolean {
   const messageObject =
     message.message && typeof message.message === "object"
       ? (message.message as Record<string, unknown>)
@@ -963,19 +1203,29 @@ export function handleUserToolResultBlocks(session: SessionState, message: Recor
   if (!messageObject) {
     return false;
   }
-  const content = Array.isArray(messageObject.content) ? messageObject.content : [];
-  const nonExecutionByToolUseId = parseToolNonExecutionMetadata(message.tool_result_meta);
+  const content = Array.isArray(messageObject.content)
+    ? messageObject.content
+    : [];
+  const nonExecutionByToolUseId = parseToolNonExecutionMetadata(
+    message.tool_result_meta,
+  );
   let handled = false;
   for (const block of content) {
     if (!block || typeof block !== "object") {
       continue;
     }
     const blockRecord = block as Record<string, unknown>;
-    const blockType = typeof blockRecord.type === "string" ? blockRecord.type : "";
+    const blockType =
+      typeof blockRecord.type === "string" ? blockRecord.type : "";
     if (TOOL_RESULT_TYPES.has(blockType)) {
       const parentToolUseId =
-        typeof message.parent_tool_use_id === "string" ? message.parent_tool_use_id : undefined;
-      const toolUseId = typeof blockRecord.tool_use_id === "string" ? blockRecord.tool_use_id : "";
+        typeof message.parent_tool_use_id === "string"
+          ? message.parent_tool_use_id
+          : undefined;
+      const toolUseId =
+        typeof blockRecord.tool_use_id === "string"
+          ? blockRecord.tool_use_id
+          : "";
       if (!toolUseId) {
         continue;
       }
@@ -1002,7 +1252,10 @@ export function handleUserToolResultBlocks(session: SessionState, message: Recor
   return handled;
 }
 
-export function handleResultMessage(session: SessionState, message: Record<string, unknown>): void {
+export function handleResultMessage(
+  session: SessionState,
+  message: Record<string, unknown>,
+): void {
   emitFastModeUpdateIfChanged(
     session,
     message.fast_mode_state,
@@ -1023,9 +1276,35 @@ export function handleResultMessage(session: SessionState, message: Record<strin
   }
 
   const errors =
-    Array.isArray(message.errors) && message.errors.every((entry) => typeof entry === "string")
+    Array.isArray(message.errors) &&
+    message.errors.every((entry) => typeof entry === "string")
       ? (message.errors as string[])
       : [];
+  const resumeDropsTurnRefusal = errors.find((entry) =>
+    entry.startsWith("Resume rejected by --resume-drops-turn:"),
+  );
+  if (
+    session.deferConnect &&
+    session.resumeDropsTurn &&
+    resumeDropsTurnRefusal
+  ) {
+    session.initializationReady = false;
+    session.initializationError = resumeDropsTurnRefusal;
+    bridgeLogger.warn({
+      target: LOG_TARGETS.APP_SESSION,
+      eventName: "session_resume_drops_turn_rejected",
+      message:
+        "guarded resume candidate rejected because the source session changed",
+      outcome: "failure",
+      sessionId: session.sessionId,
+      fields: {
+        drop_turn_id: session.resumeDropsTurn,
+        validation_fence_complete: session.resumeGuardFenceComplete === true,
+        error_message: resumeDropsTurnRefusal,
+      },
+    });
+    return;
+  }
   const assistantError = session.lastAssistantError;
   const authHint = errors.find((entry) => looksLikeAuthRequired(entry));
   if (authHint) {
@@ -1037,7 +1316,11 @@ export function handleResultMessage(session: SessionState, message: Record<strin
   finalizeOpenToolCalls(session, "failed");
   const errorKind = classifyTurnErrorKind(subtype, errors, assistantError);
   const fallback = subtype ? `turn failed: ${subtype}` : "turn failed";
-  const apiErrorStatus = numberField(message, "api_error_status", "apiErrorStatus");
+  const apiErrorStatus = numberField(
+    message,
+    "api_error_status",
+    "apiErrorStatus",
+  );
   writeEvent({
     event: "turn_error",
     session_id: session.sessionId,
@@ -1045,7 +1328,9 @@ export function handleResultMessage(session: SessionState, message: Record<strin
     error_kind: errorKind,
     ...(subtype ? { sdk_result_subtype: subtype } : {}),
     ...(assistantError ? { assistant_error: assistantError } : {}),
-    ...(apiErrorStatus !== undefined ? { api_error_status: apiErrorStatus } : {}),
+    ...(apiErrorStatus !== undefined
+      ? { api_error_status: apiErrorStatus }
+      : {}),
     ...(terminalReason ? { terminal_reason: terminalReason } : {}),
   });
   session.lastAssistantError = undefined;
@@ -1078,10 +1363,14 @@ function terminalReasonFromValue(value: unknown): TerminalReason | undefined {
   }
 }
 
-export function handleSdkMessage(session: SessionState, message: SDKMessage): void {
+export function handleSdkMessage(
+  session: SessionState,
+  message: SDKMessage,
+): void {
   const msg = message as unknown as Record<string, unknown>;
   const type = typeof msg.type === "string" ? msg.type : "";
-  const subtype = type === "system" && typeof msg.subtype === "string" ? msg.subtype : "";
+  const subtype =
+    type === "system" && typeof msg.subtype === "string" ? msg.subtype : "";
   if (subtype !== "worker_shutting_down") {
     cancelPendingWorkerShutdown(session);
   }
@@ -1098,7 +1387,11 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
     }
 
     if (subtype === "commands_changed") {
-      updateAvailableCommands(session, "commands_changed", mapSdkSlashCommands(msg.commands));
+      updateAvailableCommands(
+        session,
+        "commands_changed",
+        mapSdkSlashCommands(msg.commands),
+      );
       return;
     }
 
@@ -1134,8 +1427,10 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         sessionId: session.sessionId,
         fields: {
           error_message: error || undefined,
-          project_key: typeof key?.projectKey === "string" ? key.projectKey : undefined,
-          mirror_session_id: typeof key?.sessionId === "string" ? key.sessionId : undefined,
+          project_key:
+            typeof key?.projectKey === "string" ? key.projectKey : undefined,
+          mirror_session_id:
+            typeof key?.sessionId === "string" ? key.sessionId : undefined,
           subpath: typeof key?.subpath === "string" ? key.subpath : undefined,
         },
       });
@@ -1161,7 +1456,11 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
       if (status === "failed") {
         const subject = name ? ` ${name}` : "";
         const suffix = error ? `: ${error}` : ".";
-        emitSystemNoticeUpdate(session, "warning", `Plugin install failed${subject}${suffix}`);
+        emitSystemNoticeUpdate(
+          session,
+          "warning",
+          `Plugin install failed${subject}${suffix}`,
+        );
       }
       return;
     }
@@ -1173,14 +1472,22 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         message: "SDK permission denied event received",
         outcome: "denied",
         sessionId: session.sessionId,
-        toolCallId: typeof msg.tool_use_id === "string" ? msg.tool_use_id : undefined,
+        toolCallId:
+          typeof msg.tool_use_id === "string" ? msg.tool_use_id : undefined,
         fields: {
-          tool_name: typeof msg.tool_name === "string" ? msg.tool_name : undefined,
+          tool_name:
+            typeof msg.tool_name === "string" ? msg.tool_name : undefined,
           agent_id: typeof msg.agent_id === "string" ? msg.agent_id : undefined,
           decision_reason_type:
-            typeof msg.decision_reason_type === "string" ? msg.decision_reason_type : undefined,
-          decision_reason: typeof msg.decision_reason === "string" ? msg.decision_reason : undefined,
-          denial_message: typeof msg.message === "string" ? msg.message : undefined,
+            typeof msg.decision_reason_type === "string"
+              ? msg.decision_reason_type
+              : undefined,
+          decision_reason:
+            typeof msg.decision_reason === "string"
+              ? msg.decision_reason
+              : undefined,
+          denial_message:
+            typeof msg.message === "string" ? msg.message : undefined,
         },
       });
       return;
@@ -1195,10 +1502,17 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         sessionId: session.sessionId,
         fields: {
           sdk_subtype: subtype,
-          memory_count: Array.isArray(msg.memories) ? msg.memories.length : undefined,
-          estimated_tokens: typeof msg.estimated_tokens === "number" ? msg.estimated_tokens : undefined,
+          memory_count: Array.isArray(msg.memories)
+            ? msg.memories.length
+            : undefined,
+          estimated_tokens:
+            typeof msg.estimated_tokens === "number"
+              ? msg.estimated_tokens
+              : undefined,
           estimated_tokens_delta:
-            typeof msg.estimated_tokens_delta === "number" ? msg.estimated_tokens_delta : undefined,
+            typeof msg.estimated_tokens_delta === "number"
+              ? msg.estimated_tokens_delta
+              : undefined,
         },
       });
       return;
@@ -1225,13 +1539,18 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
 
     if (subtype === "init") {
       const previousSessionId = session.sessionId;
-      const incomingSessionId = typeof msg.session_id === "string" ? msg.session_id : session.sessionId;
+      const incomingSessionId =
+        typeof msg.session_id === "string" ? msg.session_id : session.sessionId;
       updateSessionId(session, incomingSessionId);
-      const modelName = typeof msg.model === "string" ? msg.model : session.model;
+      const modelName =
+        typeof msg.model === "string" ? msg.model : session.model;
       session.model = modelName;
       const currentModelChanged = refreshCurrentModel(session, false);
 
-      const incomingMode = typeof msg.permissionMode === "string" ? toPermissionMode(msg.permissionMode) : null;
+      const incomingMode =
+        typeof msg.permissionMode === "string"
+          ? toPermissionMode(msg.permissionMode)
+          : null;
       if (incomingMode) {
         session.mode = incomingMode;
       }
@@ -1277,8 +1596,14 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         );
       }
 
-      if (session.lastAvailableAgentsSignature === undefined && Array.isArray(msg.agents)) {
-        emitAvailableAgentsIfChanged(session, mapAvailableAgentsFromNames(msg.agents));
+      if (
+        session.lastAvailableAgentsSignature === undefined &&
+        Array.isArray(msg.agents)
+      ) {
+        emitAvailableAgentsIfChanged(
+          session,
+          mapAvailableAgentsFromNames(msg.agents),
+        );
       }
 
       void session.query
@@ -1304,16 +1629,27 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
 
     if (subtype === "status") {
       const mode =
-        typeof msg.permissionMode === "string" ? toPermissionMode(msg.permissionMode) : null;
+        typeof msg.permissionMode === "string"
+          ? toPermissionMode(msg.permissionMode)
+          : null;
       if (mode) {
         session.mode = mode;
         refreshSupportedModesForSession(session);
-        emitSessionUpdate(session.sessionId, { type: "current_mode_update", current_mode_id: mode });
+        emitSessionUpdate(session.sessionId, {
+          type: "current_mode_update",
+          current_mode_id: mode,
+        });
       }
       if (msg.status === "compacting") {
-        emitSessionUpdate(session.sessionId, { type: "compaction_update", phase: "started" });
+        emitSessionUpdate(session.sessionId, {
+          type: "compaction_update",
+          phase: "started",
+        });
       } else if (msg.status === "requesting") {
-        emitSessionUpdate(session.sessionId, { type: "session_status_update", status: "requesting" });
+        emitSessionUpdate(session.sessionId, {
+          type: "session_status_update",
+          status: "requesting",
+        });
       } else if (msg.status === null) {
         if (msg.compact_result === "success") {
           emitSessionUpdate(session.sessionId, {
@@ -1323,18 +1659,23 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
           });
         } else if (msg.compact_result === "failed") {
           const compactError =
-            typeof msg.compact_error === "string" && msg.compact_error.trim().length > 0
+            typeof msg.compact_error === "string" &&
+            msg.compact_error.trim().length > 0
               ? msg.compact_error.trim()
               : undefined;
           emitSessionUpdate(session.sessionId, {
             type: "compaction_update",
             phase: "finished",
             result: "failed",
-            error_code: compactError === "too_few_groups" ? "too_few_groups" : "unknown",
+            error_code:
+              compactError === "too_few_groups" ? "too_few_groups" : "unknown",
             ...(compactError ? { error: compactError } : {}),
           });
         }
-        emitSessionUpdate(session.sessionId, { type: "session_status_update", status: "idle" });
+        emitSessionUpdate(session.sessionId, {
+          type: "session_status_update",
+          status: "idle",
+        });
       }
       emitFastModeUpdateIfChanged(
         session,
@@ -1350,10 +1691,25 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         return;
       }
       const trigger = compactMetadata.trigger;
-      const preTokens = nonNegativeIntegerField(compactMetadata, "pre_tokens", "preTokens");
-      const postTokens = nonNegativeIntegerField(compactMetadata, "post_tokens", "postTokens");
-      const durationMs = nonNegativeIntegerField(compactMetadata, "duration_ms", "durationMs");
-      if ((trigger === "manual" || trigger === "auto") && preTokens !== undefined) {
+      const preTokens = nonNegativeIntegerField(
+        compactMetadata,
+        "pre_tokens",
+        "preTokens",
+      );
+      const postTokens = nonNegativeIntegerField(
+        compactMetadata,
+        "post_tokens",
+        "postTokens",
+      );
+      const durationMs = nonNegativeIntegerField(
+        compactMetadata,
+        "duration_ms",
+        "durationMs",
+      );
+      if (
+        (trigger === "manual" || trigger === "auto") &&
+        preTokens !== undefined
+      ) {
         emitSessionUpdate(session.sessionId, {
           type: "compaction_update",
           phase: "boundary",
@@ -1372,14 +1728,17 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         emitSessionUpdate(session.sessionId, {
           type: "agent_message_chunk",
           content: { type: "text", text: content },
-          ...(sourceMessageUuid(msg) ? { source_message_uuid: sourceMessageUuid(msg) } : {}),
+          ...(sourceMessageUuid(msg)
+            ? { source_message_uuid: sourceMessageUuid(msg) }
+            : {}),
         });
       }
       return;
     }
 
     if (subtype === "elicitation_complete") {
-      const elicitationId = typeof msg.elicitation_id === "string" ? msg.elicitation_id : "";
+      const elicitationId =
+        typeof msg.elicitation_id === "string" ? msg.elicitation_id : "";
       if (!elicitationId) {
         return;
       }
@@ -1388,7 +1747,9 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
         session_id: session.sessionId,
         completion: {
           elicitation_id: elicitationId,
-          ...(typeof msg.mcp_server_name === "string" ? { server_name: msg.mcp_server_name } : {}),
+          ...(typeof msg.mcp_server_name === "string"
+            ? { server_name: msg.mcp_server_name }
+            : {}),
         },
       });
       return;
@@ -1411,9 +1772,13 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
   }
 
   if (type === "prompt_suggestion") {
-    const suggestion = typeof msg.suggestion === "string" ? msg.suggestion.trim() : "";
+    const suggestion =
+      typeof msg.suggestion === "string" ? msg.suggestion.trim() : "";
     if (suggestion) {
-      emitSessionUpdate(session.sessionId, { type: "prompt_suggestion_update", suggestion });
+      emitSessionUpdate(session.sessionId, {
+        type: "prompt_suggestion_update",
+        suggestion,
+      });
     }
     return;
   }
@@ -1430,10 +1795,14 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
 
   if (type === "auth_status") {
     const output = Array.isArray(msg.output)
-      ? msg.output.filter((entry): entry is string => typeof entry === "string").join("\n")
+      ? msg.output
+          .filter((entry): entry is string => typeof entry === "string")
+          .join("\n")
       : "";
     const errorText = typeof msg.error === "string" ? msg.error : "";
-    const combined = [errorText, output].filter((entry) => entry.length > 0).join("\n");
+    const combined = [errorText, output]
+      .filter((entry) => entry.length > 0)
+      .join("\n");
     if (combined && looksLikeAuthRequired(combined)) {
       emitAuthRequired(session, combined);
     }
@@ -1443,7 +1812,9 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
   if (type === "stream_event") {
     if (msg.event && typeof msg.event === "object") {
       const parentToolUseId =
-        typeof msg.parent_tool_use_id === "string" ? msg.parent_tool_use_id : undefined;
+        typeof msg.parent_tool_use_id === "string"
+          ? msg.parent_tool_use_id
+          : undefined;
       handleStreamEvent(
         session,
         msg.event as Record<string, unknown>,
@@ -1455,11 +1826,15 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
   }
 
   if (type === "tool_progress") {
-    const toolUseId = typeof msg.tool_use_id === "string" ? msg.tool_use_id : "";
+    const toolUseId =
+      typeof msg.tool_use_id === "string" ? msg.tool_use_id : "";
     const toolName = typeof msg.tool_name === "string" ? msg.tool_name : "Tool";
-    const parentToolUseId = typeof msg.parent_tool_use_id === "string" ? msg.parent_tool_use_id : "";
+    const parentToolUseId =
+      typeof msg.parent_tool_use_id === "string" ? msg.parent_tool_use_id : "";
     const taskId = typeof msg.task_id === "string" ? msg.task_id : "";
-    const taskToolUseId = taskId ? session.taskToolUseIds.get(taskId) ?? "" : "";
+    const taskToolUseId = taskId
+      ? (session.taskToolUseIds.get(taskId) ?? "")
+      : "";
     if (isHiddenToolUse(session, toolUseId, toolName)) {
       return;
     }
@@ -1489,7 +1864,9 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
     });
     if (resolvedToolUseId) {
       const hasSubagentRetry = Object.hasOwn(msg, "subagent_retry");
-      const subagentRetry = hasSubagentRetry ? buildSubagentRetryUpdate(msg) : null;
+      const subagentRetry = hasSubagentRetry
+        ? buildSubagentRetryUpdate(msg)
+        : null;
       if (hasSubagentRetry && !subagentRetry) {
         bridgeLogger.warn({
           target: LOG_TARGETS.APP_TOOL,
@@ -1519,7 +1896,9 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
   if (type === "tool_use_summary") {
     const summary = typeof msg.summary === "string" ? msg.summary : "";
     const toolIds = Array.isArray(msg.preceding_tool_use_ids)
-      ? msg.preceding_tool_use_ids.filter((id): id is string => typeof id === "string")
+      ? msg.preceding_tool_use_ids.filter(
+          (id): id is string => typeof id === "string",
+        )
       : [];
     if (summary && toolIds.length > 0) {
       for (const toolUseId of toolIds) {
@@ -1536,9 +1915,13 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
     const rateLimitInfo = asRecordOrNull(msg.rate_limit_info);
     const update = buildRateLimitUpdate(msg.rate_limit_info);
     const rawIsUsingOverage =
-      typeof rateLimitInfo?.isUsingOverage === "boolean" ? rateLimitInfo.isUsingOverage : undefined;
+      typeof rateLimitInfo?.isUsingOverage === "boolean"
+        ? rateLimitInfo.isUsingOverage
+        : undefined;
     const rawOverageInUse =
-      typeof rateLimitInfo?.overageInUse === "boolean" ? rateLimitInfo.overageInUse : undefined;
+      typeof rateLimitInfo?.overageInUse === "boolean"
+        ? rateLimitInfo.overageInUse
+        : undefined;
     if (
       rawIsUsingOverage !== undefined &&
       rawOverageInUse !== undefined &&
@@ -1563,17 +1946,30 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
       outcome: update ? "success" : "dropped",
       sessionId: session.sessionId,
       fields: {
-        raw_status: typeof rateLimitInfo?.status === "string" ? rateLimitInfo.status : undefined,
+        raw_status:
+          typeof rateLimitInfo?.status === "string"
+            ? rateLimitInfo.status
+            : undefined,
         raw_rate_limit_type:
-          typeof rateLimitInfo?.rateLimitType === "string" ? rateLimitInfo.rateLimitType : undefined,
+          typeof rateLimitInfo?.rateLimitType === "string"
+            ? rateLimitInfo.rateLimitType
+            : undefined,
         raw_utilization: numberField(rateLimitInfo ?? {}, "utilization"),
         raw_resets_at: numberField(rateLimitInfo ?? {}, "resetsAt"),
         raw_overage_status:
-          typeof rateLimitInfo?.overageStatus === "string" ? rateLimitInfo.overageStatus : undefined,
-        raw_overage_resets_at: numberField(rateLimitInfo ?? {}, "overageResetsAt"),
+          typeof rateLimitInfo?.overageStatus === "string"
+            ? rateLimitInfo.overageStatus
+            : undefined,
+        raw_overage_resets_at: numberField(
+          rateLimitInfo ?? {},
+          "overageResetsAt",
+        ),
         raw_is_using_overage: rawIsUsingOverage,
         raw_overage_in_use: rawOverageInUse,
-        raw_surpassed_threshold: numberField(rateLimitInfo ?? {}, "surpassedThreshold"),
+        raw_surpassed_threshold: numberField(
+          rateLimitInfo ?? {},
+          "surpassedThreshold",
+        ),
         parsed_status: update?.status,
         parsed_rate_limit_type: update?.rate_limit_type,
         parsed_utilization: update?.utilization,
@@ -1601,9 +1997,14 @@ export function handleSdkMessage(session: SessionState, message: SDKMessage): vo
   }
 
   if (type === "user") {
+    const externalMessageUpdate = externalMessageUpdateFromSdkUser(msg);
+    if (externalMessageUpdate) {
+      emitSessionUpdate(session.sessionId, externalMessageUpdate);
+    }
     const handledBlocks = handleUserToolResultBlocks(session, msg);
 
-    const toolUseId = typeof msg.parent_tool_use_id === "string" ? msg.parent_tool_use_id : "";
+    const toolUseId =
+      typeof msg.parent_tool_use_id === "string" ? msg.parent_tool_use_id : "";
     const rawToolUseResult = messageToolUseResult(msg);
     if (!handledBlocks && toolUseId && rawToolUseResult !== undefined) {
       if (session.hiddenToolUseIds.has(toolUseId)) {

--- a/agent-sdk/src/bridge/model_metadata.ts
+++ b/agent-sdk/src/bridge/model_metadata.ts
@@ -34,13 +34,21 @@ function isEffortLevel(value: unknown): value is EffortLevel {
 function normalizeModelKey(id: string): NormalizedModelKey {
   const original = id.trim();
   if (!original) {
-    return { original, family: "unknown", versionParts: [], variantParts: [], buildParts: [] };
+    return {
+      original,
+      family: "unknown",
+      versionParts: [],
+      variantParts: [],
+      buildParts: [],
+    };
   }
 
   const lower = original.toLowerCase();
   const contextMatch = lower.match(/\[([^[\]]+)\]$/);
   const contextSuffix = contextMatch?.[1];
-  const withoutContext = contextMatch ? lower.slice(0, contextMatch.index) : lower;
+  const withoutContext = contextMatch
+    ? lower.slice(0, contextMatch.index)
+    : lower;
   const withoutPrefix = withoutContext.startsWith("claude-")
     ? withoutContext.slice("claude-".length)
     : withoutContext;
@@ -111,7 +119,10 @@ function modelKeysAreCompatible(leftId: string, rightId: string): boolean {
 function sameContextSuffix(leftId: string, rightId: string): boolean {
   const left = normalizeModelKey(leftId);
   const right = normalizeModelKey(rightId);
-  return (left.contextSuffix?.toLowerCase() ?? "") === (right.contextSuffix?.toLowerCase() ?? "");
+  return (
+    (left.contextSuffix?.toLowerCase() ?? "") ===
+    (right.contextSuffix?.toLowerCase() ?? "")
+  );
 }
 
 function sameFamilyAndVersion(leftId: string, rightId: string): boolean {
@@ -138,7 +149,8 @@ function hasVariantSiblingConflict(
     return false;
   }
 
-  const resolvedContext = normalizeModelKey(resolvedId).contextSuffix?.toLowerCase() ?? "";
+  const resolvedContext =
+    normalizeModelKey(resolvedId).contextSuffix?.toLowerCase() ?? "";
   if (!resolvedContext) {
     return false;
   }
@@ -150,7 +162,8 @@ function hasVariantSiblingConflict(
     if (!sameFamilyAndVersion(entry.id, resolvedId)) {
       return false;
     }
-    const entryContext = normalizeModelKey(entry.id).contextSuffix?.toLowerCase() ?? "";
+    const entryContext =
+      normalizeModelKey(entry.id).contextSuffix?.toLowerCase() ?? "";
     return entryContext === resolvedContext;
   });
 }
@@ -170,7 +183,9 @@ function humanizeModelId(id: string): string {
           ? "Sonnet"
           : "Haiku";
   const versionLabel =
-    normalized.versionParts.length > 0 ? ` ${normalized.versionParts.join(".")}` : "";
+    normalized.versionParts.length > 0
+      ? ` ${normalized.versionParts.join(".")}`
+      : "";
   const contextLabel =
     normalized.contextSuffix?.toLowerCase() === "1m"
       ? " [1M]"
@@ -209,7 +224,8 @@ function resolveCatalogModel(
 
   if (requestedId) {
     const exactRequested = availableModels.find(
-      (entry) => entry.id === requestedId || entry.resolved_model === requestedId,
+      (entry) =>
+        entry.id === requestedId || entry.resolved_model === requestedId,
     );
     if (
       exactRequested &&
@@ -232,23 +248,28 @@ function resolveCatalogModel(
   return compatible.length === 1 ? compatible[0] : undefined;
 }
 
-export function mapAvailableModels(models: ModelInfo[] | undefined): AvailableModel[] {
+export function mapAvailableModels(
+  models: ModelInfo[] | undefined,
+): AvailableModel[] {
   if (!Array.isArray(models)) {
     return [];
   }
 
   return models
-    .filter((entry): entry is ModelInfo & { value: string; displayName: string } => {
-      return (
-        typeof entry?.value === "string" &&
-        entry.value.trim().length > 0 &&
-        typeof entry.displayName === "string" &&
-        entry.displayName.trim().length > 0
-      );
-    })
+    .filter(
+      (entry): entry is ModelInfo & { value: string; displayName: string } => {
+        return (
+          typeof entry?.value === "string" &&
+          entry.value.trim().length > 0 &&
+          typeof entry.displayName === "string" &&
+          entry.displayName.trim().length > 0
+        );
+      },
+    )
     .map((entry) => ({
       id: entry.value,
-      ...(typeof entry.resolvedModel === "string" && entry.resolvedModel.trim().length > 0
+      ...(typeof entry.resolvedModel === "string" &&
+      entry.resolvedModel.trim().length > 0
         ? { resolved_model: entry.resolvedModel.trim() }
         : {}),
       display_name: entry.displayName,
@@ -265,23 +286,31 @@ export function mapAvailableModels(models: ModelInfo[] | undefined): AvailableMo
       ...(typeof entry.supportsAutoMode === "boolean"
         ? { supports_auto_mode: entry.supportsAutoMode }
         : {}),
-      ...(typeof entry.description === "string" && entry.description.trim().length > 0
+      ...(typeof entry.description === "string" &&
+      entry.description.trim().length > 0
         ? { description: entry.description }
         : {}),
     }));
 }
 
-export function resolveCurrentModel(session: ModelMetadataSession): CurrentModel {
+export function resolveCurrentModel(
+  session: ModelMetadataSession,
+): CurrentModel {
   const requestedId = session.requestedModelId?.trim() || undefined;
   const resolvedId =
     session.resolvedRuntimeModelId?.trim() ||
     session.model.trim() ||
     requestedId ||
     DEFAULT_MODEL_ALIAS;
-  const catalogModel = resolveCatalogModel(session.availableModels, resolvedId, requestedId);
+  const catalogModel = resolveCatalogModel(
+    session.availableModels,
+    resolvedId,
+    requestedId,
+  );
   const runtimeDisplayId = resolvedId || requestedId || DEFAULT_MODEL_ALIAS;
   const displayNameShort = shortDisplayNameForModelId(runtimeDisplayId);
-  const displayNameLong = catalogModel?.display_name ?? humanizeModelId(runtimeDisplayId);
+  const displayNameLong =
+    catalogModel?.display_name ?? humanizeModelId(runtimeDisplayId);
   return {
     resolved_id: resolvedId,
     display_name_short: displayNameShort,
@@ -303,6 +332,9 @@ export function resolveCurrentModel(session: ModelMetadataSession): CurrentModel
   };
 }
 
-export function currentModelsEqual(left: CurrentModel | undefined, right: CurrentModel): boolean {
+export function currentModelsEqual(
+  left: CurrentModel | undefined,
+  right: CurrentModel,
+): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }

--- a/agent-sdk/src/bridge/permissions.ts
+++ b/agent-sdk/src/bridge/permissions.ts
@@ -11,20 +11,34 @@ type PermissionSuggestionsByScope = {
 };
 
 const SESSION_PERMISSION_DESTINATIONS = new Set(["session", "cliArg"]);
-const PERSISTENT_PERMISSION_DESTINATIONS = new Set(["userSettings", "projectSettings", "localSettings"]);
+const PERSISTENT_PERMISSION_DESTINATIONS = new Set([
+  "userSettings",
+  "projectSettings",
+  "localSettings",
+]);
 
 function formatPermissionRule(rule: PermissionRuleValue): string {
-  return rule.ruleContent === undefined ? rule.toolName : `${rule.toolName}(${rule.ruleContent})`;
+  return rule.ruleContent === undefined
+    ? rule.toolName
+    : `${rule.toolName}(${rule.ruleContent})`;
 }
 
-export function formatPermissionUpdates(updates: PermissionUpdate[] | undefined): string {
+export function formatPermissionUpdates(
+  updates: PermissionUpdate[] | undefined,
+): string {
   if (!updates || updates.length === 0) {
     return "<none>";
   }
   return updates
     .map((update) => {
-      if (update.type === "addRules" || update.type === "replaceRules" || update.type === "removeRules") {
-        const rules = update.rules.map((rule) => formatPermissionRule(rule)).join(", ");
+      if (
+        update.type === "addRules" ||
+        update.type === "replaceRules" ||
+        update.type === "removeRules"
+      ) {
+        const rules = update.rules
+          .map((rule) => formatPermissionRule(rule))
+          .join(", ");
         return `${update.type}:${update.behavior}:${update.destination}=[${rules}]`;
       }
       if (update.type === "setMode") {
@@ -66,7 +80,9 @@ export function permissionOptionsFromSuggestions(
   const hasPersistentScoped = scoped.persistent.length > 0;
   const sessionOnly = hasSessionScoped && !hasPersistentScoped;
 
-  const options: PermissionOption[] = [{ option_id: "allow_once", name: "Allow once", kind: "allow_once" }];
+  const options: PermissionOption[] = [
+    { option_id: "allow_once", name: "Allow once", kind: "allow_once" },
+  ];
   options.push({
     option_id: sessionOnly ? "allow_session" : "allow_always",
     name: sessionOnly ? "Allow for session" : "Always allow",
@@ -87,7 +103,11 @@ export function permissionResultFromOutcome(
 
   if (outcome.outcome === "selected") {
     if (outcome.option_id === "allow_once") {
-      return { behavior: "allow", updatedInput: inputData, toolUseID: toolCallId };
+      return {
+        behavior: "allow",
+        updatedInput: inputData,
+        toolUseID: toolCallId,
+      };
     }
     if (outcome.option_id === "allow_session") {
       const sessionSuggestions = scopedSuggestions.session;
@@ -137,8 +157,15 @@ export function permissionResultFromOutcome(
         toolUseID: toolCallId,
       };
     }
-    return { behavior: "deny", message: "Permission denied", toolUseID: toolCallId };
+    return {
+      behavior: "deny",
+      message: "Permission denied",
+      toolUseID: toolCallId,
+    };
   }
-  return { behavior: "deny", message: "Permission cancelled", toolUseID: toolCallId };
+  return {
+    behavior: "deny",
+    message: "Permission cancelled",
+    toolUseID: toolCallId,
+  };
 }
-

--- a/agent-sdk/src/bridge/session_lifecycle.ts
+++ b/agent-sdk/src/bridge/session_lifecycle.ts
@@ -50,10 +50,7 @@ import {
   emitElicitationRequestEvent,
   emitUserDialogRequestEvent,
 } from "./events.js";
-import {
-  ensureToolCallVisible,
-  setToolCallStatus,
-} from "./tool_calls.js";
+import { ensureToolCallVisible, setToolCallStatus } from "./tool_calls.js";
 import { isToolSearchToolName } from "./tooling.js";
 import {
   requestExitPlanModeApproval,
@@ -61,7 +58,11 @@ import {
   EXIT_PLAN_MODE_TOOL_NAME,
   ASK_USER_QUESTION_TOOL_NAME,
 } from "./user_interaction.js";
-import { mapAvailableAgents, emitAvailableAgentsIfChanged, refreshAvailableAgents } from "./agents.js";
+import {
+  mapAvailableAgents,
+  emitAvailableAgentsIfChanged,
+  refreshAvailableAgents,
+} from "./agents.js";
 import {
   mapSdkSlashCommands,
   updateAvailableCommands,
@@ -91,7 +92,9 @@ export type PendingRewindResult = Omit<
 >;
 
 const BRIDGE_RUNTIME_PROCESS_NAME =
-  process.platform === "win32" ? "claude-rs-bridge-bun.exe" : "claude-rs-bridge-bun";
+  process.platform === "win32"
+    ? "claude-rs-bridge-bun.exe"
+    : "claude-rs-bridge-bun";
 const BRIDGE_RUNTIME_GUARD_PROMPT =
   `Do not terminate the Claude Rust bridge runtime process \`${BRIDGE_RUNTIME_PROCESS_NAME}\`; ` +
   "when cleaning up development servers, only stop processes by explicit PIDs you started in this session.";
@@ -101,8 +104,10 @@ function permissionDisplayFromCanUseOptions(
   options: Parameters<CanUseTool>[2],
 ): PermissionDisplay | undefined {
   const title = typeof options.title === "string" ? options.title.trim() : "";
-  const displayName = typeof options.displayName === "string" ? options.displayName.trim() : "";
-  const description = typeof options.description === "string" ? options.description.trim() : "";
+  const displayName =
+    typeof options.displayName === "string" ? options.displayName.trim() : "";
+  const description =
+    typeof options.description === "string" ? options.description.trim() : "";
   if (!title && !displayName && !description) {
     return undefined;
   }
@@ -161,6 +166,13 @@ export type SessionState = {
   query: Query;
   initializationTask?: Promise<void>;
   queryConsumerTask?: Promise<void>;
+  initializationReady?: boolean;
+  initializationError?: string;
+  deferConnect?: boolean;
+  resumeDropsTurn?: string;
+  resumeGuardFenceComplete?: boolean;
+  deferredBridgeEvents?: Array<{ event: BridgeEvent; requestId?: string }>;
+  deferredAuthRequired?: { detail?: string };
   input: AsyncQueue<SDKUserMessage>;
   connected: boolean;
   closing: boolean;
@@ -197,7 +209,9 @@ const pendingSessionCloseTasks = new Set<Promise<void>>();
 const DEFAULT_SETTING_SOURCES: SettingSource[] = ["user", "project", "local"];
 const DEFAULT_PERMISSION_MODE: PermissionMode = "default";
 
-function isSdkElicitationContentValue(value: Json): value is string | number | boolean | string[] {
+function isSdkElicitationContentValue(
+  value: Json,
+): value is string | number | boolean | string[] {
   return (
     typeof value === "string" ||
     typeof value === "number" ||
@@ -231,7 +245,9 @@ function optionalStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
-  const entries = value.filter((entry): entry is string => typeof entry === "string");
+  const entries = value.filter(
+    (entry): entry is string => typeof entry === "string",
+  );
   return entries.length > 0 ? entries : undefined;
 }
 
@@ -244,8 +260,10 @@ function normalizeRefusalFallbackPayload(
   payload: Record<string, unknown>,
 ): RefusalFallbackPromptPayload {
   return {
-    original_model: typeof payload.originalModel === "string" ? payload.originalModel : "",
-    fallback_model: typeof payload.fallbackModel === "string" ? payload.fallbackModel : "",
+    original_model:
+      typeof payload.originalModel === "string" ? payload.originalModel : "",
+    fallback_model:
+      typeof payload.fallbackModel === "string" ? payload.fallbackModel : "",
     ...(optionalString(payload.apiRefusalCategory) !== undefined
       ? { api_refusal_category: optionalString(payload.apiRefusalCategory) }
       : {}),
@@ -253,7 +271,11 @@ function normalizeRefusalFallbackPayload(
       ? { guidance_text: optionalString(payload.guidanceText) }
       : {}),
     ...(optionalStringArray(payload.retractedMessageUuids) !== undefined
-      ? { retracted_message_uuids: optionalStringArray(payload.retractedMessageUuids) }
+      ? {
+          retracted_message_uuids: optionalStringArray(
+            payload.retractedMessageUuids,
+          ),
+        }
       : {}),
   };
 }
@@ -263,10 +285,18 @@ function normalizeRefusalFallbackPayload(
  * itself produces (`function Wg$`). `cancelled` is the Esc/decline default and
  * is not a listed option.
  */
-function buildRefusalFallbackOptions(payload: RefusalFallbackPromptPayload): UserDialogOption[] {
+function buildRefusalFallbackOptions(
+  payload: RefusalFallbackPromptPayload,
+): UserDialogOption[] {
   return [
-    { option_id: "retry_fallback", label: `Switch to ${payload.fallback_model}` },
-    { option_id: "edit_prompt", label: `Edit prompt and retry with ${payload.original_model}` },
+    {
+      option_id: "retry_fallback",
+      label: `Switch to ${payload.fallback_model}`,
+    },
+    {
+      option_id: "edit_prompt",
+      label: `Edit prompt and retry with ${payload.original_model}`,
+    },
   ];
 }
 
@@ -295,7 +325,9 @@ function normalizedSettingsFromLaunchSettings(
   };
 
   const sandbox =
-    settings.sandbox && typeof settings.sandbox === "object" && !Array.isArray(settings.sandbox)
+    settings.sandbox &&
+    typeof settings.sandbox === "object" &&
+    !Array.isArray(settings.sandbox)
       ? (settings.sandbox as Record<string, unknown>)
       : undefined;
   if (sandbox?.enabled === true && sandbox.failIfUnavailable === undefined) {
@@ -315,7 +347,10 @@ export function sessionById(sessionId: string): SessionState | null {
   return sessions.get(sessionId) ?? null;
 }
 
-export function updateSessionId(session: SessionState, newSessionId: string): void {
+export function updateSessionId(
+  session: SessionState,
+  newSessionId: string,
+): void {
   if (session.sessionId === newSessionId) {
     return;
   }
@@ -433,7 +468,9 @@ export async function closeSessionsBeforeRegister(
   }
 }
 
-export async function closeAllSessions(options: CloseSessionOptions = {}): Promise<void> {
+export async function closeAllSessions(
+  options: CloseSessionOptions = {},
+): Promise<void> {
   const active = Array.from(sessions.values());
   sessions.clear();
   await Promise.all(
@@ -460,6 +497,10 @@ export async function createSession(params: {
   cwd: string;
   resume?: string;
   resumeSessionAt?: string;
+  resumeDropsTurn?: string;
+  forkSession?: boolean;
+  sessionId?: string;
+  deferConnect?: boolean;
   launchSettings: SessionLaunchSettings;
   connectEvent: ConnectEventKind;
   requestId?: string;
@@ -470,14 +511,18 @@ export async function createSession(params: {
   pendingRewindResult?: PendingRewindResult;
 }): Promise<SessionState> {
   const input = new AsyncQueue<SDKUserMessage>();
-  const provisionalSessionId = params.resume ?? randomUUID();
+  const provisionalSessionId =
+    params.sessionId ??
+    (params.resume && !params.forkSession ? params.resume : randomUUID());
   const initialModel = initialSessionModel(params.launchSettings);
   const initialMode = initialSessionMode(params.launchSettings);
   const supportsBypassPermissionsMode =
-    startupPermissionModeOptions(params.launchSettings).allowDangerouslySkipPermissions === true;
+    startupPermissionModeOptions(params.launchSettings)
+      .allowDangerouslySkipPermissions === true;
   const historyUpdateCount = params.resumeUpdates?.length ?? 0;
   const staleSessionCount = params.sessionsToCloseAfterConnect?.length ?? 0;
-  const staleSessionBeforeRegisterCount = params.sessionsToCloseBeforeRegister?.length ?? 0;
+  const staleSessionBeforeRegisterCount =
+    params.sessionsToCloseBeforeRegister?.length ?? 0;
 
   let session!: SessionState;
   const sessionIdForLogs = () => session?.sessionId ?? provisionalSessionId;
@@ -485,13 +530,32 @@ export async function createSession(params: {
     const toolUseId = options.toolUseID;
     if (isToolSearchToolName(toolName)) {
       session?.hiddenToolUseIds.add(toolUseId);
-      return { behavior: "allow", updatedInput: inputData, toolUseID: toolUseId };
+      return {
+        behavior: "allow",
+        updatedInput: inputData,
+        toolUseID: toolUseId,
+      };
     }
     if (toolName === EXIT_PLAN_MODE_TOOL_NAME) {
-      const existing = ensureToolCallVisible(session, toolUseId, toolName, inputData);
-      return await requestExitPlanModeApproval(session, toolUseId, inputData, existing);
+      const existing = ensureToolCallVisible(
+        session,
+        toolUseId,
+        toolName,
+        inputData,
+      );
+      return await requestExitPlanModeApproval(
+        session,
+        toolUseId,
+        inputData,
+        existing,
+      );
     }
-    const existing = ensureToolCallVisible(session, toolUseId, toolName, inputData);
+    const existing = ensureToolCallVisible(
+      session,
+      toolUseId,
+      toolName,
+      inputData,
+    );
 
     if (toolName === ASK_USER_QUESTION_TOOL_NAME) {
       return await requestAskUserQuestionAnswers(
@@ -537,10 +601,13 @@ export async function createSession(params: {
 
   const claudeCodeExecutable = process.env.CLAUDE_CODE_EXECUTABLE;
   const sdkDebugFile = process.env.CLAUDE_RS_SDK_DEBUG_FILE;
-  const enableSdkDebug = process.env.CLAUDE_RS_SDK_DEBUG === "1" || Boolean(sdkDebugFile);
+  const enableSdkDebug =
+    process.env.CLAUDE_RS_SDK_DEBUG === "1" || Boolean(sdkDebugFile);
   const enableSpawnDebug = process.env.CLAUDE_RS_SDK_SPAWN_DEBUG === "1";
   if (claudeCodeExecutable && !fs.existsSync(claudeCodeExecutable)) {
-    throw new Error(`CLAUDE_CODE_EXECUTABLE does not exist: ${claudeCodeExecutable}`);
+    throw new Error(
+      `CLAUDE_CODE_EXECUTABLE does not exist: ${claudeCodeExecutable}`,
+    );
   }
 
   let queryHandle: Query;
@@ -556,6 +623,8 @@ export async function createSession(params: {
       connect_event: params.connectEvent,
       resume_requested: params.resume !== undefined,
       resume_session_at: params.resumeSessionAt ?? "<none>",
+      resume_drops_turn: params.resumeDropsTurn ?? "<none>",
+      fork_session: params.forkSession === true,
       history_update_count: historyUpdateCount,
       stale_session_count: staleSessionCount,
       stale_session_before_register_count: staleSessionBeforeRegisterCount,
@@ -568,6 +637,8 @@ export async function createSession(params: {
         cwd: params.cwd,
         resume: params.resume,
         resumeSessionAt: params.resumeSessionAt,
+        resumeDropsTurn: params.resumeDropsTurn,
+        forkSession: params.forkSession,
         launchSettings: params.launchSettings,
         provisionalSessionId,
         input,
@@ -616,6 +687,10 @@ export async function createSession(params: {
     query: queryHandle,
     input,
     connected: false,
+    ...(params.deferConnect ? { deferConnect: true } : {}),
+    ...(params.resumeDropsTurn
+      ? { resumeDropsTurn: params.resumeDropsTurn }
+      : {}),
     closing: false,
     connectEvent: params.connectEvent,
     connectRequestId: params.requestId,
@@ -637,7 +712,9 @@ export async function createSession(params: {
     ...(params.resumeUpdates && params.resumeUpdates.length > 0
       ? { resumeUpdates: params.resumeUpdates }
       : {}),
-    ...(params.restoredInput !== undefined ? { restoredInput: params.restoredInput } : {}),
+    ...(params.restoredInput !== undefined
+      ? { restoredInput: params.restoredInput }
+      : {}),
     ...(params.pendingRewindResult !== undefined
       ? { pendingRewindResult: params.pendingRewindResult }
       : {}),
@@ -648,7 +725,11 @@ export async function createSession(params: {
   refreshCurrentModel(session);
   const { refreshSupportedModesForSession } = await import("./commands.js");
   refreshSupportedModesForSession(session);
-  await closeSessionsBeforeRegister(session, params.sessionsToCloseBeforeRegister, params.requestId);
+  await closeSessionsBeforeRegister(
+    session,
+    params.sessionsToCloseBeforeRegister,
+    params.requestId,
+  );
   sessions.set(provisionalSessionId, session);
   bridgeLogger.info({
     target: LOG_TARGETS.APP_SESSION,
@@ -662,6 +743,8 @@ export async function createSession(params: {
       connect_event: session.connectEvent,
       resume_requested: params.resume !== undefined,
       resume_session_at: params.resumeSessionAt ?? "<none>",
+      resume_drops_turn: params.resumeDropsTurn ?? "<none>",
+      fork_session: params.forkSession === true,
     },
   });
   bridgeLogger.info({
@@ -689,24 +772,36 @@ export async function createSession(params: {
         eventName: "session_initialization_completed",
         message: "session initialization completed",
         outcome: "success",
-        ...(session.connectRequestId ? { requestId: session.connectRequestId } : {}),
+        ...(session.connectRequestId
+          ? { requestId: session.connectRequestId }
+          : {}),
         sessionId: session.sessionId,
         fields: {
-          available_model_count: Array.isArray(result.models) ? result.models.length : 0,
+          available_model_count: Array.isArray(result.models)
+            ? result.models.length
+            : 0,
           connect_event: session.connectEvent,
           history_update_count: session.resumeUpdates?.length ?? 0,
         },
       });
       session.availableModels = mapAvailableModels(result.models);
       const currentModelChanged = refreshCurrentModel(session);
-      const { buildModeState, refreshSupportedModesForSession } = await import("./commands.js");
+      const { buildModeState, refreshSupportedModesForSession } = await import(
+        "./commands.js"
+      );
       refreshSupportedModesForSession(session);
       const fastModeChanged = setFastModeSnapshotIfChanged(
         session,
         result.fast_mode_state,
         result.fast_mode_disabled_reason,
       );
-      if (!session.connected) {
+      if (
+        !session.connected &&
+        session.deferConnect &&
+        !session.initializationError
+      ) {
+        session.initializationReady = true;
+      } else if (!session.connected) {
         emitConnectEvent(session);
       } else {
         if (currentModelChanged) {
@@ -740,16 +835,24 @@ export async function createSession(params: {
         return;
       }
       const message = error instanceof Error ? error.message : String(error);
+      session.initializationError = message;
       bridgeLogger.error({
         target: LOG_TARGETS.APP_SESSION,
         eventName: "session_initialization_failed",
         message: "session initialization failed before connect",
         outcome: "failure",
-        ...(session.connectRequestId ? { requestId: session.connectRequestId } : {}),
+        ...(session.connectRequestId
+          ? { requestId: session.connectRequestId }
+          : {}),
         sessionId: session.sessionId,
         fields: { error_message: message },
       });
-      failConnection(`agent initialization failed: ${message}`, session.connectRequestId);
+      if (!session.deferConnect) {
+        failConnection(
+          `agent initialization failed: ${message}`,
+          session.connectRequestId,
+        );
+      }
       session.connectRequestId = undefined;
     });
 
@@ -762,7 +865,9 @@ export async function createSession(params: {
       }
       {
         // Lazy import to break circular dependency at module-evaluation time.
-        const { flushPendingWorkerShutdown } = await import("./message_handlers.js");
+        const { flushPendingWorkerShutdown } = await import(
+          "./message_handlers.js"
+        );
         flushPendingWorkerShutdown(session);
       }
       if (!session.connected) {
@@ -774,10 +879,18 @@ export async function createSession(params: {
           ...(params.requestId ? { requestId: params.requestId } : {}),
           sessionId: session.sessionId,
         });
-        failConnection("agent stream ended before session initialization", params.requestId);
+        session.initializationError =
+          "agent stream ended before session initialization";
+        if (!session.deferConnect) {
+          failConnection(
+            "agent stream ended before session initialization",
+            params.requestId,
+          );
+        }
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      session.initializationError = message;
       bridgeLogger.error({
         target: LOG_TARGETS.APP_SESSION,
         eventName: "session_stream_failed_before_connect",
@@ -787,17 +900,80 @@ export async function createSession(params: {
         sessionId: session.sessionId,
         fields: { error_message: message },
       });
-      failConnection(`agent stream failed: ${message}`, params.requestId);
+      if (!session.deferConnect) {
+        failConnection(`agent stream failed: ${message}`, params.requestId);
+      }
     }
   })();
 
   return session;
 }
 
+export async function awaitSessionInitialization(
+  session: SessionState,
+): Promise<void> {
+  await session.initializationTask;
+  if (
+    session.deferConnect &&
+    session.resumeDropsTurn &&
+    !session.initializationError
+  ) {
+    // The guard is evaluated at fork time and a refusal is delivered as a result event,
+    // not as a rejected initialization request. A post-initialize control response is
+    // the protocol barrier proving that startup messages have reached the SDK; yield
+    // once more so the bridge's query consumer can process the already-enqueued result.
+    try {
+      await session.query.getContextUsage();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      bridgeLogger.warn({
+        target: LOG_TARGETS.APP_SESSION,
+        eventName: "session_resume_guard_barrier_failed",
+        message: "guarded resume control fence failed",
+        outcome: "failure",
+        sessionId: session.sessionId,
+        fields: { error_message: message },
+      });
+      throw new Error(`guarded resume validation fence failed: ${message}`);
+    }
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    session.resumeGuardFenceComplete = true;
+  }
+  if (session.initializationError) {
+    throw new Error(session.initializationError);
+  }
+  if (session.deferConnect && !session.initializationReady) {
+    throw new Error("candidate session did not reach initialization readiness");
+  }
+  if (!session.deferConnect && !session.connected) {
+    throw new Error("session did not connect after initialization");
+  }
+}
+
+export function commitDeferredSession(session: SessionState): void {
+  if (
+    !session.deferConnect ||
+    !session.initializationReady ||
+    session.initializationError ||
+    (session.resumeDropsTurn !== undefined && !session.resumeGuardFenceComplete)
+  ) {
+    throw new Error("candidate session is not ready to commit");
+  }
+  const deferredAuthRequired = session.deferredAuthRequired;
+  session.deferredAuthRequired = undefined;
+  session.deferConnect = false;
+  emitConnectEvent(session);
+  if (deferredAuthRequired) {
+    emitAuthRequired(session, deferredAuthRequired.detail);
+  }
+}
+
 type QueryOptionsBuilderParams = {
   cwd: string;
   resume?: string;
   resumeSessionAt?: string;
+  resumeDropsTurn?: string;
+  forkSession?: boolean;
   launchSettings: SessionLaunchSettings;
   provisionalSessionId: string;
   input: AsyncQueue<SDKUserMessage>;
@@ -873,7 +1049,9 @@ function logSdkProcessExit(
   });
 }
 
-function permissionModeFromSettingsValue(rawMode: unknown): PermissionMode | undefined {
+function permissionModeFromSettingsValue(
+  rawMode: unknown,
+): PermissionMode | undefined {
   if (typeof rawMode !== "string") {
     return undefined;
   }
@@ -888,47 +1066,58 @@ function permissionModeFromSettingsValue(rawMode: unknown): PermissionMode | und
     case "dontAsk":
       return rawMode;
     default:
-      throw new Error(`unsupported launch_settings.settings.permissions.defaultMode: ${rawMode}`);
+      throw new Error(
+        `unsupported launch_settings.settings.permissions.defaultMode: ${rawMode}`,
+      );
   }
 }
 
 function initialSessionModel(launchSettings: SessionLaunchSettings): string {
   const settings = settingsObjectFromLaunchSettings(launchSettings);
-  const model = typeof settings?.model === "string" ? settings.model.trim() : "";
+  const model =
+    typeof settings?.model === "string" ? settings.model.trim() : "";
   return model || STARTUP_FALLBACK_MODEL_ALIAS;
 }
 
-function startupModelOption(
-  launchSettings: SessionLaunchSettings,
-): {
+function startupModelOption(launchSettings: SessionLaunchSettings): {
   model?: string;
 } {
   const settings = settingsObjectFromLaunchSettings(launchSettings);
-  const model = typeof settings?.model === "string" ? settings.model.trim() : "";
+  const model =
+    typeof settings?.model === "string" ? settings.model.trim() : "";
   return model ? { model } : {};
 }
 
-function initialSessionMode(launchSettings: SessionLaunchSettings): PermissionMode {
+function initialSessionMode(
+  launchSettings: SessionLaunchSettings,
+): PermissionMode {
   const settings = settingsObjectFromLaunchSettings(launchSettings);
   const permissions =
-    settings?.permissions && typeof settings.permissions === "object" && !Array.isArray(settings.permissions)
+    settings?.permissions &&
+    typeof settings.permissions === "object" &&
+    !Array.isArray(settings.permissions)
       ? (settings.permissions as Record<string, unknown>)
       : undefined;
-  return permissionModeFromSettingsValue(permissions?.defaultMode) ?? DEFAULT_PERMISSION_MODE;
+  return (
+    permissionModeFromSettingsValue(permissions?.defaultMode) ??
+    DEFAULT_PERMISSION_MODE
+  );
 }
 
-function startupPermissionModeOptions(
-  launchSettings: SessionLaunchSettings,
-): {
+function startupPermissionModeOptions(launchSettings: SessionLaunchSettings): {
   permissionMode?: PermissionMode;
   allowDangerouslySkipPermissions?: boolean;
 } {
   const settings = settingsObjectFromLaunchSettings(launchSettings);
   const permissions =
-    settings?.permissions && typeof settings.permissions === "object" && !Array.isArray(settings.permissions)
+    settings?.permissions &&
+    typeof settings.permissions === "object" &&
+    !Array.isArray(settings.permissions)
       ? (settings.permissions as Record<string, unknown>)
       : undefined;
-  const permissionMode = permissionModeFromSettingsValue(permissions?.defaultMode);
+  const permissionMode = permissionModeFromSettingsValue(
+    permissions?.defaultMode,
+  );
   if (!permissionMode) {
     return {};
   }
@@ -963,18 +1152,20 @@ function systemPromptFromLaunchSettings(
 export function buildQueryOptions(params: QueryOptionsBuilderParams) {
   const systemPrompt = systemPromptFromLaunchSettings(params.launchSettings);
   const modelOption = startupModelOption(params.launchSettings);
-  const permissionModeOptions = startupPermissionModeOptions(params.launchSettings);
-  const shouldPassCanUseTool = permissionModeOptions.permissionMode !== "bypassPermissions";
+  const permissionModeOptions = startupPermissionModeOptions(
+    params.launchSettings,
+  );
+  const shouldPassCanUseTool =
+    permissionModeOptions.permissionMode !== "bypassPermissions";
   const settings = normalizedSettingsFromLaunchSettings(params.launchSettings);
   return {
     cwd: params.cwd,
     includePartialMessages: true,
     promptSuggestions: true,
     enableFileCheckpointing: true,
-    // ProposeSkills reports only a proposal count and expects a native review
-    // surface. Keep it out of this host until claude-rs can display the actual
-    // proposal input and accept/reject it without losing content.
-    disallowedTools: ["ProposeSkills"],
+    // Proposal tools require native review and lifecycle surfaces that the
+    // public headless SDK does not currently expose to this host.
+    disallowedTools: ["ProposeSkills", "ProposeGoal"],
     executable: "bun" as const,
     ...(params.resume ? {} : { sessionId: params.provisionalSessionId }),
     settings,
@@ -983,7 +1174,10 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
     toolConfig: { askUserQuestion: { previewFormat: "markdown" as const } },
     systemPrompt,
     ...(params.launchSettings.agent_progress_summaries !== undefined
-      ? { agentProgressSummaries: params.launchSettings.agent_progress_summaries }
+      ? {
+          agentProgressSummaries:
+            params.launchSettings.agent_progress_summaries,
+        }
       : {}),
     ...(params.claudeCodeExecutable
       ? { pathToClaudeCodeExecutable: params.claudeCodeExecutable }
@@ -1012,7 +1206,11 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
         stdio: ["pipe", "pipe", "pipe"],
         windowsHide: true,
       });
-      logSdkProcessSpawned(params.sessionIdForLogs() || undefined, child, options.cwd);
+      logSdkProcessSpawned(
+        params.sessionIdForLogs() || undefined,
+        child,
+        options.cwd,
+      );
       child.on("error", (error) => {
         const sessionId = params.sessionIdForLogs();
         bridgeLogger.error({
@@ -1034,17 +1232,28 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
     // --setting-sources argument.
     settingSources: DEFAULT_SETTING_SOURCES,
     resume: params.resume,
-    ...(params.resumeSessionAt ? { resumeSessionAt: params.resumeSessionAt } : {}),
+    ...(params.resumeSessionAt
+      ? { resumeSessionAt: params.resumeSessionAt }
+      : {}),
+    ...(params.resumeDropsTurn
+      ? { resumeDropsTurn: params.resumeDropsTurn }
+      : {}),
+    ...(params.forkSession
+      ? { forkSession: true, sessionId: params.provisionalSessionId }
+      : {}),
     ...(shouldPassCanUseTool ? { canUseTool: params.canUseTool } : {}),
-    onElicitation: async (request: {
-      mode?: string;
-      serverName?: string;
-      message?: string;
-      url?: string;
-      elicitationId?: string;
-      requestedSchema?: Record<string, unknown>;
-    }) => {
-      const requestId = randomUUID();
+    onElicitation: async (
+      request: {
+        mode?: string;
+        serverName?: string;
+        message?: string;
+        url?: string;
+        elicitationId?: string;
+        requestedSchema?: Record<string, unknown>;
+      },
+      options: { signal: AbortSignal; requestId: string },
+    ) => {
+      const requestId = options.requestId;
       const mode =
         request.mode === "form" || request.mode === "url"
           ? request.mode
@@ -1054,22 +1263,27 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
       const normalized: ElicitationRequest = {
         request_id: requestId,
         server_name:
-          typeof request.serverName === "string" && request.serverName.trim().length > 0
+          typeof request.serverName === "string" &&
+          request.serverName.trim().length > 0
             ? request.serverName
             : "unknown",
         message:
-          typeof request.message === "string" && request.message.trim().length > 0
+          typeof request.message === "string" &&
+          request.message.trim().length > 0
             ? request.message
             : "<no message>",
         mode,
         ...(typeof request.url === "string" && request.url.trim().length > 0
           ? { url: request.url }
           : {}),
-        ...(typeof request.elicitationId === "string" && request.elicitationId.trim().length > 0
+        ...(typeof request.elicitationId === "string" &&
+        request.elicitationId.trim().length > 0
           ? { elicitation_id: request.elicitationId }
           : {}),
         ...(request.requestedSchema
-          ? { requested_schema: request.requestedSchema as Record<string, Json> }
+          ? {
+              requested_schema: request.requestedSchema as Record<string, Json>,
+            }
           : {}),
       };
       bridgeLogger.info({
@@ -1104,8 +1318,40 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
           resolve({ action: "cancel" });
           return;
         }
+        if (currentSession.pendingElicitations.has(requestId)) {
+          bridgeLogger.warn({
+            target: LOG_TARGETS.BRIDGE_PERMISSION,
+            eventName: "elicitation_request_dropped",
+            message: "duplicate elicitation request dropped",
+            outcome: "dropped",
+            sessionId: params.sessionIdForLogs(),
+            requestId,
+            fields: { reason: "duplicate_request_id" },
+          });
+          resolve({ action: "cancel" });
+          return;
+        }
+        let settled = false;
+        const settle = (result: {
+          action: ElicitationAction;
+          content?: Record<string, string | number | boolean | string[]>;
+        }) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          currentSession.pendingElicitations.delete(requestId);
+          options.signal.removeEventListener("abort", onAbort);
+          resolve(result);
+        };
+        const onAbort = () => settle({ action: "cancel" });
+        if (options.signal.aborted) {
+          settle({ action: "cancel" });
+          return;
+        }
+        options.signal.addEventListener("abort", onAbort);
         currentSession.pendingElicitations.set(requestId, {
-          resolve,
+          resolve: settle,
           serverName: normalized.server_name,
           elicitationId: normalized.elicitation_id,
         });
@@ -1124,7 +1370,7 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
     // decline/abort/teardown).
     onUserDialog: async (
       request: UserDialogRequest,
-      options: { signal: AbortSignal },
+      options: { signal: AbortSignal; requestId: string },
     ): Promise<UserDialogResult> => {
       if (request.dialogKind !== REFUSAL_FALLBACK_DIALOG_KIND) {
         bridgeLogger.warn({
@@ -1133,17 +1379,20 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
           message: "request_user_dialog received for unknown kind; cancelled",
           outcome: "cancelled",
           sessionId: params.sessionIdForLogs(),
-          ...(typeof request.toolUseID === "string" ? { toolCallId: request.toolUseID } : {}),
+          ...(typeof request.toolUseID === "string"
+            ? { toolCallId: request.toolUseID }
+            : {}),
           fields: { dialog_kind: request.dialogKind },
         });
         return { behavior: "cancelled" };
       }
 
       const payload = normalizeRefusalFallbackPayload(request.payload);
-      const requestId = randomUUID();
+      const requestId = options.requestId;
       const dialogRequest = {
         request_id: requestId,
-        dialog_kind: REFUSAL_FALLBACK_DIALOG_KIND as typeof REFUSAL_FALLBACK_DIALOG_KIND,
+        dialog_kind:
+          REFUSAL_FALLBACK_DIALOG_KIND as typeof REFUSAL_FALLBACK_DIALOG_KIND,
         payload,
         options: buildRefusalFallbackOptions(payload),
       };
@@ -1154,7 +1403,9 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
         outcome: "start",
         sessionId: params.sessionIdForLogs(),
         requestId,
-        ...(typeof request.toolUseID === "string" ? { toolCallId: request.toolUseID } : {}),
+        ...(typeof request.toolUseID === "string"
+          ? { toolCallId: request.toolUseID }
+          : {}),
         fields: {
           dialog_kind: request.dialogKind,
           original_model: payload.original_model,
@@ -1162,7 +1413,9 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
         },
       });
 
-      const choice = await new Promise<RefusalFallbackPromptChoice | "cancelled">((resolve) => {
+      const choice = await new Promise<
+        RefusalFallbackPromptChoice | "cancelled"
+      >((resolve) => {
         const currentSession = sessions.get(params.sessionIdForLogs());
         if (!currentSession) {
           bridgeLogger.warn({
@@ -1173,6 +1426,19 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
             sessionId: params.sessionIdForLogs(),
             requestId,
             fields: { reason: "unknown_session" },
+          });
+          resolve("cancelled");
+          return;
+        }
+        if (currentSession.pendingUserDialogs.has(requestId)) {
+          bridgeLogger.warn({
+            target: LOG_TARGETS.APP_SESSION,
+            eventName: "user_dialog_request_dropped",
+            message: "duplicate user dialog request dropped",
+            outcome: "dropped",
+            sessionId: params.sessionIdForLogs(),
+            requestId,
+            fields: { reason: "duplicate_request_id" },
           });
           resolve("cancelled");
           return;
@@ -1204,7 +1470,9 @@ export function buildQueryOptions(params: QueryOptionsBuilderParams) {
   };
 }
 
-export function handlePermissionResponse(command: Extract<BridgeCommand, { command: "permission_response" }>): void {
+export function handlePermissionResponse(
+  command: Extract<BridgeCommand, { command: "permission_response" }>,
+): void {
   bridgeLogger.info({
     target: LOG_TARGETS.BRIDGE_PERMISSION,
     eventName: "permission_response_received",
@@ -1215,7 +1483,9 @@ export function handlePermissionResponse(command: Extract<BridgeCommand, { comma
     fields: {
       response_kind: command.outcome.outcome,
       selected_option:
-        command.outcome.outcome === "selected" ? command.outcome.option_id : "cancelled",
+        command.outcome.outcome === "selected"
+          ? command.outcome.option_id
+          : "cancelled",
     },
   });
   const session = sessionById(command.session_id);
@@ -1258,7 +1528,8 @@ export function handlePermissionResponse(command: Extract<BridgeCommand, { comma
       fields: {
         tool_name: resolver.toolName,
         response_kind: outcome.outcome,
-        selected_option: outcome.outcome === "selected" ? outcome.option_id : "cancelled",
+        selected_option:
+          outcome.outcome === "selected" ? outcome.option_id : "cancelled",
       },
     });
     resolver.onOutcome(outcome);
@@ -1268,7 +1539,8 @@ export function handlePermissionResponse(command: Extract<BridgeCommand, { comma
     bridgeLogger.warn({
       target: LOG_TARGETS.BRIDGE_PERMISSION,
       eventName: "permission_response_dropped",
-      message: "permission response dropped because resolver callback was missing",
+      message:
+        "permission response dropped because resolver callback was missing",
       outcome: "dropped",
       sessionId: command.session_id,
       toolCallId: command.tool_call_id,
@@ -1276,7 +1548,8 @@ export function handlePermissionResponse(command: Extract<BridgeCommand, { comma
     });
     return;
   }
-  const selectedOption = outcome.outcome === "selected" ? outcome.option_id : "cancelled";
+  const selectedOption =
+    outcome.outcome === "selected" ? outcome.option_id : "cancelled";
   if (
     outcome.outcome === "selected" &&
     (outcome.option_id === "allow_once" ||
@@ -1285,9 +1558,19 @@ export function handlePermissionResponse(command: Extract<BridgeCommand, { comma
   ) {
     setToolCallStatus(session, command.tool_call_id, "in_progress");
   } else if (outcome.outcome === "selected") {
-    setToolCallStatus(session, command.tool_call_id, "failed", "Permission denied");
+    setToolCallStatus(
+      session,
+      command.tool_call_id,
+      "failed",
+      "Permission denied",
+    );
   } else {
-    setToolCallStatus(session, command.tool_call_id, "failed", "Permission cancelled");
+    setToolCallStatus(
+      session,
+      command.tool_call_id,
+      "failed",
+      "Permission cancelled",
+    );
   }
 
   const permissionResult = permissionResultFromOutcome(
@@ -1314,7 +1597,9 @@ export function handlePermissionResponse(command: Extract<BridgeCommand, { comma
   resolver.resolve(permissionResult);
 }
 
-export function handleQuestionResponse(command: Extract<BridgeCommand, { command: "question_response" }>): void {
+export function handleQuestionResponse(
+  command: Extract<BridgeCommand, { command: "question_response" }>,
+): void {
   bridgeLogger.info({
     target: LOG_TARGETS.BRIDGE_PERMISSION,
     eventName: "question_response_received",
@@ -1362,9 +1647,12 @@ export function handleQuestionResponse(command: Extract<BridgeCommand, { command
       tool_name: resolver.toolName,
       response_kind: command.outcome.outcome,
       selected_option_count:
-        command.outcome.outcome === "answered" ? command.outcome.selected_option_ids.length : 0,
+        command.outcome.outcome === "answered"
+          ? command.outcome.selected_option_ids.length
+          : 0,
       has_annotation:
-        command.outcome.outcome === "answered" && command.outcome.annotation !== undefined,
+        command.outcome.outcome === "answered" &&
+        command.outcome.annotation !== undefined,
     },
   });
   resolver.onOutcome(command.outcome);
@@ -1383,7 +1671,9 @@ export function handleUserDialogResponse(
     fields: {
       response_kind: command.outcome.outcome,
       selected_option:
-        command.outcome.outcome === "selected" ? command.outcome.option_id : "cancelled",
+        command.outcome.outcome === "selected"
+          ? command.outcome.option_id
+          : "cancelled",
     },
   });
   const session = sessionById(command.session_id);
@@ -1415,7 +1705,10 @@ export function handleUserDialogResponse(
     return;
   }
   session.pendingUserDialogs.delete(command.request_id);
-  const choice = command.outcome.outcome === "selected" ? command.outcome.option_id : "cancelled";
+  const choice =
+    command.outcome.outcome === "selected"
+      ? command.outcome.option_id
+      : "cancelled";
   bridgeLogger.info({
     target: LOG_TARGETS.BRIDGE_PERMISSION,
     eventName: "user_dialog_response_applied",
@@ -1456,7 +1749,9 @@ export function handleElicitationResponse(
     });
     return;
   }
-  const pending = session.pendingElicitations.get(command.elicitation_request_id);
+  const pending = session.pendingElicitations.get(
+    command.elicitation_request_id,
+  );
   if (!pending) {
     bridgeLogger.warn({
       target: LOG_TARGETS.BRIDGE_PERMISSION,
@@ -1485,9 +1780,11 @@ export function handleElicitationResponse(
   });
   pending.resolve({
     action: command.action,
-    ...(normalizeSdkElicitationContent(command.content) ? {
-      content: normalizeSdkElicitationContent(command.content),
-    } : {}),
+    ...(normalizeSdkElicitationContent(command.content)
+      ? {
+          content: normalizeSdkElicitationContent(command.content),
+        }
+      : {}),
   });
 }
 export function shouldInvalidateResolvedRuntimeModel(
@@ -1495,7 +1792,8 @@ export function shouldInvalidateResolvedRuntimeModel(
   previousSessionModel: string,
   nextRequestedId: string,
 ): boolean {
-  const previousRequested = previousRequestedId?.trim() || previousSessionModel.trim();
+  const previousRequested =
+    previousRequestedId?.trim() || previousSessionModel.trim();
   return previousRequested !== nextRequestedId.trim();
 }
 export function emitCurrentModelUpdate(session: SessionState): boolean {
@@ -1509,7 +1807,10 @@ export function emitCurrentModelUpdate(session: SessionState): boolean {
   return true;
 }
 
-export function refreshCurrentModel(session: SessionState, emitUpdate = false): boolean {
+export function refreshCurrentModel(
+  session: SessionState,
+  emitUpdate = false,
+): boolean {
   const nextModel = resolveCurrentModel(session);
   if (currentModelsEqual(session.currentModel, nextModel)) {
     return false;

--- a/agent-sdk/src/bridge/state_parsing.ts
+++ b/agent-sdk/src/bridge/state_parsing.ts
@@ -9,7 +9,10 @@ import type {
 } from "../types.js";
 import { asRecordOrNull } from "./shared.js";
 
-export function numberField(record: Record<string, unknown>, ...keys: string[]): number | undefined {
+export function numberField(
+  record: Record<string, unknown>,
+  ...keys: string[]
+): number | undefined {
   for (const key of keys) {
     const value = record[key];
     if (typeof value === "number" && Number.isFinite(value)) {
@@ -19,7 +22,10 @@ export function numberField(record: Record<string, unknown>, ...keys: string[]):
   return undefined;
 }
 
-function nonNegativeNumberField(record: Record<string, unknown>, ...keys: string[]): number | undefined {
+function nonNegativeNumberField(
+  record: Record<string, unknown>,
+  ...keys: string[]
+): number | undefined {
   const value = numberField(record, ...keys);
   if (value === undefined || value < 0) {
     return undefined;
@@ -32,25 +38,46 @@ export function nonNegativeIntegerField(
   ...keys: string[]
 ): number | undefined {
   const value = numberField(record, ...keys);
-  return value !== undefined && value >= 0 && Number.isInteger(value) ? value : undefined;
+  return value !== undefined && value >= 0 && Number.isInteger(value)
+    ? value
+    : undefined;
 }
 
-export function buildSubagentRetryUpdate(message: Record<string, unknown>): SubagentRetryUpdate | null {
+export function buildSubagentRetryUpdate(
+  message: Record<string, unknown>,
+): SubagentRetryUpdate | null {
   const retry = asRecordOrNull(message.subagent_retry);
   if (!retry) {
     return null;
   }
   const attempt = nonNegativeIntegerField(retry, "attempt");
-  const maxRetries = nonNegativeIntegerField(retry, "max_retries", "maxRetries");
-  const retryDelayMs = nonNegativeIntegerField(retry, "retry_delay_ms", "retryDelayMs");
-  if (attempt === undefined || maxRetries === undefined || retryDelayMs === undefined) {
+  const maxRetries = nonNegativeIntegerField(
+    retry,
+    "max_retries",
+    "maxRetries",
+  );
+  const retryDelayMs = nonNegativeIntegerField(
+    retry,
+    "retry_delay_ms",
+    "retryDelayMs",
+  );
+  if (
+    attempt === undefined ||
+    maxRetries === undefined ||
+    retryDelayMs === undefined
+  ) {
     return null;
   }
 
-  const agentId = typeof retry.agent_id === "string" ? retry.agent_id.trim() : "";
+  const agentId =
+    typeof retry.agent_id === "string" ? retry.agent_id.trim() : "";
   const errorCategory =
     typeof retry.error_category === "string" ? retry.error_category.trim() : "";
-  const errorStatus = nonNegativeIntegerField(retry, "error_status", "errorStatus");
+  const errorStatus = nonNegativeIntegerField(
+    retry,
+    "error_status",
+    "errorStatus",
+  );
   return {
     state: "waiting",
     ...(agentId ? { agent_id: agentId } : {}),
@@ -69,7 +96,9 @@ export function parseFastModeState(value: unknown): FastModeState | null {
   return null;
 }
 
-export function parseFastModeDisabledReason(value: unknown): string | undefined {
+export function parseFastModeDisabledReason(
+  value: unknown,
+): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
@@ -78,13 +107,19 @@ export function parseFastModeDisabledReason(value: unknown): string | undefined 
 }
 
 export function parseRateLimitStatus(value: unknown): RateLimitStatus | null {
-  if (value === "allowed" || value === "allowed_warning" || value === "rejected") {
+  if (
+    value === "allowed" ||
+    value === "allowed_warning" ||
+    value === "rejected"
+  ) {
     return value;
   }
   return null;
 }
 
-export function parseRuntimeSessionState(value: unknown): RuntimeSessionState | null {
+export function parseRuntimeSessionState(
+  value: unknown,
+): RuntimeSessionState | null {
   if (value === "idle" || value === "running" || value === "requires_action") {
     return value;
   }
@@ -154,7 +189,10 @@ export function buildRateLimitUpdate(
     update.overage_resets_at = overageResetsAt;
   }
 
-  if (typeof info.overageDisabledReason === "string" && info.overageDisabledReason.length > 0) {
+  if (
+    typeof info.overageDisabledReason === "string" &&
+    info.overageDisabledReason.length > 0
+  ) {
     update.overage_disabled_reason = info.overageDisabledReason;
   }
 
@@ -174,7 +212,8 @@ export function buildRateLimitUpdate(
   }
 
   if (typeof info.hasChargeableSavedPaymentMethod === "boolean") {
-    update.has_chargeable_saved_payment_method = info.hasChargeableSavedPaymentMethod;
+    update.has_chargeable_saved_payment_method =
+      info.hasChargeableSavedPaymentMethod;
   }
 
   return update;
@@ -185,13 +224,24 @@ export function buildApiRetryUpdate(
 ): Extract<SessionUpdate, { type: "api_retry_update" }> | null {
   const attempt = numberField(message, "attempt");
   const maxRetries = numberField(message, "max_retries", "maxRetries");
-  const retryDelayMs = nonNegativeNumberField(message, "retry_delay_ms", "retryDelayMs");
-  if (attempt === undefined || maxRetries === undefined || retryDelayMs === undefined) {
+  const retryDelayMs = nonNegativeNumberField(
+    message,
+    "retry_delay_ms",
+    "retryDelayMs",
+  );
+  if (
+    attempt === undefined ||
+    maxRetries === undefined ||
+    retryDelayMs === undefined
+  ) {
     return null;
   }
 
   const rawStatus = message.error_status ?? message.errorStatus;
-  const errorStatus = typeof rawStatus === "number" && Number.isFinite(rawStatus) ? rawStatus : null;
+  const errorStatus =
+    typeof rawStatus === "number" && Number.isFinite(rawStatus)
+      ? rawStatus
+      : null;
 
   return {
     type: "api_retry_update",
@@ -203,17 +253,23 @@ export function buildApiRetryUpdate(
   };
 }
 
-export function normalizeSettingsParseError(value: unknown): SettingsParseErrorUpdate | null {
+export function normalizeSettingsParseError(
+  value: unknown,
+): SettingsParseErrorUpdate | null {
   const record = asRecordOrNull(value);
   if (!record) {
     return null;
   }
-  const message = typeof record.message === "string" ? record.message.trim() : "";
+  const message =
+    typeof record.message === "string" ? record.message.trim() : "";
   if (!message) {
     return null;
   }
   const path = typeof record.path === "string" ? record.path : "";
-  const file = typeof record.file === "string" && record.file.trim() ? record.file : undefined;
+  const file =
+    typeof record.file === "string" && record.file.trim()
+      ? record.file
+      : undefined;
   return {
     ...(file ? { file } : {}),
     path,
@@ -221,7 +277,9 @@ export function normalizeSettingsParseError(value: unknown): SettingsParseErrorU
   };
 }
 
-export function normalizeSettingsParseErrors(value: unknown): SettingsParseErrorUpdate[] {
+export function normalizeSettingsParseErrors(
+  value: unknown,
+): SettingsParseErrorUpdate[] {
   const entries = Array.isArray(value) ? value : [value];
   return entries.flatMap((entry) => {
     const normalized = normalizeSettingsParseError(entry);

--- a/agent-sdk/src/bridge/task_links.ts
+++ b/agent-sdk/src/bridge/task_links.ts
@@ -1,6 +1,10 @@
 import type { SessionState } from "./session_lifecycle.js";
 
-export function linkTaskToolUse(session: SessionState, taskId: string, toolUseId: string): void {
+export function linkTaskToolUse(
+  session: SessionState,
+  taskId: string,
+  toolUseId: string,
+): void {
   if (!taskId || !toolUseId) {
     return;
   }
@@ -36,6 +40,9 @@ export function unlinkTaskToolUse(session: SessionState, taskId: string): void {
   }
 }
 
-export function activeTaskIdForToolUse(session: SessionState, toolUseId: string): string | undefined {
+export function activeTaskIdForToolUse(
+  session: SessionState,
+  toolUseId: string,
+): string | undefined {
   return toolUseId ? session.taskIdsByToolUseId.get(toolUseId) : undefined;
 }

--- a/agent-sdk/src/bridge/tasks.ts
+++ b/agent-sdk/src/bridge/tasks.ts
@@ -1,4 +1,10 @@
-import type { Json, TaskItem, TaskStatus, TaskUpdateSource, ToolCall } from "../types.js";
+import type {
+  Json,
+  TaskItem,
+  TaskStatus,
+  TaskUpdateSource,
+  ToolCall,
+} from "../types.js";
 import type { SessionState } from "./session_lifecycle.js";
 import { emitSessionUpdate } from "./events.js";
 import { asRecordOrNull } from "./shared.js";
@@ -64,7 +70,8 @@ export function taskToolTitle(
     return label ? `Task output: ${label}` : "Task output";
   }
   if (name === "TaskStop") {
-    const taskId = nonEmptyString(input.task_id) ?? nonEmptyString(input.shell_id) ?? "";
+    const taskId =
+      nonEmptyString(input.task_id) ?? nonEmptyString(input.shell_id) ?? "";
     const label = context.taskSubject || taskId;
     return label ? `Stop task: ${label}` : "Stop task";
   }
@@ -102,14 +109,18 @@ function jsonRecord(value: unknown): Record<string, Json> | undefined {
 }
 
 function nonEmptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
 }
 
 function stringArray(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];
   }
-  return value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+  return value.filter(
+    (entry): entry is string => typeof entry === "string" && entry.length > 0,
+  );
 }
 
 function uniqueStrings(values: string[]): string[] {
@@ -175,7 +186,11 @@ function extractText(value: unknown): string {
   return typeof record?.text === "string" ? record.text : "";
 }
 
-function visitCandidate(value: unknown, records: Record<string, unknown>[], depth = 0): void {
+function visitCandidate(
+  value: unknown,
+  records: Record<string, unknown>[],
+  depth = 0,
+): void {
   if (value === undefined || value === null || depth > 6) {
     return;
   }
@@ -214,7 +229,10 @@ function visitCandidate(value: unknown, records: Record<string, unknown>[], dept
   }
 }
 
-function resultCandidates(rawResult: unknown, rawContent: unknown): Record<string, unknown>[] {
+function resultCandidates(
+  rawResult: unknown,
+  rawContent: unknown,
+): Record<string, unknown>[] {
   const records: Record<string, unknown>[] = [];
   visitCandidate(rawResult, records);
   visitCandidate(rawContent, records);
@@ -244,7 +262,9 @@ function humanizeFieldLabel(key: string): string {
       if (word === "id") {
         return "ID";
       }
-      return index === 0 ? `${word.charAt(0).toUpperCase()}${word.slice(1)}` : word;
+      return index === 0
+        ? `${word.charAt(0).toUpperCase()}${word.slice(1)}`
+        : word;
     })
     .join(" ");
 }
@@ -255,7 +275,9 @@ function displayScalarValue(value: unknown): string | undefined {
     if (!trimmed) {
       return undefined;
     }
-    return /^[a-z][a-z0-9]*(?:_[a-z0-9]+)+$/u.test(trimmed) ? trimmed.replace(/_/g, " ") : trimmed;
+    return /^[a-z][a-z0-9]*(?:_[a-z0-9]+)+$/u.test(trimmed)
+      ? trimmed.replace(/_/g, " ")
+      : trimmed;
   }
   if (typeof value === "boolean") {
     return value ? "yes" : "no";
@@ -267,34 +289,41 @@ function displayScalarValue(value: unknown): string | undefined {
 }
 
 function decodeXmlText(value: string): string {
-  return value.replace(/&(?:#(\d+)|#x([0-9a-fA-F]+)|amp|lt|gt|quot|apos);/g, (match, dec, hex) => {
-    if (typeof dec === "string" && dec.length > 0) {
-      const codePoint = Number.parseInt(dec, 10);
-      return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
-        ? String.fromCodePoint(codePoint)
-        : match;
-    }
-    if (typeof hex === "string" && hex.length > 0) {
-      const codePoint = Number.parseInt(hex, 16);
-      return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
-        ? String.fromCodePoint(codePoint)
-        : match;
-    }
-    switch (match) {
-      case "&amp;":
-        return "&";
-      case "&lt;":
-        return "<";
-      case "&gt;":
-        return ">";
-      case "&quot;":
-        return "\"";
-      case "&apos;":
-        return "'";
-      default:
-        return match;
-    }
-  });
+  return value.replace(
+    /&(?:#(\d+)|#x([0-9a-fA-F]+)|amp|lt|gt|quot|apos);/g,
+    (match, dec, hex) => {
+      if (typeof dec === "string" && dec.length > 0) {
+        const codePoint = Number.parseInt(dec, 10);
+        return Number.isInteger(codePoint) &&
+          codePoint >= 0 &&
+          codePoint <= 0x10ffff
+          ? String.fromCodePoint(codePoint)
+          : match;
+      }
+      if (typeof hex === "string" && hex.length > 0) {
+        const codePoint = Number.parseInt(hex, 16);
+        return Number.isInteger(codePoint) &&
+          codePoint >= 0 &&
+          codePoint <= 0x10ffff
+          ? String.fromCodePoint(codePoint)
+          : match;
+      }
+      switch (match) {
+        case "&amp;":
+          return "&";
+        case "&lt;":
+          return "<";
+        case "&gt;":
+          return ">";
+        case "&quot;":
+          return '"';
+        case "&apos;":
+          return "'";
+        default:
+          return match;
+      }
+    },
+  );
 }
 
 function xmlLeafFields(text: string): Array<[string, string]> {
@@ -308,7 +337,11 @@ function xmlLeafFields(text: string): Array<[string, string]> {
       break;
     }
     const [, key, rawValue] = match;
-    if (!key || rawValue === undefined || /<[A-Za-z][\w.-]{0,79}[\s>]/u.test(rawValue)) {
+    if (
+      !key ||
+      rawValue === undefined ||
+      /<[A-Za-z][\w.-]{0,79}[\s>]/u.test(rawValue)
+    ) {
       continue;
     }
     const value = decodeXmlText(rawValue).trim();
@@ -319,13 +352,18 @@ function xmlLeafFields(text: string): Array<[string, string]> {
   return fields;
 }
 
-function firstTaskRecord(candidates: Record<string, unknown>[]): Record<string, unknown> | undefined {
+function firstTaskRecord(
+  candidates: Record<string, unknown>[],
+): Record<string, unknown> | undefined {
   for (const candidate of candidates) {
     const nestedTask = asRecordOrNull(candidate.task);
     if (nestedTask && typeof nestedTask.id === "string") {
       return nestedTask;
     }
-    if (typeof candidate.id === "string" && typeof candidate.subject === "string") {
+    if (
+      typeof candidate.id === "string" &&
+      typeof candidate.subject === "string"
+    ) {
       return candidate;
     }
   }
@@ -342,15 +380,21 @@ function firstTaskUpdateOutput(
   candidates: Record<string, unknown>[],
 ): Record<string, unknown> | undefined {
   return candidates.find(
-    (candidate) => typeof candidate.success === "boolean" && typeof candidate.taskId === "string",
+    (candidate) =>
+      typeof candidate.success === "boolean" &&
+      typeof candidate.taskId === "string",
   );
 }
 
-function firstTaskListOutput(candidates: Record<string, unknown>[]): Record<string, unknown> | undefined {
+function firstTaskListOutput(
+  candidates: Record<string, unknown>[],
+): Record<string, unknown> | undefined {
   return candidates.find((candidate) => Array.isArray(candidate.tasks));
 }
 
-function firstTaskStopOutput(candidates: Record<string, unknown>[]): Record<string, unknown> | undefined {
+function firstTaskStopOutput(
+  candidates: Record<string, unknown>[],
+): Record<string, unknown> | undefined {
   return candidates.find(
     (candidate) =>
       typeof candidate.message === "string" &&
@@ -476,7 +520,9 @@ function removeTasks(session: SessionState, taskIds: string[]): string[] {
   }
   if (removed.length > 0) {
     const removedSet = new Set(removed);
-    session.taskOrder = session.taskOrder.filter((taskId) => !removedSet.has(taskId));
+    session.taskOrder = session.taskOrder.filter(
+      (taskId) => !removedSet.has(taskId),
+    );
   }
   return removed;
 }
@@ -537,7 +583,10 @@ function taskCreatePatch(
   const metadata = jsonValue(input.metadata);
   return {
     task_id: taskId,
-    subject: nonEmptyString(taskRecord.subject) ?? nonEmptyString(input.subject) ?? taskId,
+    subject:
+      nonEmptyString(taskRecord.subject) ??
+      nonEmptyString(input.subject) ??
+      taskId,
     description: nonEmptyString(input.description),
     active_form: nonEmptyString(input.activeForm),
     status: "pending",
@@ -555,8 +604,13 @@ function taskUpdatePatch(
   output: Record<string, unknown>,
 ): TaskPatch {
   const existing = session.tasksById.get(taskId);
-  const metadata = mergeMetadata(existing?.metadata, jsonRecord(input.metadata));
-  const status = normalizeTaskStatus(input.status) ?? normalizeTaskStatus(asRecordOrNull(output.statusChange)?.to);
+  const metadata = mergeMetadata(
+    existing?.metadata,
+    jsonRecord(input.metadata),
+  );
+  const status =
+    normalizeTaskStatus(input.status) ??
+    normalizeTaskStatus(asRecordOrNull(output.statusChange)?.to);
   const addBlocks = stringArray(input.addBlocks);
   const addBlockedBy = stringArray(input.addBlockedBy);
   const patch: TaskPatch = {
@@ -566,7 +620,10 @@ function taskUpdatePatch(
     active_form: nonEmptyString(input.activeForm),
     status,
     owner: nonEmptyString(input.owner),
-    blocks: addBlocks.length > 0 ? uniqueStrings([...(existing?.blocks ?? []), ...addBlocks]) : undefined,
+    blocks:
+      addBlocks.length > 0
+        ? uniqueStrings([...(existing?.blocks ?? []), ...addBlocks])
+        : undefined,
     blocked_by:
       addBlockedBy.length > 0
         ? uniqueStrings([...(existing?.blocked_by ?? []), ...addBlockedBy])
@@ -579,7 +636,10 @@ function taskUpdatePatch(
   return patch;
 }
 
-function taskGetPatch(taskRecord: Record<string, unknown>, existing?: TaskItem): TaskPatch | undefined {
+function taskGetPatch(
+  taskRecord: Record<string, unknown>,
+  existing?: TaskItem,
+): TaskPatch | undefined {
   const taskId = nonEmptyString(taskRecord.id);
   const subject = nonEmptyString(taskRecord.subject);
   const status = normalizeTaskStatus(taskRecord.status);
@@ -600,7 +660,10 @@ function taskGetPatch(taskRecord: Record<string, unknown>, existing?: TaskItem):
   };
 }
 
-function taskListPatch(taskRecord: Record<string, unknown>, existing?: TaskItem): TaskPatch | undefined {
+function taskListPatch(
+  taskRecord: Record<string, unknown>,
+  existing?: TaskItem,
+): TaskPatch | undefined {
   const taskId = nonEmptyString(taskRecord.id);
   const subject = nonEmptyString(taskRecord.subject);
   const status = normalizeTaskStatus(taskRecord.status);
@@ -651,7 +714,10 @@ function replaceTaskSnapshot(
   return { tasks: emitted, removedTaskIds };
 }
 
-function upsertFromExisting(existing: TaskItem | undefined, patch: TaskPatch): TaskItem {
+function upsertFromExisting(
+  existing: TaskItem | undefined,
+  patch: TaskPatch,
+): TaskItem {
   return {
     task_id: patch.task_id,
     subject: patch.subject ?? existing?.subject ?? patch.task_id,
@@ -662,7 +728,8 @@ function upsertFromExisting(existing: TaskItem | undefined, patch: TaskPatch): T
     blocks: patch.blocks ?? existing?.blocks ?? [],
     blocked_by: patch.blocked_by ?? existing?.blocked_by ?? [],
     metadata: patch.metadata ?? existing?.metadata,
-    source_tool_call_id: patch.source_tool_call_id ?? existing?.source_tool_call_id,
+    source_tool_call_id:
+      patch.source_tool_call_id ?? existing?.source_tool_call_id,
   };
 }
 
@@ -679,7 +746,10 @@ function taskStatusMarker(status: unknown): string {
 }
 
 function taskRecordLine(record: Record<string, unknown>): string {
-  const subject = typeof record.subject === "string" && record.subject.trim() ? record.subject : "Task";
+  const subject =
+    typeof record.subject === "string" && record.subject.trim()
+      ? record.subject
+      : "Task";
   return `${taskStatusMarker(record.status)} ${subject}`;
 }
 
@@ -689,7 +759,10 @@ function taskListWindow(lines: string[]): string[] {
   }
   const firstUnfinished = lines.findIndex((line) => !line.startsWith("■ "));
   const anchor = firstUnfinished >= 0 ? firstUnfinished : lines.length - 1;
-  const start = Math.min(Math.max(anchor - 4, 0), Math.max(lines.length - 9, 0));
+  const start = Math.min(
+    Math.max(anchor - 4, 0),
+    Math.max(lines.length - 9, 0),
+  );
   const end = Math.min(start + 9, lines.length);
   const visible = lines.slice(start, end);
   if (start > 0) {
@@ -719,7 +792,10 @@ export function taskToolResultText(
       return "";
     }
     if (output.success !== true) {
-      const error = typeof output.error === "string" && output.error.trim() ? output.error : "Task update failed";
+      const error =
+        typeof output.error === "string" && output.error.trim()
+          ? output.error
+          : "Task update failed";
       return error;
     }
     return "";
@@ -739,7 +815,9 @@ export function taskToolResultText(
       lines.push(task.description);
     }
     const blockedBy = Array.isArray(task.blockedBy)
-      ? task.blockedBy.filter((entry): entry is string => typeof entry === "string")
+      ? task.blockedBy.filter(
+          (entry): entry is string => typeof entry === "string",
+        )
       : [];
     if (blockedBy.length > 0) {
       lines.push(`Blocked by: ${blockedBy.join(", ")}`);
@@ -783,10 +861,12 @@ export function taskToolResultText(
   return "";
 }
 
-export function taskUpdateSucceeded(rawResult: unknown, rawContent: unknown): boolean | undefined {
-  return firstTaskUpdateOutput(resultCandidates(rawResult, rawContent))?.success as
-    | boolean
-    | undefined;
+export function taskUpdateSucceeded(
+  rawResult: unknown,
+  rawContent: unknown,
+): boolean | undefined {
+  return firstTaskUpdateOutput(resultCandidates(rawResult, rawContent))
+    ?.success as boolean | undefined;
 }
 
 export function applyTaskToolResult(
@@ -809,7 +889,9 @@ export function applyTaskToolResult(
 
   if (toolName === "TaskCreate") {
     const taskRecord = firstTaskRecord(candidates);
-    const patch = taskRecord ? taskCreatePatch(taskRecord, input, toolUseId) : undefined;
+    const patch = taskRecord
+      ? taskCreatePatch(taskRecord, input, toolUseId)
+      : undefined;
     if (!patch) {
       return;
     }
@@ -820,7 +902,8 @@ export function applyTaskToolResult(
 
   if (toolName === "TaskUpdate") {
     const output = firstTaskUpdateOutput(candidates);
-    const taskId = nonEmptyString(output?.taskId) ?? nonEmptyString(input.taskId);
+    const taskId =
+      nonEmptyString(output?.taskId) ?? nonEmptyString(input.taskId);
     if (!output || !taskId || output.success !== true) {
       return;
     }
@@ -844,11 +927,19 @@ export function applyTaskToolResult(
     const taskRecord = asRecordOrNull(output.task);
     if (!taskRecord) {
       if (taskId) {
-        emitTaskStateUpdate(session, "task_get", [], removeTasks(session, [taskId]));
+        emitTaskStateUpdate(
+          session,
+          "task_get",
+          [],
+          removeTasks(session, [taskId]),
+        );
       }
       return;
     }
-    const patch = taskGetPatch(taskRecord, session.tasksById.get(nonEmptyString(taskRecord.id) ?? ""));
+    const patch = taskGetPatch(
+      taskRecord,
+      session.tasksById.get(nonEmptyString(taskRecord.id) ?? ""),
+    );
     if (patch) {
       emitTaskStateUpdate(session, "task_get", [upsertTask(session, patch)]);
     }
@@ -864,11 +955,22 @@ export function applyTaskToolResult(
       .map((entry) => {
         const record = asRecordOrNull(entry);
         const taskId = nonEmptyString(record?.id);
-        return record ? taskListPatch(record, taskId ? session.tasksById.get(taskId) : undefined) : undefined;
+        return record
+          ? taskListPatch(
+              record,
+              taskId ? session.tasksById.get(taskId) : undefined,
+            )
+          : undefined;
       })
       .filter((patch): patch is TaskPatch => Boolean(patch));
     const snapshot = replaceTaskSnapshot(session, patches);
-    emitTaskStateUpdate(session, "task_list", snapshot.tasks, snapshot.removedTaskIds, true);
+    emitTaskStateUpdate(
+      session,
+      "task_list",
+      snapshot.tasks,
+      snapshot.removedTaskIds,
+      true,
+    );
     return;
   }
 
@@ -886,19 +988,26 @@ export function applyTaskToolResult(
       return;
     }
     const existing = session.tasksById.get(taskId);
-    const sourceToolCallId = existing?.source_tool_call_id ?? session.taskToolUseIds.get(taskId);
+    const sourceToolCallId =
+      existing?.source_tool_call_id ?? session.taskToolUseIds.get(taskId);
     if (!existing && !sourceToolCallId) {
       return;
     }
     const metadata = mergeMetadata(existing?.metadata, {
       terminal_status: "stopped",
       task_type: output.task_type as Json,
-      ...(typeof output.command === "string" ? { command: output.command } : {}),
+      ...(typeof output.command === "string"
+        ? { command: output.command }
+        : {}),
     });
     emitTaskStateUpdate(session, "task_lifecycle", [
       upsertTask(session, {
         task_id: taskId,
-        subject: existing?.subject ?? nonEmptyString(output.command) ?? nonEmptyString(output.task_type) ?? taskId,
+        subject:
+          existing?.subject ??
+          nonEmptyString(output.command) ??
+          nonEmptyString(output.task_type) ??
+          taskId,
         status: "completed",
         metadata,
         source_tool_call_id: sourceToolCallId,
@@ -908,9 +1017,14 @@ export function applyTaskToolResult(
   }
 }
 
-function lifecycleTaskStatus(subtype: string, msg: Record<string, unknown>): TaskStatus | undefined {
+function lifecycleTaskStatus(
+  subtype: string,
+  msg: Record<string, unknown>,
+): TaskStatus | undefined {
   const patch = asRecordOrNull(msg.patch);
-  const explicit = normalizeLifecycleTaskStatus(msg.status) ?? normalizeLifecycleTaskStatus(patch?.status);
+  const explicit =
+    normalizeLifecycleTaskStatus(msg.status) ??
+    normalizeLifecycleTaskStatus(patch?.status);
   if (explicit) {
     return explicit;
   }
@@ -920,10 +1034,16 @@ function lifecycleTaskStatus(subtype: string, msg: Record<string, unknown>): Tas
   return undefined;
 }
 
-function lifecycleMetadata(msg: Record<string, unknown>): Record<string, Json> | undefined {
+function lifecycleMetadata(
+  msg: Record<string, unknown>,
+): Record<string, Json> | undefined {
   const patch = asRecordOrNull(msg.patch) ?? undefined;
   const metadata: Record<string, Json> = {};
-  const copyValue = (from: Record<string, unknown> | undefined, key: string, outKey = key): void => {
+  const copyValue = (
+    from: Record<string, unknown> | undefined,
+    key: string,
+    outKey = key,
+  ): void => {
     if (!from || !Object.hasOwn(from, key)) {
       return;
     }
@@ -952,7 +1072,8 @@ function lifecycleMetadata(msg: Record<string, unknown>): Record<string, Json> |
     copyValue(msg, key);
     copyValue(patch, key);
   }
-  const terminalStatus = nonEmptyString(msg.status) ?? nonEmptyString(patch?.status);
+  const terminalStatus =
+    nonEmptyString(msg.status) ?? nonEmptyString(patch?.status);
   if (
     terminalStatus === "completed" ||
     terminalStatus === "failed" ||
@@ -982,7 +1103,9 @@ export function applyTaskLifecycleState(
   const existing = session.tasksById.get(taskId);
   const status = lifecycleTaskStatus(subtype, msg);
   const description =
-    nonEmptyString(patch?.description) ?? nonEmptyString(msg.description) ?? nonEmptyString(msg.summary);
+    nonEmptyString(patch?.description) ??
+    nonEmptyString(msg.description) ??
+    nonEmptyString(msg.summary);
   const activeForm = nonEmptyString(patch?.activeForm);
   const subject =
     nonEmptyString(patch?.subject) ??
@@ -995,7 +1118,13 @@ export function applyTaskLifecycleState(
   const metadata = mergeMetadata(existing?.metadata, lifecycleMetadata(msg));
   const sourceToolCallId = session.taskToolUseIds.get(taskId);
 
-  if (!status && !description && !activeForm && metadata === existing?.metadata && !sourceToolCallId) {
+  if (
+    !status &&
+    !description &&
+    !activeForm &&
+    metadata === existing?.metadata &&
+    !sourceToolCallId
+  ) {
     return;
   }
 

--- a/agent-sdk/src/bridge/tool_calls.ts
+++ b/agent-sdk/src/bridge/tool_calls.ts
@@ -4,7 +4,11 @@ import { bridgeLogger, LOG_TARGETS } from "./logger.js";
 import type { SessionState } from "./session_lifecycle.js";
 import { asRecordOrNull } from "./shared.js";
 import { applyTaskToolResult } from "./tasks.js";
-import { activeTaskIdForToolUse, linkTaskToolUse, unlinkTaskToolUse } from "./task_links.js";
+import {
+  activeTaskIdForToolUse,
+  linkTaskToolUse,
+  unlinkTaskToolUse,
+} from "./task_links.js";
 import {
   applyToolNonExecutionMetadata,
   backgroundToolLaunchTaskIdFromResult,
@@ -32,8 +36,19 @@ export type ToolCorrelationMetadata = {
   parentAgentId?: string;
 };
 
-const TOOL_SUMMARY_TOOL_NAMES = new Set(["Agent", "Task", "WebSearch", "WebFetch", "ExitPlanMode"]);
-const TASK_LIFECYCLE_TOOL_NAMES = new Set(["Agent", "Task", "Monitor", "Workflow"]);
+const TOOL_SUMMARY_TOOL_NAMES = new Set([
+  "Agent",
+  "Task",
+  "WebSearch",
+  "WebFetch",
+  "ExitPlanMode",
+]);
+const TASK_LIFECYCLE_TOOL_NAMES = new Set([
+  "Agent",
+  "Task",
+  "Monitor",
+  "Workflow",
+]);
 
 function jsonSize(value: unknown): number | undefined {
   if (value === undefined) {
@@ -46,18 +61,31 @@ function jsonSize(value: unknown): number | undefined {
   }
 }
 
-function toolNameFromMeta(meta: ToolCall["meta"] | undefined): string | undefined {
+function toolNameFromMeta(
+  meta: ToolCall["meta"] | undefined,
+): string | undefined {
   if (!meta || typeof meta !== "object") {
     return undefined;
   }
   const claudeCode =
-    "claudeCode" in meta && meta.claudeCode && typeof meta.claudeCode === "object" ? meta.claudeCode : undefined;
+    "claudeCode" in meta &&
+    meta.claudeCode &&
+    typeof meta.claudeCode === "object"
+      ? meta.claudeCode
+      : undefined;
   const toolName =
-    claudeCode && "toolName" in claudeCode && typeof claudeCode.toolName === "string" ? claudeCode.toolName : "";
+    claudeCode &&
+    "toolName" in claudeCode &&
+    typeof claudeCode.toolName === "string"
+      ? claudeCode.toolName
+      : "";
   return toolName || undefined;
 }
 
-function toolName(base: ToolCall | undefined, fields?: ToolCallUpdateFields): string | undefined {
+function toolName(
+  base: ToolCall | undefined,
+  fields?: ToolCallUpdateFields,
+): string | undefined {
   const fieldMeta = fields?.meta;
   if (fieldMeta && typeof fieldMeta === "object") {
     const fromFields = toolNameFromMeta(fieldMeta);
@@ -78,12 +106,16 @@ export function toolAcceptsTaskLifecycle(base: ToolCall | undefined): boolean {
   return Boolean(baseToolName && TASK_LIFECYCLE_TOOL_NAMES.has(baseToolName));
 }
 
-export function defersTaskNotificationCompletion(base: ToolCall | undefined): boolean {
+export function defersTaskNotificationCompletion(
+  base: ToolCall | undefined,
+): boolean {
   const baseToolName = toolName(base);
   return baseToolName === "Agent" || baseToolName === "Task";
 }
 
-function classifyFailureKind(rawOutput: string | undefined): "refused" | "timeout" | "failed" {
+function classifyFailureKind(
+  rawOutput: string | undefined,
+): "refused" | "timeout" | "failed" {
   if (!rawOutput) {
     return "failed";
   }
@@ -118,14 +150,22 @@ function updateOutcome(status: ToolCall["status"] | undefined): string {
   }
 }
 
-function parentToolUseIdFromMeta(meta: ToolCall["meta"] | undefined): string | null {
+function parentToolUseIdFromMeta(
+  meta: ToolCall["meta"] | undefined,
+): string | null {
   if (!meta || typeof meta !== "object") {
     return null;
   }
   const claudeCode =
-    "claudeCode" in meta && meta.claudeCode && typeof meta.claudeCode === "object" ? meta.claudeCode : undefined;
+    "claudeCode" in meta &&
+    meta.claudeCode &&
+    typeof meta.claudeCode === "object"
+      ? meta.claudeCode
+      : undefined;
   const parentToolUseId =
-    claudeCode && "parentToolUseId" in claudeCode && typeof claudeCode.parentToolUseId === "string"
+    claudeCode &&
+    "parentToolUseId" in claudeCode &&
+    typeof claudeCode.parentToolUseId === "string"
       ? claudeCode.parentToolUseId
       : null;
   return parentToolUseId;
@@ -135,15 +175,23 @@ function applyToolCorrelationMetadata(
   toolCall: ToolCall,
   metadata: ToolCorrelationMetadata | undefined,
 ): void {
-  if (!metadata?.requestId && !metadata?.subagentType && !metadata?.taskDescription) {
+  if (
+    !metadata?.requestId &&
+    !metadata?.subagentType &&
+    !metadata?.taskDescription
+  ) {
     return;
   }
   const meta =
-    toolCall.meta && typeof toolCall.meta === "object" && !Array.isArray(toolCall.meta)
+    toolCall.meta &&
+    typeof toolCall.meta === "object" &&
+    !Array.isArray(toolCall.meta)
       ? (toolCall.meta as Record<string, unknown>)
       : {};
   const claudeCode =
-    meta.claudeCode && typeof meta.claudeCode === "object" && !Array.isArray(meta.claudeCode)
+    meta.claudeCode &&
+    typeof meta.claudeCode === "object" &&
+    !Array.isArray(meta.claudeCode)
       ? (meta.claudeCode as Record<string, unknown>)
       : {};
   toolCall.meta = {
@@ -152,7 +200,9 @@ function applyToolCorrelationMetadata(
       ...claudeCode,
       ...(metadata.requestId ? { requestId: metadata.requestId } : {}),
       ...(metadata.subagentType ? { subagentType: metadata.subagentType } : {}),
-      ...(metadata.taskDescription ? { taskDescription: metadata.taskDescription } : {}),
+      ...(metadata.taskDescription
+        ? { taskDescription: metadata.taskDescription }
+        : {}),
     },
   };
 }
@@ -197,7 +247,10 @@ function applyFieldsToBase(base: ToolCall, fields: ToolCallUpdateFields): void {
     base.output_metadata = fields.output_metadata;
   }
   if (fields.task_metadata !== undefined) {
-    base.task_metadata = mergeTaskMetadata(base.task_metadata, fields.task_metadata);
+    base.task_metadata = mergeTaskMetadata(
+      base.task_metadata,
+      fields.task_metadata,
+    );
   }
   if (fields.meta !== undefined) {
     base.meta = fields.meta;
@@ -241,8 +294,12 @@ function logToolCallUpdateEmitted(
   updateKind: ToolUpdateKind,
 ): void {
   const nextStatus = fields.status ?? base?.status;
-  const rawOutput = typeof fields.raw_output === "string" ? fields.raw_output : base?.raw_output;
-  const failureKind = nextStatus === "failed" ? classifyFailureKind(rawOutput) : undefined;
+  const rawOutput =
+    typeof fields.raw_output === "string"
+      ? fields.raw_output
+      : base?.raw_output;
+  const failureKind =
+    nextStatus === "failed" ? classifyFailureKind(rawOutput) : undefined;
   const commonEvent = {
     target: LOG_TARGETS.APP_TOOL,
     eventName: "tool_call_update_emitted",
@@ -260,8 +317,11 @@ function logToolCallUpdateEmitted(
       content_block_count: fields.content?.length,
       location_count: fields.locations?.length,
       raw_output_chars: rawOutput?.length,
-      has_output_metadata: fields.output_metadata !== undefined || base?.output_metadata !== undefined,
-      has_task_metadata: fields.task_metadata !== undefined || base?.task_metadata !== undefined,
+      has_output_metadata:
+        fields.output_metadata !== undefined ||
+        base?.output_metadata !== undefined,
+      has_task_metadata:
+        fields.task_metadata !== undefined || base?.task_metadata !== undefined,
       failure_kind: failureKind,
     },
   } as const;
@@ -288,7 +348,10 @@ function emitInitialToolCall(
 ): void {
   session.toolCalls.set(toolCall.tool_call_id, toolCall);
   logToolCallSubmitted(session.sessionId, toolCall, updateKind);
-  emitSessionUpdate(session.sessionId, { type: "tool_call", tool_call: toolCall });
+  emitSessionUpdate(session.sessionId, {
+    type: "tool_call",
+    tool_call: toolCall,
+  });
 }
 
 function taskTitleContext(
@@ -326,7 +389,10 @@ export function emitToolCallUpdate(
 ): void {
   const base = session.toolCalls.get(toolUseId);
   const nextStatus = fields.status ?? base?.status;
-  const terminal = nextStatus === "completed" || nextStatus === "failed" || nextStatus === "killed";
+  const terminal =
+    nextStatus === "completed" ||
+    nextStatus === "failed" ||
+    nextStatus === "killed";
   const hasActiveRetry =
     base?.task_metadata?.subagent_retry?.state === "waiting" ||
     fields.task_metadata?.subagent_retry?.state === "waiting";
@@ -336,7 +402,13 @@ export function emitToolCallUpdate(
       subagent_retry: { state: "clear" },
     };
   }
-  logToolCallUpdateEmitted(session.sessionId, toolUseId, fields, base, updateKind);
+  logToolCallUpdateEmitted(
+    session.sessionId,
+    toolUseId,
+    fields,
+    base,
+    updateKind,
+  );
   emitSessionUpdate(session.sessionId, {
     type: "tool_call_update",
     tool_call_update: {
@@ -363,7 +435,8 @@ export function emitToolCall(
   sourceMessageUuid?: string,
 ): void {
   const existing = session.toolCalls.get(toolUseId);
-  const resolvedParentToolUseId = parentToolUseId ?? parentToolUseIdFromMeta(existing?.meta);
+  const resolvedParentToolUseId =
+    parentToolUseId ?? parentToolUseIdFromMeta(existing?.meta);
   const toolCall = createToolCall(
     toolUseId,
     name,
@@ -415,7 +488,12 @@ export function ensureToolCallVisible(
         parentToolUseId,
         taskTitleContext(session, toolName, input),
       );
-      emitToolCallUpdate(session, toolUseId, { meta: refreshed.meta }, "refresh");
+      emitToolCallUpdate(
+        session,
+        toolUseId,
+        { meta: refreshed.meta },
+        "refresh",
+      );
     }
     return existing;
   }
@@ -446,11 +524,19 @@ export function emitToolResultUpdate(
     rawContent,
     base,
     rawResult,
-    taskTitleContext(session, baseToolName, asRecordOrNull(base?.raw_input) ?? {}),
+    taskTitleContext(
+      session,
+      baseToolName,
+      asRecordOrNull(base?.raw_input) ?? {},
+    ),
   );
   applyToolNonExecutionMetadata(fields, nonExecutionMetadata);
   if (!isError && !nonExecutionMetadata) {
-    const taskId = backgroundToolLaunchTaskIdFromResult(baseToolName, rawResult, rawContent);
+    const taskId = backgroundToolLaunchTaskIdFromResult(
+      baseToolName,
+      rawResult,
+      rawContent,
+    );
     if (taskId) {
       linkTaskToolUse(session, taskId, toolUseId);
     }
@@ -471,12 +557,18 @@ export function emitToolResultUpdate(
   }
 }
 
-export function finalizeOpenToolCalls(session: SessionState, status: "completed" | "failed"): void {
+export function finalizeOpenToolCalls(
+  session: SessionState,
+  status: "completed" | "failed",
+): void {
   for (const [toolUseId, toolCall] of session.toolCalls) {
     if (toolCall.status !== "pending" && toolCall.status !== "in_progress") {
       continue;
     }
-    if (toolAcceptsTaskLifecycle(toolCall) && activeTaskIdForToolUse(session, toolUseId)) {
+    if (
+      toolAcceptsTaskLifecycle(toolCall) &&
+      activeTaskIdForToolUse(session, toolUseId)
+    ) {
       continue;
     }
     emitToolCallUpdate(session, toolUseId, { status }, "finalize");
@@ -515,7 +607,10 @@ export function emitToolProgressUpdate(
   ) {
     taskMetadata.subagent_retry = progress.subagentRetry;
   }
-  if (progress.subagentType && progress.subagentType !== existing.task_metadata?.subagent_type) {
+  if (
+    progress.subagentType &&
+    progress.subagentType !== existing.task_metadata?.subagent_type
+  ) {
     taskMetadata.subagent_type = progress.subagentType;
   }
 
@@ -531,7 +626,11 @@ export function emitToolProgressUpdate(
   }
 }
 
-export function emitToolSummaryUpdate(session: SessionState, toolUseId: string, summary: string): void {
+export function emitToolSummaryUpdate(
+  session: SessionState,
+  toolUseId: string,
+  summary: string,
+): void {
   const base = session.toolCalls.get(toolUseId);
   if (!base) {
     return;
@@ -540,7 +639,10 @@ export function emitToolSummaryUpdate(session: SessionState, toolUseId: string, 
     return;
   }
   const fields: ToolCallUpdateFields = {
-    status: base.status === "failed" || base.status === "killed" ? base.status : "completed",
+    status:
+      base.status === "failed" || base.status === "killed"
+        ? base.status
+        : "completed",
     raw_output: summary,
     content: [{ type: "content", content: { type: "text", text: summary } }],
   };
@@ -561,12 +663,17 @@ export function setToolCallStatus(
   const fields: ToolCallUpdateFields = { status };
   if (message && message.length > 0) {
     fields.raw_output = message;
-    fields.content = [{ type: "content", content: { type: "text", text: message } }];
+    fields.content = [
+      { type: "content", content: { type: "text", text: message } },
+    ];
   }
   emitToolCallUpdate(session, toolUseId, fields, "status");
 }
 
-export function resolveTaskToolUseId(session: SessionState, msg: Record<string, unknown>): string {
+export function resolveTaskToolUseId(
+  session: SessionState,
+  msg: Record<string, unknown>,
+): string {
   const direct = typeof msg.tool_use_id === "string" ? msg.tool_use_id : "";
   if (direct) {
     return direct;
@@ -583,15 +690,19 @@ export function taskProgressText(msg: Record<string, unknown>): string {
   if (summary) {
     return summary;
   }
-  const description = typeof msg.description === "string" ? msg.description : "";
-  const lastTool = typeof msg.last_tool_name === "string" ? msg.last_tool_name : "";
+  const description =
+    typeof msg.description === "string" ? msg.description : "";
+  const lastTool =
+    typeof msg.last_tool_name === "string" ? msg.last_tool_name : "";
   if (description && lastTool) {
     return `${description} (last tool: ${lastTool})`;
   }
   return description || lastTool;
 }
 
-function taskPatchStatus(value: unknown): "pending" | "in_progress" | "completed" | "failed" | "killed" | undefined {
+function taskPatchStatus(
+  value: unknown,
+): "pending" | "in_progress" | "completed" | "failed" | "killed" | undefined {
   switch (value) {
     case "pending":
       return "pending";
@@ -608,7 +719,9 @@ function taskPatchStatus(value: unknown): "pending" | "in_progress" | "completed
   }
 }
 
-function buildTaskMetadata(patch: Record<string, unknown>): TaskMetadata | undefined {
+function buildTaskMetadata(
+  patch: Record<string, unknown>,
+): TaskMetadata | undefined {
   const taskMetadata: TaskMetadata = {};
   if (typeof patch.error === "string" && patch.error.length > 0) {
     taskMetadata.error = patch.error;
@@ -616,7 +729,11 @@ function buildTaskMetadata(patch: Record<string, unknown>): TaskMetadata | undef
   if (typeof patch.is_backgrounded === "boolean") {
     taskMetadata.is_backgrounded = patch.is_backgrounded;
   }
-  if (typeof patch.end_time === "number" && Number.isFinite(patch.end_time) && patch.end_time >= 0) {
+  if (
+    typeof patch.end_time === "number" &&
+    Number.isFinite(patch.end_time) &&
+    patch.end_time >= 0
+  ) {
     taskMetadata.end_time = Math.trunc(patch.end_time);
   }
   if (
@@ -626,24 +743,35 @@ function buildTaskMetadata(patch: Record<string, unknown>): TaskMetadata | undef
   ) {
     taskMetadata.total_paused_ms = Math.trunc(patch.total_paused_ms);
   }
-  if (typeof patch.status === "string" && ["completed", "failed", "killed"].includes(patch.status)) {
+  if (
+    typeof patch.status === "string" &&
+    ["completed", "failed", "killed"].includes(patch.status)
+  ) {
     taskMetadata.terminal_status = patch.status;
   }
   if (typeof patch.blocked === "boolean") {
     taskMetadata.blocked = patch.blocked;
   }
-  if (typeof patch.parent_agent_id === "string" && patch.parent_agent_id.length > 0) {
+  if (
+    typeof patch.parent_agent_id === "string" &&
+    patch.parent_agent_id.length > 0
+  ) {
     taskMetadata.parent_agent_id = patch.parent_agent_id;
   }
   return Object.keys(taskMetadata).length > 0 ? taskMetadata : undefined;
 }
 
-export function taskUpdatedFields(msg: Record<string, unknown>): ToolCallUpdateFields {
+export function taskUpdatedFields(
+  msg: Record<string, unknown>,
+): ToolCallUpdateFields {
   const patch =
-    msg.patch && typeof msg.patch === "object" ? (msg.patch as Record<string, unknown>) : {};
+    msg.patch && typeof msg.patch === "object"
+      ? (msg.patch as Record<string, unknown>)
+      : {};
   const fields: ToolCallUpdateFields = {};
   const status = taskPatchStatus(patch.status);
-  const description = typeof patch.description === "string" ? patch.description : "";
+  const description =
+    typeof patch.description === "string" ? patch.description : "";
   const error = typeof patch.error === "string" ? patch.error : "";
 
   if (status) {
@@ -651,10 +779,14 @@ export function taskUpdatedFields(msg: Record<string, unknown>): ToolCallUpdateF
   }
   if (description) {
     fields.raw_output = description;
-    fields.content = [{ type: "content", content: { type: "text", text: description } }];
+    fields.content = [
+      { type: "content", content: { type: "text", text: description } },
+    ];
   } else if ((status === "failed" || status === "killed") && error) {
     fields.raw_output = error;
-    fields.content = [{ type: "content", content: { type: "text", text: error } }];
+    fields.content = [
+      { type: "content", content: { type: "text", text: error } },
+    ];
   }
 
   const taskMetadata = buildTaskMetadata(patch);

--- a/agent-sdk/src/bridge/tooling.test.ts
+++ b/agent-sdk/src/bridge/tooling.test.ts
@@ -24,11 +24,18 @@ test("createToolCall builds edit diff content", () => {
     old: "old",
     new: "new",
   });
-  assert.deepEqual(toolCall.meta, { claudeCode: { toolName: "Edit", parentToolUseId: null } });
+  assert.deepEqual(toolCall.meta, {
+    claudeCode: { toolName: "Edit", parentToolUseId: null },
+  });
 });
 
 test("createToolCall preserves parent tool linkage metadata", () => {
-  const toolCall = createToolCall("tc-child", "Bash", { command: "echo hi" }, "tc-parent");
+  const toolCall = createToolCall(
+    "tc-child",
+    "Bash",
+    { command: "echo hi" },
+    "tc-parent",
+  );
 
   assert.deepEqual(toolCall.meta, {
     claudeCode: { toolName: "Bash", parentToolUseId: "tc-parent" },
@@ -53,7 +60,10 @@ test("createToolCall builds write preview diff content", () => {
 });
 
 test("createToolCall includes search and webfetch context in title", () => {
-  const glob = createToolCall("tc-g", "Glob", { pattern: "**/*.md", path: "notes" });
+  const glob = createToolCall("tc-g", "Glob", {
+    pattern: "**/*.md",
+    path: "notes",
+  });
   assert.equal(glob.title, "Glob **/*.md in notes");
 
   const grep = createToolCall("tc-grep", "Grep", {
@@ -73,7 +83,9 @@ test("createToolCall includes search and webfetch context in title", () => {
     "Grep TODO in src (glob **/*.rs, type rust, content, case-insensitive, context 2, limit 10, offset 5, multiline)",
   );
 
-  const fetch = createToolCall("tc-f", "WebFetch", { url: "https://example.com" });
+  const fetch = createToolCall("tc-f", "WebFetch", {
+    url: "https://example.com",
+  });
   assert.equal(fetch.title, "WebFetch https://example.com");
 });
 
@@ -102,7 +114,9 @@ test("createToolCall builds Agent title from name and type without description f
 });
 
 test("createToolCall builds worktree titles from input rules", () => {
-  const namedEnter = createToolCall("tc-enter-name", "EnterWorktree", { name: "feature-auth" });
+  const namedEnter = createToolCall("tc-enter-name", "EnterWorktree", {
+    name: "feature-auth",
+  });
   assert.equal(namedEnter.kind, "other");
   assert.equal(namedEnter.title, "feature-auth");
 
@@ -164,9 +178,13 @@ test("createToolCall maps RemoteTrigger to other kind and action title", () => {
 });
 
 test("createToolCall uses RemoteTrigger fallback title without action", () => {
-  const toolCall = createToolCall("tc-remote-trigger-fallback", "RemoteTrigger", {
-    trigger_id: "deploy-prod",
-  });
+  const toolCall = createToolCall(
+    "tc-remote-trigger-fallback",
+    "RemoteTrigger",
+    {
+      trigger_id: "deploy-prod",
+    },
+  );
 
   assert.equal(toolCall.kind, "other");
   assert.equal(toolCall.title, "RemoteTrigger");
@@ -210,7 +228,8 @@ test("createToolCall maps Workflow to other kind and name title", () => {
     args: { topic: "rendering" },
   });
   const fallbackWorkflow = createToolCall("tc-workflow-fallback", "Workflow", {
-    script: "export const meta = { name: 'inline', description: 'Run', phases: [] };",
+    script:
+      "export const meta = { name: 'inline', description: 'Run', phases: [] };",
   });
 
   assert.equal(namedWorkflow.kind, "other");
@@ -265,7 +284,11 @@ test("createToolCall maps project and artifact tools to compact titles", () => {
     file_path: "C:/work/report.html",
     favicon: "R",
   });
-  const rolePicker = createToolCall("tc-role-picker", "ShowOnboardingRolePicker", {});
+  const rolePicker = createToolCall(
+    "tc-role-picker",
+    "ShowOnboardingRolePicker",
+    {},
+  );
 
   assert.equal(projectInfo.kind, "other");
   assert.equal(projectInfo.title, "Projects: info");
@@ -290,7 +313,10 @@ test("createToolCall maps EnterPlanMode to switch_mode kind with stable title", 
 });
 
 test("buildToolResultFields extracts plain-text output", () => {
-  const fields = buildToolResultFields(false, [{ text: "line 1" }, { text: "line 2" }]);
+  const fields = buildToolResultFields(false, [
+    { text: "line 1" },
+    { text: "line 2" },
+  ]);
   assert.equal(fields.status, "completed");
   assert.equal(fields.raw_output, "line 1\nline 2");
   assert.deepEqual(fields.content, [
@@ -306,8 +332,16 @@ test("new SDK tools retain generic inputs and structured outputs losslessly", ()
     area: "/feedback",
   };
   const feedback = createToolCall("tc-feedback", "SendFeedback", feedbackInput);
-  const feedbackOutput = { success: true, message: "Feedback queued for review." };
-  const feedbackFields = buildToolResultFields(false, feedbackOutput, feedback, feedbackOutput);
+  const feedbackOutput = {
+    success: true,
+    message: "Feedback queued for review.",
+  };
+  const feedbackFields = buildToolResultFields(
+    false,
+    feedbackOutput,
+    feedback,
+    feedbackOutput,
+  );
 
   assert.deepEqual(feedback.raw_input, feedbackInput);
   assert.equal(feedbackFields.raw_output, JSON.stringify(feedbackOutput));
@@ -334,7 +368,12 @@ test("new SDK tools retain generic inputs and structured outputs losslessly", ()
       error: "No live connection",
     },
   ];
-  const refreshFields = buildToolResultFields(false, refreshOutput, refresh, refreshOutput);
+  const refreshFields = buildToolResultFields(
+    false,
+    refreshOutput,
+    refresh,
+    refreshOutput,
+  );
 
   assert.deepEqual(refresh.raw_input, refreshInput);
   assert.equal(refreshFields.raw_output, JSON.stringify(refreshOutput));
@@ -358,7 +397,12 @@ test("new SDK tools retain generic inputs and structured outputs losslessly", ()
   };
   const proposal = createToolCall("tc-propose", "ProposeSkills", proposalInput);
   const proposalOutput = { proposalCount: 1 };
-  const proposalFields = buildToolResultFields(false, proposalOutput, proposal, proposalOutput);
+  const proposalFields = buildToolResultFields(
+    false,
+    proposalOutput,
+    proposal,
+    proposalOutput,
+  );
 
   assert.deepEqual(proposal.raw_input, proposalInput);
   assert.equal(proposalFields.raw_output, JSON.stringify(proposalOutput));
@@ -481,7 +525,10 @@ test("buildToolResultFields renders structured empty Grep output", () => {
 });
 
 test("buildToolResultFields renders structured Glob output", () => {
-  const base = createToolCall("tc-glob", "Glob", { pattern: "**/*.rs", path: "src" });
+  const base = createToolCall("tc-glob", "Glob", {
+    pattern: "**/*.rs",
+    path: "src",
+  });
   const fields = buildToolResultFields(false, "", base, {
     durationMs: 12,
     numFiles: 2,
@@ -508,7 +555,10 @@ test("normalizeToolResultText collapses persisted-output payload to first meanin
   │ ...
   │ </persisted-output>
 `);
-  assert.equal(normalized, "Output too large (132.5KB). Full output saved to: C:\\tmp\\tool-results\\bbf63b9.txt");
+  assert.equal(
+    normalized,
+    "Output too large (132.5KB). Full output saved to: C:\\tmp\\tool-results\\bbf63b9.txt",
+  );
 });
 
 test("normalizeToolResultText does not sanitize non-error output", () => {
@@ -520,7 +570,10 @@ test("normalizeToolResultText does not sanitize non-error output", () => {
 test("normalizeToolResultText sanitizes exact SDK rejection payloads for errors", () => {
   const cancelledText =
     "The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). STOP what you are doing and wait for the user to tell you how to proceed.";
-  assert.equal(normalizeToolResultText(cancelledText, true), "Cancelled by user.");
+  assert.equal(
+    normalizeToolResultText(cancelledText, true),
+    "Cancelled by user.",
+  );
 
   const deniedText =
     "Permission for this tool use was denied. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). Try a different approach or report the limitation to complete your task.";
@@ -530,11 +583,17 @@ test("normalizeToolResultText sanitizes exact SDK rejection payloads for errors"
 test("normalizeToolResultText sanitizes SDK rejection prefixes with user follow-up", () => {
   const cancelledWithUserMessage =
     "The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). To tell you how to proceed, the user said:\nPlease skip this";
-  assert.equal(normalizeToolResultText(cancelledWithUserMessage, true), "Cancelled by user.");
+  assert.equal(
+    normalizeToolResultText(cancelledWithUserMessage, true),
+    "Cancelled by user.",
+  );
 
   const deniedWithUserMessage =
     "Permission for this tool use was denied. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). The user said:\nNot now";
-  assert.equal(normalizeToolResultText(deniedWithUserMessage, true), "Permission denied.");
+  assert.equal(
+    normalizeToolResultText(deniedWithUserMessage, true),
+    "Permission denied.",
+  );
 });
 
 test("normalizeToolResultText does not sanitize substring matches in error output", () => {
@@ -559,7 +618,10 @@ test("buildToolResultFields uses normalized persisted-output text", () => {
       │ {"k":"v"}
       │ </persisted-output>`,
   );
-  assert.equal(fields.raw_output, "Output too large (14KB). Full output saved to: C:\\tmp\\tool-results\\x.txt");
+  assert.equal(
+    fields.raw_output,
+    "Output too large (14KB). Full output saved to: C:\\tmp\\tool-results\\x.txt",
+  );
   assert.deepEqual(fields.content, [
     {
       type: "content",
@@ -672,7 +734,9 @@ test("buildToolResultFields ignores model-facing Bash stale read hints", () => {
 });
 
 test("buildToolResultFields maps PowerShell structured output like shell output", () => {
-  const base = createToolCall("tc-powershell", "PowerShell", { command: "Get-ChildItem" });
+  const base = createToolCall("tc-powershell", "PowerShell", {
+    command: "Get-ChildItem",
+  });
   const fields = buildToolResultFields(
     false,
     {
@@ -690,12 +754,17 @@ test("buildToolResultFields maps PowerShell structured output like shell output"
     },
   );
 
-  assert.equal(fields.raw_output, "stdout line\nstderr line\nCommand was aborted before completion.");
+  assert.equal(
+    fields.raw_output,
+    "stdout line\nstderr line\nCommand was aborted before completion.",
+  );
   assert.equal(fields.output_metadata, undefined);
 });
 
 test("buildToolResultFields adds Bash auto-backgrounded metadata and message", () => {
-  const base = createToolCall("tc-bash-bg", "Bash", { command: "npm run watch" });
+  const base = createToolCall("tc-bash-bg", "Bash", {
+    command: "npm run watch",
+  });
   const fields = buildToolResultFields(
     false,
     {
@@ -729,7 +798,9 @@ test("buildToolResultFields adds Bash auto-backgrounded metadata and message", (
 });
 
 test("buildToolResultFields preserves Bash timeout and cwd metadata", () => {
-  const base = createToolCall("tc-bash-timeout", "Bash", { command: "npm run watch" });
+  const base = createToolCall("tc-bash-timeout", "Bash", {
+    command: "npm run watch",
+  });
   const fields = buildToolResultFields(
     false,
     {
@@ -739,6 +810,7 @@ test("buildToolResultFields preserves Bash timeout and cwd metadata", () => {
       backgroundTaskId: "task-43",
       timedOutAfterMs: 10_000.9,
       backgroundCwdHint: " session cwd unchanged ",
+      backgroundEndsWithFinalResponse: true,
     },
     base,
   );
@@ -751,12 +823,15 @@ test("buildToolResultFields preserves Bash timeout and cwd metadata", () => {
     bash: {
       timed_out_after_ms: 10_000,
       background_cwd_hint: "session cwd unchanged",
+      background_ends_with_final_response: true,
     },
   });
 });
 
 test("buildToolResultFields rejects malformed Bash timeout metadata", () => {
-  const base = createToolCall("tc-bash-invalid-timeout", "Bash", { command: "npm run watch" });
+  const base = createToolCall("tc-bash-invalid-timeout", "Bash", {
+    command: "npm run watch",
+  });
   const fields = buildToolResultFields(
     false,
     {
@@ -770,7 +845,10 @@ test("buildToolResultFields rejects malformed Bash timeout metadata", () => {
     base,
   );
 
-  assert.equal(fields.raw_output, "Command is running in background with ID: task-44.");
+  assert.equal(
+    fields.raw_output,
+    "Command is running in background with ID: task-44.",
+  );
   assert.equal(fields.output_metadata, undefined);
 });
 
@@ -977,7 +1055,10 @@ test("buildToolResultFields parses ReadMcpResourceDir transcript JSON", () => {
     content: transcriptJson,
   });
 
-  assert.equal(fields.raw_output, "api.json - file://manuals/api.json (application/json)");
+  assert.equal(
+    fields.raw_output,
+    "api.json - file://manuals/api.json (application/json)",
+  );
   assert.deepEqual(fields.content, [
     {
       type: "content",
@@ -1012,7 +1093,10 @@ test("buildToolResultFields skips invalid ReadMcpResourceDir entries", () => {
   );
 
   assert.equal(fields.status, "completed");
-  assert.equal(fields.raw_output, "valid.txt - file://manuals/valid.txt (text/plain)");
+  assert.equal(
+    fields.raw_output,
+    "valid.txt - file://manuals/valid.txt (text/plain)",
+  );
   assert.deepEqual(fields.content, [
     {
       type: "content",
@@ -1062,17 +1146,20 @@ test("buildToolResultFields marks only structured Skill background launches", ()
     skill: "review",
   });
   assert.deepEqual(
-    buildToolResultFields(false, "launched", skill, { background: true }).output_metadata,
+    buildToolResultFields(false, "launched", skill, { background: true })
+      .output_metadata,
     {
       skill: { background: true },
     },
   );
   assert.equal(
-    buildToolResultFields(false, "complete", skill, { background: false }).output_metadata,
+    buildToolResultFields(false, "complete", skill, { background: false })
+      .output_metadata,
     undefined,
   );
   assert.equal(
-    buildToolResultFields(false, "complete", skill, { background: "true" }).output_metadata,
+    buildToolResultFields(false, "complete", skill, { background: "true" })
+      .output_metadata,
     undefined,
   );
 
@@ -1080,7 +1167,8 @@ test("buildToolResultFields marks only structured Skill background launches", ()
     command: "echo ok",
   });
   assert.equal(
-    buildToolResultFields(false, "ok", bash, { background: true }).output_metadata,
+    buildToolResultFields(false, "ok", bash, { background: true })
+      .output_metadata,
     undefined,
   );
 });
@@ -1108,36 +1196,54 @@ test("buildToolResultFields suppresses successful inline Skill launch text", () 
 
 test("buildToolResultFields preserves forked Skill results and background metadata", () => {
   const skill = createToolCall("tc-skill-forked", "Skill", { skill: "review" });
-  const fields = buildToolResultFields(false, "model-facing launch text", skill, {
-    success: true,
-    commandName: "code-review",
-    status: "forked",
-    agentId: "agent-1",
-    result: "Review worker launched",
-    background: true,
-  });
+  const fields = buildToolResultFields(
+    false,
+    "model-facing launch text",
+    skill,
+    {
+      success: true,
+      commandName: "code-review",
+      status: "forked",
+      agentId: "agent-1",
+      result: "Review worker launched",
+      background: true,
+    },
+  );
 
   assert.equal(fields.title, "Skill: Code Review");
   assert.equal(fields.raw_output, "Review worker launched");
   assert.deepEqual(fields.content, [
-    { type: "content", content: { type: "text", text: "Review worker launched" } },
+    {
+      type: "content",
+      content: { type: "text", text: "Review worker launched" },
+    },
   ]);
   assert.deepEqual(fields.output_metadata, { skill: { background: true } });
 });
 
 test("buildToolResultFields falls back losslessly for malformed Skill results", () => {
-  const skill = createToolCall("tc-skill-malformed", "Skill", { skill: "review" });
-  const fields = buildToolResultFields(false, "Launching skill: review", skill, {
-    success: true,
-    commandName: "review",
-    status: "forked",
-    result: "missing agent ID",
+  const skill = createToolCall("tc-skill-malformed", "Skill", {
+    skill: "review",
   });
+  const fields = buildToolResultFields(
+    false,
+    "Launching skill: review",
+    skill,
+    {
+      success: true,
+      commandName: "review",
+      status: "forked",
+      result: "missing agent ID",
+    },
+  );
 
   assert.equal(fields.title, undefined);
   assert.equal(fields.raw_output, "Launching skill: review");
   assert.deepEqual(fields.content, [
-    { type: "content", content: { type: "text", text: "Launching skill: review" } },
+    {
+      type: "content",
+      content: { type: "text", text: "Launching skill: review" },
+    },
   ]);
 });
 
@@ -1313,7 +1419,10 @@ test("buildToolResultFields replaces a structured Read image result with its fil
       },
     ],
   });
-  assert.equal(JSON.stringify(fields).includes("raw-content-image-data"), false);
+  assert.equal(
+    JSON.stringify(fields).includes("raw-content-image-data"),
+    false,
+  );
   assert.equal(JSON.stringify(fields).includes("structured-image-data"), false);
 });
 
@@ -1344,7 +1453,10 @@ test("buildToolResultFields recognizes Read image content blocks without structu
       content: { type: "text", text: "Viewed Image capture.unknown" },
     },
   ]);
-  assert.equal(JSON.stringify(fields).includes("compatibility-image-data"), false);
+  assert.equal(
+    JSON.stringify(fields).includes("compatibility-image-data"),
+    false,
+  );
 });
 
 test("buildToolResultFields preserves failed Read image output", () => {
@@ -1387,25 +1499,23 @@ test("buildToolResultFields renders file_unchanged Read results compactly", () =
 
   assert.equal(fields.raw_output, "File unchanged: src/main.rs");
   assert.deepEqual(fields.content, [
-    { type: "content", content: { type: "text", text: "File unchanged: src/main.rs" } },
+    {
+      type: "content",
+      content: { type: "text", text: "File unchanged: src/main.rs" },
+    },
   ]);
 });
 
 test("buildToolResultFields renders array-wrapped file_unchanged Read results compactly", () => {
   const base = createToolCall("tc-read", "Read", { file_path: "src/lib.rs" });
-  const fields = buildToolResultFields(
-    false,
-    [],
-    base,
-    {
-      result: [
-        {
-          type: "file_unchanged",
-          file: { filePath: "src/lib.rs" },
-        },
-      ],
-    },
-  );
+  const fields = buildToolResultFields(false, [], base, {
+    result: [
+      {
+        type: "file_unchanged",
+        file: { filePath: "src/lib.rs" },
+      },
+    ],
+  });
 
   assert.equal(fields.raw_output, "File unchanged: src/lib.rs");
 });
@@ -1433,27 +1543,24 @@ test("buildToolResultFields uses Agent output agentType as task title", () => {
 
 test("buildToolResultFields reads array-wrapped Agent output agentType", () => {
   const base = createToolCall("tc-agent", "Agent", { prompt: "Review tests" });
-  const fields = buildToolResultFields(
-    false,
-    [],
-    base,
-    {
-      result: [
-        {
-          agentId: "agent-1",
-          agentType: "planner",
-          content: [{ type: "text", text: "Done" }],
-          status: "completed",
-        },
-      ],
-    },
-  );
+  const fields = buildToolResultFields(false, [], base, {
+    result: [
+      {
+        agentId: "agent-1",
+        agentType: "planner",
+        content: [{ type: "text", text: "Done" }],
+        status: "completed",
+      },
+    ],
+  });
 
   assert.equal(fields.title, "Agent: planner");
 });
 
 test("buildToolResultFields leaves worktree title unchanged on completed output", () => {
-  const enterBase = createToolCall("tc-enter", "EnterWorktree", { name: "feature-auth" });
+  const enterBase = createToolCall("tc-enter", "EnterWorktree", {
+    name: "feature-auth",
+  });
   const enterFields = buildToolResultFields(
     false,
     {
@@ -1465,7 +1572,9 @@ test("buildToolResultFields leaves worktree title unchanged on completed output"
   );
   assert.equal(enterFields.title, undefined);
 
-  const exitBase = createToolCall("tc-exit", "ExitWorktree", { action: "keep" });
+  const exitBase = createToolCall("tc-exit", "ExitWorktree", {
+    action: "keep",
+  });
   const exitFields = buildToolResultFields(
     false,
     {
@@ -1478,7 +1587,9 @@ test("buildToolResultFields leaves worktree title unchanged on completed output"
 });
 
 test("buildToolResultFields renders worktree location without raw JSON", () => {
-  const enterBase = createToolCall("tc-enter", "EnterWorktree", { name: "feature-auth" });
+  const enterBase = createToolCall("tc-enter", "EnterWorktree", {
+    name: "feature-auth",
+  });
   const enterFields = buildToolResultFields(
     false,
     {
@@ -1490,10 +1601,15 @@ test("buildToolResultFields renders worktree location without raw JSON", () => {
   );
   assert.equal(enterFields.raw_output, "Branch: feature-auth");
   assert.deepEqual(enterFields.content, [
-    { type: "content", content: { type: "text", text: "Branch: feature-auth" } },
+    {
+      type: "content",
+      content: { type: "text", text: "Branch: feature-auth" },
+    },
   ]);
 
-  const exitBase = createToolCall("tc-exit", "ExitWorktree", { action: "keep" });
+  const exitBase = createToolCall("tc-exit", "ExitWorktree", {
+    action: "keep",
+  });
   const exitFields = buildToolResultFields(
     false,
     {
@@ -1502,11 +1618,17 @@ test("buildToolResultFields renders worktree location without raw JSON", () => {
     },
     exitBase,
   );
-  assert.equal(exitFields.raw_output, "Path: C:\\repo\\.worktrees\\feature-auth");
+  assert.equal(
+    exitFields.raw_output,
+    "Path: C:\\repo\\.worktrees\\feature-auth",
+  );
   assert.deepEqual(exitFields.content, [
     {
       type: "content",
-      content: { type: "text", text: "Path: C:\\repo\\.worktrees\\feature-auth" },
+      content: {
+        type: "text",
+        text: "Path: C:\\repo\\.worktrees\\feature-auth",
+      },
     },
   ]);
 });
@@ -1541,8 +1663,14 @@ test("buildToolResultFields renders cron outputs as structured text without raw 
   ]);
   assert.equal(createFields.raw_output?.includes("{"), false);
 
-  const deleteBase = createToolCall("tc-cron-delete", "CronDelete", { id: "schedule-1" });
-  const deleteFields = buildToolResultFields(false, { id: "schedule-1" }, deleteBase);
+  const deleteBase = createToolCall("tc-cron-delete", "CronDelete", {
+    id: "schedule-1",
+  });
+  const deleteFields = buildToolResultFields(
+    false,
+    { id: "schedule-1" },
+    deleteBase,
+  );
   assert.equal(deleteFields.raw_output, "Schedule ID: schedule-1");
 
   const listBase = createToolCall("tc-cron-list", "CronList", {});
@@ -1609,37 +1737,89 @@ test("buildToolResultFields preserves full CronList prompt from transcript JSON"
 
 test("buildToolResultFields renders readable cron schedule text from common cron expressions", () => {
   const base = createToolCall("tc-cron-readable", "CronList", {});
-  const fields = buildToolResultFields(false, {
-    jobs: [
-      { id: "every-minute", cron: "* * * * *", prompt: "minute", recurring: true },
-      { id: "every-five-minutes", cron: "*/5 * * * *", prompt: "minutes", recurring: true },
-      {
-        id: "hourly-minute",
-        cron: "7 * * * *",
-        humanSchedule: "Every hour at :07",
-        prompt: "hourly",
-        recurring: true,
-      },
-      { id: "every-two-hours", cron: "0 */2 * * *", prompt: "hours", recurring: true },
-      { id: "daily", cron: "30 9 * * *", prompt: "daily", recurring: true },
-      { id: "weekly", cron: "30 9 * * 1", prompt: "weekly", recurring: true },
-      { id: "monthly", cron: "30 9 15 * *", prompt: "monthly", recurring: true },
-      { id: "yearly", cron: "30 9 15 6 *", prompt: "yearly", recurring: true },
-      { id: "complex", cron: "0 9 1 * 1", prompt: "complex", recurring: true },
-    ],
-  }, base);
+  const fields = buildToolResultFields(
+    false,
+    {
+      jobs: [
+        {
+          id: "every-minute",
+          cron: "* * * * *",
+          prompt: "minute",
+          recurring: true,
+        },
+        {
+          id: "every-five-minutes",
+          cron: "*/5 * * * *",
+          prompt: "minutes",
+          recurring: true,
+        },
+        {
+          id: "hourly-minute",
+          cron: "7 * * * *",
+          humanSchedule: "Every hour at :07",
+          prompt: "hourly",
+          recurring: true,
+        },
+        {
+          id: "every-two-hours",
+          cron: "0 */2 * * *",
+          prompt: "hours",
+          recurring: true,
+        },
+        { id: "daily", cron: "30 9 * * *", prompt: "daily", recurring: true },
+        { id: "weekly", cron: "30 9 * * 1", prompt: "weekly", recurring: true },
+        {
+          id: "monthly",
+          cron: "30 9 15 * *",
+          prompt: "monthly",
+          recurring: true,
+        },
+        {
+          id: "yearly",
+          cron: "30 9 15 6 *",
+          prompt: "yearly",
+          recurring: true,
+        },
+        {
+          id: "complex",
+          cron: "0 9 1 * 1",
+          prompt: "complex",
+          recurring: true,
+        },
+      ],
+    },
+    base,
+  );
 
   assert.equal(fields.raw_output?.includes("Cron: 7 * * * *"), false);
   assert.equal(fields.raw_output?.includes("Recurring:"), false);
   assert.equal(fields.raw_output?.includes("Durable:"), false);
   assert.equal(fields.raw_output?.includes("Schedule: Every minute"), true);
   assert.equal(fields.raw_output?.includes("Schedule: Every 5 minutes"), true);
-  assert.equal(fields.raw_output?.includes("Schedule: Every hour at minute 07"), true);
-  assert.equal(fields.raw_output?.includes("Schedule: Every 2 hours on the hour"), true);
-  assert.equal(fields.raw_output?.includes("Schedule: Every day at 09:30"), true);
-  assert.equal(fields.raw_output?.includes("Schedule: Every Monday at 09:30"), true);
-  assert.equal(fields.raw_output?.includes("Schedule: Every month on day 15 at 09:30"), true);
-  assert.equal(fields.raw_output?.includes("Schedule: Every June 15 at 09:30"), true);
+  assert.equal(
+    fields.raw_output?.includes("Schedule: Every hour at minute 07"),
+    true,
+  );
+  assert.equal(
+    fields.raw_output?.includes("Schedule: Every 2 hours on the hour"),
+    true,
+  );
+  assert.equal(
+    fields.raw_output?.includes("Schedule: Every day at 09:30"),
+    true,
+  );
+  assert.equal(
+    fields.raw_output?.includes("Schedule: Every Monday at 09:30"),
+    true,
+  );
+  assert.equal(
+    fields.raw_output?.includes("Schedule: Every month on day 15 at 09:30"),
+    true,
+  );
+  assert.equal(
+    fields.raw_output?.includes("Schedule: Every June 15 at 09:30"),
+    true,
+  );
   assert.equal(fields.raw_output?.includes("Cron: 0 9 1 * 1"), true);
   assert.equal(fields.raw_output?.split("__cron_list_job_divider__").length, 9);
 });
@@ -1736,10 +1916,14 @@ test("buildToolResultFields renders PushNotification output as structured text",
 });
 
 test("buildToolResultFields parses PushNotification transcript JSON", () => {
-  const base = createToolCall("tc-push-notification-history", "PushNotification", {
-    message: "Deploy completed",
-    status: "proactive",
-  });
+  const base = createToolCall(
+    "tc-push-notification-history",
+    "PushNotification",
+    {
+      message: "Deploy completed",
+      status: "proactive",
+    },
+  );
   const transcriptJson = JSON.stringify({
     message: "Notification queued",
     pushSent: true,
@@ -1763,7 +1947,7 @@ test("buildToolResultFields parses PushNotification transcript JSON", () => {
   assert.equal(fields.raw_output?.includes('"pushSent"'), false);
 });
 
-test("buildToolResultFields renders RemoteTrigger summary without raw JSON", () => {
+test("buildToolResultFields preserves RemoteTrigger response alongside its summary", () => {
   const base = createToolCall("tc-remote-trigger", "RemoteTrigger", {
     action: "run",
     trigger_id: "deploy-prod",
@@ -1779,14 +1963,17 @@ test("buildToolResultFields renders RemoteTrigger summary without raw JSON", () 
   );
 
   assert.equal(fields.status, "completed");
-  assert.equal(fields.raw_output, "Status: 200\nSummary: Trigger completed");
-  assert.equal(fields.raw_output?.includes("run_id"), false);
+  assert.equal(
+    fields.raw_output,
+    'Status: 200\nSummary: Trigger completed\nResponse: {"ok":true,"run_id":"run-1"}',
+  );
+  assert.equal(fields.raw_output?.includes("run_id"), true);
   assert.deepEqual(fields.content, [
     {
       type: "content",
       content: {
         type: "text",
-        text: "Status: 200\nSummary: Trigger completed",
+        text: 'Status: 200\nSummary: Trigger completed\nResponse: {"ok":true,"run_id":"run-1"}',
       },
     },
   ]);
@@ -1807,7 +1994,10 @@ test("buildToolResultFields renders RemoteTrigger response when summary is absen
   );
 
   assert.equal(fields.status, "completed");
-  assert.equal(fields.raw_output, 'Status: 200\nResponse: {"ok":true,"trigger_id":"deploy-prod"}');
+  assert.equal(
+    fields.raw_output,
+    'Status: 200\nResponse: {"ok":true,"trigger_id":"deploy-prod"}',
+  );
   assert.equal(fields.raw_output?.includes('"json"'), false);
 });
 
@@ -1827,7 +2017,10 @@ test("buildToolResultFields marks RemoteTrigger 4xx output failed", () => {
   );
 
   assert.equal(fields.status, "failed");
-  assert.equal(fields.raw_output, "Status: 404\nSummary: Trigger not found");
+  assert.equal(
+    fields.raw_output,
+    'Status: 404\nSummary: Trigger not found\nResponse: {"error":"not_found"}',
+  );
 });
 
 test("buildToolResultFields parses RemoteTrigger transcript JSON", () => {
@@ -1846,7 +2039,10 @@ test("buildToolResultFields parses RemoteTrigger transcript JSON", () => {
     content: transcriptJson,
   });
 
-  assert.equal(fields.raw_output, 'Status: 200\nResponse: {"enabled":true,"name":"Deploy prod"}');
+  assert.equal(
+    fields.raw_output,
+    'Status: 200\nResponse: {"enabled":true,"name":"Deploy prod"}',
+  );
   assert.equal(fields.raw_output?.includes('"json"'), false);
 });
 
@@ -1875,12 +2071,12 @@ test("buildToolResultFields renders REPL output as structured text without raw J
   assert.equal(fields.status, "completed");
   assert.equal(
     fields.raw_output,
-    "Stdout: done\nStderr: warning\nResult: {\"ok\":true}\nRegistered tools: fetchDocs, parse\nImages: 2\nDocuments: 1",
+    'Stdout: done\nStderr: warning\nResult: {"ok":true}\nRegistered tools: fetchDocs, parse\nImages: 2\nDocuments: 1',
   );
   assert.equal(fields.raw_output?.includes("await main()"), false);
   assert.equal(fields.raw_output?.includes("image-one-base64"), false);
   assert.equal(fields.raw_output?.includes("document-base64"), false);
-  assert.equal(fields.raw_output?.includes("{\"code\""), false);
+  assert.equal(fields.raw_output?.includes('{"code"'), false);
   assert.deepEqual(fields.content, [
     {
       type: "content",
@@ -1934,7 +2130,7 @@ test("buildToolResultFields parses REPL transcript JSON", () => {
 
   assert.equal(
     fields.raw_output,
-    "Stdout: loaded\nResult: {\"count\":2}\nRegistered tools: lookup\nImages: 1\nDocuments: 2",
+    'Stdout: loaded\nResult: {"count":2}\nRegistered tools: lookup\nImages: 1\nDocuments: 2',
   );
   assert.equal(fields.raw_output?.includes('"code"'), false);
   assert.equal(fields.raw_output?.includes("hidden-image"), false);
@@ -1955,7 +2151,10 @@ test("buildToolResultFields renders Monitor launch output as structured text", (
   );
 
   assert.equal(fields.status, "in_progress");
-  assert.equal(fields.raw_output, "Task ID: monitor-1\nPersistent: no\nTimeout: 30s");
+  assert.equal(
+    fields.raw_output,
+    "Task ID: monitor-1\nPersistent: no\nTimeout: 30s",
+  );
   assert.equal(fields.raw_output?.includes("{"), false);
   assert.deepEqual(fields.content, [
     {
@@ -2045,7 +2244,11 @@ test("buildToolResultFields parses Workflow transcript JSON", () => {
 
 test("buildToolResultFields suppresses EnterPlanMode structured output body", () => {
   const base = createToolCall("tc-enter-plan-mode", "EnterPlanMode", {});
-  const fields = buildToolResultFields(false, { message: "Plan mode entered" }, base);
+  const fields = buildToolResultFields(
+    false,
+    { message: "Plan mode entered" },
+    base,
+  );
 
   assert.equal(fields.status, "completed");
   assert.equal(fields.raw_output, undefined);
@@ -2053,7 +2256,11 @@ test("buildToolResultFields suppresses EnterPlanMode structured output body", ()
 });
 
 test("buildToolResultFields suppresses EnterPlanMode transcript JSON body", () => {
-  const base = createToolCall("tc-enter-plan-mode-history", "EnterPlanMode", {});
+  const base = createToolCall(
+    "tc-enter-plan-mode-history",
+    "EnterPlanMode",
+    {},
+  );
   const transcriptJson = JSON.stringify({ message: "Entered plan mode" });
 
   const fields = buildToolResultFields(false, transcriptJson, base, {
@@ -2069,7 +2276,13 @@ test("buildToolResultFields suppresses EnterPlanMode transcript JSON body", () =
 
 test("buildToolResultFields ignores removed TodoWrite verification metadata", () => {
   const base = createToolCall("tc-todo", "TodoWrite", {
-    todos: [{ content: "Verify changes", status: "pending", activeForm: "Verifying changes" }],
+    todos: [
+      {
+        content: "Verify changes",
+        status: "pending",
+        activeForm: "Verifying changes",
+      },
+    ],
   });
   const fields = buildToolResultFields(
     false,

--- a/agent-sdk/src/bridge/tooling.ts
+++ b/agent-sdk/src/bridge/tooling.ts
@@ -63,19 +63,31 @@ export function isToolSearchToolResultType(blockType: string): boolean {
 }
 
 export function isToolUseBlockType(blockType: string): boolean {
-  return blockType === "tool_use" || blockType === "server_tool_use" || blockType === "mcp_tool_use";
+  return (
+    blockType === "tool_use" ||
+    blockType === "server_tool_use" ||
+    blockType === "mcp_tool_use"
+  );
 }
 
 function inputString(input: Record<string, unknown>, key: string): string {
   return typeof input[key] === "string" ? input[key].trim() : "";
 }
 
-function inputNumber(input: Record<string, unknown>, key: string): number | undefined {
+function inputNumber(
+  input: Record<string, unknown>,
+  key: string,
+): number | undefined {
   const value = input[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
-function inputBoolean(input: Record<string, unknown>, key: string): boolean | undefined {
+function inputBoolean(
+  input: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
   return typeof input[key] === "boolean" ? input[key] : undefined;
 }
 
@@ -88,10 +100,16 @@ export function isShellToolName(name: string): boolean {
 }
 
 function isMcpResourceReadToolName(name: string): boolean {
-  return name === READ_MCP_RESOURCE_TOOL_NAME || name === READ_MCP_RESOURCE_DIR_TOOL_NAME;
+  return (
+    name === READ_MCP_RESOURCE_TOOL_NAME ||
+    name === READ_MCP_RESOURCE_DIR_TOOL_NAME
+  );
 }
 
-function agentInputTitle(name: string, input: Record<string, unknown>): string | undefined {
+function agentInputTitle(
+  name: string,
+  input: Record<string, unknown>,
+): string | undefined {
   if (!isAgentLikeToolName(name)) {
     return undefined;
   }
@@ -326,7 +344,9 @@ export function toolTitle(
   }
   if (name === REMOTE_TRIGGER_TOOL_NAME) {
     const action = typeof input.action === "string" ? input.action.trim() : "";
-    return action ? `${REMOTE_TRIGGER_TOOL_NAME}: ${action}` : REMOTE_TRIGGER_TOOL_NAME;
+    return action
+      ? `${REMOTE_TRIGGER_TOOL_NAME}: ${action}`
+      : REMOTE_TRIGGER_TOOL_NAME;
   }
   if (name === ENTER_PLAN_MODE_TOOL_NAME) {
     return name;
@@ -337,17 +357,22 @@ export function toolTitle(
   }
   if (name === MONITOR_TOOL_NAME) {
     const description = nonEmptyString(input.description);
-    return description ? `${MONITOR_TOOL_NAME}: ${description}` : MONITOR_TOOL_NAME;
+    return description
+      ? `${MONITOR_TOOL_NAME}: ${description}`
+      : MONITOR_TOOL_NAME;
   }
   if (name === WORKFLOW_TOOL_NAME) {
     const workflowName = nonEmptyString(input.name);
-    return workflowName ? `${WORKFLOW_TOOL_NAME}: ${workflowName}` : WORKFLOW_TOOL_NAME;
+    return workflowName
+      ? `${WORKFLOW_TOOL_NAME}: ${workflowName}`
+      : WORKFLOW_TOOL_NAME;
   }
   if (name === PROJECTS_TOOL_NAME) {
     return formatProjectsTitle(input);
   }
   if (name === ARTIFACT_TOOL_NAME) {
-    const label = nonEmptyString(input.label) ?? nonEmptyString(input.file_path);
+    const label =
+      nonEmptyString(input.label) ?? nonEmptyString(input.file_path);
     return label ? `${ARTIFACT_TOOL_NAME}: ${label}` : ARTIFACT_TOOL_NAME;
   }
   if (name === SHOW_ONBOARDING_ROLE_PICKER_TOOL_NAME) {
@@ -360,13 +385,17 @@ export function toolTitle(
       : SKILL_TOOL_NAME;
   }
   if (name === "EnterWorktree") {
-    const worktreeName = typeof input.name === "string" ? input.name.trim() : "";
+    const worktreeName =
+      typeof input.name === "string" ? input.name.trim() : "";
     return worktreeName || "EnterWorktree";
   }
   if (name === "ExitWorktree") {
     return "ExitWorktree";
   }
-  if ((name === "Read" || name === "Write" || name === "Edit") && typeof input.file_path === "string") {
+  if (
+    (name === "Read" || name === "Write" || name === "Edit") &&
+    typeof input.file_path === "string"
+  ) {
     return `${name} ${input.file_path}`;
   }
   if (isMcpResourceReadToolName(name)) {
@@ -384,25 +413,40 @@ export function toolTitle(
 
 function formatProjectsTitle(input: Record<string, unknown>): string {
   const method = nonEmptyString(input.method);
-  const action = method?.startsWith("project_") ? method.slice("project_".length) : method;
+  const action = method?.startsWith("project_")
+    ? method.slice("project_".length)
+    : method;
   const suffix = nonEmptyString(input.path) ?? nonEmptyString(input.query);
   const base = action ? `${PROJECTS_TOOL_NAME}: ${action}` : PROJECTS_TOOL_NAME;
   return suffix ? `${base} ${suffix}` : base;
 }
 
-function editDiffContent(name: string, input: Record<string, unknown>): ToolCall["content"] {
+function editDiffContent(
+  name: string,
+  input: Record<string, unknown>,
+): ToolCall["content"] {
   const filePath = typeof input.file_path === "string" ? input.file_path : "";
   if (!filePath) {
     return [];
   }
 
   if (name === "Edit") {
-    const oldText = typeof input.old_string === "string" ? input.old_string : "";
-    const newText = typeof input.new_string === "string" ? input.new_string : "";
+    const oldText =
+      typeof input.old_string === "string" ? input.old_string : "";
+    const newText =
+      typeof input.new_string === "string" ? input.new_string : "";
     if (!oldText && !newText) {
       return [];
     }
-    return [{ type: "diff", old_path: filePath, new_path: filePath, old: oldText, new: newText }];
+    return [
+      {
+        type: "diff",
+        old_path: filePath,
+        new_path: filePath,
+        old: oldText,
+        new: newText,
+      },
+    ];
   }
 
   if (name === "Write") {
@@ -410,7 +454,15 @@ function editDiffContent(name: string, input: Record<string, unknown>): ToolCall
     if (!newText) {
       return [];
     }
-    return [{ type: "diff", old_path: filePath, new_path: filePath, old: "", new: newText }];
+    return [
+      {
+        type: "diff",
+        old_path: filePath,
+        new_path: filePath,
+        old: "",
+        new: newText,
+      },
+    ];
   }
 
   return [];
@@ -430,7 +482,8 @@ export function createToolCall(
     status: "pending",
     content: editDiffContent(name, input),
     raw_input: input as unknown as Json,
-    locations: typeof input.file_path === "string" ? [{ path: input.file_path }] : [],
+    locations:
+      typeof input.file_path === "string" ? [{ path: input.file_path }] : [],
     meta: {
       claudeCode: {
         toolName: name,
@@ -440,7 +493,10 @@ export function createToolCall(
   };
 }
 
-function resultRecordCandidates(rawResult: unknown, rawContent: unknown): Record<string, unknown>[] {
+function resultRecordCandidates(
+  rawResult: unknown,
+  rawContent: unknown,
+): Record<string, unknown>[] {
   const candidates: Record<string, unknown>[] = [];
 
   const pushRecord = (value: unknown): void => {
@@ -497,7 +553,8 @@ function imageReadResultText(
   }
 
   const input = asRecordOrNull(rawInput);
-  const filePath = typeof input?.file_path === "string" ? input.file_path.trim() : "";
+  const filePath =
+    typeof input?.file_path === "string" ? input.file_path.trim() : "";
   const normalizedPath = filePath.replaceAll("\\", "/");
   const fileName = normalizedPath.slice(normalizedPath.lastIndexOf("/") + 1);
   return fileName ? `Viewed Image ${fileName}` : "Viewed Image";
@@ -540,14 +597,24 @@ function pushStructuredRecordCandidates(
   }
 }
 
-function mcpResourceContentFromResult(rawResult: unknown, rawContent: unknown): ToolCall["content"] {
+function mcpResourceContentFromResult(
+  rawResult: unknown,
+  rawContent: unknown,
+): ToolCall["content"] {
   const candidates: Record<string, unknown>[] = [];
-  for (const candidate of [rawResult, rawContent, parseJsonCandidate(rawResult), parseJsonCandidate(rawContent)]) {
+  for (const candidate of [
+    rawResult,
+    rawContent,
+    parseJsonCandidate(rawResult),
+    parseJsonCandidate(rawContent),
+  ]) {
     pushStructuredRecordCandidates(candidates, candidate);
   }
 
   for (const candidate of candidates) {
-    const contents = Array.isArray(candidate.contents) ? candidate.contents : null;
+    const contents = Array.isArray(candidate.contents)
+      ? candidate.contents
+      : null;
     if (!contents || contents.length === 0) {
       continue;
     }
@@ -563,13 +630,16 @@ function mcpResourceContentFromResult(rawResult: unknown, rawContent: unknown): 
         continue;
       }
       const text =
-        typeof record.text === "string" && record.text.length > 0 ? record.text : undefined;
+        typeof record.text === "string" && record.text.length > 0
+          ? record.text
+          : undefined;
       const mimeType =
         typeof record.mimeType === "string" && record.mimeType.trim().length > 0
           ? record.mimeType.trim()
           : undefined;
       const blobSavedTo =
-        typeof record.blobSavedTo === "string" && record.blobSavedTo.trim().length > 0
+        typeof record.blobSavedTo === "string" &&
+        record.blobSavedTo.trim().length > 0
           ? record.blobSavedTo.trim()
           : undefined;
       if (!text && !blobSavedTo) {
@@ -643,19 +713,32 @@ function extractToolOutputMetadata(
 
   if (toolName === "Bash") {
     for (const candidate of candidates) {
-      const hasAssistantAutoBackgrounded = typeof candidate.assistantAutoBackgrounded === "boolean";
+      const hasAssistantAutoBackgrounded =
+        typeof candidate.assistantAutoBackgrounded === "boolean";
       const timedOutAfterMs = nonNegativeInteger(candidate.timedOutAfterMs);
       const backgroundCwdHint = nonEmptyString(candidate.backgroundCwdHint);
-      if (hasAssistantAutoBackgrounded || timedOutAfterMs !== undefined || backgroundCwdHint) {
+      const hasBackgroundEndsWithFinalResponse =
+        typeof candidate.backgroundEndsWithFinalResponse === "boolean";
+      if (
+        hasAssistantAutoBackgrounded ||
+        timedOutAfterMs !== undefined ||
+        backgroundCwdHint ||
+        hasBackgroundEndsWithFinalResponse
+      ) {
         const bashMetadata: import("../types.js").BashOutputMetadata = {};
         if (hasAssistantAutoBackgrounded) {
-          bashMetadata.assistant_auto_backgrounded = candidate.assistantAutoBackgrounded as boolean;
+          bashMetadata.assistant_auto_backgrounded =
+            candidate.assistantAutoBackgrounded as boolean;
         }
         if (timedOutAfterMs !== undefined) {
           bashMetadata.timed_out_after_ms = timedOutAfterMs;
         }
         if (backgroundCwdHint) {
           bashMetadata.background_cwd_hint = backgroundCwdHint;
+        }
+        if (hasBackgroundEndsWithFinalResponse) {
+          bashMetadata.background_ends_with_final_response =
+            candidate.backgroundEndsWithFinalResponse as boolean;
         }
         metadata.bash = bashMetadata;
         break;
@@ -710,7 +793,10 @@ function extractToolOutputMetadata(
 export function parseToolNonExecutionMetadata(
   value: unknown,
 ): Map<string, import("../types.js").ToolNonExecutionMetadata> {
-  const byToolUseId = new Map<string, import("../types.js").ToolNonExecutionMetadata>();
+  const byToolUseId = new Map<
+    string,
+    import("../types.js").ToolNonExecutionMetadata
+  >();
   if (!Array.isArray(value)) {
     return byToolUseId;
   }
@@ -766,7 +852,12 @@ export function extractText(value: unknown): string {
         if (typeof entry === "string") {
           return entry;
         }
-        if (entry && typeof entry === "object" && "text" in entry && typeof entry.text === "string") {
+        if (
+          entry &&
+          typeof entry === "object" &&
+          "text" in entry &&
+          typeof entry.text === "string"
+        ) {
           return entry.text;
         }
         return "";
@@ -774,7 +865,12 @@ export function extractText(value: unknown): string {
       .filter((part) => part.length > 0)
       .join("\n");
   }
-  if (value && typeof value === "object" && "text" in value && typeof value.text === "string") {
+  if (
+    value &&
+    typeof value === "object" &&
+    "text" in value &&
+    typeof value.text === "string"
+  ) {
     return value.text;
   }
   return "";
@@ -846,7 +942,10 @@ function sanitizeSdkRejectionText(text: string): string {
   return text;
 }
 
-export function normalizeToolResultText(value: unknown, isError = false): string {
+export function normalizeToolResultText(
+  value: unknown,
+  isError = false,
+): string {
   const text = extractText(value);
   if (!text) {
     return "";
@@ -876,7 +975,15 @@ function writeDiffFromInput(rawInput: Json | undefined): ToolCall["content"] {
   if (!filePath || !content) {
     return [];
   }
-  return [{ type: "diff", old_path: filePath, new_path: filePath, old: "", new: content }];
+  return [
+    {
+      type: "diff",
+      old_path: filePath,
+      new_path: filePath,
+      old: "",
+      new: content,
+    },
+  ];
 }
 
 function editDiffFromInput(rawInput: Json | undefined): ToolCall["content"] {
@@ -900,7 +1007,15 @@ function editDiffFromInput(rawInput: Json | undefined): ToolCall["content"] {
   if (!filePath || (!oldText && !newText)) {
     return [];
   }
-  return [{ type: "diff", old_path: filePath, new_path: filePath, old: oldText, new: newText }];
+  return [
+    {
+      type: "diff",
+      old_path: filePath,
+      new_path: filePath,
+      old: oldText,
+      new: newText,
+    },
+  ];
 }
 
 function writeDiffFromResult(rawContent: unknown): ToolCall["content"] {
@@ -918,16 +1033,26 @@ function writeDiffFromResult(rawContent: unknown): ToolCall["content"] {
           : "";
     const content = typeof record.content === "string" ? record.content : "";
     const originalRaw =
-      "originalFile" in record ? record.originalFile : "original_file" in record ? record.original_file : undefined;
+      "originalFile" in record
+        ? record.originalFile
+        : "original_file" in record
+          ? record.original_file
+          : undefined;
     const gitDiff = asRecordOrNull(record.gitDiff);
     const repository =
-      typeof gitDiff?.repository === "string" && gitDiff.repository.trim().length > 0
+      typeof gitDiff?.repository === "string" &&
+      gitDiff.repository.trim().length > 0
         ? gitDiff.repository.trim()
         : undefined;
     if (!filePath || !content || originalRaw === undefined) {
       continue;
     }
-    const original = typeof originalRaw === "string" ? originalRaw : originalRaw === null ? "" : "";
+    const original =
+      typeof originalRaw === "string"
+        ? originalRaw
+        : originalRaw === null
+          ? ""
+          : "";
     return [
       {
         type: "diff",
@@ -942,7 +1067,10 @@ function writeDiffFromResult(rawContent: unknown): ToolCall["content"] {
   return [];
 }
 
-function editDiffFromResult(rawResult: unknown, rawInput: Json | undefined): ToolCall["content"] {
+function editDiffFromResult(
+  rawResult: unknown,
+  rawInput: Json | undefined,
+): ToolCall["content"] {
   const input = asRecordOrNull(rawInput);
   const filePath = typeof input?.file_path === "string" ? input.file_path : "";
   const oldText =
@@ -976,7 +1104,8 @@ function editDiffFromResult(rawResult: unknown, rawInput: Json | undefined): Too
       continue;
     }
     const repository =
-      typeof gitDiff?.repository === "string" && gitDiff.repository.trim().length > 0
+      typeof gitDiff?.repository === "string" &&
+      gitDiff.repository.trim().length > 0
         ? gitDiff.repository.trim()
         : undefined;
     return [
@@ -1047,13 +1176,17 @@ function buildShellDisplayOutput(record: Record<string, unknown>): string {
   return segments.join("\n");
 }
 
-function fileUnchangedResultText(rawResult: unknown, rawContent: unknown): string {
+function fileUnchangedResultText(
+  rawResult: unknown,
+  rawContent: unknown,
+): string {
   for (const candidate of resultRecordCandidates(rawResult, rawContent)) {
     if (candidate.type !== "file_unchanged") {
       continue;
     }
     const file = asRecordOrNull(candidate.file);
-    const filePath = typeof file?.filePath === "string" ? file.filePath.trim() : "";
+    const filePath =
+      typeof file?.filePath === "string" ? file.filePath.trim() : "";
     if (filePath) {
       return `File unchanged: ${filePath}`;
     }
@@ -1061,13 +1194,18 @@ function fileUnchangedResultText(rawResult: unknown, rawContent: unknown): strin
   return "";
 }
 
-function agentTitleFromAgentOutput(rawResult: unknown, rawContent: unknown, base?: ToolCall): string {
+function agentTitleFromAgentOutput(
+  rawResult: unknown,
+  rawContent: unknown,
+  base?: ToolCall,
+): string {
   const inputAgentName = nonEmptyString(asRecordOrNull(base?.raw_input)?.name);
   if (inputAgentName) {
     return "";
   }
   for (const candidate of resultRecordCandidates(rawResult, rawContent)) {
-    const agentType = typeof candidate.agentType === "string" ? candidate.agentType.trim() : "";
+    const agentType =
+      typeof candidate.agentType === "string" ? candidate.agentType.trim() : "";
     if (agentType) {
       return `Agent: ${agentType}`;
     }
@@ -1075,19 +1213,30 @@ function agentTitleFromAgentOutput(rawResult: unknown, rawContent: unknown, base
   return "";
 }
 
-function firstSearchRecord(toolName: string, rawResult: unknown, rawContent: unknown): Record<string, unknown> | undefined {
+function firstSearchRecord(
+  toolName: string,
+  rawResult: unknown,
+  rawContent: unknown,
+): Record<string, unknown> | undefined {
   if (toolName !== "Glob" && toolName !== "Grep") {
     return undefined;
   }
 
   const candidates = resultRecordCandidates(rawResult, rawContent);
-  for (const parsed of [parseJsonCandidate(rawResult), parseJsonCandidate(rawContent)]) {
+  for (const parsed of [
+    parseJsonCandidate(rawResult),
+    parseJsonCandidate(rawContent),
+  ]) {
     candidates.push(...resultRecordCandidates(parsed, undefined));
   }
 
   return candidates.find((candidate) => {
     if (toolName === "Glob") {
-      return Array.isArray(candidate.filenames) || "numFiles" in candidate || "truncated" in candidate;
+      return (
+        Array.isArray(candidate.filenames) ||
+        "numFiles" in candidate ||
+        "truncated" in candidate
+      );
     }
     return (
       Array.isArray(candidate.filenames) ||
@@ -1099,31 +1248,52 @@ function firstSearchRecord(toolName: string, rawResult: unknown, rawContent: unk
   });
 }
 
-function recordNumber(record: Record<string, unknown>, key: string): number | undefined {
+function recordNumber(
+  record: Record<string, unknown>,
+  key: string,
+): number | undefined {
   const value = record[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
-function recordNonNegativeInteger(record: Record<string, unknown>, key: string): number | undefined {
+function recordNonNegativeInteger(
+  record: Record<string, unknown>,
+  key: string,
+): number | undefined {
   return nonNegativeInteger(record[key]);
 }
 
-function recordString(record: Record<string, unknown>, key: string): string | undefined {
+function recordString(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
   const value = record[key];
   return typeof value === "string" ? value : undefined;
 }
 
 function searchFilenames(record: Record<string, unknown>): string[] {
   return Array.isArray(record.filenames)
-    ? record.filenames.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    ? record.filenames.filter(
+        (entry): entry is string =>
+          typeof entry === "string" && entry.trim().length > 0,
+      )
     : [];
 }
 
-function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+function pluralize(
+  count: number,
+  singular: string,
+  plural = `${singular}s`,
+): string {
   return count === 1 ? singular : plural;
 }
 
-function truncateList(values: string[], limit: number): { visible: string[]; hidden: number } {
+function truncateList(
+  values: string[],
+  limit: number,
+): { visible: string[]; hidden: number } {
   if (values.length <= limit) {
     return { visible: values, hidden: 0 };
   }
@@ -1139,7 +1309,9 @@ function globResultText(record: Record<string, unknown>): string | undefined {
   if (numFiles === 0 && filenames.length === 0) {
     lines.push("No files found");
   } else {
-    lines.push(`${numFiles} ${pluralize(numFiles, "file")} found${truncated ? " (truncated)" : ""}`);
+    lines.push(
+      `${numFiles} ${pluralize(numFiles, "file")} found${truncated ? " (truncated)" : ""}`,
+    );
   }
 
   if (filenames.length > 0) {
@@ -1169,7 +1341,8 @@ function grepResultText(record: Record<string, unknown>): string | undefined {
     (legacyNumFiles !== 0 || !hasVisibleMatches ? legacyNumFiles : undefined) ??
     (filenames.length > 0 ? filenames.length : undefined);
   const numLines =
-    recordNonNegativeInteger(record, "totalLines") ?? recordNonNegativeInteger(record, "numLines");
+    recordNonNegativeInteger(record, "totalLines") ??
+    recordNonNegativeInteger(record, "numLines");
   const numMatches = recordNumber(record, "numMatches");
   const appliedLimit = recordNumber(record, "appliedLimit");
   const appliedOffset = recordNumber(record, "appliedOffset");
@@ -1193,7 +1366,9 @@ function grepResultText(record: Record<string, unknown>): string | undefined {
     summaryParts.push(`${numFiles} ${pluralize(numFiles, "file")}`);
   }
   if (numMatches !== undefined) {
-    summaryParts.push(`${numMatches} ${pluralize(numMatches, "match", "matches")}`);
+    summaryParts.push(
+      `${numMatches} ${pluralize(numMatches, "match", "matches")}`,
+    );
   }
   if (numLines !== undefined) {
     summaryParts.push(`${numLines} ${pluralize(numLines, "line")}`);
@@ -1213,7 +1388,11 @@ function grepResultText(record: Record<string, unknown>): string | undefined {
   return lines.join("\n");
 }
 
-function searchResultText(toolName: string, rawResult: unknown, rawContent: unknown): string | undefined {
+function searchResultText(
+  toolName: string,
+  rawResult: unknown,
+  rawContent: unknown,
+): string | undefined {
   const record = firstSearchRecord(toolName, rawResult, rawContent);
   if (!record) {
     return undefined;
@@ -1231,14 +1410,22 @@ function worktreeResultFields(
   }
 
   const candidates = resultRecordCandidates(rawResult, rawContent);
-  for (const parsed of [parseJsonCandidate(rawResult), parseJsonCandidate(rawContent)]) {
+  for (const parsed of [
+    parseJsonCandidate(rawResult),
+    parseJsonCandidate(rawContent),
+  ]) {
     candidates.push(...resultRecordCandidates(parsed, undefined));
   }
 
   for (const candidate of candidates) {
     const branch =
-      typeof candidate.worktreeBranch === "string" ? candidate.worktreeBranch.trim() : "";
-    const path = typeof candidate.worktreePath === "string" ? candidate.worktreePath.trim() : "";
+      typeof candidate.worktreeBranch === "string"
+        ? candidate.worktreeBranch.trim()
+        : "";
+    const path =
+      typeof candidate.worktreePath === "string"
+        ? candidate.worktreePath.trim()
+        : "";
     const output = branch ? `Branch: ${branch}` : path ? `Path: ${path}` : "";
     const isStructuredWorktreeOutput =
       "message" in candidate ||
@@ -1257,7 +1444,11 @@ function booleanLabel(value: boolean): string {
   return value ? "yes" : "no";
 }
 
-function pushBooleanField(lines: string[], label: string, value: unknown): void {
+function pushBooleanField(
+  lines: string[],
+  label: string,
+  value: unknown,
+): void {
   if (typeof value === "boolean") {
     lines.push(`${label}: ${booleanLabel(value)}`);
   }
@@ -1315,13 +1506,27 @@ const CRON_WEEKDAY_NAMES = [
 ] as const;
 
 const CRON_MONTH_ALIASES = new Map(
-  ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"].map(
-    (name, index) => [name, index + 1],
-  ),
+  [
+    "JAN",
+    "FEB",
+    "MAR",
+    "APR",
+    "MAY",
+    "JUN",
+    "JUL",
+    "AUG",
+    "SEP",
+    "OCT",
+    "NOV",
+    "DEC",
+  ].map((name, index) => [name, index + 1]),
 );
 
 const CRON_WEEKDAY_ALIASES = new Map(
-  ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"].map((name, index) => [name, index]),
+  ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"].map((name, index) => [
+    name,
+    index,
+  ]),
 );
 
 type CronField =
@@ -1360,14 +1565,18 @@ function parseCronField(
   const stepMatch = raw.match(/^\*\/(\d+)$/);
   if (stepMatch) {
     const step = Number(stepMatch[1]);
-    return Number.isInteger(step) && step > 0 ? { kind: "step", raw, step } : { kind: "unsupported", raw };
+    return Number.isInteger(step) && step > 0
+      ? { kind: "step", raw, step }
+      : { kind: "unsupported", raw };
   }
   if (raw.includes(",")) {
     const values = raw
       .split(",")
       .map((part) => parseCronValue(part, min, max, aliases))
       .filter((value): value is number => value !== undefined);
-    return values.length === raw.split(",").length ? { kind: "list", raw, values } : { kind: "unsupported", raw };
+    return values.length === raw.split(",").length
+      ? { kind: "list", raw, values }
+      : { kind: "unsupported", raw };
   }
   const rangeMatch = raw.match(/^([^/-]+)-([^/-]+)$/);
   if (rangeMatch) {
@@ -1378,7 +1587,9 @@ function parseCronField(
       : { kind: "unsupported", raw };
   }
   const value = parseCronValue(raw, min, max, aliases);
-  return value !== undefined ? { kind: "single", raw, value } : { kind: "unsupported", raw };
+  return value !== undefined
+    ? { kind: "single", raw, value }
+    : { kind: "unsupported", raw };
 }
 
 function isCronAny(field: CronField): boolean {
@@ -1427,14 +1638,16 @@ function weekdayDescription(field: CronField): string | undefined {
     return "day";
   }
   if (field.kind === "list") {
-    const normalized = [...new Set(field.values.map((value) => (value === 7 ? 0 : value)))].sort(
-      (left, right) => left - right,
-    );
+    const normalized = [
+      ...new Set(field.values.map((value) => (value === 7 ? 0 : value))),
+    ].sort((left, right) => left - right);
     if (normalized.length === 2 && normalized[0] === 0 && normalized[1] === 6) {
       return "weekend day";
     }
     const names = normalized.map(weekdayName);
-    return names.every((name): name is string => name !== undefined) ? joinEnglishList(names) : undefined;
+    return names.every((name): name is string => name !== undefined)
+      ? joinEnglishList(names)
+      : undefined;
   }
   return undefined;
 }
@@ -1447,7 +1660,9 @@ function hourlyScheduleText(minute: CronField): string | undefined {
   if (minute.kind !== "single") {
     return undefined;
   }
-  return minute.value === 0 ? "Every hour on the hour" : `Every hour at minute ${padCronNumber(minute.value)}`;
+  return minute.value === 0
+    ? "Every hour on the hour"
+    : `Every hour at minute ${padCronNumber(minute.value)}`;
 }
 
 function cronScheduleFromExpression(cron: string): string | undefined {
@@ -1467,7 +1682,8 @@ function cronScheduleFromExpression(cron: string): string | undefined {
     return undefined;
   }
 
-  const everyDay = isCronAny(dayOfMonth) && isCronAny(month) && isCronAny(dayOfWeek);
+  const everyDay =
+    isCronAny(dayOfMonth) && isCronAny(month) && isCronAny(dayOfWeek);
   if (everyDay && minute.kind === "any" && hour.kind === "any") {
     return "Every minute";
   }
@@ -1478,7 +1694,10 @@ function cronScheduleFromExpression(cron: string): string | undefined {
     return hourlyScheduleText(minute);
   }
   if (everyDay && minute.kind === "single" && hour.kind === "step") {
-    const suffix = minute.value === 0 ? "on the hour" : `at minute ${padCronNumber(minute.value)}`;
+    const suffix =
+      minute.value === 0
+        ? "on the hour"
+        : `at minute ${padCronNumber(minute.value)}`;
     return `Every ${hour.step} ${pluralUnit(hour.step, "hour")} ${suffix}`;
   }
 
@@ -1508,14 +1727,20 @@ function cronScheduleFromExpression(cron: string): string | undefined {
   if (dayOfMonth.kind === "single" && isCronAny(dayOfWeek)) {
     if (month.kind === "single") {
       const monthLabel = monthName(month.value);
-      return monthLabel ? `Every ${monthLabel} ${dayOfMonth.value} at ${time}` : undefined;
+      return monthLabel
+        ? `Every ${monthLabel} ${dayOfMonth.value} at ${time}`
+        : undefined;
     }
     if (month.kind === "step") {
       return `Every ${month.step} ${pluralUnit(month.step, "month")} on day ${dayOfMonth.value} at ${time}`;
     }
   }
 
-  if (isCronAny(dayOfMonth) && month.kind === "single" && isCronAny(dayOfWeek)) {
+  if (
+    isCronAny(dayOfMonth) &&
+    month.kind === "single" &&
+    isCronAny(dayOfWeek)
+  ) {
     const monthLabel = monthName(month.value);
     return monthLabel ? `Every day in ${monthLabel} at ${time}` : undefined;
   }
@@ -1532,13 +1757,20 @@ function normalizeHumanSchedule(value: unknown): string | undefined {
   if (hourlyMinute) {
     const minute = Number(hourlyMinute[1]);
     if (Number.isInteger(minute) && minute >= 0 && minute <= 59) {
-      return hourlyScheduleText({ kind: "single", raw: hourlyMinute[1], value: minute });
+      return hourlyScheduleText({
+        kind: "single",
+        raw: hourlyMinute[1],
+        value: minute,
+      });
     }
   }
   return text;
 }
 
-function readableCronSchedule(cron: unknown, humanSchedule: unknown): string | undefined {
+function readableCronSchedule(
+  cron: unknown,
+  humanSchedule: unknown,
+): string | undefined {
   const cronText = nonEmptyString(cron);
   if (cronText) {
     const derived = cronScheduleFromExpression(cronText);
@@ -1572,15 +1804,23 @@ function cronCreateResultText(
   return lines.join("\n");
 }
 
-function cronDeleteResultText(candidate: Record<string, unknown>): string | undefined {
-  return typeof candidate.id === "string" ? `Schedule ID: ${candidate.id}` : undefined;
+function cronDeleteResultText(
+  candidate: Record<string, unknown>,
+): string | undefined {
+  return typeof candidate.id === "string"
+    ? `Schedule ID: ${candidate.id}`
+    : undefined;
 }
 
-function cronListResultText(candidate: Record<string, unknown>): string | undefined {
+function cronListResultText(
+  candidate: Record<string, unknown>,
+): string | undefined {
   if (!Array.isArray(candidate.jobs)) {
     return undefined;
   }
-  const jobs = candidate.jobs.map(asRecordOrNull).filter((job): job is Record<string, unknown> => job !== null);
+  const jobs = candidate.jobs
+    .map(asRecordOrNull)
+    .filter((job): job is Record<string, unknown> => job !== null);
   if (jobs.length === 0) {
     return "Jobs: none";
   }
@@ -1639,7 +1879,10 @@ function cronResultText(
   }
 
   const candidates = resultRecordCandidates(rawResult, rawContent);
-  for (const parsed of [parseJsonCandidate(rawResult), parseJsonCandidate(rawContent)]) {
+  for (const parsed of [
+    parseJsonCandidate(rawResult),
+    parseJsonCandidate(rawContent),
+  ]) {
     candidates.push(...resultRecordCandidates(parsed, undefined));
   }
 
@@ -1720,7 +1963,10 @@ function scheduleWakeupResultText(
   }
 
   const candidates = resultRecordCandidates(rawResult, rawContent);
-  for (const parsed of [parseJsonCandidate(rawResult), parseJsonCandidate(rawContent)]) {
+  for (const parsed of [
+    parseJsonCandidate(rawResult),
+    parseJsonCandidate(rawContent),
+  ]) {
     candidates.push(...resultRecordCandidates(parsed, undefined));
   }
 
@@ -1733,7 +1979,11 @@ function scheduleWakeupResultText(
       typeof candidate.clampedDelaySeconds === "number"
         ? formatDurationSeconds(candidate.clampedDelaySeconds)
         : undefined;
-    if (!scheduledFor || !clampedDelaySeconds || typeof candidate.wasClamped !== "boolean") {
+    if (
+      !scheduledFor ||
+      !clampedDelaySeconds ||
+      typeof candidate.wasClamped !== "boolean"
+    ) {
       continue;
     }
     return [
@@ -1771,7 +2021,10 @@ function pushNotificationResultText(
 
   const inputMessage = nonEmptyString(asRecordOrNull(rawInput)?.message);
   const candidates = resultRecordCandidates(rawResult, rawContent);
-  for (const parsed of [parseJsonCandidate(rawResult), parseJsonCandidate(rawContent)]) {
+  for (const parsed of [
+    parseJsonCandidate(rawResult),
+    parseJsonCandidate(rawContent),
+  ]) {
     candidates.push(...resultRecordCandidates(parsed, undefined));
   }
 
@@ -1795,11 +2048,16 @@ function pushNotificationResultText(
     }
     pushBooleanField(lines, "Push sent", candidate.pushSent);
     pushBooleanField(lines, "Local sent", candidate.localSent);
-    const disabledReason = pushNotificationDisabledReason(candidate.disabledReason);
+    const disabledReason = pushNotificationDisabledReason(
+      candidate.disabledReason,
+    );
     if (disabledReason) {
       lines.push(`Disabled reason: ${disabledReason}`);
     }
-    if (typeof candidate.idleSec === "number" && Number.isFinite(candidate.idleSec)) {
+    if (
+      typeof candidate.idleSec === "number" &&
+      Number.isFinite(candidate.idleSec)
+    ) {
       lines.push(`Idle time: ${formatDurationSeconds(candidate.idleSec)}`);
     }
     pushBooleanField(lines, "App focused", candidate.hasFocus);
@@ -1856,12 +2114,18 @@ function remoteTriggerResultFields(
   }
 
   const candidates = resultRecordCandidates(rawResult, rawContent);
-  for (const parsed of [parseJsonCandidate(rawResult), parseJsonCandidate(rawContent)]) {
+  for (const parsed of [
+    parseJsonCandidate(rawResult),
+    parseJsonCandidate(rawContent),
+  ]) {
     candidates.push(...resultRecordCandidates(parsed, undefined));
   }
 
   for (const candidate of candidates) {
-    if (typeof candidate.status !== "number" || typeof candidate.json !== "string") {
+    if (
+      typeof candidate.status !== "number" ||
+      typeof candidate.json !== "string"
+    ) {
       continue;
     }
 
@@ -1869,11 +2133,10 @@ function remoteTriggerResultFields(
     const summary = nonEmptyString(candidate.summary);
     if (summary) {
       lines.push(`Summary: ${summary}`);
-    } else {
-      const response = compactParsedJsonString(candidate.json);
-      if (response) {
-        lines.push(`Response: ${response}`);
-      }
+    }
+    const response = compactParsedJsonString(candidate.json);
+    if (response) {
+      lines.push(`Response: ${response}`);
     }
 
     return { output: lines.join("\n"), failed: candidate.status >= 400 };
@@ -1916,7 +2179,10 @@ function replResultFields(
   }
 
   const candidates = resultRecordCandidates(rawResult, rawContent);
-  for (const parsed of [parseJsonCandidate(rawResult), parseJsonCandidate(rawContent)]) {
+  for (const parsed of [
+    parseJsonCandidate(rawResult),
+    parseJsonCandidate(rawContent),
+  ]) {
     candidates.push(...resultRecordCandidates(parsed, undefined));
   }
 
@@ -1950,7 +2216,8 @@ function replResultFields(
 
     if (Array.isArray(candidate.registeredTools)) {
       const registeredTools = candidate.registeredTools.filter(
-        (tool): tool is string => typeof tool === "string" && tool.trim().length > 0,
+        (tool): tool is string =>
+          typeof tool === "string" && tool.trim().length > 0,
       );
       if (registeredTools.length > 0) {
         lines.push(`Registered tools: ${registeredTools.join(", ")}`);
@@ -1976,9 +2243,15 @@ type BackgroundLaunchResult = {
   keepRunning: boolean;
 };
 
-function collectResultCandidates(rawResult: unknown, rawContent: unknown): Record<string, unknown>[] {
+function collectResultCandidates(
+  rawResult: unknown,
+  rawContent: unknown,
+): Record<string, unknown>[] {
   const candidates = resultRecordCandidates(rawResult, rawContent);
-  for (const parsed of [parseJsonCandidate(rawResult), parseJsonCandidate(rawContent)]) {
+  for (const parsed of [
+    parseJsonCandidate(rawResult),
+    parseJsonCandidate(rawContent),
+  ]) {
     candidates.push(...resultRecordCandidates(parsed, undefined));
   }
   return candidates;
@@ -2021,7 +2294,10 @@ function parseSkillResult(
       if (!agentId || typeof candidate.result !== "string") {
         continue;
       }
-      if (candidate.background !== undefined && typeof candidate.background !== "boolean") {
+      if (
+        candidate.background !== undefined &&
+        typeof candidate.background !== "boolean"
+      ) {
         continue;
       }
       return {
@@ -2040,8 +2316,11 @@ function parseSkillResult(
       const allowedToolsValid =
         candidate.allowedTools === undefined ||
         (Array.isArray(candidate.allowedTools) &&
-          candidate.allowedTools.every((tool): tool is string => typeof tool === "string"));
-      const modelValid = candidate.model === undefined || typeof candidate.model === "string";
+          candidate.allowedTools.every(
+            (tool): tool is string => typeof tool === "string",
+          ));
+      const modelValid =
+        candidate.model === undefined || typeof candidate.model === "string";
       if (!allowedToolsValid || !modelValid) {
         continue;
       }
@@ -2068,7 +2347,8 @@ function monitorResultFields(
   for (const candidate of collectResultCandidates(rawResult, rawContent)) {
     const taskId = nonEmptyString(candidate.taskId);
     const timeoutMs =
-      typeof candidate.timeoutMs === "number" && Number.isFinite(candidate.timeoutMs)
+      typeof candidate.timeoutMs === "number" &&
+      Number.isFinite(candidate.timeoutMs)
         ? Math.max(0, Math.trunc(candidate.timeoutMs))
         : undefined;
     const persistent =
@@ -2080,7 +2360,9 @@ function monitorResultFields(
             ? false
             : undefined;
     const isStructuredMonitorOutput =
-      taskId !== undefined || timeoutMs !== undefined || persistent !== undefined;
+      taskId !== undefined ||
+      timeoutMs !== undefined ||
+      persistent !== undefined;
     if (!isStructuredMonitorOutput) {
       continue;
     }
@@ -2230,7 +2512,10 @@ function enterPlanModeStructuredOutputHandled(
   }
 
   const candidates = resultRecordCandidates(rawResult, rawContent);
-  for (const parsed of [parseJsonCandidate(rawResult), parseJsonCandidate(rawContent)]) {
+  for (const parsed of [
+    parseJsonCandidate(rawResult),
+    parseJsonCandidate(rawContent),
+  ]) {
     candidates.push(...resultRecordCandidates(parsed, undefined));
   }
 
@@ -2298,11 +2583,19 @@ function webFetchResultText(
       const codeText = nonEmptyString(candidate.codeText);
       lines.push(`Status: ${candidate.code}${codeText ? ` ${codeText}` : ""}`);
     }
-    if (typeof candidate.bytes === "number" && Number.isFinite(candidate.bytes)) {
+    if (
+      typeof candidate.bytes === "number" &&
+      Number.isFinite(candidate.bytes)
+    ) {
       lines.push(`Bytes: ${Math.max(0, Math.trunc(candidate.bytes))}`);
     }
-    if (typeof candidate.durationMs === "number" && Number.isFinite(candidate.durationMs)) {
-      lines.push(`Duration: ${Math.max(0, Math.trunc(candidate.durationMs))}ms`);
+    if (
+      typeof candidate.durationMs === "number" &&
+      Number.isFinite(candidate.durationMs)
+    ) {
+      lines.push(
+        `Duration: ${Math.max(0, Math.trunc(candidate.durationMs))}ms`,
+      );
     }
     return lines.length > 0 ? lines.join("\n") : undefined;
   }
@@ -2321,11 +2614,17 @@ export function buildToolResultFields(
   const fields: ToolCallUpdateFields = {
     status: isError ? "failed" : "completed",
   };
-  const outputMetadata = extractToolOutputMetadata(toolName, rawResult, rawContent);
+  const outputMetadata = extractToolOutputMetadata(
+    toolName,
+    rawResult,
+    rawContent,
+  );
   if (outputMetadata) {
     fields.output_metadata = outputMetadata;
   }
-  const skillResult = !isError ? parseSkillResult(toolName, rawResult, rawContent) : undefined;
+  const skillResult = !isError
+    ? parseSkillResult(toolName, rawResult, rawContent)
+    : undefined;
   if (skillResult) {
     fields.title = `${SKILL_TOOL_NAME}: ${skillDisplayName(skillResult.commandName)}`;
     if (!skillResult.success) {
@@ -2336,36 +2635,56 @@ export function buildToolResultFields(
       const output = skillResult.result.trim();
       if (output) {
         fields.raw_output = output;
-        fields.content = [{ type: "content", content: { type: "text", text: output } }];
+        fields.content = [
+          { type: "content", content: { type: "text", text: output } },
+        ];
       }
       return fields;
     }
   }
-  const imageReadText = !isError && toolName === "Read"
-    ? imageReadResultText(rawResult, rawContent, base?.raw_input)
-    : undefined;
+  const imageReadText =
+    !isError && toolName === "Read"
+      ? imageReadResultText(rawResult, rawContent, base?.raw_input)
+      : undefined;
   if (imageReadText !== undefined) {
     fields.raw_output = imageReadText;
-    fields.content = [{ type: "content", content: { type: "text", text: imageReadText } }];
+    fields.content = [
+      { type: "content", content: { type: "text", text: imageReadText } },
+    ];
     return fields;
   }
-  const fileUnchangedText = !isError && toolName === "Read" ? fileUnchangedResultText(rawResult, rawContent) : "";
+  const fileUnchangedText =
+    !isError && toolName === "Read"
+      ? fileUnchangedResultText(rawResult, rawContent)
+      : "";
   if (fileUnchangedText) {
     fields.raw_output = fileUnchangedText;
-    fields.content = [{ type: "content", content: { type: "text", text: fileUnchangedText } }];
+    fields.content = [
+      { type: "content", content: { type: "text", text: fileUnchangedText } },
+    ];
     return fields;
   }
-  const agentTitle = !isError && toolName === "Agent"
-    ? agentTitleFromAgentOutput(rawResult, rawContent, base)
-    : "";
+  const agentTitle =
+    !isError && toolName === "Agent"
+      ? agentTitleFromAgentOutput(rawResult, rawContent, base)
+      : "";
   if (agentTitle) {
     fields.title = agentTitle;
   }
-  const readMcpResourceError = mcpResourceReadErrorText(toolName, rawResult, rawContent);
+  const readMcpResourceError = mcpResourceReadErrorText(
+    toolName,
+    rawResult,
+    rawContent,
+  );
   if (readMcpResourceError) {
     fields.status = "failed";
     fields.raw_output = readMcpResourceError;
-    fields.content = [{ type: "content", content: { type: "text", text: readMcpResourceError } }];
+    fields.content = [
+      {
+        type: "content",
+        content: { type: "text", text: readMcpResourceError },
+      },
+    ];
     return fields;
   }
   const readMcpResourceDirOutput = !isError
@@ -2374,20 +2693,31 @@ export function buildToolResultFields(
   if (readMcpResourceDirOutput !== undefined) {
     fields.raw_output = readMcpResourceDirOutput;
     fields.content = [
-      { type: "content", content: { type: "text", text: readMcpResourceDirOutput } },
+      {
+        type: "content",
+        content: { type: "text", text: readMcpResourceDirOutput },
+      },
     ];
     return fields;
   }
-  const searchOutput = !isError ? searchResultText(toolName, rawResult, rawContent) : undefined;
+  const searchOutput = !isError
+    ? searchResultText(toolName, rawResult, rawContent)
+    : undefined;
   if (searchOutput !== undefined) {
     fields.raw_output = searchOutput;
-    fields.content = [{ type: "content", content: { type: "text", text: searchOutput } }];
+    fields.content = [
+      { type: "content", content: { type: "text", text: searchOutput } },
+    ];
     return fields;
   }
-  const webFetchOutput = !isError ? webFetchResultText(toolName, rawResult, rawContent) : undefined;
+  const webFetchOutput = !isError
+    ? webFetchResultText(toolName, rawResult, rawContent)
+    : undefined;
   if (webFetchOutput !== undefined) {
     fields.raw_output = webFetchOutput;
-    fields.content = [{ type: "content", content: { type: "text", text: webFetchOutput } }];
+    fields.content = [
+      { type: "content", content: { type: "text", text: webFetchOutput } },
+    ];
     return fields;
   }
   const worktreeOutput = !isError
@@ -2397,7 +2727,10 @@ export function buildToolResultFields(
     if (worktreeOutput.output) {
       fields.raw_output = worktreeOutput.output;
       fields.content = [
-        { type: "content", content: { type: "text", text: worktreeOutput.output } },
+        {
+          type: "content",
+          content: { type: "text", text: worktreeOutput.output },
+        },
       ];
     }
     return fields;
@@ -2407,7 +2740,9 @@ export function buildToolResultFields(
     : undefined;
   if (cronOutput !== undefined) {
     fields.raw_output = cronOutput;
-    fields.content = [{ type: "content", content: { type: "text", text: cronOutput } }];
+    fields.content = [
+      { type: "content", content: { type: "text", text: cronOutput } },
+    ];
     return fields;
   }
   const scheduleWakeupOutput = !isError
@@ -2416,17 +2751,28 @@ export function buildToolResultFields(
   if (scheduleWakeupOutput !== undefined) {
     fields.raw_output = scheduleWakeupOutput;
     fields.content = [
-      { type: "content", content: { type: "text", text: scheduleWakeupOutput } },
+      {
+        type: "content",
+        content: { type: "text", text: scheduleWakeupOutput },
+      },
     ];
     return fields;
   }
   const pushNotificationOutput = !isError
-    ? pushNotificationResultText(toolName, rawResult, rawContent, base?.raw_input)
+    ? pushNotificationResultText(
+        toolName,
+        rawResult,
+        rawContent,
+        base?.raw_input,
+      )
     : undefined;
   if (pushNotificationOutput !== undefined) {
     fields.raw_output = pushNotificationOutput;
     fields.content = [
-      { type: "content", content: { type: "text", text: pushNotificationOutput } },
+      {
+        type: "content",
+        content: { type: "text", text: pushNotificationOutput },
+      },
     ];
     return fields;
   }
@@ -2436,7 +2782,11 @@ export function buildToolResultFields(
   ) {
     return fields;
   }
-  const remoteTriggerOutput = remoteTriggerResultFields(toolName, rawResult, rawContent);
+  const remoteTriggerOutput = remoteTriggerResultFields(
+    toolName,
+    rawResult,
+    rawContent,
+  );
   if (remoteTriggerOutput !== undefined) {
     if (remoteTriggerOutput.failed) {
       fields.status = "failed";
@@ -2444,7 +2794,10 @@ export function buildToolResultFields(
     if (remoteTriggerOutput.output) {
       fields.raw_output = remoteTriggerOutput.output;
       fields.content = [
-        { type: "content", content: { type: "text", text: remoteTriggerOutput.output } },
+        {
+          type: "content",
+          content: { type: "text", text: remoteTriggerOutput.output },
+        },
       ];
     }
     return fields;
@@ -2474,7 +2827,10 @@ export function buildToolResultFields(
     if (backgroundLaunchOutput.output) {
       fields.raw_output = backgroundLaunchOutput.output;
       fields.content = [
-        { type: "content", content: { type: "text", text: backgroundLaunchOutput.output } },
+        {
+          type: "content",
+          content: { type: "text", text: backgroundLaunchOutput.output },
+        },
       ];
     }
     return fields;
@@ -2490,15 +2846,30 @@ export function buildToolResultFields(
     fields.raw_output = rawOutput;
   }
   if (!isError && isTaskToolName(toolName)) {
-    if (toolName === "TaskUpdate" && taskUpdateSucceeded(rawResult, rawContent) === false) {
+    if (
+      toolName === "TaskUpdate" &&
+      taskUpdateSucceeded(rawResult, rawContent) === false
+    ) {
       fields.status = "failed";
     }
-    const taskOutput = taskToolResultText(toolName, rawResult, rawContent, base?.raw_input);
+    const taskOutput = taskToolResultText(
+      toolName,
+      rawResult,
+      rawContent,
+      base?.raw_input,
+    );
     if (taskOutput) {
-      fields.content = [{ type: "content", content: { type: "text", text: taskOutput } }];
+      fields.content = [
+        { type: "content", content: { type: "text", text: taskOutput } },
+      ];
       return fields;
     }
-    if (toolName === "TaskCreate" || toolName === "TaskUpdate" || toolName === "TaskOutput" || toolName === "TaskStop") {
+    if (
+      toolName === "TaskCreate" ||
+      toolName === "TaskUpdate" ||
+      toolName === "TaskOutput" ||
+      toolName === "TaskStop"
+    ) {
       return fields;
     }
   }
@@ -2528,7 +2899,10 @@ export function buildToolResultFields(
   }
 
   if (!isError && toolName === READ_MCP_RESOURCE_TOOL_NAME) {
-    const structuredResourceContent = mcpResourceContentFromResult(rawResult, rawContent);
+    const structuredResourceContent = mcpResourceContentFromResult(
+      rawResult,
+      rawContent,
+    );
     if (structuredResourceContent.length > 0) {
       fields.content = structuredResourceContent;
       return fields;
@@ -2536,12 +2910,17 @@ export function buildToolResultFields(
   }
 
   if (rawOutput) {
-    fields.content = [{ type: "content", content: { type: "text", text: rawOutput } }];
+    fields.content = [
+      { type: "content", content: { type: "text", text: rawOutput } },
+    ];
   }
   return fields;
 }
 
-export function unwrapToolUseResult(rawResult: unknown): { isError: boolean; content: unknown } {
+export function unwrapToolUseResult(rawResult: unknown): {
+  isError: boolean;
+  content: unknown;
+} {
   if (!rawResult || typeof rawResult !== "object") {
     return { isError: false, content: rawResult };
   }

--- a/agent-sdk/src/bridge/user_interaction.ts
+++ b/agent-sdk/src/bridge/user_interaction.ts
@@ -96,8 +96,12 @@ export async function requestExitPlanModeApproval(
   return { behavior: "allow", updatedInput: inputData, toolUseID: toolUseId };
 }
 
-export function parseAskUserQuestionPrompts(inputData: Record<string, unknown>): AskUserQuestionPrompt[] {
-  const rawQuestions = Array.isArray(inputData.questions) ? inputData.questions : [];
+export function parseAskUserQuestionPrompts(
+  inputData: Record<string, unknown>,
+): AskUserQuestionPrompt[] {
+  const rawQuestions = Array.isArray(inputData.questions)
+    ? inputData.questions
+    : [];
   const prompts: AskUserQuestionPrompt[] = [];
 
   for (const rawQuestion of rawQuestions) {
@@ -105,24 +109,38 @@ export function parseAskUserQuestionPrompts(inputData: Record<string, unknown>):
     if (!questionRecord) {
       continue;
     }
-    const question = typeof questionRecord.question === "string" ? questionRecord.question.trim() : "";
+    const question =
+      typeof questionRecord.question === "string"
+        ? questionRecord.question.trim()
+        : "";
     if (!question) {
       continue;
     }
-    const headerRaw = typeof questionRecord.header === "string" ? questionRecord.header.trim() : "";
+    const headerRaw =
+      typeof questionRecord.header === "string"
+        ? questionRecord.header.trim()
+        : "";
     const header = headerRaw || `Q${prompts.length + 1}`;
     const multiSelect = Boolean(questionRecord.multiSelect);
-    const rawOptions = Array.isArray(questionRecord.options) ? questionRecord.options : [];
+    const rawOptions = Array.isArray(questionRecord.options)
+      ? questionRecord.options
+      : [];
     const options: AskUserQuestionOption[] = [];
     for (const rawOption of rawOptions) {
       const optionRecord = asRecordOrNull(rawOption);
       if (!optionRecord) {
         continue;
       }
-      const label = typeof optionRecord.label === "string" ? optionRecord.label.trim() : "";
+      const label =
+        typeof optionRecord.label === "string" ? optionRecord.label.trim() : "";
       const description =
-        typeof optionRecord.description === "string" ? optionRecord.description.trim() : "";
-      const preview = typeof optionRecord.preview === "string" ? optionRecord.preview.trim() : "";
+        typeof optionRecord.description === "string"
+          ? optionRecord.description.trim()
+          : "";
+      const preview =
+        typeof optionRecord.preview === "string"
+          ? optionRecord.preview.trim()
+          : "";
       if (!label) {
         continue;
       }
@@ -141,7 +159,9 @@ export function parseAskUserQuestionPrompts(inputData: Record<string, unknown>):
   return prompts;
 }
 
-function askUserQuestionOptions(prompt: AskUserQuestionPrompt): QuestionOption[] {
+function askUserQuestionOptions(
+  prompt: AskUserQuestionPrompt,
+): QuestionOption[] {
   return prompt.options.map((option, index) => ({
     option_id: `question_${index}`,
     label: option.label,
@@ -207,7 +227,9 @@ function buildQuestionRequest(
 function askUserQuestionTranscript(
   answers: Array<{ header: string; question: string; answer: string }>,
 ): string {
-  return answers.map((entry) => `${entry.header}: ${entry.answer}\n  ${entry.question}`).join("\n");
+  return answers
+    .map((entry) => `${entry.header}: ${entry.answer}\n  ${entry.question}`)
+    .join("\n");
 }
 
 function askUserQuestionCompletedRawInput(
@@ -228,12 +250,16 @@ function askUserQuestionCompletedRawInput(
       })),
     })),
     answers,
-    ...(Object.keys(annotations).length > 0 ? { annotations: questionAnnotationsJson(annotations) } : {}),
+    ...(Object.keys(annotations).length > 0
+      ? { annotations: questionAnnotationsJson(annotations) }
+      : {}),
     question_results: questionResults,
   };
 }
 
-function questionAnnotationsJson(annotations: Record<string, QuestionAnnotation>): { [key: string]: Json } {
+function questionAnnotationsJson(
+  annotations: Record<string, QuestionAnnotation>,
+): { [key: string]: Json } {
   return Object.fromEntries(
     Object.entries(annotations).map(([question, annotation]) => [
       question,
@@ -255,7 +281,9 @@ function deriveAnnotation(
         .map((option) => option.preview?.trim() ?? "")
         .filter((previewText) => previewText.length > 0)
         .join("\n\n");
-  const notes = annotation?.notes?.trim().length ? annotation.notes.trim() : undefined;
+  const notes = annotation?.notes?.trim().length
+    ? annotation.notes.trim()
+    : undefined;
   if (!preview && !notes) {
     return undefined;
   }
@@ -278,11 +306,20 @@ export async function requestAskUserQuestionAnswers(
 
   const answers: Record<string, string> = {};
   const annotations: Record<string, QuestionAnnotation> = {};
-  const transcript: Array<{ header: string; question: string; answer: string }> = [];
+  const transcript: Array<{
+    header: string;
+    question: string;
+    answer: string;
+  }> = [];
   const questionResults: Json[] = [];
 
   for (const [index, prompt] of prompts.entries()) {
-    const promptToolCall = askUserQuestionPromptToolCall(baseToolCall, prompt, index, prompts.length);
+    const promptToolCall = askUserQuestionPromptToolCall(
+      baseToolCall,
+      prompt,
+      index,
+      prompts.length,
+    );
     const fields: ToolCallUpdateFields = {
       title: promptToolCall.title,
       status: "in_progress",
@@ -290,7 +327,12 @@ export async function requestAskUserQuestionAnswers(
     };
     emitToolCallUpdate(session, toolUseId, fields, "status");
 
-    const request = buildQuestionRequest(promptToolCall, prompt, index, prompts.length);
+    const request = buildQuestionRequest(
+      promptToolCall,
+      prompt,
+      index,
+      prompts.length,
+    );
     const outcome = await new Promise<QuestionOutcome>((resolve) => {
       session.pendingQuestions.set(toolUseId, {
         onOutcome: resolve,
@@ -316,7 +358,11 @@ export async function requestAskUserQuestionAnswers(
 
     if (outcome.outcome !== "answered") {
       setToolCallStatus(session, toolUseId, "failed", "Question cancelled");
-      return { behavior: "deny", message: "Question cancelled", toolUseID: toolUseId };
+      return {
+        behavior: "deny",
+        message: "Question cancelled",
+        toolUseID: toolUseId,
+      };
     }
 
     const selectedOptions = request.prompt.options.filter((option) =>
@@ -326,8 +372,17 @@ export async function requestAskUserQuestionAnswers(
       selectedOptions.length === 0 ||
       (!prompt.multiSelect && selectedOptions.length !== 1)
     ) {
-      setToolCallStatus(session, toolUseId, "failed", "Question answer was invalid");
-      return { behavior: "deny", message: "Question answer was invalid", toolUseID: toolUseId };
+      setToolCallStatus(
+        session,
+        toolUseId,
+        "failed",
+        "Question answer was invalid",
+      );
+      return {
+        behavior: "deny",
+        message: "Question answer was invalid",
+        toolUseID: toolUseId,
+      };
     }
 
     const answer = selectedOptions.map((option) => option.label).join(", ");
@@ -336,7 +391,11 @@ export async function requestAskUserQuestionAnswers(
     if (annotation) {
       annotations[prompt.question] = annotation;
     }
-    transcript.push({ header: prompt.header, question: prompt.question, answer });
+    transcript.push({
+      header: prompt.header,
+      question: prompt.question,
+      answer,
+    });
     questionResults.push({
       question: prompt.question,
       header: prompt.header,
@@ -365,7 +424,14 @@ export async function requestAskUserQuestionAnswers(
       raw_output: summary,
       content: [{ type: "content", content: { type: "text", text: summary } }],
       ...(completed
-        ? { raw_input: askUserQuestionCompletedRawInput(prompts, answers, annotations, questionResults) }
+        ? {
+            raw_input: askUserQuestionCompletedRawInput(
+              prompts,
+              answers,
+              annotations,
+              questionResults,
+            ),
+          }
         : {}),
     };
     emitToolCallUpdate(session, toolUseId, progressFields, "summary");

--- a/agent-sdk/src/types.ts
+++ b/agent-sdk/src/types.ts
@@ -1,4 +1,10 @@
-export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+export type Json =
+  | null
+  | boolean
+  | number
+  | string
+  | Json[]
+  | { [key: string]: Json };
 
 export interface PromptChunk {
   kind: string;
@@ -127,6 +133,16 @@ export interface SettingsParseErrorUpdate {
   message: string;
 }
 
+export interface MessageOrigin {
+  kind: string;
+  subkind?: string;
+  from?: string;
+  name?: string;
+  from_session?: string;
+  sender_task_id?: string;
+  verified_peer_pid?: number;
+}
+
 export type ContentBlock =
   | { type: "text"; text: string }
   | { type: "image"; mime_type?: string; uri?: string; data?: string };
@@ -153,6 +169,7 @@ export interface BashOutputMetadata {
   assistant_auto_backgrounded?: boolean;
   timed_out_after_ms?: number;
   background_cwd_hint?: string;
+  background_ends_with_final_response?: boolean;
 }
 
 export interface AgentOutputMetadata {
@@ -269,6 +286,7 @@ export interface TranscriptRetraction {
   direction?: string;
   original_model?: string;
   fallback_model?: string;
+  scope?: string;
   api_refusal_category?: string;
   api_refusal_explanation?: string;
   content?: string;
@@ -304,9 +322,27 @@ export interface TaskStateUpdate {
 }
 
 export type SessionUpdate =
-  | { type: "agent_message_chunk"; content: ContentBlock; source_message_uuid?: string }
-  | { type: "user_message_chunk"; content: ContentBlock; source_message_uuid?: string }
-  | { type: "agent_thought_chunk"; content: ContentBlock; source_message_uuid?: string }
+  | {
+      type: "agent_message_chunk";
+      content: ContentBlock;
+      source_message_uuid?: string;
+    }
+  | {
+      type: "user_message_chunk";
+      content: ContentBlock;
+      source_message_uuid?: string;
+    }
+  | {
+      type: "external_message_update";
+      content: string;
+      source_message_uuid?: string;
+      origin: MessageOrigin;
+    }
+  | {
+      type: "agent_thought_chunk";
+      content: ContentBlock;
+      source_message_uuid?: string;
+    }
   | { type: "tool_call"; tool_call: ToolCall }
   | { type: "tool_call_update"; tool_call_update: ToolCallUpdate }
   | ({ type: "transcript_retraction" } & TranscriptRetraction)
@@ -340,7 +376,11 @@ export type SessionUpdate =
   | { type: "runtime_session_state_update"; state: RuntimeSessionState }
   | ({ type: "settings_parse_error" } & SettingsParseErrorUpdate)
   | { type: "session_status_update"; status: "requesting" | "idle" }
-  | { type: "system_notice_update"; severity: SystemNoticeSeverity; message: string }
+  | {
+      type: "system_notice_update";
+      severity: SystemNoticeSeverity;
+      message: string;
+    }
   | { type: "compaction_update"; phase: "started" }
   | {
       type: "compaction_update";
@@ -634,6 +674,68 @@ export interface RewindTarget {
   input_text: string;
   index: number;
   previous_assistant_uuid?: string;
+  resume_anchor_uuid?: string;
+}
+
+export interface StructuredUsageWindow {
+  utilization: number;
+  resets_at?: string;
+}
+
+export interface StructuredModelUsageWindow extends StructuredUsageWindow {
+  display_name: string;
+}
+
+export interface StructuredExtraUsage {
+  monthly_limit?: number;
+  used_credits?: number;
+  utilization?: number;
+  currency?: string;
+}
+
+export interface StructuredSessionUsage {
+  total_cost_usd?: number;
+  total_api_duration_ms?: number;
+  total_duration_ms?: number;
+  total_lines_added?: number;
+  total_lines_removed?: number;
+  model_count?: number;
+}
+
+export interface StructuredActivityWindow {
+  request_count: number;
+  session_count: number;
+  behaviors: StructuredBehaviorAttribution[];
+  agents: StructuredNamedAttribution[];
+  skills: StructuredNamedAttribution[];
+  plugins: StructuredNamedAttribution[];
+  mcp_servers: StructuredNamedAttribution[];
+}
+
+export interface StructuredBehaviorAttribution {
+  key: string;
+  pct: number;
+  count: number;
+}
+
+export interface StructuredNamedAttribution {
+  name: string;
+  pct: number;
+}
+
+export interface StructuredUsageSnapshot {
+  subscription_type?: string;
+  rate_limits_available?: boolean;
+  five_hour?: StructuredUsageWindow;
+  seven_day?: StructuredUsageWindow;
+  seven_day_oauth_apps?: StructuredUsageWindow;
+  seven_day_opus?: StructuredUsageWindow;
+  seven_day_sonnet?: StructuredUsageWindow;
+  model_scoped?: StructuredModelUsageWindow[];
+  extra_usage?: StructuredExtraUsage;
+  session?: StructuredSessionUsage;
+  activity_day?: StructuredActivityWindow;
+  activity_week?: StructuredActivityWindow;
 }
 
 export type RewindRestoreMode = "both" | "conversation" | "code";
@@ -672,6 +774,12 @@ export type BridgeCommand =
       session_id: string;
       launch_settings: SessionLaunchSettings;
       metadata?: Record<string, Json>;
+    }
+  | {
+      command: "resume_session_at";
+      session_id: string;
+      target_user_message_id: string;
+      launch_settings: SessionLaunchSettings;
     }
   | {
       command: "prompt";
@@ -753,6 +861,10 @@ export type BridgeCommand =
     }
   | {
       command: "get_context_usage";
+      session_id: string;
+    }
+  | {
+      command: "get_usage";
       session_id: string;
     }
   | {
@@ -852,15 +964,47 @@ export type BridgeEvent =
   | { event: "auth_required"; method_name: string; method_description: string }
   | { event: "connection_failed"; message: string }
   | { event: "session_update"; session_id: string; update: SessionUpdate }
-  | { event: "permission_request"; session_id: string; request: PermissionRequest }
+  | {
+      event: "permission_request";
+      session_id: string;
+      request: PermissionRequest;
+    }
   | { event: "question_request"; session_id: string; request: QuestionRequest }
-  | { event: "user_dialog_request"; session_id: string; request: UserDialogRequestPayload }
-  | { event: "elicitation_request"; session_id: string; request: ElicitationRequest }
-  | { event: "elicitation_complete"; session_id: string; completion: ElicitationComplete }
-  | { event: "mcp_auth_redirect"; session_id: string; redirect: McpAuthRedirect }
-  | { event: "mcp_operation_error"; session_id: string; error: McpOperationError }
-  | { event: "mcp_set_servers_result"; session_id: string; result: McpSetServersResult }
-  | { event: "turn_complete"; session_id: string; terminal_reason?: TerminalReason }
+  | {
+      event: "user_dialog_request";
+      session_id: string;
+      request: UserDialogRequestPayload;
+    }
+  | {
+      event: "elicitation_request";
+      session_id: string;
+      request: ElicitationRequest;
+    }
+  | {
+      event: "elicitation_complete";
+      session_id: string;
+      completion: ElicitationComplete;
+    }
+  | {
+      event: "mcp_auth_redirect";
+      session_id: string;
+      redirect: McpAuthRedirect;
+    }
+  | {
+      event: "mcp_operation_error";
+      session_id: string;
+      error: McpOperationError;
+    }
+  | {
+      event: "mcp_set_servers_result";
+      session_id: string;
+      result: McpSetServersResult;
+    }
+  | {
+      event: "turn_complete";
+      session_id: string;
+      terminal_reason?: TerminalReason;
+    }
   | {
       event: "turn_error";
       session_id: string;
@@ -872,6 +1016,11 @@ export type BridgeEvent =
       terminal_reason?: TerminalReason;
     }
   | { event: "slash_error"; session_id: string; message: string }
+  | {
+      event: "session_resume_failed";
+      session_id: string;
+      message: string;
+    }
   | { event: "runtime_reload_completed"; session_id: string }
   | { event: "runtime_reload_failed"; session_id: string; message: string }
   | {
@@ -895,9 +1044,16 @@ export type BridgeEvent =
       percentage?: number;
     }
   | {
+      event: "usage_snapshot";
+      session_id: string;
+      snapshot?: StructuredUsageSnapshot;
+      error?: string;
+    }
+  | {
       event: "rewind_targets";
       session_id: string;
       targets: RewindTarget[];
+      error?: string;
     }
   | {
       event: "rewind_result";

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.14.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.220"
+        "@anthropic-ai/claude-agent-sdk": "0.3.227"
       },
       "bin": {
         "claude-rs": "bin/claude-rs.js"
@@ -22,22 +22,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
-      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.227.tgz",
+      "integrity": "sha512-jNw9vBjaqHwuLy93d02PSBmounWjzEyO2RKA7/PR+5ooewIH7ceYo40yxaW2rJnGvXvjpLiuk7ZXM6/TFHQ+qQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.227",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.227"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
-      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.227.tgz",
+      "integrity": "sha512-9iL2Q5QSLAVRgAZnXeSag6g2k9e7ZOHktYxL5LzTg05lbcYCeop4eVs7R8+qsJRIHtbGthA919hrnzkq1Ij9GQ==",
       "cpu": [
         "arm64"
       ],
@@ -59,9 +59,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
-      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.227.tgz",
+      "integrity": "sha512-GDdYKtv3wC0kLGS5wrxUf5Oq2hkKW0Nw/CyqcxHEnmeuc8istbQM6dveTK66ufPyI5Q7FiHxmo/kL7YLlFdvtw==",
       "cpu": [
         "x64"
       ],
@@ -72,9 +72,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
-      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.227.tgz",
+      "integrity": "sha512-/Ve9ZVcULeYP6kxaEBFEwCDPAJRl/9O38PgXcOSCYIott6H3IA+4nb51Ee0ljITeA52IPyEo7stbduIjiPsp+g==",
       "cpu": [
         "arm64"
       ],
@@ -88,9 +88,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
-      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.227.tgz",
+      "integrity": "sha512-21cruWs2wTVUYqpDn2z3SgG3fnDmf3tpH7iSw/V1NIrvaiiN+tFfeliIEvZPzLzT26048GEvK6GZcFG5k5mshQ==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
-      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.227.tgz",
+      "integrity": "sha512-eBSNIOauM5+crbIH/f8G1vgGMIMHVwh+NDH6esCRKdbRVvcnE4+urdVFSaKz0G7Ji8c6WGKLQYqrdrAVdPyODw==",
       "cpu": [
         "x64"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
-      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.227.tgz",
+      "integrity": "sha512-YfpJj8YVkzG2MhPOnc24NtErwWRpWYDNxc2Ig359kR4ZbfGKlmonKvkXceUQaeFXSh1LNUZAjsm2Y04XdBaUbQ==",
       "cpu": [
         "x64"
       ],
@@ -136,9 +136,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
-      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.227.tgz",
+      "integrity": "sha512-4vkR0Hn1TI6ypomZcpMTk7h8Wtk1iY59XDtpyk5bk7eMNxuNtlm8a4DX7OS00sn4/I3cUoDOhRpTVA4p7j5oxA==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +149,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
-      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
+      "version": "0.3.227",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.227.tgz",
+      "integrity": "sha512-iCEk00U8o8Y+0fsSCFbFGWGRokrfxo9kCwzBuKPjzvQEux06g7ps/O+Y0q9Nw/4iPCTXgUbekiSNcqg9CWaN9A==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.220"
+    "@anthropic-ai/claude-agent-sdk": "0.3.227"
   },
   "scripts": {
     "prepack": "npm --prefix agent-sdk run build",

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -398,7 +398,8 @@ fn log_bridge_command_sent(
     size_bytes: usize,
 ) {
     match bridge_command {
-        "initialize" | "create_session" | "resume_session" | "new_session" | "shutdown" => {
+        "initialize" | "create_session" | "resume_session" | "resume_session_at"
+        | "new_session" | "shutdown" => {
             tracing::info!(
                 target: crate::logging::targets::BRIDGE_PROTOCOL,
                 event_name = "bridge_command_sent",
@@ -456,7 +457,11 @@ fn log_bridge_event_received(envelope: &EventEnvelope, size_bytes: usize) {
             tool_call_id,
             size_bytes,
         ),
-        "auth_required" | "turn_error" | "slash_error" | "mcp_operation_error" => tracing::warn!(
+        "auth_required"
+        | "turn_error"
+        | "slash_error"
+        | "session_resume_failed"
+        | "mcp_operation_error" => tracing::warn!(
             target: crate::logging::targets::BRIDGE_PROTOCOL,
             event_name = "bridge_event_received",
             message = "bridge event received",
@@ -686,6 +691,13 @@ impl AgentConnection {
         })
     }
 
+    pub fn get_usage(&self, session_id: String) -> anyhow::Result<()> {
+        self.send(CommandEnvelope {
+            request_id: None,
+            command: BridgeCommand::GetUsage { session_id },
+        })
+    }
+
     pub fn get_rewind_targets(&self, session_id: String) -> anyhow::Result<()> {
         self.send(CommandEnvelope {
             request_id: None,
@@ -869,6 +881,23 @@ impl AgentConnection {
                 session_id,
                 launch_settings,
                 metadata: std::collections::BTreeMap::new(),
+            },
+        })
+    }
+
+    pub fn resume_session_at(
+        &self,
+        session_id: String,
+        target_user_message_id: String,
+        launch_settings: SessionLaunchSettings,
+        operation_id: String,
+    ) -> anyhow::Result<()> {
+        self.send(CommandEnvelope {
+            request_id: Some(operation_id),
+            command: BridgeCommand::ResumeSessionAt {
+                session_id,
+                target_user_message_id,
+                launch_settings,
             },
         })
     }
@@ -1211,6 +1240,19 @@ mod tests {
     }
 
     #[test]
+    fn get_usage_sends_bridge_command() {
+        let (conn, mut rx) = AgentConnection::test_channel();
+
+        conn.get_usage("session-1".to_owned()).expect("structured usage");
+
+        let envelope = rx.try_recv().expect("command");
+        assert_eq!(
+            envelope.command,
+            BridgeCommand::GetUsage { session_id: "session-1".to_owned() }
+        );
+    }
+
+    #[test]
     fn reload_plugins_sends_bridge_command() {
         let (conn, mut rx) = AgentConnection::test_channel();
 
@@ -1233,6 +1275,30 @@ mod tests {
         assert_eq!(
             envelope.command,
             BridgeCommand::GetRewindTargets { session_id: "session-1".to_owned() }
+        );
+    }
+
+    #[test]
+    fn resume_session_at_sends_request_correlated_bridge_command() {
+        let (conn, mut rx) = AgentConnection::test_channel();
+
+        conn.resume_session_at(
+            "session-1".to_owned(),
+            "user-2".to_owned(),
+            crate::agent::wire::SessionLaunchSettings::default(),
+            "resume-at-1".to_owned(),
+        )
+        .expect("resume-at command");
+
+        let envelope = rx.try_recv().expect("command");
+        assert_eq!(envelope.request_id.as_deref(), Some("resume-at-1"));
+        assert_eq!(
+            envelope.command,
+            BridgeCommand::ResumeSessionAt {
+                session_id: "session-1".to_owned(),
+                target_user_message_id: "user-2".to_owned(),
+                launch_settings: crate::agent::wire::SessionLaunchSettings::default(),
+            }
         );
     }
 

--- a/src/agent/events.rs
+++ b/src/agent/events.rs
@@ -94,6 +94,8 @@ pub enum ClientEvent {
     AuthRequired { method_name: String, method_description: String },
     /// Slash-command execution failed with a user-facing error.
     SlashCommandError { session_id: Option<String>, message: String },
+    /// A request-correlated resume-at operation failed before replacing the active session.
+    SessionResumeFailed { session_id: String, operation_id: String, message: String },
     /// Terminal ownership was handed to a child process.
     TerminalReleasedToChild { reason: ReleaseReason },
     /// Terminal ownership returned from a child process.
@@ -128,8 +130,17 @@ pub enum ClientEvent {
     StatusSnapshotReceived { session_id: String, account: model::AccountInfo },
     /// Session context window usage received from bridge.
     ContextUsageReceived { session_id: String, percentage: Option<u8> },
+    StructuredUsageReceived {
+        session_id: String,
+        snapshot: Option<crate::agent::types::StructuredUsageSnapshot>,
+        error: Option<String>,
+    },
     /// Rewind target candidates loaded from persisted SDK session history.
-    RewindTargetsReceived { session_id: String, targets: Vec<model::RewindTarget> },
+    RewindTargetsReceived {
+        session_id: String,
+        targets: Vec<model::RewindTarget>,
+        error: Option<String>,
+    },
     /// Result of a rewind operation that touched files.
     RewindResultReceived { result: model::RewindResult },
     /// MCP server snapshot received from bridge.
@@ -187,19 +198,21 @@ impl ClientEvent {
             | Self::RuntimeReloadFailed { session_id, .. }
             | Self::StatusSnapshotReceived { session_id, .. }
             | Self::ContextUsageReceived { session_id, .. }
-            | Self::RewindTargetsReceived { session_id, .. }
+            | Self::StructuredUsageReceived { session_id, .. }
             | Self::McpSnapshotReceived { session_id, .. } => Some(session_id),
             Self::SlashCommandError { session_id, .. } => session_id.as_deref(),
             Self::RewindResultReceived { result } => Some(result.session_id.as_str()),
             Self::Connected { .. }
             | Self::ConnectionFailed(_)
             | Self::AuthRequired { .. }
+            | Self::SessionResumeFailed { .. }
             | Self::McpConfigRemoveSucceeded { .. }
             | Self::McpConfigRemoveFailed { .. }
             | Self::TerminalReleasedToChild { .. }
             | Self::TerminalReturnedFromChild { .. }
             | Self::SessionReplaced { .. }
             | Self::SessionsListed { .. }
+            | Self::RewindTargetsReceived { .. }
             | Self::UpdateAvailable { .. }
             | Self::ServiceStatus { .. }
             | Self::AuthCompleted { .. }

--- a/src/agent/model/rewind.rs
+++ b/src/agent/model/rewind.rs
@@ -9,6 +9,7 @@ pub struct RewindTarget {
     pub input_text: String,
     pub index: u64,
     pub previous_assistant_uuid: Option<String>,
+    pub resume_anchor_uuid: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/agent/model/session.rs
+++ b/src/agent/model/session.rs
@@ -186,15 +186,35 @@ pub struct TranscriptRetraction {
     pub direction: Option<String>,
     pub original_model: Option<String>,
     pub fallback_model: Option<String>,
+    pub scope: Option<String>,
     pub api_refusal_category: Option<String>,
     pub api_refusal_explanation: Option<String>,
     pub content: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageOrigin {
+    pub kind: String,
+    pub subkind: Option<String>,
+    pub from: Option<String>,
+    pub name: Option<String>,
+    pub from_session: Option<String>,
+    pub sender_task_id: Option<String>,
+    pub verified_peer_pid: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExternalMessageUpdate {
+    pub content: String,
+    pub source_message_uuid: Option<String>,
+    pub origin: MessageOrigin,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum SessionUpdate {
     AgentMessageChunk(ContentChunk),
     UserMessageChunk(ContentChunk),
+    ExternalMessageUpdate(ExternalMessageUpdate),
     AgentThoughtChunk(ContentChunk),
     ToolCall(ToolCall),
     ToolCallUpdate(ToolCallUpdate),

--- a/src/agent/model/tools.rs
+++ b/src/agent/model/tools.rs
@@ -314,6 +314,7 @@ pub struct BashOutputMetadata {
     pub assistant_auto_backgrounded: Option<bool>,
     pub timed_out_after_ms: Option<u64>,
     pub background_cwd_hint: Option<String>,
+    pub background_ends_with_final_response: Option<bool>,
 }
 
 impl BashOutputMetadata {
@@ -340,6 +341,15 @@ impl BashOutputMetadata {
     #[must_use]
     pub fn background_cwd_hint(mut self, background_cwd_hint: Option<String>) -> Self {
         self.background_cwd_hint = background_cwd_hint;
+        self
+    }
+
+    #[must_use]
+    pub fn background_ends_with_final_response(
+        mut self,
+        background_ends_with_final_response: Option<bool>,
+    ) -> Self {
+        self.background_ends_with_final_response = background_ends_with_final_response;
         self
     }
 }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -32,6 +32,84 @@ pub struct RewindTarget {
     pub input_text: String,
     pub index: u64,
     pub previous_assistant_uuid: Option<String>,
+    pub resume_anchor_uuid: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StructuredUsageWindow {
+    pub utilization: f64,
+    pub resets_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StructuredModelUsageWindow {
+    pub display_name: String,
+    pub utilization: f64,
+    pub resets_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StructuredExtraUsage {
+    pub monthly_limit: Option<f64>,
+    pub used_credits: Option<f64>,
+    pub utilization: Option<f64>,
+    pub currency: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StructuredSessionUsage {
+    pub total_cost_usd: Option<f64>,
+    pub total_api_duration_ms: Option<f64>,
+    pub total_duration_ms: Option<f64>,
+    pub total_lines_added: Option<f64>,
+    pub total_lines_removed: Option<f64>,
+    pub model_count: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StructuredActivityWindow {
+    pub request_count: u64,
+    pub session_count: u64,
+    #[serde(default)]
+    pub behaviors: Vec<StructuredBehaviorAttribution>,
+    #[serde(default)]
+    pub agents: Vec<StructuredNamedAttribution>,
+    #[serde(default)]
+    pub skills: Vec<StructuredNamedAttribution>,
+    #[serde(default)]
+    pub plugins: Vec<StructuredNamedAttribution>,
+    #[serde(default)]
+    pub mcp_servers: Vec<StructuredNamedAttribution>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StructuredBehaviorAttribution {
+    pub key: String,
+    pub pct: f64,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StructuredNamedAttribution {
+    pub name: String,
+    pub pct: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StructuredUsageSnapshot {
+    pub subscription_type: Option<String>,
+    pub rate_limits_available: Option<bool>,
+    pub five_hour: Option<StructuredUsageWindow>,
+    pub seven_day: Option<StructuredUsageWindow>,
+    pub seven_day_oauth_apps: Option<StructuredUsageWindow>,
+    pub seven_day_opus: Option<StructuredUsageWindow>,
+    pub seven_day_sonnet: Option<StructuredUsageWindow>,
+    #[serde(default)]
+    pub model_scoped: Vec<StructuredModelUsageWindow>,
+    pub extra_usage: Option<StructuredExtraUsage>,
+    pub session: Option<StructuredSessionUsage>,
+    pub activity_day: Option<StructuredActivityWindow>,
+    pub activity_week: Option<StructuredActivityWindow>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -185,6 +263,17 @@ pub struct SettingsParseErrorUpdate {
     pub message: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageOrigin {
+    pub kind: String,
+    pub subkind: Option<String>,
+    pub from: Option<String>,
+    pub name: Option<String>,
+    pub from_session: Option<String>,
+    pub sender_task_id: Option<String>,
+    pub verified_peer_pid: Option<u64>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RateLimitUpdate {
     pub status: RateLimitStatus,
@@ -295,6 +384,7 @@ pub struct TranscriptRetraction {
     pub direction: Option<String>,
     pub original_model: Option<String>,
     pub fallback_model: Option<String>,
+    pub scope: Option<String>,
     pub api_refusal_category: Option<String>,
     pub api_refusal_explanation: Option<String>,
     pub content: Option<String>,
@@ -325,6 +415,7 @@ pub struct BashOutputMetadata {
     pub assistant_auto_backgrounded: Option<bool>,
     pub timed_out_after_ms: Option<u64>,
     pub background_cwd_hint: Option<String>,
+    pub background_ends_with_final_response: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -475,6 +566,11 @@ pub enum SessionUpdate {
     UserMessageChunk {
         content: ContentBlock,
         source_message_uuid: Option<String>,
+    },
+    ExternalMessageUpdate {
+        content: String,
+        source_message_uuid: Option<String>,
+        origin: MessageOrigin,
     },
     AgentThoughtChunk {
         content: ContentBlock,
@@ -1473,6 +1569,7 @@ mod tests {
             "direction": "retry",
             "original_model": "claude-opus-4-1",
             "fallback_model": "claude-sonnet-4-5",
+            "scope": "local",
             "api_refusal_category": "cyber",
             "api_refusal_explanation": "policy text",
             "content": "Retried with fallback model"
@@ -1487,6 +1584,7 @@ mod tests {
         assert_eq!(retraction.request_id.as_deref(), Some("req-1"));
         assert_eq!(retraction.original_model.as_deref(), Some("claude-opus-4-1"));
         assert_eq!(retraction.fallback_model.as_deref(), Some("claude-sonnet-4-5"));
+        assert_eq!(retraction.scope.as_deref(), Some("local"));
     }
 
     #[test]

--- a/src/agent/wire.rs
+++ b/src/agent/wire.rs
@@ -55,6 +55,12 @@ pub enum BridgeCommand {
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
         metadata: BTreeMap<String, serde_json::Value>,
     },
+    ResumeSessionAt {
+        session_id: String,
+        target_user_message_id: String,
+        #[serde(default, skip_serializing_if = "SessionLaunchSettings::is_empty")]
+        launch_settings: SessionLaunchSettings,
+    },
     Prompt {
         session_id: String,
         chunks: Vec<types::PromptChunk>,
@@ -123,6 +129,9 @@ pub enum BridgeCommand {
     GetContextUsage {
         session_id: String,
     },
+    GetUsage {
+        session_id: String,
+    },
     GetRewindTargets {
         session_id: String,
     },
@@ -176,6 +185,7 @@ impl BridgeCommand {
             Self::Initialize { .. } => "initialize",
             Self::CreateSession { .. } => "create_session",
             Self::ResumeSession { .. } => "resume_session",
+            Self::ResumeSessionAt { .. } => "resume_session_at",
             Self::Prompt { .. } => "prompt",
             Self::CancelTurn { .. } => "cancel_turn",
             Self::SetModel { .. } => "set_model",
@@ -192,6 +202,7 @@ impl BridgeCommand {
             Self::ElicitationResponse { .. } => "elicitation_response",
             Self::GetStatusSnapshot { .. } => "get_status_snapshot",
             Self::GetContextUsage { .. } => "get_context_usage",
+            Self::GetUsage { .. } => "get_usage",
             Self::GetRewindTargets { .. } => "get_rewind_targets",
             Self::Rewind { .. } => "rewind",
             Self::ReloadPlugins { .. } => "reload_plugins",
@@ -210,6 +221,7 @@ impl BridgeCommand {
     pub fn session_id(&self) -> Option<&str> {
         match self {
             Self::ResumeSession { session_id, .. }
+            | Self::ResumeSessionAt { session_id, .. }
             | Self::Prompt { session_id, .. }
             | Self::CancelTurn { session_id }
             | Self::SetModel { session_id, .. }
@@ -225,6 +237,7 @@ impl BridgeCommand {
             | Self::ElicitationResponse { session_id, .. }
             | Self::GetStatusSnapshot { session_id }
             | Self::GetContextUsage { session_id }
+            | Self::GetUsage { session_id }
             | Self::GetRewindTargets { session_id }
             | Self::Rewind { session_id, .. }
             | Self::ReloadPlugins { session_id }
@@ -248,6 +261,7 @@ impl BridgeCommand {
             Self::Initialize { .. }
             | Self::CreateSession { .. }
             | Self::ResumeSession { .. }
+            | Self::ResumeSessionAt { .. }
             | Self::Prompt { .. }
             | Self::CancelTurn { .. }
             | Self::SetModel { .. }
@@ -262,6 +276,7 @@ impl BridgeCommand {
             | Self::ElicitationResponse { .. }
             | Self::GetStatusSnapshot { .. }
             | Self::GetContextUsage { .. }
+            | Self::GetUsage { .. }
             | Self::GetRewindTargets { .. }
             | Self::Rewind { .. }
             | Self::ReloadPlugins { .. }
@@ -363,6 +378,10 @@ pub enum BridgeEvent {
         session_id: String,
         message: String,
     },
+    SessionResumeFailed {
+        session_id: String,
+        message: String,
+    },
     RuntimeReloadCompleted {
         session_id: String,
     },
@@ -396,9 +415,15 @@ pub enum BridgeEvent {
         session_id: String,
         percentage: Option<u8>,
     },
+    UsageSnapshot {
+        session_id: String,
+        snapshot: Option<types::StructuredUsageSnapshot>,
+        error: Option<String>,
+    },
     RewindTargets {
         session_id: String,
         targets: Vec<types::RewindTarget>,
+        error: Option<String>,
     },
     RewindResult {
         session_id: String,
@@ -439,6 +464,7 @@ impl BridgeEvent {
             Self::TurnComplete { .. } => "turn_complete",
             Self::TurnError { .. } => "turn_error",
             Self::SlashError { .. } => "slash_error",
+            Self::SessionResumeFailed { .. } => "session_resume_failed",
             Self::RuntimeReloadCompleted { .. } => "runtime_reload_completed",
             Self::RuntimeReloadFailed { .. } => "runtime_reload_failed",
             Self::SessionReplaced { .. } => "session_replaced",
@@ -446,6 +472,7 @@ impl BridgeEvent {
             Self::SessionsListed { .. } => "sessions_listed",
             Self::StatusSnapshot { .. } => "status_snapshot",
             Self::ContextUsage { .. } => "context_usage",
+            Self::UsageSnapshot { .. } => "usage_snapshot",
             Self::RewindTargets { .. } => "rewind_targets",
             Self::RewindResult { .. } => "rewind_result",
             Self::McpSnapshot { .. } => "mcp_snapshot",
@@ -468,11 +495,13 @@ impl BridgeEvent {
             | Self::TurnComplete { session_id, .. }
             | Self::TurnError { session_id, .. }
             | Self::SlashError { session_id, .. }
+            | Self::SessionResumeFailed { session_id, .. }
             | Self::RuntimeReloadCompleted { session_id, .. }
             | Self::RuntimeReloadFailed { session_id, .. }
             | Self::SessionReplaced { session_id, .. }
             | Self::StatusSnapshot { session_id, .. }
             | Self::ContextUsage { session_id, .. }
+            | Self::UsageSnapshot { session_id, .. }
             | Self::RewindTargets { session_id, .. }
             | Self::RewindResult { session_id, .. }
             | Self::McpSnapshot { session_id, .. } => Some(session_id.as_str()),
@@ -503,6 +532,7 @@ impl BridgeEvent {
             | Self::TurnComplete { .. }
             | Self::TurnError { .. }
             | Self::SlashError { .. }
+            | Self::SessionResumeFailed { .. }
             | Self::RuntimeReloadCompleted { .. }
             | Self::RuntimeReloadFailed { .. }
             | Self::SessionReplaced { .. }
@@ -510,6 +540,7 @@ impl BridgeEvent {
             | Self::SessionsListed { .. }
             | Self::StatusSnapshot { .. }
             | Self::ContextUsage { .. }
+            | Self::UsageSnapshot { .. }
             | Self::RewindTargets { .. }
             | Self::RewindResult { .. }
             | Self::McpSnapshot { .. } => None,
@@ -537,6 +568,26 @@ mod tests {
         let json = serde_json::to_string(&env).expect("serialize");
         let decoded: CommandEnvelope = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(decoded, env);
+    }
+
+    #[test]
+    fn session_resume_failed_event_deserializes_with_operation_identity() {
+        let decoded: EventEnvelope = serde_json::from_value(serde_json::json!({
+            "request_id": "resume-at-1",
+            "event": "session_resume_failed",
+            "session_id": "source-session",
+            "message": "resume rejected"
+        }))
+        .expect("deserialize resume failure");
+
+        assert_eq!(decoded.request_id.as_deref(), Some("resume-at-1"));
+        assert_eq!(
+            decoded.event,
+            BridgeEvent::SessionResumeFailed {
+                session_id: "source-session".to_owned(),
+                message: "resume rejected".to_owned(),
+            }
+        );
     }
 
     #[test]
@@ -656,6 +707,42 @@ mod tests {
                 "session_id": "s1"
             })
         );
+    }
+
+    #[test]
+    fn structured_usage_event_deserializes_tolerant_snapshot() {
+        let decoded: EventEnvelope = serde_json::from_value(serde_json::json!({
+            "event": "usage_snapshot",
+            "session_id": "session-1",
+            "snapshot": {
+                "rate_limits_available": true,
+                "five_hour": {
+                    "utilization": 42.0,
+                    "resets_at": "2026-08-12T10:00:00Z"
+                },
+                "session": {
+                    "total_cost_usd": 0.125,
+                    "total_lines_added": 12.0,
+                    "model_count": 2
+                },
+                "activity_day": {
+                    "request_count": 4,
+                    "session_count": 2
+                }
+            }
+        }))
+        .expect("deserialize structured usage");
+
+        let BridgeEvent::UsageSnapshot { session_id, snapshot: Some(snapshot), error } =
+            decoded.event
+        else {
+            panic!("expected usage snapshot event");
+        };
+        assert_eq!(session_id, "session-1");
+        assert!(error.is_none());
+        assert_eq!(snapshot.five_hour.map(|window| window.utilization), Some(42.0));
+        assert_eq!(snapshot.session.and_then(|session| session.model_count), Some(2));
+        assert_eq!(snapshot.activity_day.map(|window| window.request_count), Some(4));
     }
 
     #[test]
@@ -940,6 +1027,7 @@ mod tests {
                     "first_text": "second prompt",
                     "input_text": "second prompt",
                     "previous_assistant_uuid": "assistant-1",
+                    "resume_anchor_uuid": "assistant-1",
                     "index": 3
                 },
                 {
@@ -963,6 +1051,7 @@ mod tests {
                         input_text: "second prompt".to_owned(),
                         index: 3,
                         previous_assistant_uuid: Some("assistant-1".to_owned()),
+                        resume_anchor_uuid: Some("assistant-1".to_owned()),
                     },
                     types::RewindTarget {
                         uuid: "user-1".to_owned(),
@@ -970,8 +1059,10 @@ mod tests {
                         input_text: "first prompt".to_owned(),
                         index: 0,
                         previous_assistant_uuid: None,
+                        resume_anchor_uuid: None,
                     },
                 ],
+                error: None,
             }
         );
     }

--- a/src/app/config/edit.rs
+++ b/src/app/config/edit.rs
@@ -82,7 +82,10 @@ pub(super) fn activate_setting(app: &mut App, spec: &SettingSpec) {
         SettingId::Model => open_model_overlay(app),
         SettingId::OutputStyle => open_output_style_overlay(app),
         SettingId::ThinkingEffort => open_thinking_effort_overlay(app),
-        SettingId::Theme | SettingId::Notifications | SettingId::EditorMode => {
+        SettingId::CrossSessionInbound
+        | SettingId::Theme
+        | SettingId::Notifications
+        | SettingId::EditorMode => {
             cycle_static_enum(app, spec, 1);
         }
     }
@@ -116,7 +119,10 @@ pub(super) fn step_setting(app: &mut App, spec: &SettingSpec, delta: isize) {
                 store::set_default_permission_mode(document, next);
             });
         }
-        SettingId::Theme | SettingId::Notifications | SettingId::EditorMode => {
+        SettingId::CrossSessionInbound
+        | SettingId::Theme
+        | SettingId::Notifications
+        | SettingId::EditorMode => {
             cycle_static_enum(app, spec, delta);
         }
         SettingId::Language
@@ -402,11 +408,15 @@ where
             }
             app.reconcile_runtime_from_persisted_settings_change();
             app.config.last_error = None;
-            app.config.status_message = Some(format!(
-                "Saved {}: {}",
-                spec.label,
-                setting_display_value(app, spec, &resolved_setting(app, spec))
-            ));
+            let value = setting_display_value(app, spec, &resolved_setting(app, spec));
+            app.config.status_message = Some(if spec.id == SettingId::CrossSessionInbound {
+                format!(
+                    "Saved {}: {} for future sessions. The running session is unchanged; resume or start a new session to apply it.",
+                    spec.label, value
+                )
+            } else {
+                format!("Saved {}: {}", spec.label, value)
+            });
             true
         }
         Err(err) => {
@@ -457,6 +467,7 @@ const fn default_static_value(setting_id: SettingId) -> &'static str {
         SettingId::Theme => "dark",
         SettingId::OutputStyle => OutputStyle::Default.as_stored(),
         SettingId::ThinkingEffort => "medium",
+        SettingId::CrossSessionInbound => "refuse",
         SettingId::Notifications => "iterm2",
         SettingId::EditorMode => "default",
         SettingId::AlwaysThinking

--- a/src/app/config/resolve.rs
+++ b/src/app/config/resolve.rs
@@ -21,6 +21,7 @@ pub(super) fn resolve_setting_document(
         SettingId::DefaultPermissionMode => {
             resolve_string_setting(document, spec, DefaultPermissionMode::Default.as_stored())
         }
+        SettingId::CrossSessionInbound => resolve_string_setting(document, spec, "refuse"),
         SettingId::Language => resolve_language_setting(document, spec),
         SettingId::ShowTips | SettingId::RespectGitignore | SettingId::TerminalProgressBar => {
             resolve_bool_setting(document, spec, true)

--- a/src/app/config/settings.rs
+++ b/src/app/config/settings.rs
@@ -8,6 +8,7 @@ use super::status::model_status_label;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SettingId {
     AlwaysThinking,
+    CrossSessionInbound,
     Model,
     DefaultPermissionMode,
     EditorMode,
@@ -312,12 +313,16 @@ const EDITOR_MODE_OPTIONS: &[SettingOption] = &[
     SettingOption { stored: "default", label: "Default" },
     SettingOption { stored: "vim", label: "Vim" },
 ];
+const CROSS_SESSION_INBOUND_OPTIONS: &[SettingOption] = &[
+    SettingOption { stored: "refuse", label: "Refuse" },
+    SettingOption { stored: "accept", label: "Accept" },
+];
 pub(crate) const DEFAULT_MODEL_ALIAS_ID: &str = "fable";
 pub(crate) const DEFAULT_MODEL_ALIAS_LABEL: &str = "Fable 5";
 pub(crate) const LANGUAGE_MIN_CHARS: usize = 2;
 pub(crate) const LANGUAGE_MAX_CHARS: usize = 30;
 
-const CONFIG_SETTINGS: [SettingSpec; 14] = [
+const CONFIG_SETTINGS: [SettingSpec; 15] = [
     SettingSpec {
         id: SettingId::AlwaysThinking,
         entry_id: "A04",
@@ -329,6 +334,20 @@ const CONFIG_SETTINGS: [SettingSpec; 14] = [
         editor: EditorKind::Toggle,
         source: ValueSource::PersistedOnly,
         options: SettingOptions::None,
+        fallback: FallbackPolicy::AppDefault,
+        supported: true,
+    },
+    SettingSpec {
+        id: SettingId::CrossSessionInbound,
+        entry_id: "A21",
+        label: "Cross-session messages",
+        description: "Controls messages sent by your other Claude sessions. Refuse is the safe default; Accept is an explicit local opt-in. Changes apply when a session starts or resumes, not to the running session. Hold and automatic mode are unavailable because the Agent SDK exposes no held-message review API.",
+        file: SettingFile::LocalSettings,
+        json_path: &["crossSessionInbound"],
+        kind: SettingKind::Enum,
+        editor: EditorKind::Cycle,
+        source: ValueSource::PersistedOnly,
+        options: SettingOptions::Static(CROSS_SESSION_INBOUND_OPTIONS),
         fallback: FallbackPolicy::AppDefault,
         supported: true,
     },

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -282,6 +282,12 @@ fn space_persists_setting_toggles_to_the_expected_document() {
             vec!["terminalProgressBarEnabled"],
             Value::Bool(false),
         ),
+        (
+            SettingId::CrossSessionInbound,
+            ".claude/settings.local.json",
+            vec!["crossSessionInbound"],
+            Value::String("accept".to_owned()),
+        ),
     ];
 
     for (setting_id, relative_path, json_path, expected) in cases {
@@ -295,6 +301,14 @@ fn space_persists_setting_toggles_to_the_expected_document() {
         let saved = read_json_file(&path);
         assert_eq!(json_at(&saved, &json_path), Some(&expected));
         assert!(app.config.last_error.is_none());
+        if setting_id == SettingId::CrossSessionInbound {
+            assert_eq!(
+                app.config.status_message.as_deref(),
+                Some(
+                    "Saved Cross-session messages: Accept for future sessions. The running session is unchanged; resume or start a new session to apply it."
+                )
+            );
+        }
     }
 }
 

--- a/src/app/connect/bridge_lifecycle.rs
+++ b/src/app/connect/bridge_lifecycle.rs
@@ -688,7 +688,7 @@ mod tests {
             let dispatch =
                 handle_bridge_event(&event_tx, &connection, &mut connected_once, false, envelope);
             tokio::pin!(dispatch);
-            let marker = wait_for_file(&marker_path);
+            let marker = wait_for_nonempty_file(&marker_path);
             tokio::pin!(marker);
 
             tokio::select! {
@@ -737,11 +737,14 @@ mod tests {
         r#"{"event":"initialized","result":{"agent_name":"test","agent_version":"0","auth_methods":[],"capabilities":{"prompt_image":false,"prompt_embedded_context":false,"supports_session_listing":false,"supports_resume_session":false}}}"#
     }
 
-    async fn wait_for_file(path: &Path) -> std::io::Result<String> {
+    async fn wait_for_nonempty_file(path: &Path) -> std::io::Result<String> {
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
                 match fs::read_to_string(path) {
-                    Ok(contents) => return Ok(contents),
+                    Ok(contents) if !contents.is_empty() => return Ok(contents),
+                    Ok(_) => {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
                     Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                         tokio::time::sleep(Duration::from_millis(10)).await;
                     }

--- a/src/app/connect/event_dispatch.rs
+++ b/src/app/connect/event_dispatch.rs
@@ -40,7 +40,8 @@ pub(super) async fn handle_bridge_event(
     resume_requested: bool,
     envelope: EventEnvelope,
 ) {
-    match envelope.event {
+    let EventEnvelope { request_id, event } = envelope;
+    match event {
         crate::agent::wire::BridgeEvent::Connected {
             session_id,
             cwd,
@@ -157,6 +158,21 @@ pub(super) async fn handle_bridge_event(
                 .send(ClientEvent::SlashCommandError { session_id: Some(session_id), message })
                 .await;
         }
+        crate::agent::wire::BridgeEvent::SessionResumeFailed { session_id, message } => {
+            if let Some(operation_id) = request_id {
+                let _ = event_tx
+                    .send(ClientEvent::SessionResumeFailed { session_id, operation_id, message })
+                    .await;
+            } else {
+                tracing::error!(
+                    target: crate::logging::targets::BRIDGE_PROTOCOL,
+                    event_name = "session_resume_failure_missing_request_id",
+                    message = "session resume failure omitted its required request id",
+                    outcome = "failure",
+                    session_id,
+                );
+            }
+        }
         crate::agent::wire::BridgeEvent::RuntimeReloadCompleted { session_id } => {
             let _ = event_tx.send(ClientEvent::RuntimeReloadCompleted { session_id }).await;
         }
@@ -209,11 +225,17 @@ pub(super) async fn handle_bridge_event(
             let _ =
                 event_tx.send(ClientEvent::ContextUsageReceived { session_id, percentage }).await;
         }
-        crate::agent::wire::BridgeEvent::RewindTargets { session_id, targets } => {
+        crate::agent::wire::BridgeEvent::UsageSnapshot { session_id, snapshot, error } => {
+            let _ = event_tx
+                .send(ClientEvent::StructuredUsageReceived { session_id, snapshot, error })
+                .await;
+        }
+        crate::agent::wire::BridgeEvent::RewindTargets { session_id, targets, error } => {
             let _ = event_tx
                 .send(ClientEvent::RewindTargetsReceived {
                     session_id,
                     targets: map_rewind_targets(targets),
+                    error,
                 })
                 .await;
         }

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -66,7 +66,8 @@ struct StartConnectionParams {
 }
 
 pub(crate) use session_start::{
-    SessionStartReason, begin_resume_session, begin_rewind, start_new_session,
+    SessionStartReason, begin_resume_session, begin_resume_session_at, begin_rewind,
+    start_new_session,
 };
 
 /// Four full UI drain batches absorb short bridge bursts while keeping retained
@@ -171,7 +172,7 @@ pub fn create_app(cli: &Cli) -> App {
         sdk_inventory: SdkInventoryState::default(),
         input: super::InputState::new(),
         status: AppStatus::Connecting,
-        resuming_session_id: None,
+        pending_session_resume: None,
         show_session_overview: !matches!(
             &cli.command,
             Some(Command::Resume { session_id: Some(_) })

--- a/src/app/connect/session_start.rs
+++ b/src/app/connect/session_start.rs
@@ -92,6 +92,15 @@ fn build_session_settings_object(app: &App) -> Value {
         "outputStyle".to_owned(),
         Value::String(app.config.output_style_effective().as_stored().to_owned()),
     );
+    let cross_session_inbound = app
+        .config
+        .committed_local_settings_document
+        .get("crossSessionInbound")
+        .and_then(Value::as_str)
+        .filter(|value| matches!(*value, "accept" | "refuse"))
+        .unwrap_or("refuse");
+    settings
+        .insert("crossSessionInbound".to_owned(), Value::String(cross_session_inbound.to_owned()));
     settings.insert(
         "spinnerTipsEnabled".to_owned(),
         Value::Bool(
@@ -188,9 +197,23 @@ pub(crate) fn begin_resume_session(
     conn: &AgentConnection,
     session_id: String,
 ) -> anyhow::Result<()> {
-    app.resuming_session_id = Some(session_id.clone());
+    app.set_pending_session_resume(session_id.clone(), None);
     app.show_session_overview = false;
     resume_session(app, conn, session_id)
+}
+
+pub(crate) fn begin_resume_session_at(
+    app: &mut App,
+    conn: &AgentConnection,
+    session_id: String,
+    target_user_message_id: String,
+) -> anyhow::Result<()> {
+    let operation_id = uuid::Uuid::new_v4().to_string();
+    app.set_pending_session_resume(session_id.clone(), Some(operation_id.clone()));
+    app.show_session_overview = false;
+    let launch_settings = session_launch_settings_for_reason(app, SessionStartReason::Resume);
+    log_session_request(app, SessionStartReason::Resume, &launch_settings, Some(&session_id));
+    conn.resume_session_at(session_id, target_user_message_id, launch_settings, operation_id)
 }
 
 pub(crate) fn begin_rewind(
@@ -239,6 +262,11 @@ mod tests {
         assert_setting_value(&launch_settings, "fastMode", &Value::Bool(false));
         assert_setting_value(&launch_settings, "effortLevel", &Value::String("high".to_owned()));
         assert_setting_value(&launch_settings, "outputStyle", &Value::String("Default".to_owned()));
+        assert_setting_value(
+            &launch_settings,
+            "crossSessionInbound",
+            &Value::String("refuse".to_owned()),
+        );
         assert_setting_value(&launch_settings, "spinnerTipsEnabled", &Value::Bool(true));
         assert_setting_value(&launch_settings, "terminalProgressBarEnabled", &Value::Bool(true));
         assert_eq!(launch_settings.agent_progress_summaries, Some(true));
@@ -299,6 +327,58 @@ mod tests {
                 "enabled": true,
                 "failIfUnavailable": true
             }),
+        );
+    }
+
+    #[test]
+    fn persisted_launch_settings_preserve_nested_sandbox_credentials() {
+        let mut app = App::test_default();
+        app.config.committed_settings_document = serde_json::json!({
+            "sandbox": {
+                "enabled": true,
+                "credentials": {
+                    "files": [{
+                        "path": ".secrets/token",
+                        "mode": "mask",
+                        "extract": "token=(.+)",
+                        "onExtractNoMatch": "deny",
+                        "decode": "jwt",
+                        "maskClaims": ["sub"],
+                        "maskDuplicates": true,
+                        "injectHosts": ["api.example.test"]
+                    }],
+                    "envVars": [{
+                        "name": "API_TOKEN",
+                        "mode": "mask",
+                        "decode": "jwt",
+                        "maskClaims": ["sub"],
+                        "injectHosts": ["api.example.test"]
+                    }],
+                    "allowPlaintextInject": false,
+                    "awsPairs": [{
+                        "accessKeyIdVar": "AWS_ACCESS_KEY_ID",
+                        "secretAccessKeyVar": "AWS_SECRET_ACCESS_KEY",
+                        "sessionTokenVar": "AWS_SESSION_TOKEN"
+                    }],
+                    "sigv4": {
+                        "streaming": "deny",
+                        "presigned": "passthrough",
+                        "sigv4a": "deny"
+                    }
+                }
+            }
+        });
+
+        let launch_settings = session_launch_settings_for_reason(&app, SessionStartReason::Startup);
+        let sandbox = settings_object(&launch_settings)
+            .get("sandbox")
+            .and_then(Value::as_object)
+            .expect("sandbox settings");
+
+        assert_eq!(sandbox.get("failIfUnavailable"), Some(&Value::Bool(false)));
+        assert_eq!(
+            sandbox.get("credentials"),
+            app.config.committed_settings_document["sandbox"].get("credentials")
         );
     }
 
@@ -367,6 +447,30 @@ mod tests {
         assert_setting_value(&launch_settings, "spinnerTipsEnabled", &Value::Bool(false));
         assert_setting_value(&launch_settings, "terminalProgressBarEnabled", &Value::Bool(false));
         assert_eq!(launch_settings.agent_progress_summaries, Some(true));
+    }
+
+    #[test]
+    fn persisted_launch_settings_allow_only_explicit_local_cross_session_accept() {
+        let mut app = App::test_default();
+        app.config.committed_local_settings_document =
+            serde_json::json!({ "crossSessionInbound": "accept" });
+
+        let launch_settings = session_launch_settings_for_reason(&app, SessionStartReason::Startup);
+
+        assert_setting_value(
+            &launch_settings,
+            "crossSessionInbound",
+            &Value::String("accept".to_owned()),
+        );
+
+        app.config.committed_local_settings_document =
+            serde_json::json!({ "crossSessionInbound": "hold" });
+        let launch_settings = session_launch_settings_for_reason(&app, SessionStartReason::Startup);
+        assert_setting_value(
+            &launch_settings,
+            "crossSessionInbound",
+            &Value::String("refuse".to_owned()),
+        );
     }
 
     #[test]

--- a/src/app/connect/type_converters.rs
+++ b/src/app/connect/type_converters.rs
@@ -256,6 +256,7 @@ pub(super) fn map_rewind_targets(targets: Vec<types::RewindTarget>) -> Vec<model
             input_text: target.input_text,
             index: target.index,
             previous_assistant_uuid: target.previous_assistant_uuid,
+            resume_anchor_uuid: target.resume_anchor_uuid,
         })
         .collect()
 }
@@ -379,6 +380,21 @@ pub(super) fn map_session_update(update: types::SessionUpdate) -> Option<model::
             Some(model::SessionUpdate::UserMessageChunk(
                 model::ContentChunk::new(content).source_message_uuid(source_message_uuid),
             ))
+        }
+        types::SessionUpdate::ExternalMessageUpdate { content, source_message_uuid, origin } => {
+            Some(model::SessionUpdate::ExternalMessageUpdate(model::ExternalMessageUpdate {
+                content,
+                source_message_uuid,
+                origin: model::MessageOrigin {
+                    kind: origin.kind,
+                    subkind: origin.subkind,
+                    from: origin.from,
+                    name: origin.name,
+                    from_session: origin.from_session,
+                    sender_task_id: origin.sender_task_id,
+                    verified_peer_pid: origin.verified_peer_pid,
+                },
+            }))
         }
         types::SessionUpdate::AgentMessageChunk { content, source_message_uuid } => {
             let content = convert_content_block(content)?;
@@ -815,6 +831,7 @@ fn convert_transcript_retraction(
         direction: retraction.direction,
         original_model: retraction.original_model,
         fallback_model: retraction.fallback_model,
+        scope: retraction.scope,
         api_refusal_category: retraction.api_refusal_category,
         api_refusal_explanation: retraction.api_refusal_explanation,
         content: retraction.content,
@@ -878,6 +895,7 @@ fn convert_tool_output_metadata(
                 .assistant_auto_backgrounded(bash.assistant_auto_backgrounded)
                 .timed_out_after_ms(bash.timed_out_after_ms)
                 .background_cwd_hint(bash.background_cwd_hint)
+                .background_ends_with_final_response(bash.background_ends_with_final_response)
         }))
         .agent(output_metadata.agent.map(|agent| {
             model::AgentOutputMetadata::new()
@@ -1342,6 +1360,34 @@ mod tests {
     }
 
     #[test]
+    fn map_session_update_preserves_external_message_provenance() {
+        let mapped = map_session_update(types::SessionUpdate::ExternalMessageUpdate {
+            content: "Peer message".to_owned(),
+            source_message_uuid: Some("message-peer".to_owned()),
+            origin: types::MessageOrigin {
+                kind: "peer".to_owned(),
+                subkind: Some("peer-send-message".to_owned()),
+                from: Some("reported-route".to_owned()),
+                name: Some("Build session".to_owned()),
+                from_session: Some("session-peer".to_owned()),
+                sender_task_id: Some("task-peer".to_owned()),
+                verified_peer_pid: Some(4242),
+            },
+        })
+        .expect("external update should map");
+
+        let model::SessionUpdate::ExternalMessageUpdate(update) = mapped else {
+            panic!("expected external message update");
+        };
+        assert_eq!(update.content, "Peer message");
+        assert_eq!(update.source_message_uuid.as_deref(), Some("message-peer"));
+        assert_eq!(update.origin.kind, "peer");
+        assert_eq!(update.origin.name.as_deref(), Some("Build session"));
+        assert_eq!(update.origin.from_session.as_deref(), Some("session-peer"));
+        assert_eq!(update.origin.verified_peer_pid, Some(4242));
+    }
+
+    #[test]
     fn map_session_update_preserves_rate_limit_credits_metadata() {
         let mapped = map_session_update(types::SessionUpdate::RateLimitUpdate {
             status: types::RateLimitStatus::Rejected,
@@ -1379,6 +1425,7 @@ mod tests {
                 direction: None,
                 original_model: None,
                 fallback_model: None,
+                scope: Some("local".to_owned()),
                 api_refusal_category: None,
                 api_refusal_explanation: None,
                 content: None,
@@ -1528,6 +1575,7 @@ mod tests {
                     assistant_auto_backgrounded: Some(true),
                     timed_out_after_ms: Some(10_000),
                     background_cwd_hint: Some("session cwd unchanged".to_owned()),
+                    background_ends_with_final_response: Some(true),
                 }),
                 agent: Some(types::AgentOutputMetadata {
                     resolved_model: Some("claude-sonnet-4-7".to_owned()),
@@ -1559,7 +1607,8 @@ mod tests {
                         model::BashOutputMetadata::new()
                             .assistant_auto_backgrounded(Some(true))
                             .timed_out_after_ms(Some(10_000))
-                            .background_cwd_hint(Some("session cwd unchanged".to_owned())),
+                            .background_cwd_hint(Some("session cwd unchanged".to_owned()))
+                            .background_ends_with_final_response(Some(true)),
                     ))
                     .agent(Some(
                         model::AgentOutputMetadata::new()

--- a/src/app/events/client.rs
+++ b/src/app/events/client.rs
@@ -77,6 +77,7 @@ fn client_event_family(event: &ClientEvent) -> ClientEventFamily {
         ClientEvent::Connected { .. }
         | ClientEvent::ConnectionFailed(_)
         | ClientEvent::AuthRequired { .. }
+        | ClientEvent::SessionResumeFailed { .. }
         | ClientEvent::SessionReplaced { .. }
         | ClientEvent::SessionsListed { .. }
         | ClientEvent::UpdateAvailable { .. }
@@ -92,6 +93,7 @@ fn client_event_family(event: &ClientEvent) -> ClientEventFamily {
         | ClientEvent::TerminalReturnedFromChild { .. }
         | ClientEvent::RuntimeReloadCompleted { .. }
         | ClientEvent::RuntimeReloadFailed { .. }
+        | ClientEvent::StructuredUsageReceived { .. }
         | ClientEvent::UsageRefreshStarted { .. }
         | ClientEvent::UsageSnapshotReceived { .. }
         | ClientEvent::UsageRefreshFailed { .. }

--- a/src/app/events/client/host.rs
+++ b/src/app/events/client/host.rs
@@ -33,6 +33,9 @@ pub(super) fn handle(app: &mut App, event: ClientEvent) {
                 crate::app::usage::apply_refresh_started(app);
             }
         }
+        ClientEvent::StructuredUsageReceived { session_id: _, snapshot, error } => {
+            crate::app::usage::apply_structured_sdk_result(app, snapshot, error);
+        }
         ClientEvent::UsageSnapshotReceived { epoch, snapshot } => {
             if app.session_runtime.session_scope_epoch == epoch {
                 crate::app::usage::apply_refresh_success(app, snapshot);

--- a/src/app/events/client/session.rs
+++ b/src/app/events/client/session.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::{App, session};
+use super::super::{App, SystemSeverity, session};
 use crate::agent::events::ClientEvent;
 
 pub(super) fn handle(app: &mut App, event: ClientEvent) {
@@ -66,6 +66,9 @@ pub(super) fn handle(app: &mut App, event: ClientEvent) {
         ClientEvent::ConnectionFailed(message) => {
             session::handle_connection_failed_event(app, &message);
         }
+        ClientEvent::SessionResumeFailed { session_id, operation_id, message } => {
+            session::handle_session_resume_failed_event(app, &session_id, &operation_id, &message);
+        }
         ClientEvent::UpdateAvailable { latest_version, current_version } => {
             session::handle_update_available_event(app, &latest_version, &current_version);
         }
@@ -84,12 +87,8 @@ pub(super) fn handle(app: &mut App, event: ClientEvent) {
         ClientEvent::ContextUsageReceived { session_id: _, percentage } => {
             crate::app::session_runtime::apply_context_usage_snapshot(app, percentage);
         }
-        ClientEvent::RewindTargetsReceived { session_id, targets } => {
-            app.sdk_inventory.rewind_targets = targets;
-            app.sdk_inventory.rewind_targets_session_id =
-                Some(crate::agent::model::SessionId::new(session_id));
-            app.sdk_inventory.rewind_targets_in_flight = false;
-            crate::app::slash::sync_with_cursor(app);
+        ClientEvent::RewindTargetsReceived { session_id, targets, error } => {
+            apply_rewind_targets(app, session_id, targets, error);
         }
         ClientEvent::RewindResultReceived { result } => {
             session::handle_rewind_result_event(app, &result);
@@ -97,6 +96,47 @@ pub(super) fn handle(app: &mut App, event: ClientEvent) {
         ClientEvent::FatalError(error) => session::handle_fatal_error_event(app, error),
         _ => unreachable!("client event family routed a non-session event to the session handler"),
     }
+}
+
+fn apply_rewind_targets(
+    app: &mut App,
+    session_id: String,
+    targets: Vec<crate::agent::model::RewindTarget>,
+    error: Option<String>,
+) {
+    let expected_session_id = app
+        .sdk_inventory
+        .rewind_targets_request_session_id
+        .as_ref()
+        .map(crate::agent::model::SessionId::as_str);
+    if !app.sdk_inventory.rewind_targets_in_flight
+        || expected_session_id != Some(session_id.as_str())
+    {
+        tracing::debug!(
+            target: crate::logging::targets::APP_SESSION,
+            event_name = "rewind_targets_result_dropped",
+            message = "rewind targets result dropped for a stale request",
+            outcome = "dropped",
+            session_id = %session_id,
+        );
+        return;
+    }
+    let picker_owns_request =
+        app.session_picker.turn_session_id.as_deref() == Some(session_id.as_str());
+    app.sdk_inventory.rewind_targets = targets;
+    app.sdk_inventory.rewind_targets_session_id =
+        error.is_none().then(|| crate::agent::model::SessionId::new(session_id));
+    app.sdk_inventory.rewind_targets_in_flight = false;
+    app.sdk_inventory.rewind_targets_request_session_id = None;
+    if let Some(message) = error.as_deref()
+        && !picker_owns_request
+    {
+        super::super::notices::emit_system_notice(app, SystemSeverity::Error, message);
+    }
+    app.sdk_inventory.rewind_targets_error = error;
+    app.session_picker.turn_selected = 0;
+    app.session_picker.turn_scroll_offset = 0;
+    crate::app::slash::sync_with_cursor(app);
 }
 
 fn refresh_session_snapshots(app: &mut App) {

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -28,6 +28,7 @@ use crate::app::tasks::apply_task_state_update;
 #[cfg(test)]
 use crossterm::event::KeyEvent;
 use crossterm::event::{Event, KeyEventKind};
+use std::fmt::Write as _;
 
 pub use client::handle_client_event;
 
@@ -256,6 +257,7 @@ fn handle_session_update_event(app: &mut App, update: model::SessionUpdate) {
     let needs_history_retention = matches!(
         &update,
         model::SessionUpdate::AgentMessageChunk(_)
+            | model::SessionUpdate::ExternalMessageUpdate(_)
             | model::SessionUpdate::ToolCall(_)
             | model::SessionUpdate::ToolCallUpdate(_)
             | model::SessionUpdate::TranscriptRetraction(_)
@@ -293,6 +295,9 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             apply_task_state_update(app, update);
         }
         model::SessionUpdate::UserMessageChunk(_) => {}
+        model::SessionUpdate::ExternalMessageUpdate(update) => {
+            handle_external_message_update(app, &update);
+        }
         model::SessionUpdate::AgentThoughtChunk(chunk) => {
             let chunk_chars = match &chunk.content {
                 model::ContentBlock::Text(text) => text.text.chars().count(),
@@ -454,6 +459,42 @@ fn handle_session_update(app: &mut App, update: model::SessionUpdate) {
             compaction::handle_update(app, update);
         }
     }
+}
+
+fn handle_external_message_update(app: &mut App, update: &model::ExternalMessageUpdate) {
+    let origin = &update.origin;
+    let mut label = match (origin.kind.as_str(), origin.subkind.as_deref()) {
+        ("task-notification", Some("peer-send-message")) | ("peer", _) => {
+            "Message from another Claude session".to_owned()
+        }
+        ("task-notification", Some("scheduled-trigger")) => {
+            "Scheduled Claude task message".to_owned()
+        }
+        ("task-notification", _) => "Claude task notification".to_owned(),
+        _ => "Claude-generated input".to_owned(),
+    };
+    if let Some(name) = origin.name.as_deref().filter(|value| !value.is_empty()) {
+        let _ = write!(label, " (sender-reported name: {name})");
+    }
+    if let Some(from_session) = origin.from_session.as_deref().filter(|value| !value.is_empty()) {
+        let _ = write!(label, " [session {from_session}]");
+    }
+    if let Some(pid) = origin.verified_peer_pid {
+        let _ = write!(label, " [verified connecting PID {pid}]");
+    }
+    let rendered = format!("{label}:\n\n{}", update.content);
+    push_system_message_with_severity(app, Some(SystemSeverity::Info), &rendered);
+    tracing::info!(
+        target: crate::logging::targets::APP_SESSION,
+        event_name = "external_claude_message_rendered",
+        message = "non-human Claude message rendered with origin metadata",
+        outcome = "success",
+        origin_kind = %origin.kind,
+        origin_subkind = ?origin.subkind,
+        source_session = ?origin.from_session,
+        verified_peer_pid = ?origin.verified_peer_pid,
+        source_message_uuid = ?update.source_message_uuid,
+    );
 }
 
 fn handle_runtime_session_state_update(app: &mut App, state: model::RuntimeSessionState) {

--- a/src/app/events/retraction.rs
+++ b/src/app/events/retraction.rs
@@ -74,6 +74,7 @@ pub(super) fn handle_transcript_retraction(
         request_id = retraction.request_id.as_deref().unwrap_or(""),
         original_model = retraction.original_model.as_deref().unwrap_or(""),
         fallback_model = retraction.fallback_model.as_deref().unwrap_or(""),
+        scope = retraction.scope.as_deref().unwrap_or("session"),
     );
 }
 

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -73,7 +73,7 @@ pub(super) fn handle_connected_client_event(app: &mut App, event: ConnectedEvent
     }
     maybe_emit_fast_mode_disabled_notice(app, None);
     clear_pending_command(app);
-    app.resuming_session_id = None;
+    app.clear_pending_session_resume();
     crate::app::file_index::restart(app);
     app.rebuild_chat_focus_from_state();
     crate::app::config::refresh_runtime_tabs_for_session_change(app);
@@ -159,7 +159,7 @@ pub(super) fn handle_auth_required_event(
     let method_name_for_log = method_name.clone();
     clear_pending_command(app);
     app.status = AppStatus::Ready;
-    app.resuming_session_id = None;
+    app.clear_pending_session_resume();
     app.session_runtime.login_hint = Some(LoginHint { method_name, method_description });
     app.bump_session_scope_epoch();
     app.clear_session_runtime_identity();
@@ -191,7 +191,7 @@ pub(super) fn handle_connection_failed_event(app: &mut App, msg: &str) {
     app.mcp = super::super::McpState::default();
     app.config.pending_session_title_change = None;
     crate::app::usage::reset_for_session_change(app);
-    app.resuming_session_id = None;
+    app.clear_pending_session_resume();
     app.finalize_turn_runtime_artifacts(model::ToolCallStatus::Failed);
     app.input.clear();
     app.pending_submit = None;
@@ -208,8 +208,6 @@ pub(super) fn handle_connection_failed_event(app: &mut App, msg: &str) {
 }
 
 pub(super) fn handle_slash_command_error_event(app: &mut App, msg: &str) {
-    app.sdk_inventory.rewind_targets_in_flight = false;
-    app.sdk_inventory.rewind_targets_session_id = None;
     if app.config.pending_session_title_change.take().is_some() {
         app.config.last_error = Some(msg.to_owned());
         app.config.status_message = None;
@@ -218,7 +216,41 @@ pub(super) fn handle_slash_command_error_event(app: &mut App, msg: &str) {
     }
     super::notices::emit_system_notice(app, SystemSeverity::Error, msg);
     clear_pending_command(app);
-    app.resuming_session_id = None;
+    app.clear_pending_session_resume();
+}
+
+pub(super) fn handle_session_resume_failed_event(
+    app: &mut App,
+    session_id: &str,
+    operation_id: &str,
+    message: &str,
+) {
+    let matches_pending_operation = app.pending_session_resume_id() == Some(session_id)
+        && app.pending_resume_at_operation_id() == Some(operation_id);
+    if !matches_pending_operation {
+        tracing::debug!(
+            target: crate::logging::targets::APP_SESSION,
+            event_name = "session_resume_failure_dropped",
+            message = "session resume failure dropped for a stale operation",
+            outcome = "dropped",
+            session_id,
+            operation_id,
+        );
+        return;
+    }
+
+    super::notices::emit_system_notice(app, SystemSeverity::Error, message);
+    clear_pending_command(app);
+    app.clear_pending_session_resume();
+    tracing::warn!(
+        target: crate::logging::targets::APP_SESSION,
+        event_name = "session_resume_failed",
+        message = "session resume-at operation failed",
+        outcome = "failure",
+        session_id,
+        operation_id,
+        error_message = message,
+    );
 }
 
 pub(super) fn handle_auth_completed_event(app: &mut App, conn: &Rc<AgentConnection>) {
@@ -343,7 +375,7 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
     if let Some(restored_input) = restored_input.as_deref() {
         app.input.set_text(restored_input);
     }
-    app.resuming_session_id = None;
+    app.clear_pending_session_resume();
     crate::app::file_index::restart(app);
     crate::app::config::refresh_runtime_tabs_for_session_change(app);
     // After session replacement, terminal scrollback is stale. Rebuild from

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -269,6 +269,7 @@ mod tests {
             input_text: "prompt".to_owned(),
             index: 0,
             previous_assistant_uuid: None,
+            resume_anchor_uuid: None,
         }];
         app.sdk_inventory.rewind_targets_session_id = Some(model::SessionId::new("session-1"));
         app.sdk_inventory.rewind_targets_in_flight = true;

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -15,7 +15,6 @@ use crate::app::{
 };
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use pretty_assertions::assert_eq;
-use std::fmt::Write as _;
 use std::rc::Rc;
 use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::oneshot;
@@ -106,6 +105,7 @@ fn transcript_retraction(
         direction: None,
         original_model: None,
         fallback_model: None,
+        scope: None,
         api_refusal_category: None,
         api_refusal_explanation: None,
         content: None,
@@ -3679,6 +3679,37 @@ fn system_notice_update_uses_notice_lane() {
     };
     assert_eq!(notice.severity, SystemSeverity::Warning);
     assert_eq!(notice.text.text, "Plugin install failed.");
+}
+
+#[test]
+fn external_claude_message_is_rendered_as_non_human_input_with_provenance() {
+    let mut app = make_test_app();
+    handle_client_event(
+        &mut app,
+        session_update(model::SessionUpdate::ExternalMessageUpdate(model::ExternalMessageUpdate {
+            content: "Please inspect the build.".to_owned(),
+            source_message_uuid: Some("message-peer".to_owned()),
+            origin: model::MessageOrigin {
+                kind: "peer".to_owned(),
+                subkind: None,
+                from: Some("reported-route".to_owned()),
+                name: Some("Build session".to_owned()),
+                from_session: Some("session-peer".to_owned()),
+                sender_task_id: None,
+                verified_peer_pid: Some(4242),
+            },
+        })),
+    );
+
+    assert_eq!(app.transcript.messages.len(), 1);
+    let MessageBlock::Text(block) = &app.transcript.messages[0].blocks[0] else {
+        panic!("expected external message text block");
+    };
+    assert!(block.text.contains("Message from another Claude session"));
+    assert!(block.text.contains("sender-reported name: Build session"));
+    assert!(block.text.contains("session session-peer"));
+    assert!(block.text.contains("verified connecting PID 4242"));
+    assert!(block.text.contains("Please inspect the build."));
 }
 
 #[test]

--- a/src/app/events/tests/client_events.rs
+++ b/src/app/events/tests/client_events.rs
@@ -110,7 +110,7 @@ fn connected_updates_cwd_and_clears_resuming_marker() {
         "/test",
         "-",
     ));
-    app.resuming_session_id = Some("resume-123".into());
+    app.set_pending_session_resume("resume-123".into(), Some("resume-at-1".into()));
 
     handle_client_event(
         &mut app,
@@ -128,7 +128,7 @@ fn connected_updates_cwd_and_clears_resuming_marker() {
 
     assert_eq!(app.cwd_raw, "/changed");
     assert_eq!(app.cwd, "/changed");
-    assert!(app.resuming_session_id.is_none());
+    assert!(app.pending_session_resume.is_none());
     let Some(first) = app.transcript.messages.first() else {
         panic!("missing welcome message");
     };
@@ -232,11 +232,16 @@ fn connected_resets_session_scoped_view_data() {
     app.usage.snapshot = Some(UsageSnapshot {
         source: UsageSourceKind::Oauth,
         fetched_at: std::time::SystemTime::now(),
+        subscription_type: None,
         five_hour: None,
         seven_day: None,
+        seven_day_oauth_apps: None,
         seven_day_opus: None,
         seven_day_sonnet: None,
+        model_scoped: Vec::new(),
         extra_usage: None,
+        session: None,
+        activity: None,
     });
     app.session_runtime.account_info = Some(crate::agent::model::AccountInfo {
         email: Some("old@example.com".into()),
@@ -1001,11 +1006,16 @@ fn stale_usage_refresh_result_for_old_epoch_is_ignored() {
             snapshot: UsageSnapshot {
                 source: UsageSourceKind::Oauth,
                 fetched_at: std::time::SystemTime::now(),
+                subscription_type: None,
                 five_hour: None,
                 seven_day: None,
+                seven_day_oauth_apps: None,
                 seven_day_opus: None,
                 seven_day_sonnet: None,
+                model_scoped: Vec::new(),
                 extra_usage: None,
+                session: None,
+                activity: None,
             },
         },
     );
@@ -1026,21 +1036,26 @@ fn pending_limits_response_prints_summary_on_usage_refresh_success() {
             snapshot: UsageSnapshot {
                 source: UsageSourceKind::Oauth,
                 fetched_at: SystemTime::now(),
+                subscription_type: None,
                 five_hour: Some(UsageWindow {
-                    label: "5-hour",
+                    label: "5-hour".to_owned(),
                     utilization: 47.0,
                     resets_at: None,
                     reset_description: Some("resets in 2h 14m".to_owned()),
                 }),
                 seven_day: Some(UsageWindow {
-                    label: "7-day",
+                    label: "7-day".to_owned(),
                     utilization: 62.0,
                     resets_at: None,
                     reset_description: Some("resets in 4d 11h".to_owned()),
                 }),
+                seven_day_oauth_apps: None,
                 seven_day_opus: None,
                 seven_day_sonnet: None,
+                model_scoped: Vec::new(),
                 extra_usage: None,
+                session: None,
+                activity: None,
             },
         },
     );
@@ -1095,16 +1110,21 @@ fn stale_usage_refresh_result_does_not_print_pending_limits_response() {
             snapshot: UsageSnapshot {
                 source: UsageSourceKind::Oauth,
                 fetched_at: SystemTime::now(),
+                subscription_type: None,
                 five_hour: Some(UsageWindow {
-                    label: "5-hour",
+                    label: "5-hour".to_owned(),
                     utilization: 47.0,
                     resets_at: None,
                     reset_description: Some("resets in 2h 14m".to_owned()),
                 }),
                 seven_day: None,
+                seven_day_oauth_apps: None,
                 seven_day_opus: None,
                 seven_day_sonnet: None,
+                model_scoped: Vec::new(),
                 extra_usage: None,
+                session: None,
+                activity: None,
             },
         },
     );
@@ -1138,16 +1158,65 @@ fn stale_plugin_inventory_result_for_old_cwd_is_ignored() {
 fn slash_command_error_while_resuming_returns_ready_and_clears_marker() {
     let mut app = make_test_app();
     app.status = AppStatus::CommandPending;
-    app.resuming_session_id = Some("resume-123".into());
+    app.set_pending_session_resume("resume-123".into(), None);
 
     handle_client_event(&mut app, slash_command_error("resume failed".into()));
 
     assert!(matches!(app.status, AppStatus::Ready));
-    assert!(app.resuming_session_id.is_none());
+    assert!(app.pending_session_resume.is_none());
 }
 
 #[test]
-fn slash_command_error_clears_rewind_target_loading_state() {
+fn matching_resume_at_failure_is_visible_and_clears_pending_state() {
+    let mut app = make_test_app();
+    app.status = AppStatus::CommandPending;
+    app.turn.pending_command_label = Some("Forking before selected message...".into());
+    app.set_pending_session_resume("source-session".into(), Some("resume-at-1".into()));
+
+    handle_client_event(
+        &mut app,
+        ClientEvent::SessionResumeFailed {
+            session_id: "source-session".into(),
+            operation_id: "resume-at-1".into(),
+            message: "session changed while selecting a turn".into(),
+        },
+    );
+
+    assert!(matches!(app.status, AppStatus::Ready));
+    assert!(app.turn.pending_command_label.is_none());
+    assert!(app.pending_session_resume.is_none());
+    let last = app.transcript.messages.last().expect("visible error notice");
+    let MessageBlock::Notice(notice) = last.blocks.first().expect("error notice block") else {
+        panic!("expected error notice");
+    };
+    assert!(notice.text.text.contains("session changed while selecting a turn"));
+}
+
+#[test]
+fn stale_resume_at_failure_does_not_cancel_current_operation() {
+    let mut app = make_test_app();
+    app.status = AppStatus::CommandPending;
+    app.turn.pending_command_label = Some("Forking before selected message...".into());
+    app.set_pending_session_resume("source-session".into(), Some("resume-at-current".into()));
+    let message_count = app.transcript.messages.len();
+
+    handle_client_event(
+        &mut app,
+        ClientEvent::SessionResumeFailed {
+            session_id: "source-session".into(),
+            operation_id: "resume-at-old".into(),
+            message: "old failure".into(),
+        },
+    );
+
+    assert!(matches!(app.status, AppStatus::CommandPending));
+    assert_eq!(app.pending_session_resume_id(), Some("source-session"));
+    assert_eq!(app.pending_resume_at_operation_id(), Some("resume-at-current"));
+    assert_eq!(app.transcript.messages.len(), message_count);
+}
+
+#[test]
+fn unrelated_slash_command_error_does_not_clear_rewind_target_loading_state() {
     let mut app = make_test_app();
     app.sdk_inventory.rewind_targets_in_flight = true;
     app.sdk_inventory.rewind_targets_session_id = Some(model::SessionId::new("session-1"));
@@ -1157,12 +1226,131 @@ fn slash_command_error_clears_rewind_target_loading_state() {
         input_text: "hello".into(),
         index: 0,
         previous_assistant_uuid: None,
+        resume_anchor_uuid: None,
     }];
 
     handle_client_event(&mut app, slash_command_error("failed to load rewind targets".into()));
 
+    assert!(app.sdk_inventory.rewind_targets_in_flight);
+    assert_eq!(
+        app.sdk_inventory.rewind_targets_session_id.as_ref().map(model::SessionId::as_str),
+        Some("session-1")
+    );
+}
+
+#[test]
+fn matching_rewind_target_response_populates_fullscreen_turn_picker() {
+    let mut app = make_test_app();
+    app.session_picker.turn_session_id = Some("listed-session".to_owned());
+    app.sdk_inventory.rewind_targets_in_flight = true;
+    app.sdk_inventory.rewind_targets_request_session_id =
+        Some(model::SessionId::new("listed-session"));
+    let targets = vec![model::RewindTarget {
+        uuid: "user-2".into(),
+        first_text: "second prompt".into(),
+        input_text: "second prompt".into(),
+        index: 2,
+        previous_assistant_uuid: Some("assistant-1".into()),
+        resume_anchor_uuid: Some("assistant-1".into()),
+    }];
+
+    handle_client_event(
+        &mut app,
+        ClientEvent::RewindTargetsReceived {
+            session_id: "listed-session".into(),
+            targets: targets.clone(),
+            error: None,
+        },
+    );
+
+    assert_eq!(app.sdk_inventory.rewind_targets, targets);
+    assert_eq!(
+        app.sdk_inventory.rewind_targets_session_id.as_ref().map(model::SessionId::as_str),
+        Some("listed-session")
+    );
     assert!(!app.sdk_inventory.rewind_targets_in_flight);
+    assert!(app.sdk_inventory.rewind_targets_request_session_id.is_none());
+}
+
+#[test]
+fn stale_rewind_target_response_cannot_replace_picker_results() {
+    let mut app = make_test_app();
+    app.sdk_inventory.rewind_targets_in_flight = true;
+    app.sdk_inventory.rewind_targets_request_session_id =
+        Some(model::SessionId::new("new-session"));
+
+    handle_client_event(
+        &mut app,
+        ClientEvent::RewindTargetsReceived {
+            session_id: "old-session".into(),
+            targets: vec![model::RewindTarget {
+                uuid: "old-user".into(),
+                first_text: "stale".into(),
+                input_text: "stale".into(),
+                index: 0,
+                previous_assistant_uuid: None,
+                resume_anchor_uuid: None,
+            }],
+            error: None,
+        },
+    );
+
+    assert!(app.sdk_inventory.rewind_targets.is_empty());
+    assert!(app.sdk_inventory.rewind_targets_in_flight);
+    assert_eq!(
+        app.sdk_inventory.rewind_targets_request_session_id.as_ref().map(model::SessionId::as_str),
+        Some("new-session")
+    );
+}
+
+#[test]
+fn matching_rewind_target_error_stays_local_to_the_request() {
+    let mut app = make_test_app();
+    app.session_picker.turn_session_id = Some("listed-session".to_owned());
+    app.sdk_inventory.rewind_targets_in_flight = true;
+    app.sdk_inventory.rewind_targets_request_session_id =
+        Some(model::SessionId::new("listed-session"));
+
+    handle_client_event(
+        &mut app,
+        ClientEvent::RewindTargetsReceived {
+            session_id: "listed-session".into(),
+            targets: Vec::new(),
+            error: Some("failed to load rewind targets: history unavailable".into()),
+        },
+    );
+
+    assert!(app.sdk_inventory.rewind_targets.is_empty());
     assert!(app.sdk_inventory.rewind_targets_session_id.is_none());
+    assert!(!app.sdk_inventory.rewind_targets_in_flight);
+    assert_eq!(
+        app.sdk_inventory.rewind_targets_error.as_deref(),
+        Some("failed to load rewind targets: history unavailable")
+    );
+}
+
+#[test]
+fn slash_rewind_target_error_is_visible_without_clearing_unrelated_state() {
+    let mut app = make_test_app();
+    app.sdk_inventory.rewind_targets_in_flight = true;
+    app.sdk_inventory.rewind_targets_request_session_id =
+        Some(model::SessionId::new("active-session"));
+
+    handle_client_event(
+        &mut app,
+        ClientEvent::RewindTargetsReceived {
+            session_id: "active-session".into(),
+            targets: Vec::new(),
+            error: Some("failed to load rewind targets: history unavailable".into()),
+        },
+    );
+
+    let message = app.transcript.messages.last().expect("rewind target error notice");
+    let crate::app::MessageBlock::Notice(notice) = message.blocks.first().expect("notice text")
+    else {
+        panic!("expected notice block");
+    };
+    assert_eq!(notice.text.text, "failed to load rewind targets: history unavailable");
 }
 
 #[test]
@@ -1561,7 +1749,7 @@ fn non_matching_config_option_update_keeps_pending() {
 #[test]
 fn resume_does_not_add_confirmation_system_message() {
     let mut app = make_test_app();
-    app.resuming_session_id = Some("requested-123".into());
+    app.set_pending_session_resume("requested-123".into(), None);
 
     handle_client_event(
         &mut app,
@@ -1580,7 +1768,7 @@ fn resume_does_not_add_confirmation_system_message() {
 
     assert_eq!(app.transcript.messages.len(), 1);
     assert!(matches!(app.transcript.messages[0].role, MessageRole::Welcome));
-    assert!(app.resuming_session_id.is_none());
+    assert!(app.pending_session_resume.is_none());
     assert!(matches!(app.status, AppStatus::Ready));
 }
 

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -453,8 +453,7 @@ fn finish_ready_turn_exit(app: &mut App, exit: TurnExitState, tool_status: model
     app.finalize_turn_runtime_artifacts(tool_status);
     app.status = AppStatus::Ready;
     app.files_accessed = 0;
-    app.sdk_inventory.rewind_targets_session_id = None;
-    app.sdk_inventory.rewind_targets_in_flight = false;
+    app.sdk_inventory.clear_rewind_targets();
     app.sync_git_context();
 
     let removed_tail_assistant = remove_empty_tail_assistant(app, exit.tail_assistant_idx);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -74,11 +74,12 @@ pub use state::{
     MessageBlock, MessageBlockId, MessageRole, MessageUsage, ModeInfo, ModeState, NoticeBlock,
     NoticeDedupKey, NoticeStage, PasteSessionState, PendingCommandAck, PostExitAction,
     RateLimitIncidentKey, RecentSessionInfo, SelectionPoint, SessionPickerState, SessionUsageState,
-    SubagentPermissionContext, SystemSeverity, TerminalSize, TerminalSizeChange, TextBlock,
-    TextBlockSpacing, ToolCallInfo, ToolCallScope, TurnNoticeLocation, TurnNoticeRef,
-    UpdatePromptAction, UpdatePromptState, UsageSnapshot, UsageSourceKind, UsageSourceMode,
-    UsageState, UsageWindow, UserDialogBlock, WelcomeBlock, hash_text_block_content,
-    hash_welcome_block_content, is_execute_tool_name,
+    SessionUsageSummary, SubagentPermissionContext, SystemSeverity, TerminalSize,
+    TerminalSizeChange, TextBlock, TextBlockSpacing, ToolCallInfo, ToolCallScope,
+    TurnNoticeLocation, TurnNoticeRef, UpdatePromptAction, UpdatePromptState, UsageActivitySummary,
+    UsageActivityWindow, UsageBehaviorAttribution, UsageNamedAttribution, UsageSnapshot,
+    UsageSourceKind, UsageSourceMode, UsageState, UsageWindow, UserDialogBlock, WelcomeBlock,
+    hash_text_block_content, hash_welcome_block_content, is_execute_tool_name,
 };
 pub use trust::TrustSelection;
 pub use update_check::start_update_check;

--- a/src/app/session_picker.rs
+++ b/src/app/session_picker.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 Simon Peter Rothgang
 
-use super::connect::begin_resume_session;
+use super::connect::{begin_resume_session, begin_resume_session_at};
 use super::events::push_system_message_with_severity;
 use super::view;
 use super::{App, AppStatus, SystemSeverity};
@@ -17,6 +17,10 @@ pub(crate) fn startup_picker_is_loading(app: &App) -> bool {
     app.startup.startup_picker_is_loading(app.session_runtime.conn.is_some())
 }
 
+pub(crate) fn picker_turn_count(app: &App) -> usize {
+    app.sdk_inventory.rewind_targets.len()
+}
+
 pub fn handle_key(app: &mut App, key: KeyEvent) {
     if is_ctrl(key, 'q') || is_ctrl(key, 'c') {
         app.should_quit = true;
@@ -24,6 +28,11 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
     }
 
     if startup_picker_is_loading(app) {
+        return;
+    }
+
+    if app.session_picker.turn_session_id.is_some() {
+        handle_turn_key(app, key);
         return;
     }
 
@@ -47,12 +56,111 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
         (KeyCode::Home, _) => app.session_picker.selected = 0,
         (KeyCode::End, _) => app.session_picker.selected = session_count.saturating_sub(1),
         (KeyCode::Enter, KeyModifiers::NONE) => activate_selection(app),
+        (KeyCode::Right, KeyModifiers::NONE) => open_turn_selection(app),
         (KeyCode::Esc, KeyModifiers::NONE) => {
             app.startup.resolve_session_picker();
             view::set_chat_surface(app);
         }
         _ => {}
     }
+}
+
+fn handle_turn_key(app: &mut App, key: KeyEvent) {
+    if matches!((key.code, key.modifiers), (KeyCode::Esc | KeyCode::Left, KeyModifiers::NONE)) {
+        close_turn_selection(app);
+        return;
+    }
+    if app.sdk_inventory.rewind_targets_in_flight {
+        return;
+    }
+    let turn_count = picker_turn_count(app);
+    if turn_count == 0 {
+        return;
+    }
+    match (key.code, key.modifiers) {
+        (KeyCode::Up | KeyCode::Char('k'), KeyModifiers::NONE) => {
+            app.session_picker.turn_selected = app.session_picker.turn_selected.saturating_sub(1);
+        }
+        (KeyCode::Down | KeyCode::Char('j'), KeyModifiers::NONE) => {
+            app.session_picker.turn_selected =
+                (app.session_picker.turn_selected + 1).min(turn_count.saturating_sub(1));
+        }
+        (KeyCode::Home, _) => app.session_picker.turn_selected = 0,
+        (KeyCode::End, _) => app.session_picker.turn_selected = turn_count.saturating_sub(1),
+        (KeyCode::Enter, KeyModifiers::NONE) => activate_turn_selection(app),
+        _ => {}
+    }
+}
+
+fn open_turn_selection(app: &mut App) {
+    let Some(session_id) = app
+        .recent_sessions
+        .iter()
+        .take(MAX_PICKER_SESSIONS)
+        .nth(app.session_picker.selected)
+        .map(|session| session.session_id.clone())
+    else {
+        return;
+    };
+    let Some(conn) = app.session_runtime.conn.clone() else {
+        return;
+    };
+
+    app.session_picker.turn_session_id = Some(session_id.clone());
+    app.session_picker.turn_selected = 0;
+    app.session_picker.turn_scroll_offset = 0;
+    app.sdk_inventory.rewind_targets.clear();
+    app.sdk_inventory.rewind_targets_session_id = None;
+    app.sdk_inventory.rewind_targets_error = None;
+    app.sdk_inventory.rewind_targets_request_session_id =
+        Some(crate::agent::model::SessionId::new(session_id.clone()));
+    app.sdk_inventory.rewind_targets_in_flight = true;
+    if let Err(error) = conn.get_rewind_targets(session_id) {
+        close_turn_selection(app);
+        push_system_message_with_severity(
+            app,
+            Some(SystemSeverity::Error),
+            &format!("Failed to load session turns: {error}"),
+        );
+    }
+}
+
+fn close_turn_selection(app: &mut App) {
+    app.session_picker.turn_session_id = None;
+    app.session_picker.turn_selected = 0;
+    app.session_picker.turn_scroll_offset = 0;
+    app.sdk_inventory.clear_rewind_targets();
+}
+
+fn activate_turn_selection(app: &mut App) {
+    let Some(session_id) = app.session_picker.turn_session_id.clone() else {
+        return;
+    };
+    let Some(target) =
+        app.sdk_inventory.rewind_targets.get(app.session_picker.turn_selected).cloned()
+    else {
+        return;
+    };
+    let Some(conn) = app.session_runtime.conn.clone() else {
+        return;
+    };
+
+    app.startup.resolve_session_picker();
+    app.status = AppStatus::CommandPending;
+    app.turn.pending_command_label = Some("Forking before selected message...".to_owned());
+    app.turn.pending_command_ack = None;
+    if let Err(error) = begin_resume_session_at(app, &conn, session_id, target.uuid) {
+        app.turn.pending_command_label = None;
+        app.turn.pending_command_ack = None;
+        app.status = AppStatus::Ready;
+        app.clear_pending_session_resume();
+        push_system_message_with_severity(
+            app,
+            Some(SystemSeverity::Error),
+            &format!("Failed to fork before selected message: {error}"),
+        );
+    }
+    view::set_chat_surface(app);
 }
 
 fn activate_selection(app: &mut App) {
@@ -76,7 +184,7 @@ fn activate_selection(app: &mut App) {
         app.turn.pending_command_label = None;
         app.turn.pending_command_ack = None;
         app.status = AppStatus::Ready;
-        app.resuming_session_id = None;
+        app.clear_pending_session_resume();
         push_system_message_with_severity(
             app,
             Some(SystemSeverity::Error),
@@ -168,7 +276,7 @@ mod tests {
 
         assert_eq!(app.surface_mode, SurfaceMode::Chat);
         assert!(matches!(app.status, AppStatus::CommandPending));
-        assert_eq!(app.resuming_session_id.as_deref(), Some("session-1"));
+        assert_eq!(app.pending_session_resume_id(), Some("session-1"));
         let envelope = rx.try_recv().expect("resume command");
         assert!(matches!(
             envelope.command,
@@ -176,6 +284,67 @@ mod tests {
                 session_id,
                 ..
             } if session_id == "session-1"
+        ));
+    }
+
+    #[test]
+    fn space_is_ignored_to_avoid_accidental_destructive_navigation() {
+        let mut app = picker_app();
+        let (connection, mut rx) = AgentConnection::test_channel();
+        app.session_runtime.conn = Some(Rc::new(connection));
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+
+        assert!(app.session_picker.turn_session_id.is_none());
+        assert!(!app.sdk_inventory.rewind_targets_in_flight);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn right_opens_turn_picker_and_left_returns_to_sessions() {
+        let mut app = picker_app();
+        let (connection, _rx) = AgentConnection::test_channel();
+        app.session_runtime.conn = Some(Rc::new(connection));
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        assert_eq!(app.session_picker.turn_session_id.as_deref(), Some("session-1"));
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
+        assert!(app.session_picker.turn_session_id.is_none());
+        assert!(!app.sdk_inventory.rewind_targets_in_flight);
+        assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::SessionPicker));
+    }
+
+    #[test]
+    fn enter_on_turn_sends_resume_at_without_changing_plain_resume_command() {
+        let mut app = picker_app();
+        let (connection, mut rx) = AgentConnection::test_channel();
+        app.session_runtime.conn = Some(Rc::new(connection));
+        app.session_picker.turn_session_id = Some("session-1".to_owned());
+        app.sdk_inventory.rewind_targets = vec![crate::agent::model::RewindTarget {
+            uuid: "user-2".to_owned(),
+            first_text: "second prompt".to_owned(),
+            input_text: "second prompt".to_owned(),
+            index: 3,
+            previous_assistant_uuid: Some("assistant-1".to_owned()),
+            resume_anchor_uuid: Some("assistant-1".to_owned()),
+        }];
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert_eq!(app.surface_mode, SurfaceMode::Chat);
+        assert_eq!(app.pending_session_resume_id(), Some("session-1"));
+        let operation_id =
+            app.pending_resume_at_operation_id().expect("pending resume-at operation");
+        let envelope = rx.try_recv().expect("resume-at command");
+        assert_eq!(envelope.request_id.as_deref(), Some(operation_id));
+        assert!(matches!(
+            envelope.command,
+            BridgeCommand::ResumeSessionAt {
+                session_id,
+                target_user_message_id,
+                ..
+            } if session_id == "session-1" && target_user_message_id == "user-2"
         ));
     }
 
@@ -200,7 +369,7 @@ mod tests {
 
         assert_eq!(app.surface_mode, SurfaceMode::Chat);
         assert!(matches!(app.status, AppStatus::Ready));
-        assert!(app.resuming_session_id.is_none());
+        assert!(app.pending_session_resume.is_none());
         assert!(app.turn.pending_command_label.is_none());
         let last = app.transcript.messages.last().expect("error message");
         let text = match last.blocks.first().expect("text block") {

--- a/src/app/slash/catalog.rs
+++ b/src/app/slash/catalog.rs
@@ -246,9 +246,9 @@ pub(crate) const APP_SLASH_COMMANDS: &[AppSlashCommandSpec] = &[
     AppSlashCommandSpec {
         command: AppSlashCommand::Resume,
         name: "/resume",
-        usage: "Usage: /resume <session_id>",
+        usage: "Usage: /resume [session_id]",
         short_description: "Resume a session by ID",
-        long_description: "Resume a recent or manually supplied session ID.",
+        long_description: "Open the session picker, or resume a manually supplied session ID.",
         args: NO_ARGS,
     },
     AppSlashCommandSpec {

--- a/src/app/slash/executors.rs
+++ b/src/app/slash/executors.rs
@@ -14,7 +14,10 @@ use crate::app::connect::{
     SessionStartReason, begin_resume_session, begin_rewind, start_new_session,
 };
 use crate::app::events::push_system_message_with_severity;
-use crate::app::{App, AppStatus, CancelOrigin, ReleaseReason, SystemSeverity};
+use crate::app::{
+    App, AppStatus, CancelOrigin, FullscreenView, ReleaseReason, SessionPickerState,
+    SystemSeverity, view,
+};
 use std::fmt::Write as _;
 use std::path::Path;
 use std::process::{ExitStatus, Stdio};
@@ -962,6 +965,25 @@ fn handle_new_session_submit(app: &mut App, args: &[&str]) -> bool {
 }
 
 fn handle_resume_submit(app: &mut App, args: &[&str]) -> bool {
+    if args.is_empty() {
+        push_user_message(app, "/resume");
+        if require_connection(app, "Cannot open resume picker: not connected yet.").is_none() {
+            return true;
+        }
+        let current_session_id =
+            app.session_runtime.session_id.as_ref().map(crate::agent::model::SessionId::as_str);
+        let selected = current_session_id
+            .and_then(|session_id| {
+                app.recent_sessions
+                    .iter()
+                    .take(crate::app::session_picker::MAX_PICKER_SESSIONS)
+                    .position(|session| session.session_id == session_id)
+            })
+            .unwrap_or(0);
+        app.session_picker = SessionPickerState { selected, ..SessionPickerState::default() };
+        view::set_fullscreen_view(app, FullscreenView::SessionPicker);
+        return true;
+    }
     let [session_id_arg] = args else {
         push_system_message(app, usage(AppSlashCommand::Resume));
         return true;

--- a/src/app/slash/navigation.rs
+++ b/src/app/slash/navigation.rs
@@ -82,8 +82,10 @@ fn request_rewind_targets_for_active_argument(app: &mut App) {
     app.sdk_inventory.rewind_targets_in_flight = true;
     app.sdk_inventory.rewind_targets.clear();
     app.sdk_inventory.rewind_targets_session_id = None;
+    app.sdk_inventory.rewind_targets_request_session_id = Some(session_id.clone());
     if let Err(err) = conn.get_rewind_targets(session_id_text.clone()) {
         app.sdk_inventory.rewind_targets_in_flight = false;
+        app.sdk_inventory.rewind_targets_request_session_id = None;
         tracing::warn!(
             target: crate::logging::targets::APP_SESSION,
             event_name = "rewind_targets_request_failed",

--- a/src/app/slash/tests.rs
+++ b/src/app/slash/tests.rs
@@ -945,6 +945,7 @@ fn rewind_argument_candidates_use_cached_targets() {
             input_text: "first prompt".to_owned(),
             index: 0,
             previous_assistant_uuid: None,
+            resume_anchor_uuid: None,
         },
         model::RewindTarget {
             uuid: "user-2".to_owned(),
@@ -952,6 +953,7 @@ fn rewind_argument_candidates_use_cached_targets() {
             input_text: "second prompt".to_owned(),
             index: 3,
             previous_assistant_uuid: Some("assistant-1".to_owned()),
+            resume_anchor_uuid: Some("assistant-1".to_owned()),
         },
     ];
     app.input.set_text("/rewind second");
@@ -985,6 +987,7 @@ fn rewind_argument_candidates_hide_stale_targets() {
         input_text: "first prompt".to_owned(),
         index: 0,
         previous_assistant_uuid: None,
+        resume_anchor_uuid: None,
     }];
 
     let candidates = argument_candidates(&app, "/rewind", 0);
@@ -1053,6 +1056,7 @@ fn rewind_argument_context_shows_no_matching_messages_for_filtered_empty_result(
         input_text: "first prompt".to_owned(),
         index: 0,
         previous_assistant_uuid: None,
+        resume_anchor_uuid: None,
     }];
     app.input.set_text("/rewind missing");
     let _ = app.input.set_cursor(0, "/rewind missing".chars().count());
@@ -1364,17 +1368,53 @@ fn new_session_command_is_rendered_as_user_message() {
 }
 
 #[test]
-fn resume_with_missing_id_returns_usage() {
+fn resume_without_id_opens_fullscreen_picker() {
     let mut app = App::test_default();
+    let _receiver = attach_test_connection(&mut app);
     let consumed = try_handle_submit(&mut app, "/resume");
     assert!(consumed);
-    let Some(last) = app.transcript.messages.last() else {
-        panic!("expected usage message");
-    };
-    let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+    assert!(matches!(
+        app.surface_mode,
+        crate::app::SurfaceMode::Fullscreen(crate::app::FullscreenView::SessionPicker)
+    ));
+    let last = app.transcript.messages.last().expect("resume command message");
+    let MessageBlock::Text(block) = last.blocks.first().expect("text block") else {
         panic!("expected text block");
     };
-    assert_eq!(block.text, "Usage: /resume <session_id>");
+    assert_eq!(block.text, "/resume");
+}
+
+#[test]
+fn resume_picker_preselects_current_session_when_listed() {
+    let mut app = App::test_default();
+    let _receiver = attach_test_connection(&mut app);
+    app.session_runtime.session_id = Some(model::SessionId::new("current-session"));
+    app.recent_sessions = vec![
+        crate::app::RecentSessionInfo {
+            session_id: "other-session".into(),
+            summary: "other".into(),
+            last_modified_ms: 2,
+            file_size_bytes: 1,
+            cwd: None,
+            git_branch: None,
+            custom_title: None,
+            first_prompt: Some("other".into()),
+        },
+        crate::app::RecentSessionInfo {
+            session_id: "current-session".into(),
+            summary: "current".into(),
+            last_modified_ms: 1,
+            file_size_bytes: 1,
+            cwd: None,
+            git_branch: None,
+            custom_title: None,
+            first_prompt: Some("current".into()),
+        },
+    ];
+
+    assert!(try_handle_submit(&mut app, "/resume"));
+
+    assert_eq!(app.session_picker.selected, 1);
 }
 
 #[test]
@@ -1388,7 +1428,7 @@ fn resume_with_extra_args_returns_usage() {
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
         panic!("expected text block");
     };
-    assert_eq!(block.text, "Usage: /resume <session_id>");
+    assert_eq!(block.text, "Usage: /resume [session_id]");
 }
 
 #[test]
@@ -1416,6 +1456,7 @@ fn rewind_with_cached_target_requires_connection() {
         input_text: "first prompt".to_owned(),
         index: 0,
         previous_assistant_uuid: None,
+        resume_anchor_uuid: None,
     }];
 
     let consumed = try_handle_submit(&mut app, "/rewind user-1 conversation");
@@ -1442,6 +1483,7 @@ fn rewind_with_cached_target_sends_bridge_command() {
         input_text: "first prompt".to_owned(),
         index: 0,
         previous_assistant_uuid: None,
+        resume_anchor_uuid: None,
     }];
 
     let consumed = try_handle_submit(&mut app, "/rewind user-1 conversation");
@@ -1491,7 +1533,7 @@ async fn resume_sets_command_pending_when_connected() {
             let consumed = try_handle_submit(&mut app, "/resume abc-123");
             assert!(consumed);
             assert!(matches!(app.status, AppStatus::CommandPending));
-            assert_eq!(app.resuming_session_id.as_deref(), Some("abc-123"));
+            assert_eq!(app.pending_session_resume_id(), Some("abc-123"));
 
             tokio::task::yield_now().await;
             assert!(rx.try_recv().is_ok());
@@ -2104,26 +2146,31 @@ fn limits_with_fresh_snapshot_prints_markdown_table_in_chat() {
     app.usage.snapshot = Some(UsageSnapshot {
         source: UsageSourceKind::Oauth,
         fetched_at: SystemTime::now(),
+        subscription_type: None,
         five_hour: Some(UsageWindow {
-            label: "5-hour",
+            label: "5-hour".to_owned(),
             utilization: 47.0,
             resets_at: None,
             reset_description: Some("resets in 2h 14m".to_owned()),
         }),
         seven_day: Some(UsageWindow {
-            label: "7-day",
+            label: "7-day".to_owned(),
             utilization: 62.0,
             resets_at: None,
             reset_description: Some("resets in 4d 11h".to_owned()),
         }),
+        seven_day_oauth_apps: None,
         seven_day_opus: None,
         seven_day_sonnet: None,
+        model_scoped: Vec::new(),
         extra_usage: Some(ExtraUsage {
             monthly_limit: Some(20.0),
             used_credits: Some(12.4),
             utilization: Some(62.0),
             currency: Some("USD".to_owned()),
         }),
+        session: None,
+        activity: None,
     });
 
     let consumed = try_handle_submit(&mut app, "/limits");
@@ -2142,20 +2189,15 @@ fn limits_with_fresh_snapshot_prints_markdown_table_in_chat() {
 }
 
 #[test]
-fn limits_without_fresh_snapshot_prints_loading_message() {
+fn limits_without_fresh_snapshot_waits_for_final_response() {
     let mut app = App::test_default();
+    let message_count = app.transcript.messages.len();
 
     let consumed = try_handle_submit(&mut app, "/limits");
 
     assert!(consumed);
     assert!(app.usage.pending_limits_response);
-    let Some(last) = app.transcript.messages.last() else {
-        panic!("expected loading message");
-    };
-    let Some(MessageBlock::Text(block)) = last.blocks.first() else {
-        panic!("expected text block");
-    };
-    assert_eq!(block.text, "Getting recent usage info.");
+    assert_eq!(app.transcript.messages.len(), message_count);
 }
 
 #[test]

--- a/src/app/state/app.rs
+++ b/src/app/state/app.rs
@@ -3,6 +3,11 @@
 
 use super::prelude::*;
 
+pub(crate) struct PendingSessionResume {
+    session_id: String,
+    operation_id: Option<String>,
+}
+
 #[allow(clippy::struct_excessive_bools)]
 pub struct App {
     pub surface_mode: SurfaceMode,
@@ -18,8 +23,8 @@ pub struct App {
     pub sdk_inventory: SdkInventoryState,
     pub input: InputState,
     pub status: AppStatus,
-    /// Session id currently being resumed via `/resume`.
-    pub(crate) resuming_session_id: Option<String>,
+    /// Authoritative source and request identity for an in-flight session resume.
+    pub(crate) pending_session_resume: Option<PendingSessionResume>,
     /// Whether the synthetic session overview is eligible for chat transcript output.
     pub(crate) show_session_overview: bool,
     pub should_quit: bool,
@@ -110,6 +115,26 @@ pub struct App {
 }
 
 impl App {
+    pub(crate) fn set_pending_session_resume(
+        &mut self,
+        session_id: String,
+        operation_id: Option<String>,
+    ) {
+        self.pending_session_resume = Some(PendingSessionResume { session_id, operation_id });
+    }
+
+    pub(crate) fn clear_pending_session_resume(&mut self) {
+        self.pending_session_resume = None;
+    }
+
+    pub(crate) fn pending_session_resume_id(&self) -> Option<&str> {
+        self.pending_session_resume.as_ref().map(|pending| pending.session_id.as_str())
+    }
+
+    pub(crate) fn pending_resume_at_operation_id(&self) -> Option<&str> {
+        self.pending_session_resume.as_ref().and_then(|pending| pending.operation_id.as_deref())
+    }
+
     #[must_use]
     pub fn session_thinking_effort_effective(&self) -> model::EffortLevel {
         self.session_runtime
@@ -167,7 +192,7 @@ impl App {
             sdk_inventory: SdkInventoryState::default(),
             input: InputState::new(),
             status: AppStatus::Ready,
-            resuming_session_id: None,
+            pending_session_resume: None,
             show_session_overview: true,
             turn: TurnState::default(),
             should_quit: false,

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -57,8 +57,9 @@ pub use types::{
     AppStatus, CancelOrigin, ExtraUsage, HistoryRetentionPolicy, HistoryRetentionStats, LoginHint,
     McpState, MessageUsage, ModeInfo, ModeState, PasteSessionState, PendingCommandAck,
     PostExitAction, RecentSessionInfo, RenderCacheBudget, SelectionPoint, SessionPickerState,
-    SessionUsageState, ToolCallScope, UpdatePromptAction, UpdatePromptState, UsageSnapshot,
-    UsageSourceKind, UsageSourceMode, UsageState, UsageWindow,
+    SessionUsageState, SessionUsageSummary, ToolCallScope, UpdatePromptAction, UpdatePromptState,
+    UsageActivitySummary, UsageActivityWindow, UsageBehaviorAttribution, UsageNamedAttribution,
+    UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow,
 };
 
 mod prelude {

--- a/src/app/state/sdk_inventory.rs
+++ b/src/app/state/sdk_inventory.rs
@@ -14,8 +14,12 @@ pub struct SdkInventoryState {
     pub rewind_targets: Vec<model::RewindTarget>,
     /// Session id that owns `rewind_targets`.
     pub rewind_targets_session_id: Option<model::SessionId>,
+    /// Session id expected by the in-flight rewind-target request.
+    pub rewind_targets_request_session_id: Option<model::SessionId>,
     /// True while a rewind target refresh request is in flight.
     pub rewind_targets_in_flight: bool,
+    /// Error returned for the latest correlated rewind-target request.
+    pub rewind_targets_error: Option<String>,
     /// Subagents advertised by the agent via `AvailableAgentsUpdate`.
     pub available_agents: Vec<model::AvailableAgent>,
     /// Models advertised by the agent SDK for the active session.
@@ -26,6 +30,8 @@ impl SdkInventoryState {
     pub fn clear_rewind_targets(&mut self) {
         self.rewind_targets.clear();
         self.rewind_targets_session_id = None;
+        self.rewind_targets_request_session_id = None;
         self.rewind_targets_in_flight = false;
+        self.rewind_targets_error = None;
     }
 }

--- a/src/app/state/tool_call_info.rs
+++ b/src/app/state/tool_call_info.rs
@@ -103,6 +103,15 @@ impl ToolCallInfo {
     }
 
     #[must_use]
+    pub fn background_ends_with_final_response(&self) -> bool {
+        self.output_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.bash.as_ref())
+            .and_then(|metadata| metadata.background_ends_with_final_response)
+            .unwrap_or(false)
+    }
+
+    #[must_use]
     pub fn task_is_backgrounded(&self) -> bool {
         self.task_metadata.as_ref().and_then(|metadata| metadata.is_backgrounded).unwrap_or(false)
     }

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -76,6 +76,12 @@ pub struct SessionPickerState {
     pub selected: usize,
     /// Scroll offset for when the list exceeds the visible area.
     pub scroll_offset: usize,
+    /// Session whose turns are being inspected for a resume-at fork.
+    pub turn_session_id: Option<String>,
+    /// Highlighted turn in `app.sdk_inventory.rewind_targets`.
+    pub turn_selected: usize,
+    /// Scroll offset for the turn list.
+    pub turn_scroll_offset: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -96,23 +102,54 @@ pub enum UsageSourceMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UsageSourceKind {
+    Sdk,
     Oauth,
     Cli,
 }
 
-impl UsageSourceKind {
-    #[must_use]
-    pub const fn label(self) -> &'static str {
-        match self {
-            Self::Oauth => "oauth",
-            Self::Cli => "cli",
-        }
-    }
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionUsageSummary {
+    pub total_cost_usd: Option<f64>,
+    pub total_api_duration_ms: Option<f64>,
+    pub total_duration_ms: Option<f64>,
+    pub total_lines_added: Option<f64>,
+    pub total_lines_removed: Option<f64>,
+    pub model_count: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UsageActivityWindow {
+    pub request_count: u64,
+    pub session_count: u64,
+    pub behaviors: Vec<UsageBehaviorAttribution>,
+    pub agents: Vec<UsageNamedAttribution>,
+    pub skills: Vec<UsageNamedAttribution>,
+    pub plugins: Vec<UsageNamedAttribution>,
+    pub mcp_servers: Vec<UsageNamedAttribution>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UsageBehaviorAttribution {
+    pub key: String,
+    pub pct: f64,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UsageNamedAttribution {
+    pub name: String,
+    pub pct: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UsageActivitySummary {
+    pub day: Option<UsageActivityWindow>,
+    pub week: Option<UsageActivityWindow>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct UsageWindow {
-    pub label: &'static str,
+    pub label: String,
     pub utilization: f64,
     pub resets_at: Option<std::time::SystemTime>,
     pub reset_description: Option<String>,
@@ -130,11 +167,16 @@ pub struct ExtraUsage {
 pub struct UsageSnapshot {
     pub source: UsageSourceKind,
     pub fetched_at: std::time::SystemTime,
+    pub subscription_type: Option<String>,
     pub five_hour: Option<UsageWindow>,
     pub seven_day: Option<UsageWindow>,
+    pub seven_day_oauth_apps: Option<UsageWindow>,
     pub seven_day_opus: Option<UsageWindow>,
     pub seven_day_sonnet: Option<UsageWindow>,
+    pub model_scoped: Vec<UsageWindow>,
     pub extra_usage: Option<ExtraUsage>,
+    pub session: Option<SessionUsageSummary>,
+    pub activity: Option<UsageActivitySummary>,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/src/app/usage/cli.rs
+++ b/src/app/usage/cli.rs
@@ -79,15 +79,20 @@ fn parse_usage_output(text: &str) -> Result<UsageSnapshot, String> {
     Ok(UsageSnapshot {
         source: UsageSourceKind::Cli,
         fetched_at: SystemTime::now(),
+        subscription_type: None,
         five_hour: Some(five_hour),
         seven_day,
+        seven_day_oauth_apps: None,
         seven_day_opus,
         seven_day_sonnet,
+        model_scoped: Vec::new(),
         extra_usage: None,
+        session: None,
+        activity: None,
     })
 }
 
-fn extract_window(text: &str, labels: &[&str], window_label: &'static str) -> Option<UsageWindow> {
+fn extract_window(text: &str, labels: &[&str], window_label: &str) -> Option<UsageWindow> {
     let lines = text.lines().collect::<Vec<_>>();
     let normalized_labels =
         labels.iter().map(|label| normalized_for_label_search(label)).collect::<Vec<_>>();
@@ -111,7 +116,7 @@ fn extract_window(text: &str, labels: &[&str], window_label: &'static str) -> Op
         });
 
         return Some(UsageWindow {
-            label: window_label,
+            label: window_label.to_owned(),
             utilization,
             resets_at: None,
             reset_description,

--- a/src/app/usage/mod.rs
+++ b/src/app/usage/mod.rs
@@ -3,8 +3,11 @@ mod cli;
 mod oauth;
 
 use crate::agent::events::ClientEvent;
+use crate::agent::types::StructuredUsageSnapshot;
 use crate::app::{
-    App, ExtraUsage, SystemSeverity, UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageWindow,
+    App, ExtraUsage, SessionUsageSummary, SystemSeverity, UsageActivitySummary,
+    UsageActivityWindow, UsageBehaviorAttribution, UsageNamedAttribution, UsageSnapshot,
+    UsageSourceKind, UsageSourceMode, UsageWindow,
 };
 use std::fmt::Write as _;
 use std::time::{Duration, SystemTime};
@@ -33,7 +36,6 @@ pub(crate) fn request_limits_summary(app: &mut App) {
     }
 
     app.usage.pending_limits_response = true;
-    push_info_message(app, "Getting recent usage info.");
     request_refresh(app);
 }
 
@@ -44,9 +46,20 @@ pub(crate) fn request_refresh(app: &mut App) {
 
     apply_refresh_started(app);
 
+    if app.usage.active_source == UsageSourceMode::Auto
+        && let (Some(connection), Some(session_id)) =
+            (app.session_runtime.conn.as_ref(), app.session_runtime.session_id.as_ref())
+        && connection.get_usage(session_id.as_str().to_owned()).is_ok()
+    {
+        return;
+    }
+
+    spawn_host_refresh(app, app.usage.active_source, None);
+}
+
+fn spawn_host_refresh(app: &App, source_mode: UsageSourceMode, sdk_error: Option<String>) {
     let event_tx = app.event_tx.clone();
     let epoch = app.session_runtime.session_scope_epoch;
-    let source_mode = app.usage.active_source;
     let cwd_raw = app.cwd_raw.clone();
 
     tokio::task::spawn_local(async move {
@@ -56,16 +69,138 @@ pub(crate) fn request_refresh(app: &mut App) {
                 let _ = event_tx.send(ClientEvent::UsageSnapshotReceived { epoch, snapshot }).await;
             }
             Err(error) => {
+                let message = sdk_error.map_or(error.message.clone(), |sdk_error| {
+                    format!(
+                        "Structured SDK usage unavailable ({sdk_error}). Account usage fallback failed: {}",
+                        error.message
+                    )
+                });
                 let _ = event_tx
-                    .send(ClientEvent::UsageRefreshFailed {
-                        epoch,
-                        message: error.message,
-                        source: error.source,
-                    })
+                    .send(ClientEvent::UsageRefreshFailed { epoch, message, source: error.source })
                     .await;
             }
         }
     });
+}
+
+pub(crate) fn apply_structured_sdk_result(
+    app: &mut App,
+    snapshot: Option<StructuredUsageSnapshot>,
+    error: Option<String>,
+) {
+    if let Some(snapshot) = snapshot {
+        apply_refresh_success(app, map_structured_sdk_snapshot(snapshot));
+        emit_pending_limits_success(app);
+        return;
+    }
+
+    let message = error.unwrap_or_else(|| "structured SDK usage returned no snapshot".to_owned());
+    if tokio::runtime::Handle::try_current().is_ok() {
+        spawn_host_refresh(app, UsageSourceMode::Auto, Some(message));
+    } else {
+        apply_refresh_failure(app, message.clone(), UsageSourceKind::Sdk);
+        emit_pending_limits_failure(app, &message);
+    }
+}
+
+fn map_structured_sdk_snapshot(snapshot: StructuredUsageSnapshot) -> UsageSnapshot {
+    let rate_limits_available = snapshot.rate_limits_available != Some(false);
+    let map_window = |window: Option<crate::agent::types::StructuredUsageWindow>, label: &str| {
+        rate_limits_available.then_some(window).flatten().map(|window| UsageWindow {
+            label: label.to_owned(),
+            utilization: window.utilization.clamp(0.0, 100.0),
+            resets_at: window.resets_at.as_deref().and_then(oauth::parse_timestamp),
+            reset_description: None,
+        })
+    };
+    let extra_usage =
+        rate_limits_available.then_some(snapshot.extra_usage).flatten().map(|extra| {
+            ExtraUsage {
+                // The experimental SDK declaration does not specify the denomination of these two raw fields. Do not present guessed monetary values.
+                monthly_limit: None,
+                used_credits: None,
+                utilization: extra.utilization.map(|value| value.clamp(0.0, 100.0)),
+                currency: extra.currency,
+            }
+        });
+    let model_scoped = if rate_limits_available {
+        snapshot
+            .model_scoped
+            .into_iter()
+            .map(|window| UsageWindow {
+                label: format!("7-day {}", window.display_name),
+                utilization: window.utilization.clamp(0.0, 100.0),
+                resets_at: window.resets_at.as_deref().and_then(oauth::parse_timestamp),
+                reset_description: None,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let session = snapshot.session.map(|session| SessionUsageSummary {
+        total_cost_usd: session.total_cost_usd,
+        total_api_duration_ms: session.total_api_duration_ms,
+        total_duration_ms: session.total_duration_ms,
+        total_lines_added: nonnegative_number(session.total_lines_added),
+        total_lines_removed: nonnegative_number(session.total_lines_removed),
+        model_count: session.model_count,
+    });
+    let activity = UsageActivitySummary {
+        day: snapshot.activity_day.map(map_activity_window),
+        week: snapshot.activity_week.map(map_activity_window),
+    };
+    let activity = (activity.day.is_some() || activity.week.is_some()).then_some(activity);
+
+    UsageSnapshot {
+        source: UsageSourceKind::Sdk,
+        fetched_at: SystemTime::now(),
+        subscription_type: snapshot.subscription_type,
+        five_hour: map_window(snapshot.five_hour, "5-hour"),
+        seven_day: map_window(snapshot.seven_day, "7-day"),
+        seven_day_oauth_apps: map_window(snapshot.seven_day_oauth_apps, "7-day OAuth apps"),
+        seven_day_opus: map_window(snapshot.seven_day_opus, "7-day Opus"),
+        seven_day_sonnet: map_window(snapshot.seven_day_sonnet, "7-day Sonnet"),
+        model_scoped,
+        extra_usage,
+        session,
+        activity,
+    }
+}
+
+fn map_activity_window(
+    window: crate::agent::types::StructuredActivityWindow,
+) -> UsageActivityWindow {
+    UsageActivityWindow {
+        request_count: window.request_count,
+        session_count: window.session_count,
+        behaviors: window
+            .behaviors
+            .into_iter()
+            .map(|item| UsageBehaviorAttribution {
+                key: item.key,
+                pct: item.pct.clamp(0.0, 100.0),
+                count: item.count,
+            })
+            .collect(),
+        agents: map_named_attributions(window.agents),
+        skills: map_named_attributions(window.skills),
+        plugins: map_named_attributions(window.plugins),
+        mcp_servers: map_named_attributions(window.mcp_servers),
+    }
+}
+
+fn map_named_attributions(
+    items: Vec<crate::agent::types::StructuredNamedAttribution>,
+) -> Vec<UsageNamedAttribution> {
+    items
+        .into_iter()
+        .map(|item| UsageNamedAttribution { name: item.name, pct: item.pct.clamp(0.0, 100.0) })
+        .collect()
+}
+
+fn nonnegative_number(value: Option<f64>) -> Option<f64> {
+    let value = value?;
+    (value.is_finite() && value >= 0.0).then_some(value)
 }
 
 pub(crate) fn apply_refresh_started(app: &mut App) {
@@ -117,12 +252,16 @@ pub(crate) fn visible_windows(snapshot: &UsageSnapshot) -> Vec<&UsageWindow> {
     if let Some(window) = snapshot.seven_day.as_ref() {
         windows.push(window);
     }
+    if let Some(window) = snapshot.seven_day_oauth_apps.as_ref() {
+        windows.push(window);
+    }
     if let Some(window) = snapshot.seven_day_sonnet.as_ref() {
         windows.push(window);
     }
     if let Some(window) = snapshot.seven_day_opus.as_ref() {
         windows.push(window);
     }
+    windows.extend(snapshot.model_scoped.iter());
     windows
 }
 
@@ -136,13 +275,8 @@ pub(crate) fn format_window_reset(window: &UsageWindow) -> Option<String> {
 }
 
 pub(crate) fn format_limits_summary(snapshot: &UsageSnapshot) -> String {
-    let mut rows = Vec::new();
-    if let Some(window) = snapshot.five_hour.as_ref() {
-        rows.push(format_limits_window_row(window));
-    }
-    if let Some(window) = snapshot.seven_day.as_ref() {
-        rows.push(format_limits_window_row(window));
-    }
+    let rows =
+        visible_windows(snapshot).into_iter().map(format_limits_window_row).collect::<Vec<_>>();
 
     let mut out = String::new();
     if rows.is_empty() {
@@ -193,7 +327,7 @@ fn format_limits_window_row(window: &UsageWindow) -> String {
     let reset = format_window_reset(window).unwrap_or_else(|| "unavailable".to_owned());
     format!(
         "| {} | {:.0}% | {} |",
-        markdown_cell(window.label),
+        markdown_cell(&window.label),
         window.utilization,
         markdown_cell(&reset)
     )

--- a/src/app/usage/oauth.rs
+++ b/src/app/usage/oauth.rs
@@ -127,28 +127,29 @@ fn decode_usage_payload(body: &[u8]) -> Result<UsageSnapshot, OauthFetchError> {
         ));
     }
 
-    let _ = payload.seven_day_oauth_apps;
     let _ = payload.iguana_necktie;
 
     Ok(UsageSnapshot {
         source: UsageSourceKind::Oauth,
         fetched_at: SystemTime::now(),
+        subscription_type: None,
         five_hour,
         seven_day: map_window(payload.seven_day, "7-day"),
+        seven_day_oauth_apps: map_window(payload.seven_day_oauth_apps, "7-day OAuth apps"),
         seven_day_opus: map_window(payload.seven_day_opus, "7-day Opus"),
         seven_day_sonnet: map_window(payload.seven_day_sonnet, "7-day Sonnet"),
+        model_scoped: Vec::new(),
         extra_usage: map_extra_usage(payload.extra_usage),
+        session: None,
+        activity: None,
     })
 }
 
-fn map_window(
-    payload: Option<OAuthUsageWindowPayload>,
-    label: &'static str,
-) -> Option<UsageWindow> {
+fn map_window(payload: Option<OAuthUsageWindowPayload>, label: &str) -> Option<UsageWindow> {
     let payload = payload?;
     let utilization = payload.utilization?;
     Some(UsageWindow {
-        label,
+        label: label.to_owned(),
         utilization: utilization.clamp(0.0, 100.0),
         resets_at: payload.resets_at.as_ref().and_then(parse_timestamp_value),
         reset_description: None,
@@ -195,6 +196,11 @@ fn parse_timestamp_value(value: &serde_json::Value) -> Option<SystemTime> {
             .or_else(|| raw.trim().parse::<i64>().ok().and_then(system_time_from_epoch)),
         _ => None,
     }
+}
+
+pub(super) fn parse_timestamp(raw: &str) -> Option<SystemTime> {
+    parse_iso8601_timestamp(raw)
+        .or_else(|| raw.trim().parse::<i64>().ok().and_then(system_time_from_epoch))
 }
 
 fn system_time_from_epoch(raw: i64) -> Option<SystemTime> {

--- a/src/app/usage/tests.rs
+++ b/src/app/usage/tests.rs
@@ -6,7 +6,7 @@ use crate::app::{ExtraUsage, UsageSourceKind};
 fn formats_day_scale_reset() {
     let target = SystemTime::now() + Duration::from_secs(4 * 24 * 60 * 60 + 12 * 60 * 60);
     let formatted = format_window_reset(&UsageWindow {
-        label: "7-day",
+        label: "7-day".to_owned(),
         utilization: 50.0,
         resets_at: Some(target),
         reset_description: None,
@@ -18,7 +18,7 @@ fn formats_day_scale_reset() {
 #[test]
 fn prefers_reset_description_when_no_timestamp_exists() {
     let window = UsageWindow {
-        label: "7-day",
+        label: "7-day".to_owned(),
         utilization: 40.0,
         resets_at: None,
         reset_description: Some("Resets Feb 12 at 1:30pm (Asia/Calcutta)".to_owned()),
@@ -34,25 +34,32 @@ fn collects_only_present_windows() {
     let snapshot = UsageSnapshot {
         source: UsageSourceKind::Oauth,
         fetched_at: SystemTime::now(),
+        subscription_type: None,
         five_hour: Some(UsageWindow {
-            label: "5-hour",
+            label: "5-hour".to_owned(),
             utilization: 10.0,
             resets_at: None,
             reset_description: None,
         }),
         seven_day: None,
+        seven_day_oauth_apps: None,
         seven_day_opus: Some(UsageWindow {
-            label: "7-day Opus",
+            label: "7-day Opus".to_owned(),
             utilization: 30.0,
             resets_at: None,
             reset_description: None,
         }),
         seven_day_sonnet: None,
+        model_scoped: Vec::new(),
         extra_usage: None,
+        session: None,
+        activity: None,
     };
 
-    let labels =
-        visible_windows(&snapshot).into_iter().map(|window| window.label).collect::<Vec<_>>();
+    let labels = visible_windows(&snapshot)
+        .into_iter()
+        .map(|window| window.label.as_str())
+        .collect::<Vec<_>>();
     assert_eq!(labels, vec!["5-hour", "7-day Opus"]);
 }
 
@@ -61,26 +68,31 @@ fn formats_limits_summary_as_markdown_table() {
     let snapshot = UsageSnapshot {
         source: UsageSourceKind::Oauth,
         fetched_at: SystemTime::now(),
+        subscription_type: None,
         five_hour: Some(UsageWindow {
-            label: "5-hour",
+            label: "5-hour".to_owned(),
             utilization: 47.4,
             resets_at: None,
             reset_description: Some("resets in 2h 14m".to_owned()),
         }),
         seven_day: Some(UsageWindow {
-            label: "7-day",
+            label: "7-day".to_owned(),
             utilization: 62.0,
             resets_at: None,
             reset_description: Some("resets in 4d 11h".to_owned()),
         }),
+        seven_day_oauth_apps: None,
         seven_day_opus: None,
         seven_day_sonnet: None,
+        model_scoped: Vec::new(),
         extra_usage: Some(ExtraUsage {
             monthly_limit: Some(20.0),
             used_credits: Some(12.4),
             utilization: Some(62.0),
             currency: Some("USD".to_owned()),
         }),
+        session: None,
+        activity: None,
     };
 
     let summary = format_limits_summary(&snapshot);
@@ -97,16 +109,21 @@ fn limits_summary_omits_absent_optional_sections() {
     let snapshot = UsageSnapshot {
         source: UsageSourceKind::Oauth,
         fetched_at: SystemTime::now(),
+        subscription_type: None,
         five_hour: Some(UsageWindow {
-            label: "5-hour",
+            label: "5-hour".to_owned(),
             utilization: 10.0,
             resets_at: None,
             reset_description: None,
         }),
         seven_day: None,
+        seven_day_oauth_apps: None,
         seven_day_opus: None,
         seven_day_sonnet: None,
+        model_scoped: Vec::new(),
         extra_usage: None,
+        session: None,
+        activity: None,
     };
 
     let summary = format_limits_summary(&snapshot);
@@ -121,19 +138,128 @@ fn limits_summary_escapes_markdown_table_cells() {
     let snapshot = UsageSnapshot {
         source: UsageSourceKind::Oauth,
         fetched_at: SystemTime::now(),
+        subscription_type: None,
         five_hour: Some(UsageWindow {
-            label: "5-hour",
+            label: "5-hour".to_owned(),
             utilization: 10.0,
             resets_at: None,
             reset_description: Some("resets | soon\nreally".to_owned()),
         }),
         seven_day: None,
+        seven_day_oauth_apps: None,
         seven_day_opus: None,
         seven_day_sonnet: None,
+        model_scoped: Vec::new(),
         extra_usage: None,
+        session: None,
+        activity: None,
     };
 
     let summary = format_limits_summary(&snapshot);
 
     assert!(summary.contains("| 5-hour | 10% | resets \\| soon really |"));
+}
+
+#[test]
+fn maps_structured_sdk_usage_without_conflating_session_and_account_totals() {
+    let snapshot = map_structured_sdk_snapshot(StructuredUsageSnapshot {
+        subscription_type: Some("max".to_owned()),
+        rate_limits_available: Some(true),
+        five_hour: Some(crate::agent::types::StructuredUsageWindow {
+            utilization: 42.0,
+            resets_at: Some("2026-08-12T10:00:00Z".to_owned()),
+        }),
+        seven_day: None,
+        seven_day_oauth_apps: None,
+        seven_day_opus: None,
+        seven_day_sonnet: None,
+        model_scoped: vec![crate::agent::types::StructuredModelUsageWindow {
+            display_name: "Fable".to_owned(),
+            utilization: 33.0,
+            resets_at: None,
+        }],
+        extra_usage: Some(crate::agent::types::StructuredExtraUsage {
+            monthly_limit: Some(2_000.0),
+            used_credits: Some(375.0),
+            utilization: Some(18.75),
+            currency: Some("USD".to_owned()),
+        }),
+        session: Some(crate::agent::types::StructuredSessionUsage {
+            total_cost_usd: Some(0.125),
+            total_api_duration_ms: Some(1_500.0),
+            total_duration_ms: Some(2_000.0),
+            total_lines_added: Some(12.0),
+            total_lines_removed: Some(3.0),
+            model_count: Some(2),
+        }),
+        activity_day: Some(crate::agent::types::StructuredActivityWindow {
+            request_count: 4,
+            session_count: 2,
+            behaviors: vec![crate::agent::types::StructuredBehaviorAttribution {
+                key: "long_context".to_owned(),
+                pct: 25.0,
+                count: 1,
+            }],
+            agents: vec![crate::agent::types::StructuredNamedAttribution {
+                name: "Explore".to_owned(),
+                pct: 40.0,
+            }],
+            skills: Vec::new(),
+            plugins: Vec::new(),
+            mcp_servers: Vec::new(),
+        }),
+        activity_week: None,
+    });
+
+    assert_eq!(snapshot.source, UsageSourceKind::Sdk);
+    assert_eq!(snapshot.subscription_type.as_deref(), Some("max"));
+    assert_eq!(snapshot.five_hour.as_ref().map(|window| window.utilization), Some(42.0));
+    assert_eq!(snapshot.extra_usage.as_ref().and_then(|extra| extra.monthly_limit), None);
+    assert_eq!(snapshot.extra_usage.as_ref().and_then(|extra| extra.used_credits), None);
+    assert_eq!(snapshot.extra_usage.as_ref().and_then(|extra| extra.utilization), Some(18.75));
+    assert_eq!(
+        snapshot.model_scoped.first().map(|window| window.label.as_str()),
+        Some("7-day Fable")
+    );
+    assert_eq!(snapshot.session.as_ref().and_then(|session| session.total_lines_added), Some(12.0));
+    assert_eq!(
+        snapshot
+            .activity
+            .as_ref()
+            .and_then(|activity| activity.day.as_ref())
+            .map(|day| day.request_count),
+        Some(4)
+    );
+    assert_eq!(
+        snapshot
+            .activity
+            .as_ref()
+            .and_then(|activity| activity.day.as_ref())
+            .and_then(|day| day.behaviors.first())
+            .map(|behavior| behavior.key.as_str()),
+        Some("long_context")
+    );
+}
+
+#[test]
+fn suppresses_plan_windows_when_sdk_reports_rate_limits_unavailable() {
+    let snapshot = map_structured_sdk_snapshot(StructuredUsageSnapshot {
+        subscription_type: None,
+        rate_limits_available: Some(false),
+        five_hour: Some(crate::agent::types::StructuredUsageWindow {
+            utilization: 42.0,
+            resets_at: None,
+        }),
+        seven_day: None,
+        seven_day_oauth_apps: None,
+        seven_day_opus: None,
+        seven_day_sonnet: None,
+        model_scoped: Vec::new(),
+        extra_usage: None,
+        session: None,
+        activity_day: None,
+        activity_week: None,
+    });
+
+    assert!(snapshot.five_hour.is_none());
 }

--- a/src/ui/config/usage.rs
+++ b/src/ui/config/usage.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::theme;
 use crate::app::usage;
-use crate::app::{App, ExtraUsage, UsageWindow};
+use crate::app::{
+    App, ExtraUsage, SessionUsageSummary, UsageActivitySummary, UsageActivityWindow, UsageWindow,
+};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Margin, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -17,24 +19,35 @@ pub(super) fn render(frame: &mut Frame, area: Rect, app: &App) {
     let windows = app.usage.snapshot.as_ref().map_or_else(Vec::new, usage::visible_windows);
 
     let mut constraints = vec![Constraint::Length(1)];
-    if windows.is_empty() {
-        constraints.push(Constraint::Min(3));
-    } else {
+    let snapshot = app.usage.snapshot.as_ref();
+    let has_snapshot_content = !windows.is_empty()
+        || snapshot.and_then(|snapshot| snapshot.extra_usage.as_ref()).is_some()
+        || snapshot.and_then(|snapshot| snapshot.session.as_ref()).is_some()
+        || snapshot.and_then(|snapshot| snapshot.activity.as_ref()).is_some();
+    if has_snapshot_content {
         for window in &windows {
             constraints.push(Constraint::Length(window_height(window, content_area.width)));
             constraints.push(Constraint::Length(1));
         }
-        if let Some(extra_usage) =
-            app.usage.snapshot.as_ref().and_then(|snapshot| snapshot.extra_usage.as_ref())
-        {
+        if let Some(extra_usage) = snapshot.and_then(|snapshot| snapshot.extra_usage.as_ref()) {
             constraints
                 .push(Constraint::Length(extra_usage_height(extra_usage, content_area.width)));
+            constraints.push(Constraint::Length(1));
+        }
+        if let Some(session) = snapshot.and_then(|snapshot| snapshot.session.as_ref()) {
+            constraints.push(Constraint::Length(session_usage_height(session, content_area.width)));
+            constraints.push(Constraint::Length(1));
+        }
+        if let Some(activity) = snapshot.and_then(|snapshot| snapshot.activity.as_ref()) {
+            constraints.push(Constraint::Length(activity_height(activity, content_area.width)));
             constraints.push(Constraint::Length(1));
         }
         if let Some(error) = app.usage.last_error.as_deref() {
             constraints.push(Constraint::Length(error_height(error, content_area.width)));
         }
         constraints.push(Constraint::Min(0));
+    } else {
+        constraints.push(Constraint::Min(3));
     }
 
     let sections = Layout::default()
@@ -42,9 +55,21 @@ pub(super) fn render(frame: &mut Frame, area: Rect, app: &App) {
         .constraints(constraints)
         .split(content_area);
 
-    render_spacer(frame, sections[0]);
+    if let Some(snapshot) = snapshot {
+        let plan = snapshot
+            .subscription_type
+            .as_deref()
+            .map(|value| format!("Plan: {value}"))
+            .unwrap_or_default();
+        frame.render_widget(
+            Paragraph::new(plan).style(Style::default().fg(theme::DIM)),
+            sections[0],
+        );
+    } else {
+        render_spacer(frame, sections[0]);
+    }
 
-    if windows.is_empty() {
+    if !has_snapshot_content {
         render_empty_state(frame, sections[1], app);
         return;
     }
@@ -61,6 +86,18 @@ pub(super) fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     if let Some(extra_usage) = snapshot.extra_usage.as_ref() {
         render_extra_usage(frame, sections[section_index], extra_usage);
+        render_spacer(frame, sections[section_index + 1]);
+        section_index += 2;
+    }
+
+    if let Some(session) = snapshot.session.as_ref() {
+        render_session_usage(frame, sections[section_index], session);
+        render_spacer(frame, sections[section_index + 1]);
+        section_index += 2;
+    }
+
+    if let Some(activity) = snapshot.activity.as_ref() {
+        render_activity(frame, sections[section_index], activity);
         render_spacer(frame, sections[section_index + 1]);
         section_index += 2;
     }
@@ -109,7 +146,7 @@ fn render_empty_state(frame: &mut Frame, area: Rect, app: &App) {
 
 fn render_window(frame: &mut Frame, area: Rect, window: &UsageWindow) {
     let label_line = Line::from(vec![
-        Span::styled(window.label.to_owned(), Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(window.label.clone(), Style::default().add_modifier(Modifier::BOLD)),
         Span::styled(format!("   {}", window_detail_text(window)), Style::default().fg(theme::DIM)),
     ]);
     let label_height = wrapped_height(Text::from(vec![label_line.clone()]), area.width);
@@ -163,6 +200,26 @@ fn render_extra_usage(frame: &mut Frame, area: Rect, extra_usage: &ExtraUsage) {
     );
 }
 
+fn render_session_usage(frame: &mut Frame, area: Rect, session: &SessionUsageSummary) {
+    render_detail_card(frame, area, "Current session totals", &format_session_usage(session));
+}
+
+fn render_activity(frame: &mut Frame, area: Rect, activity: &UsageActivitySummary) {
+    render_detail_card(frame, area, "Approximate local activity", &format_activity(activity));
+}
+
+fn render_detail_card(frame: &mut Frame, area: Rect, title: &str, detail: &str) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(Style::default().fg(theme::DIM));
+    frame.render_widget(block.clone(), area);
+    frame.render_widget(
+        Paragraph::new(detail.to_owned()).wrap(Wrap { trim: false }),
+        area.inner(Margin { vertical: 1, horizontal: 2 }),
+    );
+}
+
 fn render_error(frame: &mut Frame, area: Rect, error: &str) {
     let block = Block::default()
         .borders(Borders::ALL)
@@ -203,9 +260,114 @@ fn format_extra_usage(extra_usage: &ExtraUsage) -> String {
     }
 }
 
+fn format_session_usage(session: &SessionUsageSummary) -> String {
+    let mut details = Vec::new();
+    if let Some(cost) = session.total_cost_usd {
+        details.push(format!("${cost:.4} cost"));
+    }
+    if let Some(duration) = session.total_duration_ms {
+        details.push(format!("{} elapsed", format_duration_ms(duration)));
+    }
+    if let Some(duration) = session.total_api_duration_ms {
+        details.push(format!("{} API time", format_duration_ms(duration)));
+    }
+    if session.total_lines_added.is_some() || session.total_lines_removed.is_some() {
+        details.push(format!(
+            "+{:.0} / -{:.0} lines",
+            session.total_lines_added.unwrap_or(0.0),
+            session.total_lines_removed.unwrap_or(0.0)
+        ));
+    }
+    if let Some(model_count) = session.model_count {
+        details
+            .push(format!("{model_count} {}", if model_count == 1 { "model" } else { "models" }));
+    }
+    if details.is_empty() { "No session totals reported.".to_owned() } else { details.join(" · ") }
+}
+
+fn format_duration_ms(milliseconds: f64) -> String {
+    let seconds = (milliseconds.max(0.0) / 1_000.0).round();
+    let minutes = (seconds / 60.0).floor();
+    let remaining_seconds = seconds % 60.0;
+    if minutes > 0.0 {
+        format!("{minutes:.0}m {remaining_seconds:.0}s")
+    } else {
+        format!("{remaining_seconds:.0}s")
+    }
+}
+
+fn format_activity(activity: &UsageActivitySummary) -> String {
+    let mut rows = Vec::new();
+    if let Some(day) = activity.day.as_ref() {
+        rows.push(format_activity_window("Last 24 hours", day));
+    }
+    if let Some(week) = activity.week.as_ref() {
+        rows.push(format_activity_window("Last 7 days", week));
+    }
+    rows.push(
+        "Local transcript scan; approximate, behavior categories overlap, and data excludes other devices and claude.ai."
+            .to_owned(),
+    );
+    rows.join("\n")
+}
+
+fn format_activity_window(label: &str, window: &UsageActivityWindow) -> String {
+    let mut rows = vec![format!(
+        "{label}: {} {} across {} {}",
+        window.request_count,
+        if window.request_count == 1 { "request" } else { "requests" },
+        window.session_count,
+        if window.session_count == 1 { "session" } else { "sessions" }
+    )];
+    if !window.behaviors.is_empty() {
+        rows.push(format!(
+            "Behaviors: {}",
+            window
+                .behaviors
+                .iter()
+                .take(5)
+                .map(|item| {
+                    format!(
+                        "{} {:.0}% ({} {})",
+                        item.key.replace('_', " "),
+                        item.pct,
+                        item.count,
+                        if item.count == 1 { "request" } else { "requests" }
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    append_named_attributions(&mut rows, "Agents", &window.agents);
+    append_named_attributions(&mut rows, "Skills", &window.skills);
+    append_named_attributions(&mut rows, "Plugins", &window.plugins);
+    append_named_attributions(&mut rows, "MCP servers", &window.mcp_servers);
+    rows.join("\n")
+}
+
+fn append_named_attributions(
+    rows: &mut Vec<String>,
+    label: &str,
+    items: &[crate::app::UsageNamedAttribution],
+) {
+    if items.is_empty() {
+        return;
+    }
+    rows.push(format!(
+        "{label}: {}",
+        items
+            .iter()
+            .take(5)
+            .map(|item| format!("{} {:.0}%", item.name, item.pct))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+}
+
 fn window_height(window: &UsageWindow, width: u16) -> u16 {
     let label_line = Line::from(vec![
-        Span::styled(window.label.to_owned(), Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(window.label.clone(), Style::default().add_modifier(Modifier::BOLD)),
         Span::styled(format!("   {}", window_detail_text(window)), Style::default().fg(theme::DIM)),
     ]);
     let reset_line = Line::from(Span::styled(
@@ -227,6 +389,18 @@ fn extra_usage_height(extra_usage: &ExtraUsage, width: u16) -> u16 {
         inner_width,
     )
     .saturating_add(2)
+}
+
+fn session_usage_height(session: &SessionUsageSummary, width: u16) -> u16 {
+    detail_card_height(&format_session_usage(session), width)
+}
+
+fn activity_height(activity: &UsageActivitySummary, width: u16) -> u16 {
+    detail_card_height(&format_activity(activity), width)
+}
+
+fn detail_card_height(detail: &str, width: u16) -> u16 {
+    wrapped_height(Text::from(detail.to_owned()), width.saturating_sub(4)).saturating_add(2)
 }
 
 fn error_height(error: &str, width: u16) -> u16 {
@@ -302,26 +476,31 @@ mod tests {
         app.usage.snapshot = Some(UsageSnapshot {
             source: UsageSourceKind::Oauth,
             fetched_at: SystemTime::now(),
+            subscription_type: None,
             five_hour: Some(UsageWindow {
-                label: "5-hour",
+                label: "5-hour".to_owned(),
                 utilization: 47.0,
                 resets_at: None,
                 reset_description: Some("resets in 2h 14m".to_owned()),
             }),
             seven_day: Some(UsageWindow {
-                label: "7-day",
+                label: "7-day".to_owned(),
                 utilization: 62.0,
                 resets_at: None,
                 reset_description: Some("resets in 4d 11h".to_owned()),
             }),
+            seven_day_oauth_apps: None,
             seven_day_opus: None,
             seven_day_sonnet: None,
+            model_scoped: Vec::new(),
             extra_usage: Some(ExtraUsage {
                 monthly_limit: Some(20.0),
                 used_credits: Some(12.4),
                 utilization: Some(62.0),
                 currency: Some("USD".to_owned()),
             }),
+            session: None,
+            activity: None,
         });
         app.usage.last_error = Some("Network timeout while refreshing cached data.".to_owned());
 
@@ -333,8 +512,6 @@ mod tests {
         assert!(rendered.contains("USD"));
         assert!(rendered.contains("Extra credits"));
         assert!(rendered.contains("Latest refresh error"));
-        assert!(!rendered.contains("source:"));
-
         let rendered_lines = rendered.lines().collect::<Vec<_>>();
         let first_reset_index = rendered_lines
             .iter()
@@ -349,21 +526,26 @@ mod tests {
         app.usage.snapshot = Some(UsageSnapshot {
             source: UsageSourceKind::Oauth,
             fetched_at: SystemTime::now(),
+            subscription_type: None,
             five_hour: Some(UsageWindow {
-                label: "5-hour",
+                label: "5-hour".to_owned(),
                 utilization: 47.0,
                 resets_at: None,
                 reset_description: Some("resets soon".to_owned()),
             }),
             seven_day: None,
+            seven_day_oauth_apps: None,
             seven_day_opus: None,
             seven_day_sonnet: None,
+            model_scoped: Vec::new(),
             extra_usage: Some(ExtraUsage {
                 monthly_limit: Some(100.0),
                 used_credits: Some(99.99),
                 utilization: Some(99.0),
                 currency: Some("USD".to_owned()),
             }),
+            session: None,
+            activity: None,
         });
 
         let rows = render_usage_rows(&app, 20, 18);
@@ -371,5 +553,61 @@ mod tests {
         assert!(rows.iter().any(|row| row.contains("99.99")));
         assert!(rows.iter().any(|row| row.contains("USD")));
         assert!(rows.iter().any(|row| row.contains("used")));
+    }
+
+    #[test]
+    fn renders_structured_session_totals_and_approximate_activity_without_plan_windows() {
+        let mut app = usage_app();
+        app.usage.snapshot = Some(UsageSnapshot {
+            source: UsageSourceKind::Sdk,
+            fetched_at: SystemTime::now(),
+            subscription_type: Some("max".to_owned()),
+            five_hour: None,
+            seven_day: None,
+            seven_day_oauth_apps: None,
+            seven_day_opus: None,
+            seven_day_sonnet: None,
+            model_scoped: Vec::new(),
+            extra_usage: None,
+            session: Some(SessionUsageSummary {
+                total_cost_usd: Some(0.125),
+                total_api_duration_ms: Some(1_500.0),
+                total_duration_ms: Some(2_000.0),
+                total_lines_added: Some(12.0),
+                total_lines_removed: Some(3.0),
+                model_count: Some(2),
+            }),
+            activity: Some(UsageActivitySummary {
+                day: Some(UsageActivityWindow {
+                    request_count: 4,
+                    session_count: 2,
+                    behaviors: vec![crate::app::UsageBehaviorAttribution {
+                        key: "long_context".to_owned(),
+                        pct: 25.0,
+                        count: 1,
+                    }],
+                    agents: vec![crate::app::UsageNamedAttribution {
+                        name: "Explore".to_owned(),
+                        pct: 40.0,
+                    }],
+                    skills: Vec::new(),
+                    plugins: Vec::new(),
+                    mcp_servers: Vec::new(),
+                }),
+                week: None,
+            }),
+        });
+
+        let rendered = render_usage_rows(&app, 100, 24).join("\n");
+        assert!(rendered.contains("Current session totals"));
+        assert!(rendered.contains("Plan: max"));
+        assert!(rendered.contains("$0.1250 cost"));
+        assert!(rendered.contains("+12 / -3 lines"));
+        assert!(rendered.contains("Approximate local activity"));
+        assert!(rendered.contains("Last 24 hours: 4 requests across 2 sessions"));
+        assert!(rendered.contains("Behaviors: long context 25% (1 request)"));
+        assert!(rendered.contains("Agents: Explore 40%"));
+        assert!(rendered.contains("behavior categories overlap"));
+        assert!(rendered.contains("claude.ai"));
     }
 }

--- a/src/ui/session_picker.rs
+++ b/src/ui/session_picker.rs
@@ -6,24 +6,31 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use std::time::{SystemTime, UNIX_EPOCH};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::theme;
+
+const SESSION_DESCRIPTION: &str = "Recent sessions for this project directory.";
+const TURN_DESCRIPTION: &str = "The original session will not change. The selected message and everything after it will be omitted from the fork.";
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
 
+    let selecting_turn = app.session_picker.turn_session_id.is_some();
     let outer = Block::default()
         .borders(Borders::ALL)
-        .title("Resume Session")
+        .title(if selecting_turn { "Fork Before Message" } else { "Resume Session" })
         .border_style(Style::default().fg(theme::DIM));
     frame.render_widget(outer, area);
 
     let inner = area.inner(Margin { vertical: 1, horizontal: 2 });
+    let description = if selecting_turn { TURN_DESCRIPTION } else { SESSION_DESCRIPTION };
+    let description_height = wrapped_line_count(description, inner.width);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),
-            Constraint::Length(1),
+            Constraint::Length(2),
+            Constraint::Length(description_height),
             Constraint::Min(3),
             Constraint::Length(1),
         ])
@@ -31,18 +38,46 @@ pub fn render(frame: &mut Frame, app: &mut App) {
 
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "Select a session to resume",
+            if selecting_turn {
+                "Select where the fork should stop"
+            } else {
+                "Select a session to resume"
+            },
             Style::default().fg(theme::RUST_ORANGE).add_modifier(Modifier::BOLD),
         ))),
         chunks[0],
     );
     frame.render_widget(
-        Paragraph::new("Recent sessions for this project directory.")
-            .style(Style::default().fg(theme::DIM)),
+        Paragraph::new(description)
+            .style(Style::default().fg(theme::DIM))
+            .wrap(Wrap { trim: false }),
         chunks[1],
     );
 
-    if crate::app::session_picker::startup_picker_is_loading(app) {
+    if selecting_turn && app.sdk_inventory.rewind_targets_in_flight {
+        frame.render_widget(
+            Paragraph::new("Loading session messages...")
+                .style(Style::default().fg(theme::DIM))
+                .wrap(Wrap { trim: false }),
+            chunks[2],
+        );
+    } else if selecting_turn && app.sdk_inventory.rewind_targets_error.is_some() {
+        frame.render_widget(
+            Paragraph::new(app.sdk_inventory.rewind_targets_error.as_deref().unwrap_or_default())
+                .style(Style::default().fg(theme::STATUS_ERROR))
+                .wrap(Wrap { trim: false }),
+            chunks[2],
+        );
+    } else if selecting_turn && crate::app::session_picker::picker_turn_count(app) == 0 {
+        frame.render_widget(
+            Paragraph::new("No resumable user messages found in this session.")
+                .style(Style::default().fg(theme::DIM))
+                .wrap(Wrap { trim: false }),
+            chunks[2],
+        );
+    } else if selecting_turn {
+        render_turn_list(frame, chunks[2], app);
+    } else if crate::app::session_picker::startup_picker_is_loading(app) {
         frame.render_widget(
             Paragraph::new("Loading recent sessions...")
                 .style(Style::default().fg(theme::DIM))
@@ -64,6 +99,51 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         Paragraph::new(footer_text(app)).style(Style::default().fg(theme::DIM)),
         chunks[3],
     );
+}
+
+fn wrapped_line_count(text: &str, width: u16) -> u16 {
+    u16::try_from(Paragraph::new(text).wrap(Wrap { trim: false }).line_count(width.max(1)))
+        .unwrap_or(u16::MAX)
+        .max(1)
+}
+
+fn render_turn_list(frame: &mut Frame, area: Rect, app: &mut App) {
+    let visible_count = usize::from(area.height.max(1));
+    let turn_count = crate::app::session_picker::picker_turn_count(app);
+    let max_offset = turn_count.saturating_sub(visible_count);
+    app.session_picker.turn_scroll_offset = app.session_picker.turn_scroll_offset.min(max_offset);
+    if app.session_picker.turn_selected < app.session_picker.turn_scroll_offset {
+        app.session_picker.turn_scroll_offset = app.session_picker.turn_selected;
+    }
+    if app.session_picker.turn_selected >= app.session_picker.turn_scroll_offset + visible_count {
+        app.session_picker.turn_scroll_offset =
+            app.session_picker.turn_selected + 1 - visible_count;
+    }
+
+    let start = app.session_picker.turn_scroll_offset;
+    let end = (start + visible_count).min(turn_count);
+    let lines = app.sdk_inventory.rewind_targets[start..end]
+        .iter()
+        .enumerate()
+        .map(|(idx, target)| {
+            let selected = start + idx == app.session_picker.turn_selected;
+            let style = if selected {
+                Style::default().fg(ratatui::style::Color::White).bg(theme::RUST_ORANGE)
+            } else {
+                Style::default()
+            };
+            let marker = if selected { ">" } else { " " };
+            Line::from(Span::styled(
+                format!(
+                    "{marker} Msg. {} - {}",
+                    turn_count.saturating_sub(start + idx),
+                    truncate(&target.first_text, 60)
+                ),
+                style,
+            ))
+        })
+        .collect::<Vec<_>>();
+    frame.render_widget(Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false }), area);
 }
 
 fn render_session_list(frame: &mut Frame, area: Rect, app: &mut App) {
@@ -90,10 +170,18 @@ fn render_session_list(frame: &mut Frame, area: Rect, app: &mut App) {
             Style::default()
         };
         let marker = if selected { ">" } else { " " };
-        lines.push(Line::from(Span::styled(
-            format!("{marker} {}", display_primary(session)),
-            base_style.add_modifier(Modifier::BOLD),
-        )));
+        let current = app
+            .session_runtime
+            .session_id
+            .as_ref()
+            .is_some_and(|active| active.as_str() == session.session_id);
+        let current_label = if current { " [current]" } else { "" };
+        lines.push(session_line(
+            area.width,
+            &format!("{marker} {}{current_label}", display_primary(session)),
+            base_style,
+            selected,
+        ));
         if start + idx + 1 < end {
             lines.push(Line::default());
         }
@@ -102,11 +190,41 @@ fn render_session_list(frame: &mut Frame, area: Rect, app: &mut App) {
     frame.render_widget(Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false }), area);
 }
 
+fn session_line(width: u16, left: &str, base_style: Style, selected: bool) -> Line<'static> {
+    const FULL_ACTION: &str = "messages ›";
+    const COMPACT_ACTION: &str = "›";
+
+    let available_width = usize::from(width);
+    let action = if available_width >= UnicodeWidthStr::width(FULL_ACTION) + 3 {
+        FULL_ACTION
+    } else {
+        COMPACT_ACTION
+    };
+    let action_width = UnicodeWidthStr::width(action);
+    let max_left_width = available_width.saturating_sub(action_width.saturating_add(1));
+    let fitted_left = fit_with_ellipsis(left, max_left_width);
+    let left_width = UnicodeWidthStr::width(fitted_left.as_str());
+    let gap = available_width.saturating_sub(left_width.saturating_add(action_width));
+    let action_style = if selected {
+        base_style.add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::DIM).add_modifier(Modifier::BOLD)
+    };
+
+    Line::from(vec![
+        Span::styled(fitted_left, base_style.add_modifier(Modifier::BOLD)),
+        Span::styled(" ".repeat(gap), base_style),
+        Span::styled(action, action_style),
+    ])
+}
+
 fn footer_text(app: &App) -> &'static str {
     if crate::app::session_picker::startup_picker_is_loading(app) {
         "Preparing session picker | Ctrl+Q to quit"
+    } else if app.session_picker.turn_session_id.is_some() {
+        "Enter to fork before message | Left/Esc back | Ctrl+Q to quit"
     } else {
-        "Enter to resume | Esc to start new session | Ctrl+Q to quit"
+        "Enter to resume | Right choose message | Esc close | Ctrl+Q to quit"
     }
 }
 
@@ -132,6 +250,29 @@ fn truncate(value: &str, max_chars: usize) -> String {
     let mut chars = value.chars();
     let truncated: String = chars.by_ref().take(max_chars).collect();
     if chars.next().is_some() { format!("{truncated}...") } else { truncated }
+}
+
+fn fit_with_ellipsis(value: &str, max_width: usize) -> String {
+    if UnicodeWidthStr::width(value) <= max_width {
+        return value.to_owned();
+    }
+    if max_width <= 3 {
+        return ".".repeat(max_width);
+    }
+
+    let content_width = max_width - 3;
+    let mut used_width = 0;
+    let mut fitted = String::new();
+    for ch in value.chars() {
+        let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used_width + char_width > content_width {
+            break;
+        }
+        fitted.push(ch);
+        used_width += char_width;
+    }
+    fitted.push_str("...");
+    fitted
 }
 
 fn format_relative_age(last_modified_ms: u64) -> String {
@@ -255,5 +396,69 @@ mod tests {
 
         assert!(text.contains("Session 10"));
         assert!(!text.contains("Session 11"));
+    }
+
+    #[test]
+    fn renders_message_drop_level_and_navigation_help() {
+        let mut app = App::test_default();
+        app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::SessionPicker);
+        app.session_picker.turn_session_id = Some("s1".to_owned());
+        app.sdk_inventory.rewind_targets = vec![
+            crate::agent::model::RewindTarget {
+                uuid: "user-2".to_owned(),
+                first_text: "Resume from this message".to_owned(),
+                input_text: "Resume from this message".to_owned(),
+                index: 2,
+                previous_assistant_uuid: Some("assistant-1".to_owned()),
+                resume_anchor_uuid: Some("assistant-1".to_owned()),
+            },
+            crate::agent::model::RewindTarget {
+                uuid: "user-1".to_owned(),
+                first_text: "Start from the beginning".to_owned(),
+                input_text: "Start from the beginning".to_owned(),
+                index: 0,
+                previous_assistant_uuid: None,
+                resume_anchor_uuid: None,
+            },
+        ];
+
+        let text = draw_text(&mut app);
+
+        assert!(text.contains("Fork Before Message"));
+        assert!(text.contains("> Msg. 2 - Resume from this message"));
+        assert!(text.contains("  Msg. 1 - Start from the beginning"));
+        assert!(text.contains("Left/Esc back"));
+    }
+
+    #[test]
+    fn marks_the_current_session_and_exposes_message_navigation() {
+        let mut app = App::test_default();
+        app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::SessionPicker);
+        app.session_runtime.session_id = Some(crate::agent::model::SessionId::new("s1"));
+        app.recent_sessions = vec![session("s1", "Current Session")];
+
+        let text = draw_text(&mut app);
+
+        assert!(text.contains("[current]"));
+        let session_row = text
+            .lines()
+            .find(|line| line.contains("Current Session"))
+            .expect("current session row");
+        let action_column = session_row.find("messages ›").expect("message action");
+        assert!(action_column > 50, "message action should be aligned to the right: {session_row}");
+        assert!(text.contains("Right choose message"));
+    }
+
+    #[test]
+    fn renders_correlated_rewind_target_error_in_picker() {
+        let mut app = App::test_default();
+        app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::SessionPicker);
+        app.session_picker.turn_session_id = Some("s1".to_owned());
+        app.sdk_inventory.rewind_targets_error = Some("Session history is unavailable".to_owned());
+
+        let text = draw_text(&mut app);
+
+        assert!(text.contains("Session history is unavailable"));
+        assert!(!text.contains("No resumable user messages"));
     }
 }

--- a/src/ui/tool_call/mod.rs
+++ b/src/ui/tool_call/mod.rs
@@ -185,6 +185,10 @@ fn tool_output_badge_spans(tc: &ToolCallInfo) -> Vec<Span<'static>> {
         ));
     }
 
+    if tc.background_ends_with_final_response() {
+        badges.push(Span::styled("  [ends with final response]", Style::default().fg(theme::DIM)));
+    }
+
     if matches!(tc.sdk_tool_name.as_str(), "Agent" | "Task") {
         if let Some(retry) = subagent_retry_badge(tc) {
             badges.push(Span::styled(

--- a/src/ui/tool_call/remote_trigger.rs
+++ b/src/ui/tool_call/remote_trigger.rs
@@ -28,6 +28,8 @@ fn input_has_body(tc: &ToolCallInfo) -> bool {
     input.is_some_and(|input| {
         typed::json_string(input, "action").is_some()
             || typed::json_string(input, "trigger_id").is_some()
+            || typed::json_string(input, "session_id").is_some()
+            || typed::json_string(input, "cursor").is_some()
             || input.contains_key("body")
     })
 }
@@ -42,6 +44,12 @@ fn render_input_content(tc: &ToolCallInfo) -> Vec<Line<'static>> {
         }
         if let Some(trigger_id) = typed::json_string(input, "trigger_id") {
             remote_fields.push(ToolField::new("Trigger ID", trigger_id));
+        }
+        if let Some(session_id) = typed::json_string(input, "session_id") {
+            remote_fields.push(ToolField::new("Session ID", session_id));
+        }
+        if let Some(cursor) = typed::json_string(input, "cursor") {
+            remote_fields.push(ToolField::new("Cursor", cursor));
         }
         if let Some(body) = input.get("body").and_then(typed::compact_json) {
             remote_fields.push(ToolField::new("Body", body));
@@ -104,6 +112,26 @@ mod tests {
             ]
         );
         assert_eq!(lines[0].spans[0].style.fg, Some(theme::DIM));
+    }
+
+    #[test]
+    fn paginated_run_log_renders_session_and_cursor() {
+        let tc = remote_trigger_tool_call(
+            json!({
+                "action": "get_run_log",
+                "session_id": "cse_run-1",
+                "cursor": "next-page"
+            }),
+            None,
+            model::ToolCallStatus::InProgress,
+        );
+
+        let lines = render_tool_content(&tc);
+
+        assert_eq!(
+            rendered_line_texts(&lines),
+            vec!["Action: get_run_log", "Session ID: cse_run-1", "Cursor: next-page",]
+        );
     }
 
     #[test]

--- a/src/ui/tool_call/tests.rs
+++ b/src/ui/tool_call/tests.rs
@@ -970,6 +970,18 @@ fn bash_title_distinguishes_timeout_auto_backgrounding() {
 }
 
 #[test]
+fn bash_title_renders_final_response_lifetime() {
+    let mut tc = test_tool_call("tc-bash-lifetime", "Bash", model::ToolCallStatus::Completed);
+    tc.output_metadata = Some(model::ToolOutputMetadata::new().bash(Some(
+        model::BashOutputMetadata::new().background_ends_with_final_response(Some(true)),
+    )));
+
+    let rendered = standard::render_tool_call_title(&tc, ToolCallRenderContext::default(), 100, 0);
+    let text: String = rendered.spans.iter().map(|span| span.content.as_ref()).collect();
+    assert!(text.contains("[ends with final response]"));
+}
+
+#[test]
 fn bash_title_preserves_command_title_in_plan_mode() {
     let mut tc = test_tool_call("echo hi", "Bash", model::ToolCallStatus::Completed);
     tc.terminal_command = Some("echo hi".to_owned());


### PR DESCRIPTION
## Summary

- Upgrade `@anthropic-ai/claude-agent-sdk` from `0.3.220` to `0.3.227` in the application package and Agent SDK bridge.
- Adapt the TypeScript bridge and Rust wire model to the updated SDK surface while preserving request correlation, message provenance, tool metadata, and session-scoped event ordering.
- Add guarded resume-at support, including fullscreen turn selection, resume-anchor validation, correlated failure handling, and deferred session replacement that commits only after validation succeeds.
- Integrate structured SDK usage data with the existing OAuth and CLI fallbacks, and extend the usage view with model-scoped limits, session totals, plan information, and approximate local activity.
- Support cross-session inbound controls and peer-message provenance, preserve newer sandbox and MCP settings, and render additional metadata from newer SDK tools and results.

## Why

SDK `0.3.227` exposes capabilities and metadata that the existing bridge contract did not represent. Updating the dependency without migrating both sides of the bridge would discard new fields, weaken session replacement guarantees, and leave resume, usage, cross-session messaging, and newer tool results partially unsupported.

This migration keeps the Rust client and TypeScript bridge aligned with the new SDK contract while retaining compatibility fallbacks for data that may be unavailable or malformed.

Closes #333 

## Validation

- Automated: Agent SDK bridge suite (`348` tests) and complete Rust test suite (`1,754` library tests plus binary, integration, contract, and documentation tests).
- Manual: Not performed.
- Screenshot/video (if UI changed): Not captured.

## Notes

- Breaking changes: None expected for users; the internal bridge protocol is extended with new commands, events, and optional metadata.
- Docs updated: N/A.
- Governance/release impact: Updates the bundled Claude Agent SDK runtime dependency from `0.3.220` to `0.3.227`.
- Review focus: Guarded resume-at validation and session handoff, bridge event ordering and request correlation, structured usage fallback behavior, and cross-session message provenance.
