### PR TITLE
feat(input): recall latest user message with up arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - **Claude Agent SDK 0.3.227 migration** (#338, @srothgan): Add guarded resume-at, structured usage, cross-session message provenance, and current SDK metadata support.
-- **Active-turn commands** (@srothgan): Allow safe commands during active turns and preserve blocked drafts instead of cancelling the turn.
+- **Active-turn commands** (#339, @srothgan): Allow safe commands during active turns and preserve blocked drafts instead of cancelling the turn.
+- **Latest-message recall** (#340, @srothgan): Recall the latest user message with Up when the chat input is empty, while preserving normal multiline cursor movement.
 
 ## [0.14.3] - 2026-08-01 [Changes][v0.14.3]
 

--- a/docs/src/shortcuts.md
+++ b/docs/src/shortcuts.md
@@ -22,7 +22,8 @@ When the app is blocked before a usable session is available, `Ctrl+C` quits.
 | `Ctrl+C` | Clear the local draft, or quit when the draft is empty. |
 | `Tab` | Focus prompts or accept suggestions. |
 | `Shift+Tab` | Cycle mode. |
-| Arrow keys | Move through text. |
+| `Up` | Move up through text, or recall the latest user message when the input is empty. |
+| `Down`, `Left`, `Right` | Move through text. |
 | `Home`, `End` | Move to line start or line end. |
 | `Ctrl+Left`, `Ctrl+Right` | Move by word. |
 | `Alt+Left`, `Alt+Right` | Move by word. |

--- a/src/app/keymap/catalog.rs
+++ b/src/app/keymap/catalog.rs
@@ -131,15 +131,15 @@ const ACTION_CATALOG: &[KeyActionDescriptor] = &[
     KeyActionDescriptor {
         action: KeyAction::Input(InputAction::MoveUp),
         id: "input.move_up",
-        label: "Move up",
-        description: "Move the input cursor up, or browse chat history.",
+        label: "Move up / recall latest message",
+        description: "Move the input cursor up, or recall the latest user message when empty.",
         default_contexts: &[KeyContext::ChatInput],
     },
     KeyActionDescriptor {
         action: KeyAction::Input(InputAction::MoveDown),
         id: "input.move_down",
         label: "Move down",
-        description: "Move the input cursor down, or browse chat history.",
+        description: "Move the input cursor down.",
         default_contexts: &[KeyContext::ChatInput],
     },
     KeyActionDescriptor {

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -726,9 +726,32 @@ fn handle_printable_key(app: &mut App, key: KeyEvent) -> bool {
 }
 
 fn try_move_input_cursor_up(app: &mut App) -> bool {
+    if app.input.is_empty()
+        && let Some(text) = app.transcript.latest_user_text().map(str::to_owned)
+    {
+        app.input.set_text(&remove_recalled_image_badges(&text));
+        return true;
+    }
+
     let before = (app.input.cursor_row(), app.input.cursor_col());
     let _ = app.input.textarea_move_up();
     (app.input.cursor_row(), app.input.cursor_col()) != before
+}
+
+fn remove_recalled_image_badges(text: &str) -> String {
+    text.split('\n')
+        .enumerate()
+        .map(|(row, line)| {
+            let mut recalled_line = line.to_owned();
+            for atom in input_atoms::resolve_line_atoms(row, line).into_iter().rev() {
+                if matches!(atom.kind, InputAtomKind::ImageBadge { .. }) {
+                    recalled_line.replace_range(atom.start_byte..atom.end_byte, "");
+                }
+            }
+            recalled_line
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn try_move_input_cursor_down(app: &mut App) -> bool {
@@ -883,8 +906,8 @@ fn handle_subagent_key(app: &mut App, key: KeyEvent) -> KeyOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::FocusTarget;
     use crate::app::keymap::{KeyBinding, KeyBindingSource, KeyCodeSpec, KeySpec, ResolvedKeymap};
+    use crate::app::{ChatMessage, FocusTarget, MessageBlock, MessageRole, TextBlock};
     use crossterm::event::{KeyCode, KeyModifiers};
     use std::time::{Duration, Instant};
 
@@ -957,6 +980,81 @@ mod tests {
 
         assert_eq!(outcome, KeyOutcome::Handled(true));
         assert_eq!(app.input.cursor_col(), 1);
+    }
+
+    fn user_message(text: &str) -> ChatMessage {
+        ChatMessage::new(
+            MessageRole::User,
+            vec![MessageBlock::Text(TextBlock::from_complete(text))],
+            None,
+        )
+    }
+
+    #[test]
+    fn up_on_empty_input_recalls_latest_user_message_at_end() {
+        let mut app = App::test_default();
+        app.transcript.messages.push(user_message("older prompt"));
+        app.transcript.messages.push(ChatMessage::new(
+            MessageRole::Assistant,
+            vec![MessageBlock::Text(TextBlock::from_complete("reply"))],
+            None,
+        ));
+        app.transcript.messages.push(user_message("first line\nlatest \u{1F980}"));
+
+        let outcome = handle_normal_key(&mut app, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+        assert_eq!(app.input.text(), "first line\nlatest \u{1F980}");
+        assert_eq!(app.input.cursor(), (1, "latest \u{1F980}".chars().count()));
+    }
+
+    #[test]
+    fn up_on_empty_input_removes_unrecoverable_image_badges() {
+        let mut app = App::test_default();
+        app.transcript.messages.push(user_message("review [Image #1]\n[Image #2] keep [Image #0]"));
+
+        let outcome = handle_normal_key(&mut app, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+        assert_eq!(app.input.text(), "review \n keep [Image #0]");
+        assert_eq!(app.input.cursor(), (1, " keep [Image #0]".chars().count()));
+        assert!(app.pending_images.is_empty());
+    }
+
+    #[test]
+    fn up_on_nonempty_input_moves_cursor_without_recalling_history() {
+        let mut app = App::test_default();
+        app.transcript.messages.push(user_message("history prompt"));
+        app.input.set_text("draft first\ndraft second");
+
+        let outcome = handle_normal_key(&mut app, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+        assert_eq!(app.input.text(), "draft first\ndraft second");
+        assert_eq!(app.input.cursor_row(), 0);
+    }
+
+    #[test]
+    fn up_on_whitespace_input_does_not_recall_history() {
+        let mut app = App::test_default();
+        app.transcript.messages.push(user_message("history prompt"));
+        app.input.set_text(" ");
+
+        let outcome = handle_normal_key(&mut app, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+        assert_eq!(app.input.text(), " ");
+    }
+
+    #[test]
+    fn up_on_empty_input_without_user_history_is_a_noop() {
+        let mut app = App::test_default();
+
+        let outcome = handle_normal_key(&mut app, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+
+        assert_eq!(outcome, KeyOutcome::Handled(true));
+        assert!(app.input.is_empty());
+        assert_eq!(app.input.cursor(), (0, 0));
     }
 
     #[test]

--- a/src/app/state/transcript.rs
+++ b/src/app/state/transcript.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use super::messages::ChatMessage;
+use super::messages::{ChatMessage, MessageBlock, MessageRole};
 use super::render_budget;
 
 #[derive(Default)]
@@ -31,5 +31,17 @@ impl Transcript {
     #[must_use]
     pub fn new(messages: Vec<ChatMessage>) -> Self {
         Self { messages, ..Self::default() }
+    }
+
+    #[must_use]
+    pub(crate) fn latest_user_text(&self) -> Option<&str> {
+        self.messages.iter().rev().find_map(|message| {
+            if !matches!(message.role, MessageRole::User) {
+                return None;
+            }
+            message.blocks.iter().rev().find_map(|block| {
+                if let MessageBlock::Text(text) = block { Some(text.text.as_str()) } else { None }
+            })
+        })
     }
 }

--- a/src/app/user_dialog.rs
+++ b/src/app/user_dialog.rs
@@ -12,7 +12,7 @@ use super::inline_interactions::{
     clear_inline_interaction_focus, focus_next_inline_interaction, focused_interaction_id,
     has_focused_user_dialog, pop_next_valid_interaction_id,
 };
-use super::{App, InvalidationLevel, MessageBlock, MessageRole};
+use super::{App, InvalidationLevel, MessageBlock};
 use crate::agent::model;
 use crate::app::keymap::InteractionAction;
 use crate::app::keys::KeyOutcome;
@@ -167,14 +167,7 @@ fn respond_dialog(app: &mut App, resolution: DialogResolution) {
 }
 
 fn repopulate_composer_from_last_user_message(app: &mut App) {
-    let last_user_text = app.transcript.messages.iter().rev().find_map(|message| {
-        if !matches!(message.role, MessageRole::User) {
-            return None;
-        }
-        message.blocks.iter().rev().find_map(|block| {
-            if let MessageBlock::Text(text) = block { Some(text.text.clone()) } else { None }
-        })
-    });
+    let last_user_text = app.transcript.latest_user_text().map(str::to_owned);
     if let Some(text) = last_user_text {
         app.input.set_text(&text);
     }
@@ -183,7 +176,9 @@ fn repopulate_composer_from_last_user_message(app: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{App, AppStatus, ChatMessage, SystemSeverity, TextBlock, UserDialogBlock};
+    use crate::app::{
+        App, AppStatus, ChatMessage, MessageRole, SystemSeverity, TextBlock, UserDialogBlock,
+    };
     use crossterm::event::{KeyCode, KeyModifiers};
     use tokio::sync::oneshot;
 

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -311,6 +311,7 @@ mod tests {
         assert!(has_row(&rows, "Shift+Enter, Ctrl+Enter", "Insert newline"));
         assert!(has_row(&rows, "Home", "Move line start"));
         assert!(has_row(&rows, "End", "Move line end"));
+        assert!(has_row(&rows, "Up", "Move up / recall latest message"));
         assert!(has_row(&rows, "Ctrl+A", "Move line start, then up"));
         assert!(has_row(&rows, "Ctrl+E", "Move line end, then down"));
         assert!(has_row(&rows, "Ctrl+Y", "Yank"));


### PR DESCRIPTION
## Summary

- Recall the latest user message when the focused chat input is empty and the user presses Up, while preserving normal cursor movement for non-empty and multiline drafts.
- Reuse a transcript-level latest-user-text query for both input recall and edit-prompt recovery, and remove image badges whose attachments cannot be restored.
- Document the shortcut in live help, the keyboard-shortcuts guide, and the changelog, with regression coverage for input and help behavior.

## Why

Re-entering or revising the previous prompt currently requires copying it from the transcript. Up already represented the input's move-up action and its metadata implied history behavior, but the handler only attempted cursor movement. This change makes the empty-composer behavior useful without overriding navigation inside an existing draft or presenting stale image attachments as reusable.

Closes #

## Validation

- Automated: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features --offline -- -D warnings`; `cargo test --offline`; `cargo check --offline`; targeted input-recall, live-help, and documentation-contract tests.
- Manual: performed with empty, filled and only space in input field
- Screenshot/video (if UI changed): N/A — text-only input and shortcut-help behavior.

## Notes

- Breaking changes: N/A
- Docs updated: `docs/src/shortcuts.md`, live `/docs shortcuts` help, and `CHANGELOG.md`.
- Governance/release impact: N/A
