### PR TITLE
feat(commands): support safe submissions during active turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - **Claude Agent SDK 0.3.227 migration** (#338, @srothgan): Add guarded resume-at, structured usage, cross-session message provenance, and current SDK metadata support.
+- **Active-turn commands** (@srothgan): Allow safe commands during active turns and preserve blocked drafts instead of cancelling the turn.
 
 ## [0.14.3] - 2026-08-01 [Changes][v0.14.3]
 

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -189,7 +189,7 @@ fn open_does_not_force_stop_active_turn() {
 
     assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::Config));
     assert!(matches!(app.status, AppStatus::Running));
-    assert!(app.turn.pending_cancel_origin.is_none());
+    assert!(!app.turn.cancel_requested);
 }
 
 #[test]

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -15,8 +15,8 @@ mod tool_updates;
 mod turn;
 
 use super::{
-    App, AppStatus, ChatMessage, FullscreenView, InvalidationLevel, MessageBlock, MessageRole,
-    PendingCommandAck, SurfaceMode, SystemSeverity, TerminalSizeChange, TextBlock,
+    App, AppStatus, ChatMessage, ChatMessageId, FullscreenView, InvalidationLevel, MessageBlock,
+    MessageRole, PendingCommandAck, SurfaceMode, SystemSeverity, TerminalSizeChange, TextBlock,
 };
 use crate::agent::model;
 #[cfg(all(test, target_os = "macos"))]
@@ -511,7 +511,7 @@ fn handle_runtime_session_state_update(app: &mut App, state: model::RuntimeSessi
         model::RuntimeSessionState::Idle => {
             if matches!(app.status, AppStatus::Thinking | AppStatus::Running)
                 && !app.turn.compaction.is_active()
-                && app.turn.pending_cancel_origin.is_none()
+                && !app.turn.cancel_requested
             {
                 app.status = AppStatus::Ready;
             }
@@ -544,6 +544,47 @@ pub(crate) fn push_system_message_with_severity(
         None,
     ));
     app.enforce_history_retention_tracked();
+}
+
+pub(crate) fn push_submission_feedback(app: &mut App, severity: SystemSeverity, message: &str) {
+    let owner = submission_feedback_owner(app);
+    push_submission_feedback_for_owner(app, owner, severity, message);
+}
+
+pub(crate) fn submission_feedback_owner(app: &App) -> Option<ChatMessageId> {
+    if !app.is_agent_turn_active() {
+        return None;
+    }
+    app.active_turn_assistant_idx()
+        .and_then(|message_idx| app.transcript.messages.get(message_idx))
+        .map(|message| message.id)
+}
+
+pub(crate) fn push_submission_feedback_for_owner(
+    app: &mut App,
+    owner: Option<ChatMessageId>,
+    severity: SystemSeverity,
+    message: &str,
+) {
+    if owner.is_some_and(|message_id| {
+        notices::emit_system_notice_for_message(app, message_id, severity, message)
+    }) {
+        return;
+    }
+    push_system_message_with_severity(app, Some(severity), message);
+}
+
+pub(crate) fn push_active_turn_submission_blocked_notice(app: &mut App, label: &str) {
+    let message = format!(
+        "{label} can only be submitted between agent turns. Wait for the current turn to finish or cancel it explicitly."
+    );
+    notices::upsert_turn_notice(
+        app,
+        super::NoticeDedupKey::ActiveTurnSubmissionBlocked,
+        super::NoticeStage::Informational,
+        SystemSeverity::Info,
+        &message,
+    );
 }
 
 fn handle_config_option_update(app: &mut App, config: model::ConfigOptionUpdate) {

--- a/src/app/events/notices.rs
+++ b/src/app/events/notices.rs
@@ -2,8 +2,8 @@
 // Copyright 2025 Simon Peter Rothgang
 
 use super::super::{
-    App, ChatMessage, InvalidationLevel, MessageBlock, MessageRole, NoticeBlock, NoticeDedupKey,
-    NoticeStage, SystemSeverity, TurnNoticeLocation, TurnNoticeRef,
+    App, ChatMessage, ChatMessageId, InvalidationLevel, MessageBlock, MessageRole, NoticeBlock,
+    NoticeDedupKey, NoticeStage, SystemSeverity, TurnNoticeLocation, TurnNoticeRef,
 };
 
 #[derive(Clone)]
@@ -14,6 +14,21 @@ struct TurnNoticeTracking {
 
 pub(super) fn emit_system_notice(app: &mut App, severity: SystemSeverity, message: &str) {
     insert_notice(app, severity, message, None);
+}
+
+pub(super) fn emit_system_notice_for_message(
+    app: &mut App,
+    message_id: ChatMessageId,
+    severity: SystemSeverity,
+    message: &str,
+) -> bool {
+    let Some(message_idx) = app.transcript.messages.iter().position(|candidate| {
+        candidate.id == message_id && matches!(candidate.role, MessageRole::Assistant)
+    }) else {
+        return false;
+    };
+    insert_inline_notice(app, message_idx, severity, message, None);
+    true
 }
 
 pub(super) fn upsert_turn_notice(

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -8,7 +8,7 @@ use crate::app::keymap::{
 };
 use crate::app::slash::{SlashCandidate, SlashContext, SlashState};
 use crate::app::{
-    CancelOrigin, ChatRebuildKind, ComposerRenderState, FocusOwner, FocusTarget, FullscreenView,
+    ChatRebuildKind, ComposerRenderState, FocusOwner, FocusTarget, FullscreenView,
     InlinePermission, InlineQuestion, LiveRegionRenderState, ReleaseReason, SurfaceMode,
     TerminalLifecycleState, TextBlockSpacing, ToolCallInfo, ToolCallScope, UsageSnapshot,
     UsageSourceKind, UsageWindow, mention,
@@ -1105,7 +1105,7 @@ fn test_app_defaults() {
     assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::None);
     assert!(app.sdk_inventory.tasks.is_empty());
     assert!(app.mention.is_none());
-    assert!(!app.turn.cancelled_pending_hint);
+    assert!(!app.turn.cancel_requested);
     assert!(matches!(app.status, AppStatus::Ready));
 }
 
@@ -1244,11 +1244,11 @@ fn turn_complete_after_cancel_renders_interrupted_hint() {
     let mut app = make_test_app();
 
     handle_local_cancel_enqueued(&mut app);
-    assert!(app.turn.cancelled_pending_hint);
+    assert!(app.turn.cancel_requested);
 
     handle_client_event(&mut app, turn_complete(None));
 
-    assert!(!app.turn.cancelled_pending_hint);
+    assert!(!app.turn.cancel_requested);
     let last = app.transcript.messages.last().expect("expected interruption hint message");
     assert!(matches!(last.role, MessageRole::System(Some(SystemSeverity::Info))));
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
@@ -1289,8 +1289,7 @@ fn startup_resume_history_renders_from_canonical_messages() {
     assert!(live_rows_contain_text(&mut app, "startup assistant reply"));
     assert!(!session_overview_has_welcome(&app));
     assert!(matches!(app.status, AppStatus::Ready));
-    assert_eq!(app.turn.pending_cancel_origin, None);
-    assert!(!app.turn.pending_auto_submit_after_cancel);
+    assert!(!app.turn.cancel_requested);
 
     handle_client_event(
         &mut app,
@@ -1347,8 +1346,7 @@ fn startup_resume_history_allows_immediate_prompt_submit() {
         crate::agent::wire::BridgeCommand::Prompt { session_id, .. }
             if session_id == "startup-resume"
     ));
-    assert_eq!(app.turn.pending_cancel_origin, None);
-    assert!(!app.turn.pending_auto_submit_after_cancel);
+    assert!(!app.turn.cancel_requested);
     assert!(rx.try_recv().is_err(), "resume submit should not send cancel");
 }
 
@@ -2471,7 +2469,7 @@ fn turn_error_after_cancel_shows_interrupted_hint_instead_of_error_block() {
     app.transcript.messages.push(user_msg("build app"));
 
     handle_local_cancel_enqueued(&mut app);
-    assert!(app.turn.cancelled_pending_hint);
+    assert!(app.turn.cancel_requested);
 
     handle_client_event(
         &mut app,
@@ -2483,7 +2481,7 @@ fn turn_error_after_cancel_shows_interrupted_hint_instead_of_error_block() {
         },
     );
 
-    assert!(!app.turn.cancelled_pending_hint);
+    assert!(!app.turn.cancel_requested);
     assert!(matches!(app.status, AppStatus::Ready));
 
     let Some(last) = app.transcript.messages.last() else {
@@ -3273,11 +3271,11 @@ fn second_esc_after_permission_rejection_requests_turn_cancel() {
     };
     assert_eq!(selected.option_id.clone(), "deny");
     assert!(app.turn.pending_interaction_ids.is_empty());
-    assert_eq!(app.turn.pending_cancel_origin, None);
+    assert!(!app.turn.cancel_requested);
 
     handle_terminal_event(&mut app, Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
 
-    assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual));
+    assert!(app.turn.cancel_requested);
     let envelope = rx.try_recv().expect("second Esc should send turn cancel");
     assert!(matches!(
         envelope.command,

--- a/src/app/events/tests/client_events.rs
+++ b/src/app/events/tests/client_events.rs
@@ -1812,8 +1812,7 @@ fn resume_history_renders_user_message_chunks() {
     assert!(canonical_messages_contain_text(&app, "assistant reply"));
     assert!(!session_overview_has_welcome(&app));
     assert!(matches!(app.status, AppStatus::Ready));
-    assert_eq!(app.turn.pending_cancel_origin, None);
-    assert!(!app.turn.pending_auto_submit_after_cancel);
+    assert!(!app.turn.cancel_requested);
 
     handle_client_event(
         &mut app,

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -2,9 +2,9 @@
 // Copyright 2025 Simon Peter Rothgang
 
 use super::super::{
-    App, AppStatus, CancelOrigin, ChatMessage, FocusTarget, InlinePermission, InlineQuestion,
-    InvalidationLevel, MessageBlock, MessageRole, NoticeStage, SubagentPermissionContext,
-    SystemSeverity, TextBlock, ToolCallInfo, ToolCallScope, UserDialogBlock,
+    App, AppStatus, ChatMessage, FocusTarget, InlinePermission, InlineQuestion, InvalidationLevel,
+    MessageBlock, MessageRole, NoticeStage, SubagentPermissionContext, SystemSeverity, TextBlock,
+    ToolCallInfo, ToolCallScope, UserDialogBlock,
 };
 use super::compaction;
 use super::rate_limit::{format_rate_limit_summary, rate_limit_notice_key};
@@ -26,8 +26,7 @@ const AUTH_REQUIRED_NEXT_STEPS_HINT: &str = "Authentication required. Type /logi
 struct TurnExitState {
     tail_assistant_idx: Option<usize>,
     turn_was_active: bool,
-    cancelled_requested: Option<CancelOrigin>,
-    show_interrupted_hint: bool,
+    cancel_requested: bool,
 }
 
 pub(super) fn handle_permission_request_event(
@@ -424,11 +423,7 @@ fn reject_permission_request(
 }
 
 pub(super) fn handle_turn_cancelled_event(app: &mut App) {
-    if app.turn.pending_cancel_origin.is_none() {
-        app.turn.pending_cancel_origin = Some(CancelOrigin::Manual);
-    }
-    app.turn.cancelled_pending_hint =
-        matches!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual));
+    app.turn.cancel_requested = true;
     let _ = app.finalize_in_progress_tool_calls(model::ToolCallStatus::Failed);
 }
 
@@ -440,12 +435,10 @@ fn begin_turn_exit(app: &mut App, emit_manual_compaction_success: bool) -> TurnE
             .iter()
             .rposition(|m| matches!(m.role, MessageRole::Assistant)),
         turn_was_active: matches!(app.status, AppStatus::Thinking | AppStatus::Running),
-        cancelled_requested: app.turn.pending_cancel_origin,
-        show_interrupted_hint: matches!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual)),
+        cancel_requested: app.turn.cancel_requested,
     };
     compaction::finish_inferred(app, emit_manual_compaction_success);
-    app.turn.pending_cancel_origin = None;
-    app.turn.cancelled_pending_hint = false;
+    app.turn.cancel_requested = false;
     state
 }
 
@@ -457,12 +450,10 @@ fn finish_ready_turn_exit(app: &mut App, exit: TurnExitState, tool_status: model
     app.sync_git_context();
 
     let removed_tail_assistant = remove_empty_tail_assistant(app, exit.tail_assistant_idx);
-    if exit.show_interrupted_hint {
+    if exit.cancel_requested {
         push_interrupted_hint(app);
     }
-    if removed_tail_assistant.is_none()
-        && (exit.turn_was_active || exit.cancelled_requested.is_some())
-    {
+    if removed_tail_assistant.is_none() && (exit.turn_was_active || exit.cancel_requested) {
         mark_turn_exit_assistant_layout_dirty(app, exit.tail_assistant_idx);
     }
     app.turn.reset_for_turn_exit();
@@ -483,7 +474,7 @@ pub(super) fn handle_turn_complete_event(
             terminal_reason = reason.as_stored(),
         );
     }
-    let tool_status = if exit.cancelled_requested.is_some() {
+    let tool_status = if exit.cancel_requested {
         model::ToolCallStatus::Failed
     } else {
         model::ToolCallStatus::Completed
@@ -497,9 +488,6 @@ pub(super) fn handle_turn_complete_event(
             super::super::notify::NotifyEvent::TurnComplete,
         );
     }
-    if app.surface_mode == super::super::SurfaceMode::Chat {
-        super::super::input_submit::maybe_auto_submit_after_cancel(app);
-    }
 }
 
 pub(super) fn handle_turn_error_event(
@@ -511,7 +499,7 @@ pub(super) fn handle_turn_error_event(
 ) {
     let exit = begin_turn_exit(app, false);
 
-    if exit.cancelled_requested.is_some() {
+    if exit.cancel_requested {
         let summary = summarize_internal_error(msg);
         tracing::warn!(
             target: crate::logging::targets::APP_SESSION,
@@ -526,9 +514,6 @@ pub(super) fn handle_turn_error_event(
         finish_ready_turn_exit(app, exit, model::ToolCallStatus::Failed);
         request_post_turn_resize_purge_replay_if_needed(app);
         crate::app::session_runtime::request_context_usage_refresh(app);
-        if app.surface_mode == super::super::SurfaceMode::Chat {
-            super::super::input_submit::maybe_auto_submit_after_cancel(app);
-        }
         return;
     }
 
@@ -546,7 +531,6 @@ pub(super) fn handle_turn_error_event(
     );
     apply_turn_error_class_side_effects(app, error_class, &summary, api_error_status);
     app.finalize_turn_runtime_artifacts(model::ToolCallStatus::Failed);
-    app.turn.pending_auto_submit_after_cancel = false;
     app.input.clear();
     app.pending_submit = None;
     app.status = AppStatus::Error;
@@ -896,7 +880,7 @@ mod tests {
     fn cancelled_turn_error_removes_empty_tail_assistant_before_hint() {
         let mut app = App::test_default();
         app.status = AppStatus::Thinking;
-        app.turn.pending_cancel_origin = Some(CancelOrigin::Manual);
+        app.turn.cancel_requested = true;
         app.transcript.messages.push(user_message("hello"));
         app.transcript.messages.push(empty_assistant_message());
 

--- a/src/app/input_submit.rs
+++ b/src/app/input_submit.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 Simon Peter Rothgang
 
-use super::{App, AppStatus, CancelOrigin, ChatMessage, MessageBlock, MessageRole, TextBlock};
+use super::{App, AppStatus, ChatMessage, MessageBlock, MessageRole, TextBlock};
 use crate::agent::model;
 use crate::app::slash;
 
@@ -22,79 +22,30 @@ pub(super) fn submit_input(app: &mut App) {
     }
     app.session_runtime.prompt_suggestion = None;
 
-    // `/cancel` is an explicit control action: execute immediately.
-    if slash::is_cancel_command(&text) {
-        app.turn.pending_auto_submit_after_cancel = false;
-        app.input.clear();
-        dispatch_submission(app, text);
-        return;
-    }
-
-    if app.turn.compaction.is_active() {
-        app.turn.pending_auto_submit_after_cancel = false;
+    let submission = slash::ResolvedSubmission::resolve(text);
+    if app.is_agent_turn_active() && submission.class().requires_idle_turn() {
+        let label = submission.blocked_label();
+        crate::app::events::push_active_turn_submission_blocked_notice(app, &label);
         tracing::debug!(
             target: crate::logging::targets::APP_INPUT,
-            event_name = "submit_blocked_by_compaction",
-            message = "input submit ignored while compaction is active",
+            event_name = "submit_blocked_by_active_turn",
+            message = "submission rejected while agent turn is active",
             outcome = "blocked",
+            submission = %label,
         );
         return;
     }
 
-    // While a turn is active, keep the current draft text in the input and
-    // only request cancellation of the running turn.
-    if is_turn_busy(app) {
-        match request_cancel(app, CancelOrigin::AutoQueue) {
-            Ok(()) => {
-                app.turn.pending_auto_submit_after_cancel = true;
-                tracing::debug!(
-                    target: crate::logging::targets::APP_INPUT,
-                    event_name = "submit_deferred_for_cancel",
-                    message = "input submit deferred until the active turn is cancelled",
-                    outcome = "start",
-                );
-            }
-            Err(message) => {
-                app.turn.pending_auto_submit_after_cancel = false;
-                tracing::error!(
-                    target: crate::logging::targets::APP_INPUT,
-                    event_name = "cancel_request_failed",
-                    message = "failed to request cancel for deferred submit",
-                    outcome = "failure",
-                    error_message = %message,
-                );
-            }
-        }
-        return;
-    }
-
-    app.turn.pending_auto_submit_after_cancel = false;
     app.input.clear();
-    dispatch_submission(app, text);
+    dispatch_submission(app, submission);
 }
 
-fn is_turn_busy(app: &App) -> bool {
-    matches!(app.status, AppStatus::Thinking | AppStatus::Running)
-        || app.turn.pending_cancel_origin.is_some()
-        || app.turn.compaction.is_active()
-}
-
-pub(super) fn request_cancel(app: &mut App, origin: CancelOrigin) -> Result<(), String> {
-    if matches!(origin, CancelOrigin::Manual) {
-        app.turn.pending_auto_submit_after_cancel = false;
-    }
-
+pub(super) fn request_cancel(app: &mut App) -> Result<(), String> {
     if !matches!(app.status, AppStatus::Thinking | AppStatus::Running) {
         return Ok(());
     }
 
-    if let Some(existing_origin) = app.turn.pending_cancel_origin {
-        if matches!(existing_origin, CancelOrigin::AutoQueue)
-            && matches!(origin, CancelOrigin::Manual)
-        {
-            app.turn.pending_cancel_origin = Some(CancelOrigin::Manual);
-            app.turn.cancelled_pending_hint = true;
-        }
+    if app.turn.cancel_requested {
         return Ok(());
     }
 
@@ -107,8 +58,6 @@ pub(super) fn request_cancel(app: &mut App, origin: CancelOrigin) -> Result<(), 
 
     let session_id = sid.to_string();
     conn.cancel(session_id.clone()).map_err(|e| e.to_string())?;
-    app.turn.pending_cancel_origin = Some(origin);
-    app.turn.cancelled_pending_hint = matches!(origin, CancelOrigin::Manual);
     crate::app::events::handle_local_cancel_enqueued(app);
     tracing::info!(
         target: crate::logging::targets::APP_INPUT,
@@ -116,31 +65,15 @@ pub(super) fn request_cancel(app: &mut App, origin: CancelOrigin) -> Result<(), 
         message = "turn cancel requested",
         outcome = "success",
         session_id = %session_id,
-        origin = ?origin,
     );
     Ok(())
 }
 
-pub(super) fn maybe_auto_submit_after_cancel(app: &mut App) {
-    if !app.turn.pending_auto_submit_after_cancel {
+fn dispatch_submission(app: &mut App, submission: slash::ResolvedSubmission) {
+    if slash::try_handle_submission(app, &submission) {
         return;
     }
-    if !matches!(app.status, AppStatus::Ready) || app.turn.pending_cancel_origin.is_some() {
-        return;
-    }
-    if app.input.text().trim().is_empty() {
-        app.turn.pending_auto_submit_after_cancel = false;
-        return;
-    }
-    app.turn.pending_auto_submit_after_cancel = false;
-    submit_input(app);
-}
-
-fn dispatch_submission(app: &mut App, text: String) {
-    if slash::try_handle_submit(app, &text) {
-        return;
-    }
-    dispatch_prompt_turn(app, text);
+    dispatch_prompt_turn(app, submission.into_text());
 }
 
 fn dispatch_prompt_turn(app: &mut App, text: String) {
@@ -191,6 +124,7 @@ fn dispatch_prompt_turn(app: &mut App, text: String) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::events::ClientEvent;
     use crate::agent::wire::BridgeCommand;
     use crate::app::{FullscreenView, SurfaceMode};
 
@@ -203,90 +137,70 @@ mod tests {
     }
 
     #[test]
-    fn submit_input_while_running_keeps_input_and_requests_cancel() {
+    fn submit_input_while_running_preserves_prompt_and_does_not_cancel() {
         let (mut app, mut rx) = app_with_connection();
         app.status = AppStatus::Running;
-        app.input.set_text("queued prompt");
+        app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+        app.bind_active_turn_assistant(0);
+        app.input.set_text("next prompt");
+        app.pending_images.push(crate::app::clipboard_image::ImageAttachment {
+            data: "image-data".to_owned(),
+            mime_type: "image/png".to_owned(),
+        });
+        let before = app.input.snapshot();
 
         submit_input(&mut app);
 
-        assert_eq!(app.input.text(), "queued prompt");
-        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
-        assert!(app.turn.pending_auto_submit_after_cancel);
+        assert_eq!(app.input.snapshot(), before);
+        assert_eq!(app.pending_images.len(), 1);
+        assert_eq!(app.pending_images[0].data, "image-data");
+        assert_eq!(app.pending_images[0].mime_type, "image/png");
+        assert!(!app.turn.cancel_requested);
         assert!(matches!(app.status, AppStatus::Running));
-        assert!(app.transcript.messages.is_empty());
+        assert!(rx.try_recv().is_err(), "rejected prompt must not dispatch or cancel");
+        let [MessageBlock::Notice(notice)] = app.transcript.messages[0].blocks.as_slice() else {
+            panic!("expected inline active-turn notice");
+        };
+        assert!(notice.text.text.contains("New prompts"));
+        assert_eq!(notice.severity, super::super::SystemSeverity::Info);
+    }
+
+    #[test]
+    fn repeated_active_turn_rejections_update_one_inline_notice() {
+        let (mut app, mut rx) = app_with_connection();
+        app.status = AppStatus::Running;
+        app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+        app.bind_active_turn_assistant(0);
+        app.input.set_text("first prompt");
+
+        submit_input(&mut app);
+        app.input.set_text("/resume");
+        submit_input(&mut app);
+
+        assert_eq!(app.input.text(), "/resume");
+        assert_eq!(app.transcript.messages[0].blocks.len(), 1);
+        let Some(MessageBlock::Notice(notice)) = app.transcript.messages[0].blocks.first() else {
+            panic!("expected updated inline notice");
+        };
+        assert!(notice.text.text.contains("`/resume`"));
+        assert_eq!(app.turn.notice_refs.len(), 1);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn explicit_cancel_request_is_idempotent() {
+        let (mut app, mut rx) = app_with_connection();
+        app.status = AppStatus::Running;
+
+        request_cancel(&mut app).expect("first cancel request");
+        request_cancel(&mut app).expect("duplicate cancel request");
+
+        assert!(app.turn.cancel_requested);
         let envelope = rx.try_recv().expect("cancel command should be sent");
-        assert!(matches!(
-            envelope.command,
-            BridgeCommand::CancelTurn { session_id } if session_id == "session-1"
-        ));
-    }
-
-    #[test]
-    fn manual_cancel_promotes_existing_auto_cancel() {
-        let (mut app, mut rx) = app_with_connection();
-        app.status = AppStatus::Thinking;
-        app.turn.pending_auto_submit_after_cancel = true;
-
-        request_cancel(&mut app, CancelOrigin::AutoQueue).expect("auto cancel request");
-        request_cancel(&mut app, CancelOrigin::Manual).expect("manual cancel request");
-
-        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual));
-        assert!(app.turn.cancelled_pending_hint);
-        assert!(!app.turn.pending_auto_submit_after_cancel);
-        let envelope = rx.try_recv().expect("single cancel command should be sent");
-        assert!(matches!(
-            envelope.command,
-            BridgeCommand::CancelTurn { session_id } if session_id == "session-1"
-        ));
-        assert!(rx.try_recv().is_err(), "manual promotion should not send second cancel");
-    }
-
-    #[test]
-    fn manual_cancel_prevents_later_auto_submit_after_cancel() {
-        let (mut app, mut rx) = app_with_connection();
-        app.status = AppStatus::Running;
-        app.input.set_text("draft");
-
-        submit_input(&mut app);
-        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
-        assert!(app.turn.pending_auto_submit_after_cancel);
-        let cancel = rx.try_recv().expect("cancel command should be sent");
-        assert!(matches!(
-            cancel.command, BridgeCommand::CancelTurn { session_id } if session_id == "session-1"
-        ));
-
-        request_cancel(&mut app, CancelOrigin::Manual).expect("manual cancel request");
-        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual));
-        assert!(!app.turn.pending_auto_submit_after_cancel);
-
-        app.status = AppStatus::Ready;
-        app.turn.pending_cancel_origin = None;
-        maybe_auto_submit_after_cancel(&mut app);
-
-        assert_eq!(app.input.text(), "draft");
-        assert!(matches!(app.status, AppStatus::Ready));
-        assert!(app.transcript.messages.is_empty());
-        assert!(rx.try_recv().is_err(), "manual cancel should suppress queued prompt submit");
-    }
-
-    #[test]
-    fn submit_input_with_pending_cancel_keeps_input_and_sends_no_second_cancel() {
-        let (mut app, mut rx) = app_with_connection();
-        app.status = AppStatus::Running;
-        app.input.set_text("draft");
-
-        submit_input(&mut app);
-        submit_input(&mut app);
-
-        assert_eq!(app.input.text(), "draft");
-        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
-        assert!(app.turn.pending_auto_submit_after_cancel);
-        let envelope = rx.try_recv().expect("first cancel command should be sent");
         assert!(matches!(
             envelope.command, BridgeCommand::CancelTurn { session_id } if session_id == "session-1"
         ));
-        assert!(rx.try_recv().is_err(), "second submit should not send extra cancel");
+        assert!(rx.try_recv().is_err(), "duplicate request must not send a second cancel");
     }
 
     #[test]
@@ -298,7 +212,7 @@ mod tests {
         submit_input(&mut app);
 
         assert!(app.input.text().is_empty());
-        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::Manual));
+        assert!(app.turn.cancel_requested);
         let envelope = rx.try_recv().expect("cancel command should be sent");
         assert!(matches!(
             envelope.command,
@@ -320,6 +234,97 @@ mod tests {
             panic!("expected docs system message");
         };
         assert!(matches!(last.role, MessageRole::System(Some(super::super::SystemSeverity::Info))));
+    }
+
+    #[test]
+    fn read_only_command_executes_inline_during_active_turn() {
+        let (mut app, mut rx) = app_with_connection();
+        app.status = AppStatus::Thinking;
+        app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+        app.bind_active_turn_assistant(0);
+        app.input.set_text("/docs commands");
+
+        submit_input(&mut app);
+
+        assert!(app.input.text().is_empty());
+        assert!(matches!(app.status, AppStatus::Thinking));
+        let [MessageBlock::Notice(notice)] = app.transcript.messages[0].blocks.as_slice() else {
+            panic!("expected inline docs notice");
+        };
+        assert!(notice.text.text.contains("Docs: Commands"));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn invalid_command_syntax_reports_usage_instead_of_active_turn_block() {
+        let (mut app, mut rx) = app_with_connection();
+        app.status = AppStatus::Running;
+        app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+        app.bind_active_turn_assistant(0);
+        app.input.set_text("/resume one two");
+
+        submit_input(&mut app);
+
+        assert!(app.input.text().is_empty());
+        let [MessageBlock::Notice(notice)] = app.transcript.messages[0].blocks.as_slice() else {
+            panic!("expected inline usage notice");
+        };
+        assert_eq!(notice.text.text, "Usage: /resume [session_id]");
+        assert!(!notice.text.text.contains("between agent turns"));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn sdk_promoted_command_is_blocked_during_active_turn() {
+        let (mut app, mut rx) = app_with_connection();
+        app.status = AppStatus::Running;
+        app.sdk_inventory.available_commands =
+            vec![model::AvailableCommand::new("/remote-command", "Remote command")];
+        app.input.set_text("/remote-command");
+
+        submit_input(&mut app);
+
+        assert_eq!(app.input.text(), "/remote-command");
+        assert!(matches!(app.status, AppStatus::Running));
+        let Some(MessageBlock::Notice(notice)) =
+            app.transcript.messages.last().and_then(|message| message.blocks.first())
+        else {
+            panic!("expected active-turn block notice");
+        };
+        assert!(notice.text.text.contains("`/remote-command`"));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn mutating_app_command_is_blocked_during_active_turn() {
+        let (mut app, mut rx) = app_with_connection();
+        app.status = AppStatus::Running;
+        app.input.set_text("/model sonnet");
+
+        submit_input(&mut app);
+
+        assert_eq!(app.input.text(), "/model sonnet");
+        assert!(matches!(app.status, AppStatus::Running));
+        let Some(MessageBlock::Notice(notice)) =
+            app.transcript.messages.last().and_then(|message| message.blocks.first())
+        else {
+            panic!("expected active-turn block notice");
+        };
+        assert!(notice.text.text.contains("`/model`"));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn prompt_is_blocked_while_compaction_is_active() {
+        let (mut app, mut rx) = app_with_connection();
+        app.turn.compaction.begin();
+        app.input.set_text("wait for compaction");
+
+        submit_input(&mut app);
+
+        assert_eq!(app.input.text(), "wait for compaction");
+        assert!(matches!(app.status, AppStatus::Ready));
+        assert!(rx.try_recv().is_err());
     }
 
     #[test]
@@ -406,66 +411,66 @@ mod tests {
     }
 
     #[test]
-    fn auto_submit_dispatches_draft_once_ready() {
+    fn rejected_prompt_is_not_submitted_when_the_active_turn_completes() {
         let (mut app, mut rx) = app_with_connection();
         app.status = AppStatus::Running;
-        app.input.set_text("send after cancel");
+        app.input.set_text("submit manually later");
 
         submit_input(&mut app);
-        assert!(app.turn.pending_auto_submit_after_cancel);
-        let cancel = rx.try_recv().expect("cancel command should be sent");
-        assert!(matches!(
-            cancel.command, BridgeCommand::CancelTurn { session_id } if session_id == "session-1"
-        ));
+        crate::app::events::handle_client_event(
+            &mut app,
+            ClientEvent::TurnComplete { session_id: "session-1".to_owned(), terminal_reason: None },
+        );
 
-        app.status = AppStatus::Ready;
-        app.turn.pending_cancel_origin = None;
-        maybe_auto_submit_after_cancel(&mut app);
-
-        assert!(!app.turn.pending_auto_submit_after_cancel);
-        assert!(app.input.text().is_empty());
-        assert!(matches!(app.status, AppStatus::Thinking));
-        assert_eq!(app.transcript.messages.len(), 2);
-        assert_eq!(app.active_turn_assistant_idx(), Some(1));
-        assert!(matches!(app.transcript.messages[0].role, MessageRole::User));
-        assert!(matches!(app.transcript.messages[1].role, MessageRole::Assistant));
-        assert!(app.transcript.messages[1].blocks.is_empty());
-        let prompt = rx.try_recv().expect("prompt command should be sent");
-        assert!(matches!(
-            prompt.command,
-            BridgeCommand::Prompt { session_id, .. } if session_id == "session-1"
-        ));
+        assert_eq!(app.input.text(), "submit manually later");
+        assert!(matches!(app.status, AppStatus::Ready));
+        while let Ok(envelope) = rx.try_recv() {
+            assert!(!matches!(envelope.command, BridgeCommand::Prompt { .. }));
+        }
     }
 
     #[test]
-    fn auto_submit_opens_config_only_after_cancel_finishes() {
+    fn status_submit_while_running_opens_fullscreen_and_keeps_turn_running() {
         let (mut app, mut rx) = app_with_connection();
         let dir = tempfile::tempdir().expect("tempdir");
         app.settings_home_override = Some(dir.path().to_path_buf());
         app.cwd_raw = dir.path().to_string_lossy().to_string();
         app.status = AppStatus::Running;
-        app.input.set_text("/config");
+        app.input.set_text("/status");
 
         submit_input(&mut app);
 
-        assert_eq!(app.surface_mode, SurfaceMode::Chat);
-        assert_eq!(app.input.text(), "/config");
-        assert_eq!(app.turn.pending_cancel_origin, Some(CancelOrigin::AutoQueue));
-        assert!(app.turn.pending_auto_submit_after_cancel);
-        let cancel = rx.try_recv().expect("cancel command should be sent");
-        assert!(matches!(
-            cancel.command, BridgeCommand::CancelTurn { session_id } if session_id == "session-1"
-        ));
-
-        app.status = AppStatus::Ready;
-        app.turn.pending_cancel_origin = None;
-        maybe_auto_submit_after_cancel(&mut app);
-
-        assert!(!app.turn.pending_auto_submit_after_cancel);
         assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::Config));
+        assert_eq!(app.config.active_tab, super::super::ConfigTab::Status);
         assert!(app.input.text().is_empty());
-        assert!(matches!(app.status, AppStatus::Ready));
-        assert!(rx.try_recv().is_err(), "config open should not dispatch a prompt turn");
+        assert!(matches!(app.status, AppStatus::Running));
+        let snapshot = rx.try_recv().expect("status view should request a current snapshot");
+        assert!(matches!(
+            snapshot.command,
+            BridgeCommand::GetStatusSnapshot { session_id } if session_id == "session-1"
+        ));
+    }
+
+    #[test]
+    fn mcp_and_plugins_open_during_active_turn() {
+        for (input, expected_tab) in
+            [("/mcp", super::super::ConfigTab::Mcp), ("/plugins", super::super::ConfigTab::Plugins)]
+        {
+            let (mut app, _rx) = app_with_connection();
+            let dir = tempfile::tempdir().expect("tempdir");
+            app.settings_home_override = Some(dir.path().to_path_buf());
+            app.cwd_raw = dir.path().to_string_lossy().to_string();
+            app.status = AppStatus::Running;
+            app.input.set_text(input);
+
+            submit_input(&mut app);
+
+            assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::Config));
+            assert_eq!(app.config.active_tab, expected_tab);
+            assert!(app.input.text().is_empty());
+            assert!(matches!(app.status, AppStatus::Running));
+            assert!(!app.turn.cancel_requested);
+        }
     }
 
     #[test]

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 Simon Peter Rothgang
 use super::paste_burst::CharAction;
-use super::{App, AppStatus, CancelOrigin, FocusOwner, InvalidationLevel, ModeInfo, ModeState};
+use super::{App, AppStatus, FocusOwner, InvalidationLevel, ModeInfo, ModeState};
 #[cfg(not(test))]
 use crate::app::SystemSeverity;
 use crate::app::inline_interactions::{
@@ -461,7 +461,7 @@ fn handle_turn_control(app: &mut App) -> bool {
         app.request_chat_repaint();
     }
     if matches!(app.status, AppStatus::Thinking | AppStatus::Running)
-        && let Err(message) = super::input_submit::request_cancel(app, CancelOrigin::Manual)
+        && let Err(message) = super::input_submit::request_cancel(app)
     {
         tracing::error!(
             target: crate::logging::targets::APP_INPUT,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -67,8 +67,8 @@ pub use service_status_check::start_service_status_check;
 pub use settings::{AppSettings, UpdatePrompt};
 pub(crate) use state::MarkdownRenderKey;
 pub use state::{
-    ActiveCompaction, App, AppStatus, AutocompleteKind, BlockCache, CacheMetrics, CancelOrigin,
-    ChatMessage, ChatMessageId, ChatRenderState, CompactionState, ComposerRenderState, ExtraUsage,
+    ActiveCompaction, App, AppStatus, AutocompleteKind, BlockCache, CacheMetrics, ChatMessage,
+    ChatMessageId, ChatRenderState, CompactionState, ComposerRenderState, ExtraUsage,
     HistoryOutputId, ImageAttachmentBlock, IncrementalMarkdown, InlinePermission, InlineQuestion,
     InvalidationLevel, LayoutInvalidation, LiveRegionRenderState, LoginHint, McpState,
     MessageBlock, MessageBlockId, MessageRole, MessageUsage, ModeInfo, ModeState, NoticeBlock,

--- a/src/app/session_runtime.rs
+++ b/src/app/session_runtime.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 Simon Peter Rothgang
 
-use crate::app::{App, AppStatus};
+use crate::app::App;
 use std::time::{Duration, Instant};
 
 const CONTEXT_USAGE_REFRESH_INTERVAL: Duration = Duration::from_secs(45);
@@ -114,8 +114,7 @@ pub(crate) fn tick_context_usage_refresh(app: &mut App, now: Instant) {
 }
 
 fn context_usage_refresh_is_active(app: &App) -> bool {
-    matches!(app.status, AppStatus::Thinking | AppStatus::Running)
-        || app.turn.compaction.is_active()
+    app.is_agent_turn_active()
 }
 
 pub(crate) fn request_status_snapshot_refresh(app: &mut App) {

--- a/src/app/slash/catalog.rs
+++ b/src/app/slash/catalog.rs
@@ -30,6 +30,24 @@ pub(crate) enum AppSlashCommand {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SubmissionClass {
+    Invalid,
+    TurnControl,
+    Fullscreen,
+    Informational,
+    TurnExclusive,
+}
+
+impl SubmissionClass {
+    pub(crate) const fn requires_idle_turn(self) -> bool {
+        match self {
+            Self::TurnExclusive => true,
+            Self::Invalid | Self::TurnControl | Self::Fullscreen | Self::Informational => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SlashArgSpec {
     pub value: &'static str,
     pub description: &'static str,
@@ -295,6 +313,84 @@ impl AppSlashCommand {
 
     pub(crate) fn usage(self) -> &'static str {
         command_spec(self.name()).map_or(self.name(), |spec| spec.usage)
+    }
+
+    pub(crate) fn submission_class(self, args: &[&str]) -> SubmissionClass {
+        match self {
+            Self::Cancel => {
+                if args.is_empty() {
+                    SubmissionClass::TurnControl
+                } else {
+                    SubmissionClass::Invalid
+                }
+            }
+            Self::Config | Self::Help | Self::Mcp | Self::Plugins | Self::Status | Self::Usage => {
+                if args.is_empty() {
+                    SubmissionClass::Fullscreen
+                } else {
+                    SubmissionClass::Invalid
+                }
+            }
+            Self::Limits => {
+                if args.is_empty() {
+                    SubmissionClass::Informational
+                } else {
+                    SubmissionClass::Invalid
+                }
+            }
+            Self::Docs => {
+                if matches!(args, ["mode" | "models" | "shortcuts" | "commands" | "agents"]) {
+                    SubmissionClass::Informational
+                } else {
+                    SubmissionClass::Invalid
+                }
+            }
+            Self::OneMContext => match args {
+                ["status"] => SubmissionClass::Informational,
+                ["enable" | "disable"] => SubmissionClass::TurnExclusive,
+                _ => SubmissionClass::Invalid,
+            },
+            Self::OpusVersion => match args {
+                ["status"] => SubmissionClass::Informational,
+                ["4.5" | "4.6" | "4.7" | "4.8" | "default"] => SubmissionClass::TurnExclusive,
+                _ => SubmissionClass::Invalid,
+            },
+            Self::Compact | Self::Fast | Self::Login | Self::Logout | Self::NewSession => {
+                if args.is_empty() {
+                    SubmissionClass::TurnExclusive
+                } else {
+                    SubmissionClass::Invalid
+                }
+            }
+            Self::Agent | Self::Mode | Self::Model => {
+                if matches!(args, [_]) {
+                    SubmissionClass::TurnExclusive
+                } else {
+                    SubmissionClass::Invalid
+                }
+            }
+            Self::Effort => {
+                if matches!(args, ["low" | "medium" | "high" | "xhigh" | "max"]) {
+                    SubmissionClass::TurnExclusive
+                } else {
+                    SubmissionClass::Invalid
+                }
+            }
+            Self::Resume => {
+                if args.len() <= 1 {
+                    SubmissionClass::TurnExclusive
+                } else {
+                    SubmissionClass::Invalid
+                }
+            }
+            Self::Rewind => {
+                if matches!(args, [_, "both" | "conversation" | "code"]) {
+                    SubmissionClass::TurnExclusive
+                } else {
+                    SubmissionClass::Invalid
+                }
+            }
+        }
     }
 }
 

--- a/src/app/slash/executors.rs
+++ b/src/app/slash/executors.rs
@@ -4,8 +4,8 @@
 //! Slash command executors: dispatching parsed commands to their handler functions.
 
 use super::{
-    AppSlashCommand, parse, push_system_message, push_user_message, require_active_session,
-    require_connection, set_command_pending,
+    AppSlashCommand, ResolvedSubmission, SubmissionClass, push_system_message, push_user_message,
+    require_active_session, require_connection, set_command_pending,
 };
 use crate::agent::events::ClientEvent;
 use crate::agent::types::RewindRestoreMode;
@@ -13,10 +13,9 @@ use crate::app::config::{self, SettingFile, store};
 use crate::app::connect::{
     SessionStartReason, begin_resume_session, begin_rewind, start_new_session,
 };
-use crate::app::events::push_system_message_with_severity;
+use crate::app::events::push_submission_feedback;
 use crate::app::{
-    App, AppStatus, CancelOrigin, FullscreenView, ReleaseReason, SessionPickerState,
-    SystemSeverity, view,
+    App, AppStatus, FullscreenView, ReleaseReason, SessionPickerState, SystemSeverity, view,
 };
 use std::fmt::Write as _;
 use std::path::Path;
@@ -32,43 +31,49 @@ const OPUS_4_8_MODEL_ID: &str = "claude-opus-4-8";
 ///
 /// Returns `true` if the slash input was fully handled and should not be sent as a prompt.
 /// Returns `false` when the input should continue through the normal prompt path.
-pub fn try_handle_submit(app: &mut App, text: &str) -> bool {
-    let Some(parsed) = parse(text) else {
+pub(crate) fn try_handle_submission(app: &mut App, submission: &ResolvedSubmission) -> bool {
+    let ResolvedSubmission::Slash { name, args, command, .. } = submission else {
         return false;
     };
+    let args = args.iter().map(String::as_str).collect::<Vec<_>>();
 
-    let Some(command) = AppSlashCommand::from_name(parsed.name) else {
-        return handle_unknown_submit(app, parsed.name);
+    let Some(command) = command else {
+        return handle_unknown_submit(app, name);
     };
+    if submission.class() == SubmissionClass::Invalid {
+        push_system_message(app, command.usage());
+        return true;
+    }
 
     match command {
-        AppSlashCommand::OneMContext => handle_1m_context_submit(app, &parsed.args),
+        AppSlashCommand::OneMContext => handle_1m_context_submit(app, &args),
         AppSlashCommand::Cancel => handle_cancel_submit(app),
-        AppSlashCommand::Compact => handle_compact_submit(app, &parsed.args),
-        AppSlashCommand::Config => handle_config_submit(app, &parsed.args),
-        AppSlashCommand::Limits => handle_limits_submit(app, &parsed.args),
-        AppSlashCommand::Docs => handle_docs_submit(app, &parsed.args),
-        AppSlashCommand::Agent => handle_agent_submit(app, &parsed.args),
-        AppSlashCommand::Effort => handle_effort_submit(app, &parsed.args),
-        AppSlashCommand::Fast => handle_fast_submit(app, &parsed.args),
-        AppSlashCommand::Help => handle_help_submit(app, &parsed.args),
-        AppSlashCommand::Mcp => handle_mcp_submit(app, &parsed.args),
-        AppSlashCommand::Plugins => handle_plugins_submit(app, &parsed.args),
-        AppSlashCommand::OpusVersion => handle_opus_version_submit(app, &parsed.args),
-        AppSlashCommand::Status => handle_status_submit(app, &parsed.args),
-        AppSlashCommand::Usage => handle_usage_submit(app, &parsed.args),
-        AppSlashCommand::Login => handle_login_submit(app, &parsed.args),
-        AppSlashCommand::Logout => handle_logout_submit(app, &parsed.args),
-        AppSlashCommand::Mode => handle_mode_submit(app, &parsed.args),
-        AppSlashCommand::Model => handle_model_submit(app, &parsed.args),
-        AppSlashCommand::NewSession => handle_new_session_submit(app, &parsed.args),
-        AppSlashCommand::Resume => handle_resume_submit(app, &parsed.args),
-        AppSlashCommand::Rewind => handle_rewind_submit(app, &parsed.args),
+        AppSlashCommand::Compact => handle_compact_submit(app),
+        AppSlashCommand::Config => handle_config_submit(app),
+        AppSlashCommand::Limits => handle_limits_submit(app),
+        AppSlashCommand::Docs => handle_docs_submit(app, &args),
+        AppSlashCommand::Agent => handle_agent_submit(app, &args),
+        AppSlashCommand::Effort => handle_effort_submit(app, &args),
+        AppSlashCommand::Fast => handle_fast_submit(app),
+        AppSlashCommand::Help => handle_help_submit(app),
+        AppSlashCommand::Mcp => handle_mcp_submit(app),
+        AppSlashCommand::Plugins => handle_plugins_submit(app),
+        AppSlashCommand::OpusVersion => handle_opus_version_submit(app, &args),
+        AppSlashCommand::Status => handle_status_submit(app),
+        AppSlashCommand::Usage => handle_usage_submit(app),
+        AppSlashCommand::Login => handle_login_submit(app),
+        AppSlashCommand::Logout => handle_logout_submit(app),
+        AppSlashCommand::Mode => handle_mode_submit(app, &args),
+        AppSlashCommand::Model => handle_model_submit(app, &args),
+        AppSlashCommand::NewSession => handle_new_session_submit(app),
+        AppSlashCommand::Resume => handle_resume_submit(app, &args),
+        AppSlashCommand::Rewind => handle_rewind_submit(app, &args),
     }
 }
 
-fn usage(command: AppSlashCommand) -> &'static str {
-    command.usage()
+#[cfg(test)]
+pub fn try_handle_submit(app: &mut App, text: &str) -> bool {
+    try_handle_submission(app, &ResolvedSubmission::resolve(text.to_owned()))
 }
 
 fn opus_model_id_for_version(version: &str) -> Option<&'static str> {
@@ -93,16 +98,10 @@ fn opus_version_label_for_model_id(model_id: &str) -> Option<&'static str> {
 
 fn handle_opus_version_submit(app: &mut App, args: &[&str]) -> bool {
     let [subcommand] = args else {
-        push_system_message(app, usage(AppSlashCommand::OpusVersion));
-        return true;
+        unreachable!("validated /opus-version arguments must contain one value");
     };
-    let subcommand = subcommand.trim();
-    if subcommand.is_empty() || args.len() != 1 {
-        push_system_message(app, usage(AppSlashCommand::OpusVersion));
-        return true;
-    }
 
-    match subcommand {
+    match *subcommand {
         "status" => {
             match current_opus_version_pin(app) {
                 Ok(Some(model_id)) => {
@@ -116,11 +115,11 @@ fn handle_opus_version_submit(app: &mut App, args: &[&str]) -> bool {
                             "Opus is pinned to {model_id} in this folder via `.claude/settings.local.json`."
                         )
                     };
-                    push_system_message_with_severity(app, Some(SystemSeverity::Info), &message);
+                    push_submission_feedback(app, SystemSeverity::Info, &message);
                 }
-                Ok(None) => push_system_message_with_severity(
+                Ok(None) => push_submission_feedback(
                     app,
-                    Some(SystemSeverity::Info),
+                    SystemSeverity::Info,
                     "Opus is using the default alias resolution in this folder.",
                 ),
                 Err(err) => {
@@ -137,8 +136,7 @@ fn handle_opus_version_submit(app: &mut App, args: &[&str]) -> bool {
         }
         _ => {
             let Some(model_id) = opus_model_id_for_version(subcommand) else {
-                push_system_message(app, usage(AppSlashCommand::OpusVersion));
-                return true;
+                unreachable!("validated /opus-version argument must be supported");
             };
             if let Err(err) = set_opus_version_pin(app, Some(model_id)) {
                 push_system_message(
@@ -153,26 +151,20 @@ fn handle_opus_version_submit(app: &mut App, args: &[&str]) -> bool {
 
 fn handle_1m_context_submit(app: &mut App, args: &[&str]) -> bool {
     let [subcommand] = args else {
-        push_system_message(app, usage(AppSlashCommand::OneMContext));
-        return true;
+        unreachable!("validated /1m-context arguments must contain one value");
     };
-    let subcommand = subcommand.trim();
-    if subcommand.is_empty() || args.len() != 1 {
-        push_system_message(app, usage(AppSlashCommand::OneMContext));
-        return true;
-    }
 
-    match subcommand {
+    match *subcommand {
         "status" => {
             match current_1m_context_disabled(app) {
-                Ok(true) => push_system_message_with_severity(
+                Ok(true) => push_submission_feedback(
                     app,
-                    Some(SystemSeverity::Info),
+                    SystemSeverity::Info,
                     "1M context is disabled for future sessions in this folder via `.claude/settings.local.json`.",
                 ),
-                Ok(false) => push_system_message_with_severity(
+                Ok(false) => push_submission_feedback(
                     app,
-                    Some(SystemSeverity::Info),
+                    SystemSeverity::Info,
                     "1M context is enabled for future sessions in this folder.",
                 ),
                 Err(err) => {
@@ -193,10 +185,7 @@ fn handle_1m_context_submit(app: &mut App, args: &[&str]) -> bool {
             }
             true
         }
-        _ => {
-            push_system_message(app, usage(AppSlashCommand::OneMContext));
-            true
-        }
+        _ => unreachable!("validated /1m-context argument must be supported"),
     }
 }
 
@@ -248,7 +237,7 @@ fn set_1m_context_disabled(app: &mut App, disabled: bool) -> Result<(), String> 
             "Enabled 1M context for future sessions in this folder. Run /new-session to apply it."
         }
     };
-    push_system_message_with_severity(app, Some(SystemSeverity::Info), message);
+    push_submission_feedback(app, SystemSeverity::Info, message);
     Ok(())
 }
 
@@ -304,7 +293,7 @@ fn set_opus_version_pin(app: &mut App, model: Option<&str>) -> Result<(), String
             "Cleared the project-local Opus version pin for future sessions in this folder. Run /new-session to apply it.".to_owned()
         }
     };
-    push_system_message_with_severity(app, Some(SystemSeverity::Info), &message);
+    push_submission_feedback(app, SystemSeverity::Info, &message);
     Ok(())
 }
 
@@ -312,17 +301,13 @@ fn handle_cancel_submit(app: &mut App) -> bool {
     if !matches!(app.status, AppStatus::Thinking | AppStatus::Running) {
         return true;
     }
-    if let Err(message) = crate::app::input_submit::request_cancel(app, CancelOrigin::Manual) {
+    if let Err(message) = crate::app::input_submit::request_cancel(app) {
         push_system_message(app, format!("Failed to run /cancel: {message}"));
     }
     true
 }
 
-fn handle_compact_submit(app: &mut App, args: &[&str]) -> bool {
-    if !args.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Compact));
-        return true;
-    }
+fn handle_compact_submit(app: &mut App) -> bool {
     if require_active_session(
         app,
         "Cannot compact: not connected yet.",
@@ -337,24 +322,14 @@ fn handle_compact_submit(app: &mut App, args: &[&str]) -> bool {
     false
 }
 
-fn handle_config_submit(app: &mut App, args: &[&str]) -> bool {
-    if !args.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Config));
-        return true;
-    }
-
+fn handle_config_submit(app: &mut App) -> bool {
     if let Err(err) = crate::app::config::open(app) {
         push_system_message(app, format!("Failed to open settings: {err}"));
     }
     true
 }
 
-fn handle_help_submit(app: &mut App, args: &[&str]) -> bool {
-    if !args.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Help));
-        return true;
-    }
-
+fn handle_help_submit(app: &mut App) -> bool {
     if let Err(err) = crate::app::config::open(app) {
         push_system_message(app, format!("Failed to open help: {err}"));
         return true;
@@ -364,33 +339,24 @@ fn handle_help_submit(app: &mut App, args: &[&str]) -> bool {
 }
 
 fn handle_docs_submit(app: &mut App, args: &[&str]) -> bool {
-    let topic = match args {
-        [topic] if !topic.trim().is_empty() => topic.trim(),
-        _ => {
-            push_system_message(app, docs_usage());
-            return true;
-        }
+    let [topic] = args else {
+        unreachable!("validated /docs arguments must contain one topic");
     };
 
-    let body = match topic {
+    let body = match *topic {
         "mode" => build_docs_mode_markdown(app),
         "models" => build_docs_models_markdown(app),
         "shortcuts" => build_docs_shortcuts_markdown(app),
         "commands" => build_docs_commands_markdown(app),
         "agents" => build_docs_agents_markdown(app),
-        other => {
-            push_system_message(app, format!("Unknown docs topic: {other}\n{}", docs_usage()));
-            return true;
-        }
+        _ => unreachable!("validated /docs topic must be supported"),
     };
 
-    push_system_message_with_severity(app, Some(SystemSeverity::Info), &body);
+    push_submission_feedback(app, SystemSeverity::Info, &body);
     true
 }
 
-fn handle_plugins_submit(app: &mut App, args: &[&str]) -> bool {
-    let _ = args;
-
+fn handle_plugins_submit(app: &mut App) -> bool {
     if let Err(err) = crate::app::config::open(app) {
         push_system_message(app, format!("Failed to open plugins: {err}"));
         return true;
@@ -399,12 +365,7 @@ fn handle_plugins_submit(app: &mut App, args: &[&str]) -> bool {
     true
 }
 
-fn handle_mcp_submit(app: &mut App, args: &[&str]) -> bool {
-    if !args.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Mcp));
-        return true;
-    }
-
+fn handle_mcp_submit(app: &mut App) -> bool {
     if let Err(err) = crate::app::config::open(app) {
         push_system_message(app, format!("Failed to open MCP: {err}"));
         return true;
@@ -413,12 +374,7 @@ fn handle_mcp_submit(app: &mut App, args: &[&str]) -> bool {
     true
 }
 
-fn handle_status_submit(app: &mut App, args: &[&str]) -> bool {
-    if !args.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Status));
-        return true;
-    }
-
+fn handle_status_submit(app: &mut App) -> bool {
     if let Err(err) = crate::app::config::open(app) {
         push_system_message(app, format!("Failed to open status: {err}"));
         return true;
@@ -427,12 +383,7 @@ fn handle_status_submit(app: &mut App, args: &[&str]) -> bool {
     true
 }
 
-fn handle_usage_submit(app: &mut App, args: &[&str]) -> bool {
-    if !args.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Usage));
-        return true;
-    }
-
+fn handle_usage_submit(app: &mut App) -> bool {
     if let Err(err) = crate::app::config::open(app) {
         push_system_message(app, format!("Failed to open usage: {err}"));
         return true;
@@ -441,22 +392,12 @@ fn handle_usage_submit(app: &mut App, args: &[&str]) -> bool {
     true
 }
 
-fn handle_limits_submit(app: &mut App, args: &[&str]) -> bool {
-    if !args.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Limits));
-        return true;
-    }
-
+fn handle_limits_submit(app: &mut App) -> bool {
     crate::app::usage::request_limits_summary(app);
     true
 }
 
-fn handle_login_submit(app: &mut App, args: &[&str]) -> bool {
-    if !args.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Login));
-        return true;
-    }
-
+fn handle_login_submit(app: &mut App) -> bool {
     push_user_message(app, "/login");
     tracing::debug!(
         target: crate::logging::targets::APP_AUTH,
@@ -466,9 +407,9 @@ fn handle_login_submit(app: &mut App, args: &[&str]) -> bool {
     );
 
     if crate::app::auth::has_credentials() {
-        push_system_message_with_severity(
+        push_submission_feedback(
             app,
-            Some(SystemSeverity::Info),
+            SystemSeverity::Info,
             "Already authenticated. Use /logout first to re-authenticate.",
         );
         return true;
@@ -545,12 +486,7 @@ fn handle_login_submit(app: &mut App, args: &[&str]) -> bool {
     true
 }
 
-fn handle_logout_submit(app: &mut App, args: &[&str]) -> bool {
-    if !args.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Logout));
-        return true;
-    }
-
+fn handle_logout_submit(app: &mut App) -> bool {
     push_user_message(app, "/logout");
     tracing::debug!(
         target: crate::logging::targets::APP_AUTH,
@@ -560,9 +496,9 @@ fn handle_logout_submit(app: &mut App, args: &[&str]) -> bool {
     );
 
     if !crate::app::auth::has_credentials() {
-        push_system_message_with_severity(
+        push_submission_feedback(
             app,
-            Some(SystemSeverity::Info),
+            SystemSeverity::Info,
             "Not currently authenticated. Nothing to log out from.",
         );
         return true;
@@ -693,14 +629,9 @@ fn resolve_claude_cli(app: &mut App, subcommand: &str) -> Option<std::path::Path
 
 fn handle_mode_submit(app: &mut App, args: &[&str]) -> bool {
     let [requested_mode_arg] = args else {
-        push_system_message(app, usage(AppSlashCommand::Mode));
-        return true;
+        unreachable!("validated /mode arguments must contain one value");
     };
-    let requested_mode = requested_mode_arg.trim();
-    if requested_mode.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Mode));
-        return true;
-    }
+    let requested_mode = *requested_mode_arg;
 
     let Some((conn, sid)) = require_active_session(
         app,
@@ -740,14 +671,9 @@ fn handle_mode_submit(app: &mut App, args: &[&str]) -> bool {
 
 fn handle_model_submit(app: &mut App, args: &[&str]) -> bool {
     let [model_name_arg] = args else {
-        push_system_message(app, usage(AppSlashCommand::Model));
-        return true;
+        unreachable!("validated /model arguments must contain one value");
     };
-    let model_name = model_name_arg.trim();
-    if model_name.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Model));
-        return true;
-    }
+    let model_name = *model_name_arg;
 
     let Some((conn, sid)) = require_active_session(
         app,
@@ -791,12 +717,10 @@ fn handle_model_submit(app: &mut App, args: &[&str]) -> bool {
 
 fn handle_effort_submit(app: &mut App, args: &[&str]) -> bool {
     let [effort_arg] = args else {
-        push_system_message(app, usage(AppSlashCommand::Effort));
-        return true;
+        unreachable!("validated /effort arguments must contain one value");
     };
-    let Some(effort) = crate::agent::model::EffortLevel::from_stored(effort_arg.trim()) else {
-        push_system_message(app, usage(AppSlashCommand::Effort));
-        return true;
+    let Some(effort) = crate::agent::model::EffortLevel::from_stored(effort_arg) else {
+        unreachable!("validated /effort argument must be supported");
     };
 
     let Some((conn, sid)) = require_active_session(
@@ -837,12 +761,7 @@ fn handle_effort_submit(app: &mut App, args: &[&str]) -> bool {
     true
 }
 
-fn handle_fast_submit(app: &mut App, args: &[&str]) -> bool {
-    if !args.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Fast));
-        return true;
-    }
-
+fn handle_fast_submit(app: &mut App) -> bool {
     let Some((conn, sid)) = require_active_session(
         app,
         "Cannot toggle fast mode: not connected yet.",
@@ -883,14 +802,9 @@ fn handle_fast_submit(app: &mut App, args: &[&str]) -> bool {
 
 fn handle_agent_submit(app: &mut App, args: &[&str]) -> bool {
     let [agent_arg] = args else {
-        push_system_message(app, usage(AppSlashCommand::Agent));
-        return true;
+        unreachable!("validated /agent arguments must contain one value");
     };
-    let requested_agent = agent_arg.trim();
-    if requested_agent.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Agent));
-        return true;
-    }
+    let requested_agent = *agent_arg;
 
     let Some((conn, sid)) = require_active_session(
         app,
@@ -940,12 +854,7 @@ fn handle_agent_submit(app: &mut App, args: &[&str]) -> bool {
     true
 }
 
-fn handle_new_session_submit(app: &mut App, args: &[&str]) -> bool {
-    if !args.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::NewSession));
-        return true;
-    }
-
+fn handle_new_session_submit(app: &mut App) -> bool {
     push_user_message(app, "/new-session");
 
     let Some(conn) = require_connection(app, "Cannot create new session: not connected yet.")
@@ -985,14 +894,9 @@ fn handle_resume_submit(app: &mut App, args: &[&str]) -> bool {
         return true;
     }
     let [session_id_arg] = args else {
-        push_system_message(app, usage(AppSlashCommand::Resume));
-        return true;
+        unreachable!("validated /resume arguments must contain at most one value");
     };
-    let session_id = session_id_arg.trim();
-    if session_id.is_empty() {
-        push_system_message(app, usage(AppSlashCommand::Resume));
-        return true;
-    }
+    let session_id = *session_id_arg;
 
     push_user_message(app, format!("/resume {session_id}"));
     let Some(conn) = require_connection(app, "Cannot resume session: not connected yet.") else {
@@ -1011,19 +915,12 @@ fn handle_resume_submit(app: &mut App, args: &[&str]) -> bool {
 }
 
 fn handle_rewind_submit(app: &mut App, args: &[&str]) -> bool {
-    let [target_uuid, restore_mode_arg] = args else {
-        push_system_message(app, usage(AppSlashCommand::Rewind));
-        return true;
+    let [target_uuid_arg, restore_mode_arg] = args else {
+        unreachable!("validated /rewind arguments must contain a target and restore mode");
     };
-    let target_uuid = target_uuid.trim();
-    let restore_mode_arg = restore_mode_arg.trim();
-    if target_uuid.is_empty() || restore_mode_arg.is_empty() || args.len() != 2 {
-        push_system_message(app, usage(AppSlashCommand::Rewind));
-        return true;
-    }
+    let target_uuid = *target_uuid_arg;
     let Some(restore_mode) = RewindRestoreMode::from_stored(restore_mode_arg) else {
-        push_system_message(app, usage(AppSlashCommand::Rewind));
-        return true;
+        unreachable!("validated /rewind restore mode must be supported");
     };
     let Some(target) =
         app.sdk_inventory.rewind_targets.iter().find(|target| target.uuid == target_uuid)
@@ -1062,10 +959,6 @@ fn handle_unknown_submit(app: &mut App, command_name: &str) -> bool {
     }
     push_system_message(app, format!("{command_name} is not yet supported"));
     true
-}
-
-fn docs_usage() -> &'static str {
-    usage(AppSlashCommand::Docs)
 }
 
 fn build_docs_mode_markdown(app: &App) -> String {

--- a/src/app/slash/mod.rs
+++ b/src/app/slash/mod.rs
@@ -18,12 +18,14 @@ use super::{
     dialog::DialogState,
 };
 use crate::agent::model;
-use crate::app::events::push_system_message_with_severity;
+use crate::app::events::push_submission_feedback;
 use std::rc::Rc;
 
 const MAX_CANDIDATES: usize = 50;
 // Re-export public API
-pub(crate) use catalog::{APP_SLASH_COMMANDS, AppSlashCommand, command_spec};
+pub(crate) use catalog::{APP_SLASH_COMMANDS, AppSlashCommand, SubmissionClass, command_spec};
+pub(crate) use executors::try_handle_submission;
+#[cfg(test)]
 pub use executors::try_handle_submit;
 pub use navigation::{
     confirm_selection, deactivate, move_down, move_up, sync_with_cursor, update_query,
@@ -73,6 +75,55 @@ struct ParsedSlash<'a> {
     args: Vec<&'a str>,
 }
 
+#[derive(Debug)]
+pub(crate) enum ResolvedSubmission {
+    Prompt {
+        text: String,
+    },
+    Slash {
+        text: String,
+        name: String,
+        args: Vec<String>,
+        command: Option<AppSlashCommand>,
+        class: SubmissionClass,
+    },
+}
+
+impl ResolvedSubmission {
+    pub(crate) fn resolve(text: String) -> Self {
+        let Some(parsed) = parse(&text) else {
+            return Self::Prompt { text };
+        };
+        let name = parsed.name.to_owned();
+        let command = AppSlashCommand::from_name(&name);
+        let class = command.map_or(SubmissionClass::TurnExclusive, |command| {
+            command.submission_class(&parsed.args)
+        });
+        let args = parsed.args.into_iter().map(str::to_owned).collect();
+        Self::Slash { text, name, args, command, class }
+    }
+
+    pub(crate) fn class(&self) -> SubmissionClass {
+        match self {
+            Self::Prompt { .. } => SubmissionClass::TurnExclusive,
+            Self::Slash { class, .. } => *class,
+        }
+    }
+
+    pub(crate) fn blocked_label(&self) -> String {
+        match self {
+            Self::Prompt { .. } => "New prompts".to_owned(),
+            Self::Slash { name, .. } => format!("`{name}`"),
+        }
+    }
+
+    pub(crate) fn into_text(self) -> String {
+        match self {
+            Self::Prompt { text } | Self::Slash { text, .. } => text,
+        }
+    }
+}
+
 fn parse(text: &str) -> Option<ParsedSlash<'_>> {
     let trimmed = text.trim();
     if !trimmed.starts_with('/') {
@@ -81,10 +132,6 @@ fn parse(text: &str) -> Option<ParsedSlash<'_>> {
     let mut parts = trimmed.split_whitespace();
     let name = parts.next()?;
     Some(ParsedSlash { name, args: parts.collect() })
-}
-
-pub fn is_cancel_command(text: &str) -> bool {
-    parse(text).is_some_and(|parsed| parsed.name == "/cancel")
 }
 
 pub(crate) fn app_owned_command_name(name: &str) -> Option<&'static str> {
@@ -98,7 +145,7 @@ fn normalize_slash_name(name: &str) -> String {
 
 fn push_system_message(app: &mut App, text: impl Into<String>) {
     let text = text.into();
-    push_system_message_with_severity(app, Some(SystemSeverity::Error), &text);
+    push_submission_feedback(app, SystemSeverity::Error, &text);
 }
 
 fn push_user_message(app: &mut App, text: impl Into<String>) {

--- a/src/app/slash/tests.rs
+++ b/src/app/slash/tests.rs
@@ -32,6 +32,47 @@ fn parse_slash_name_and_args() {
 }
 
 #[test]
+fn resolved_submission_is_the_active_turn_policy_authority() {
+    let classify = |input: &str| ResolvedSubmission::resolve(input.to_owned()).class();
+
+    assert_eq!(classify("/cancel"), SubmissionClass::TurnControl);
+    for input in ["/config", "/help", "/mcp", "/plugins", "/status", "/usage"] {
+        assert_eq!(classify(input), SubmissionClass::Fullscreen, "unexpected class for {input}");
+    }
+    for input in ["/docs commands", "/limits", "/1m-context status", "/opus-version status"] {
+        assert_eq!(classify(input), SubmissionClass::Informational, "unexpected class for {input}");
+    }
+    for input in [
+        "next prompt",
+        "/remote-command",
+        "/compact",
+        "/1m-context enable",
+        "/opus-version 4.8",
+        "/agent reviewer",
+        "/effort high",
+        "/fast",
+        "/login",
+        "/logout",
+        "/mode plan",
+        "/model sonnet",
+        "/new-session",
+        "/resume",
+        "/rewind user-1 conversation",
+    ] {
+        assert_eq!(classify(input), SubmissionClass::TurnExclusive, "unexpected class for {input}");
+    }
+    for input in [
+        "/cancel extra",
+        "/docs nope",
+        "/plugins extra",
+        "/resume one two",
+        "/rewind user-1 invalid",
+    ] {
+        assert_eq!(classify(input), SubmissionClass::Invalid, "unexpected class for {input}");
+    }
+}
+
+#[test]
 fn unsupported_command_is_handled_locally() {
     let mut app = App::test_default();
     let consumed = try_handle_submit(&mut app, "/definitely-unknown");
@@ -719,19 +760,19 @@ fn mcp_with_extra_args_returns_usage() {
 }
 
 #[test]
-fn plugins_with_extra_args_still_opens_plugins_tab() {
+fn plugins_with_extra_args_returns_usage() {
     let mut app = App::test_default();
-    let dir = tempfile::tempdir().expect("tempdir");
-    app.settings_home_override = Some(dir.path().to_path_buf());
 
     let consumed = try_handle_submit(&mut app, "/plugins extra");
 
     assert!(consumed);
-    assert_eq!(
-        app.surface_mode,
-        super::super::SurfaceMode::Fullscreen(super::super::FullscreenView::Config)
-    );
-    assert_eq!(app.config.active_tab, super::super::ConfigTab::Plugins);
+    let Some(last) = app.transcript.messages.last() else {
+        panic!("expected usage message");
+    };
+    let Some(MessageBlock::Text(block)) = last.blocks.first() else {
+        panic!("expected text block");
+    };
+    assert_eq!(block.text, "Usage: /plugins");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -1262,8 +1303,7 @@ fn docs_with_unknown_topic_returns_usage() {
     let Some(MessageBlock::Text(block)) = last.blocks.first() else {
         panic!("expected text block");
     };
-    assert!(block.text.contains("Unknown docs topic: nope"));
-    assert!(block.text.contains("Usage: /docs <mode|models|shortcuts|commands|agents>"));
+    assert_eq!(block.text, "Usage: /docs <mode|models|shortcuts|commands|agents>");
 }
 
 #[test]

--- a/src/app/state/history_retention.rs
+++ b/src/app/state/history_retention.rs
@@ -179,7 +179,8 @@ impl super::App {
                             NoticeDedupKey::RateLimit(incident) => {
                                 incident.rate_limit_type.as_ref().map_or(0, String::capacity)
                             }
-                            NoticeDedupKey::ApiRetry => 0,
+                            NoticeDedupKey::ApiRetry
+                            | NoticeDedupKey::ActiveTurnSubmissionBlocked => 0,
                         });
                     }
                 }

--- a/src/app/state/messages.rs
+++ b/src/app/state/messages.rs
@@ -401,6 +401,7 @@ pub struct RateLimitIncidentKey {
 pub enum NoticeDedupKey {
     RateLimit(RateLimitIncidentKey),
     ApiRetry,
+    ActiveTurnSubmissionBlocked,
 }
 
 pub struct NoticeBlock {

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -54,10 +54,10 @@ pub use transcript::Transcript;
 pub use turn::{ActiveCompaction, CompactionState, TurnState};
 pub use turn_notices::{NoticeStage, TurnNoticeLocation, TurnNoticeRef};
 pub use types::{
-    AppStatus, CancelOrigin, ExtraUsage, HistoryRetentionPolicy, HistoryRetentionStats, LoginHint,
-    McpState, MessageUsage, ModeInfo, ModeState, PasteSessionState, PendingCommandAck,
-    PostExitAction, RecentSessionInfo, RenderCacheBudget, SelectionPoint, SessionPickerState,
-    SessionUsageState, SessionUsageSummary, ToolCallScope, UpdatePromptAction, UpdatePromptState,
+    AppStatus, ExtraUsage, HistoryRetentionPolicy, HistoryRetentionStats, LoginHint, McpState,
+    MessageUsage, ModeInfo, ModeState, PasteSessionState, PendingCommandAck, PostExitAction,
+    RecentSessionInfo, RenderCacheBudget, SelectionPoint, SessionPickerState, SessionUsageState,
+    SessionUsageSummary, ToolCallScope, UpdatePromptAction, UpdatePromptState,
     UsageActivitySummary, UsageActivityWindow, UsageBehaviorAttribution, UsageNamedAttribution,
     UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow,
 };
@@ -77,8 +77,8 @@ mod prelude {
     pub(super) use super::turn::TurnState;
     pub(super) use super::turn_notices::TurnNoticeRef;
     pub(super) use super::types::{
-        AppStatus, CancelOrigin, HistoryRetentionPolicy, HistoryRetentionStats, McpState,
-        PasteSessionState, PendingCommandAck, RecentSessionInfo, RenderCacheBudget, SelectionPoint,
+        AppStatus, HistoryRetentionPolicy, HistoryRetentionStats, McpState, PasteSessionState,
+        PendingCommandAck, RecentSessionInfo, RenderCacheBudget, SelectionPoint,
         SessionPickerState, ToolCallScope, UpdatePromptState, UsageState,
     };
     pub(super) use crate::agent::events::ClientEvent;

--- a/src/app/state/turn.rs
+++ b/src/app/state/turn.rs
@@ -85,14 +85,8 @@ pub struct TurnState {
     /// The first entry is the focused interaction that receives keyboard input.
     /// Up / Down arrow keys cycle focus through the list.
     pub pending_interaction_ids: Vec<String>,
-    /// Set when a cancel notification succeeds; consumed on `TurnComplete`
-    /// to render a red interruption hint in chat.
-    pub cancelled_pending_hint: bool,
-    /// Origin of the in-flight cancellation request, if any.
-    pub pending_cancel_origin: Option<CancelOrigin>,
-    /// Auto-submit the current input draft once cancellation transitions the app
-    /// back to `Ready`.
-    pub pending_auto_submit_after_cancel: bool,
+    /// Whether an explicit cancellation request is awaiting turn exit.
+    pub cancel_requested: bool,
     /// Message index that owns the current main-assistant turn indicators.
     pub assistant_message_idx: Option<usize>,
     /// IDs of root Task/Agent tool calls currently `InProgress`.
@@ -103,12 +97,9 @@ pub struct TurnState {
 }
 
 impl TurnState {
-    /// Clear all cancellation bookkeeping (after a cancel resolves or on
-    /// session reset). Keeps the three cancel flags from drifting apart.
+    /// Clear cancellation bookkeeping after a cancel resolves or on session reset.
     pub fn clear_cancel_state(&mut self) {
-        self.cancelled_pending_hint = false;
-        self.pending_cancel_origin = None;
-        self.pending_auto_submit_after_cancel = false;
+        self.cancel_requested = false;
     }
 
     /// Clear turn-local tracking that must not survive a completed or failed
@@ -119,8 +110,7 @@ impl TurnState {
         self.pending_command_ack = None;
         self.compaction.reset();
         self.pending_interaction_ids.clear();
-        self.cancelled_pending_hint = false;
-        self.pending_cancel_origin = None;
+        self.cancel_requested = false;
         self.assistant_message_idx = None;
         self.active_task_ids.clear();
         self.notice_refs.clear();
@@ -129,6 +119,14 @@ impl TurnState {
     /// Clear all state scoped to the active session/turn lifecycle.
     pub fn reset_for_new_session(&mut self) {
         self.reset_for_turn_exit();
-        self.pending_auto_submit_after_cancel = false;
+    }
+}
+
+impl App {
+    #[must_use]
+    pub(crate) fn is_agent_turn_active(&self) -> bool {
+        matches!(self.status, AppStatus::Thinking | AppStatus::Running)
+            || self.turn.compaction.is_active()
+            || self.turn.cancel_requested
     }
 }

--- a/src/app/state/turn_notices.rs
+++ b/src/app/state/turn_notices.rs
@@ -5,6 +5,7 @@ use super::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum NoticeStage {
+    Informational,
     Warning,
     Rejected,
     PlanLimitTurnError,

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 Simon Peter Rothgang
 
+use super::messages::ChatMessageId;
 use crate::agent::model;
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
@@ -187,6 +188,7 @@ pub struct UsageState {
     pub active_source: UsageSourceMode,
     pub last_attempted_source: Option<UsageSourceKind>,
     pub pending_limits_response: bool,
+    pub pending_limits_feedback_owner: Option<ChatMessageId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -301,12 +303,6 @@ pub enum ToolCallScope {
     MainAgent,
     SubagentRoot,
     SubagentChild { parent_tool_use_id: String },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CancelOrigin {
-    Manual,
-    AutoQueue,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -252,7 +252,14 @@ fn compaction_allows_drafting_but_blocks_submit() {
 
     assert!(app.pending_submit.is_none());
     assert_eq!(app.input.text(), "draft!");
-    assert!(app.transcript.messages.is_empty());
+    let [message] = app.transcript.messages.as_slice() else {
+        panic!("expected one active-turn submission notice");
+    };
+    assert!(matches!(message.role, MessageRole::System(Some(SystemSeverity::Info))));
+    let [MessageBlock::Notice(notice)] = message.blocks.as_slice() else {
+        panic!("expected informational notice block");
+    };
+    assert!(notice.text.text.contains("between agent turns"));
     assert!(rx.try_recv().is_err());
 }
 

--- a/src/app/usage/mod.rs
+++ b/src/app/usage/mod.rs
@@ -30,12 +30,14 @@ pub(crate) fn request_refresh_if_needed(app: &mut App) {
 }
 
 pub(crate) fn request_limits_summary(app: &mut App) {
+    let feedback_owner = crate::app::events::submission_feedback_owner(app);
     if app.usage.snapshot.as_ref().is_some_and(snapshot_is_fresh) {
-        push_limits_summary(app);
+        push_limits_summary(app, feedback_owner);
         return;
     }
 
     app.usage.pending_limits_response = true;
+    app.usage.pending_limits_feedback_owner = feedback_owner;
     request_refresh(app);
 }
 
@@ -228,20 +230,23 @@ pub(crate) fn reset_for_session_change(app: &mut App) {
     app.usage.last_error = None;
     app.usage.last_attempted_source = None;
     app.usage.pending_limits_response = false;
+    app.usage.pending_limits_feedback_owner = None;
 }
 
 pub(crate) fn emit_pending_limits_success(app: &mut App) {
     if !std::mem::take(&mut app.usage.pending_limits_response) {
         return;
     }
-    push_limits_summary(app);
+    let feedback_owner = app.usage.pending_limits_feedback_owner.take();
+    push_limits_summary(app, feedback_owner);
 }
 
 pub(crate) fn emit_pending_limits_failure(app: &mut App, message: &str) {
     if !std::mem::take(&mut app.usage.pending_limits_response) {
         return;
     }
-    push_error_message(app, &format!("Unable to get recent usage info: {message}"));
+    let feedback_owner = app.usage.pending_limits_feedback_owner.take();
+    push_error_message(app, feedback_owner, &format!("Unable to get recent usage info: {message}"));
 }
 
 pub(crate) fn visible_windows(snapshot: &UsageSnapshot) -> Vec<&UsageWindow> {
@@ -302,23 +307,37 @@ fn snapshot_is_fresh(snapshot: &UsageSnapshot) -> bool {
     snapshot.fetched_at.elapsed().is_ok_and(|age| age < USAGE_REFRESH_TTL)
 }
 
-fn push_limits_summary(app: &mut App) {
+fn push_limits_summary(app: &mut App, feedback_owner: Option<crate::app::ChatMessageId>) {
     let message = app
         .usage
         .snapshot
         .as_ref()
         .map_or_else(|| "No usage data available.".to_owned(), format_limits_summary);
-    push_info_message(app, &message);
+    push_info_message(app, feedback_owner, &message);
 }
 
-fn push_info_message(app: &mut App, message: &str) {
-    crate::app::events::push_system_message_with_severity(app, Some(SystemSeverity::Info), message);
-}
-
-fn push_error_message(app: &mut App, message: &str) {
-    crate::app::events::push_system_message_with_severity(
+fn push_info_message(
+    app: &mut App,
+    feedback_owner: Option<crate::app::ChatMessageId>,
+    message: &str,
+) {
+    crate::app::events::push_submission_feedback_for_owner(
         app,
-        Some(SystemSeverity::Error),
+        feedback_owner,
+        SystemSeverity::Info,
+        message,
+    );
+}
+
+fn push_error_message(
+    app: &mut App,
+    feedback_owner: Option<crate::app::ChatMessageId>,
+    message: &str,
+) {
+    crate::app::events::push_submission_feedback_for_owner(
+        app,
+        feedback_owner,
+        SystemSeverity::Error,
         message,
     );
 }

--- a/src/app/usage/tests.rs
+++ b/src/app/usage/tests.rs
@@ -1,6 +1,76 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
-use crate::app::{ExtraUsage, UsageSourceKind};
+use crate::app::{
+    App, AppStatus, ChatMessage, MessageBlock, MessageRole, SystemSeverity, UsageSourceKind,
+};
+
+fn limits_snapshot() -> UsageSnapshot {
+    UsageSnapshot {
+        source: UsageSourceKind::Sdk,
+        fetched_at: SystemTime::now(),
+        subscription_type: None,
+        five_hour: Some(UsageWindow {
+            label: "5-hour".to_owned(),
+            utilization: 42.0,
+            resets_at: None,
+            reset_description: None,
+        }),
+        seven_day: None,
+        seven_day_oauth_apps: None,
+        seven_day_opus: None,
+        seven_day_sonnet: None,
+        model_scoped: Vec::new(),
+        extra_usage: None,
+        session: None,
+        activity: None,
+    }
+}
+
+#[test]
+fn delayed_limits_feedback_stays_with_the_turn_that_requested_it() {
+    let mut app = App::test_default();
+    app.status = AppStatus::Running;
+    app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+    app.bind_active_turn_assistant(0);
+
+    request_limits_summary(&mut app);
+
+    let original_owner = app.transcript.messages[0].id;
+    assert_eq!(app.usage.pending_limits_feedback_owner, Some(original_owner));
+
+    app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+    app.bind_active_turn_assistant(1);
+    app.usage.snapshot = Some(limits_snapshot());
+    emit_pending_limits_success(&mut app);
+
+    let [MessageBlock::Notice(notice)] = app.transcript.messages[0].blocks.as_slice() else {
+        panic!("expected limits feedback on the requesting turn");
+    };
+    assert_eq!(notice.severity, SystemSeverity::Info);
+    assert!(notice.text.text.contains("| 5-hour | 42% |"));
+    assert!(app.transcript.messages[1].blocks.is_empty());
+    assert!(app.usage.pending_limits_feedback_owner.is_none());
+}
+
+#[test]
+fn delayed_between_turn_limits_feedback_does_not_attach_to_a_later_turn() {
+    let mut app = App::test_default();
+
+    request_limits_summary(&mut app);
+
+    assert!(app.usage.pending_limits_feedback_owner.is_none());
+    app.status = AppStatus::Running;
+    app.transcript.messages.push(ChatMessage::new(MessageRole::Assistant, Vec::new(), None));
+    app.bind_active_turn_assistant(0);
+    app.usage.snapshot = Some(limits_snapshot());
+    emit_pending_limits_success(&mut app);
+
+    assert!(app.transcript.messages[0].blocks.is_empty());
+    let Some(message) = app.transcript.messages.get(1) else {
+        panic!("expected standalone limits feedback");
+    };
+    assert!(matches!(message.role, MessageRole::System(Some(SystemSeverity::Info))));
+}
 
 #[test]
 fn formats_day_scale_reset() {

--- a/src/ui/config/usage.rs
+++ b/src/ui/config/usage.rs
@@ -451,6 +451,7 @@ mod tests {
             active_source: UsageSourceMode::Auto,
             last_attempted_source: None,
             pending_limits_response: false,
+            pending_limits_feedback_owner: None,
         };
         app
     }

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -47,7 +47,7 @@ fn has_login_hint(app: &App) -> bool {
 }
 
 fn has_cancel_hint(app: &App) -> bool {
-    app.turn.pending_cancel_origin.is_some()
+    app.turn.cancel_requested
 }
 
 fn has_prompt_suggestion_hint(app: &App) -> bool {
@@ -225,7 +225,7 @@ mod tests {
     };
     use crate::app::mention::CommittedMentionSpan;
     use crate::app::subagent::find_subagent_spans;
-    use crate::app::{App, CancelOrigin, FocusTarget, LoginHint};
+    use crate::app::{App, FocusTarget, LoginHint};
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
     use ratatui::style::{Color, Modifier};
@@ -279,7 +279,7 @@ mod tests {
     #[test]
     fn visual_line_count_includes_cancel_hint_row() {
         let mut app = App::test_default();
-        app.turn.pending_cancel_origin = Some(CancelOrigin::AutoQueue);
+        app.turn.cancel_requested = true;
         assert_eq!(visual_line_count(&mut app, 80), CANCEL_HINT_LINES + 1);
     }
 

--- a/src/ui/input_rows.rs
+++ b/src/ui/input_rows.rs
@@ -25,14 +25,11 @@ pub(crate) fn build_composer_hint_rows(app: &App) -> Vec<Line<'static>> {
         )));
     }
 
-    if app.turn.pending_cancel_origin.is_some() {
+    if app.turn.cancel_requested {
         let spinner_ch = SPINNER_FRAMES[app.spinner_frame % SPINNER_FRAMES.len()];
         rows.push(Line::from(vec![
             Span::styled(format!("{spinner_ch} "), Style::default().fg(theme::DIM)),
-            Span::styled(
-                "Cancelling current turn... draft will auto-submit when ready.",
-                Style::default().fg(theme::DIM),
-            ),
+            Span::styled("Cancelling current turn...", Style::default().fg(theme::DIM)),
         ]));
     }
 
@@ -91,7 +88,7 @@ pub(crate) fn blocked_input_lines(app: &App) -> Vec<Line<'static>> {
 #[cfg(test)]
 mod tests {
     use super::{blocked_input_lines, build_composer_hint_rows};
-    use crate::app::{App, AppStatus, CancelOrigin, FocusTarget, LoginHint};
+    use crate::app::{App, AppStatus, FocusTarget, LoginHint};
 
     fn line_text(line: &ratatui::text::Line<'_>) -> String {
         line.spans.iter().map(|span| span.content.as_ref()).collect()
@@ -113,7 +110,7 @@ mod tests {
     #[test]
     fn build_composer_hint_rows_preserves_cancel_and_suggestion_rows() {
         let mut app = App::test_default();
-        app.turn.pending_cancel_origin = Some(CancelOrigin::AutoQueue);
+        app.turn.cancel_requested = true;
         app.session_runtime.prompt_suggestion = Some("Write tests".to_owned());
 
         let rows = build_composer_hint_rows(&app);


### PR DESCRIPTION
## Summary

Allow safe local commands to run while an agent turn is active without interrupting the turn, while rejecting prompts and turn-exclusive commands with an inline informational notice. The submission pipeline now has one policy authority, preserves blocked drafts and attachments, and removes the previous cancel-and-auto-submit behavior.

- Available during active turns: `/cancel`, `/config`, `/help`, `/mcp`, `/plugins`, `/status`, `/usage`, and informational commands.
- Blocked until the turn ends: prompts, mutating commands, `/resume`, and SDK-promoted commands.
- Delayed `/limits` feedback remains associated with the assistant turn that received the request.

## Why

Submitting input during an active turn previously coupled ordinary submissions to cancellation and deferred auto-submission. That behavior made command handling implicit, allowed unrelated commands to interrupt turns, and spread command eligibility across multiple code paths.

The new policy makes active-turn behavior explicit and conservative: locally safe commands remain available, turn-exclusive work waits until the turn ends, unknown SDK commands default to blocked, and rejected input remains available for deliberate submission later.

## Validation

- Automated: Complete Rust test suite (`1,762` library tests plus binary, integration, contract, and documentation tests), including active-turn command policy, cancellation lifecycle, draft preservation, notice deduplication, and delayed usage feedback coverage.
- Manual: Not performed.
- Screenshot/video (if UI changed): Not captured.

## Notes

- Breaking changes: Pressing Enter with a prompt or turn-exclusive command during an active turn no longer cancels the turn or auto-submits the draft afterward.
- Docs updated: N/A.
- Governance/release impact: N/A.
- Review focus: Command classification completeness, active-turn lifecycle boundaries, explicit cancellation, composer preservation, and notice ownership.
