### PR TITLE
fix(tui): make shutdown lifecycle reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - **Active-turn commands** (#339, @srothgan): Allow safe commands during active turns and preserve blocked drafts instead of cancelling the turn.
 - **Latest-message recall** (#340, @srothgan): Recall the latest user message with Up when the chat input is empty, while preserving normal multiline cursor movement.
 
+### Fixes
+
+- **Reliable TUI shutdown** (#341, @srothgan): Close fullscreen views without interrupting active turns, support forced cleanup, restore terminal state, and preserve resume guidance.
+
 ## [0.14.3] - 2026-08-01 [Changes][v0.14.3]
 
 ### Features

--- a/docs/src/shortcuts.md
+++ b/docs/src/shortcuts.md
@@ -10,7 +10,7 @@ Keyboard shortcuts are context-sensitive. Use `/docs shortcuts` in the app to sh
 | `Ctrl+L` | Redraw. |
 | `Ctrl+Z` on Unix | Suspend the process. |
 
-When the app is blocked before a usable session is available, `Ctrl+C` quits.
+In a fullscreen view, `Ctrl+C` closes the view and returns to chat. After shutdown begins, pressing `Ctrl+C` again forces any remaining cleanup to stop.
 
 ## Chat Input
 

--- a/src/app/config/controller.rs
+++ b/src/app/config/controller.rs
@@ -50,8 +50,8 @@ pub(crate) fn activate_tab(app: &mut App, tab: ConfigTab) {
 }
 
 pub fn handle_key(app: &mut App, key: KeyEvent) {
-    if is_ctrl_shortcut(key, 'q') || is_ctrl_shortcut(key, 'c') {
-        app.should_quit = true;
+    if is_ctrl_shortcut(key, 'q') {
+        app.request_shutdown();
         return;
     }
 

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -178,7 +178,7 @@ pub fn create_app(cli: &Cli) -> App {
             Some(Command::Resume { session_id: Some(_) })
         ),
         turn: super::state::TurnState::default(),
-        should_quit: false,
+        shutdown: super::ShutdownState::Running,
         exit_error: None,
         cwd_raw: cwd.to_string_lossy().to_string(),
         cwd: cwd_display,
@@ -294,6 +294,24 @@ pub(crate) struct BridgeTask {
     join_handle: tokio::task::JoinHandle<()>,
 }
 
+pub(super) struct ConnectionShutdown {
+    join_handle: tokio::task::JoinHandle<()>,
+}
+
+impl ConnectionShutdown {
+    pub(super) async fn wait(&mut self) {
+        log_bridge_task_join_result((&mut self.join_handle).await);
+    }
+
+    pub(super) async fn force(self) {
+        self.join_handle.abort();
+        match self.join_handle.await {
+            Err(err) if err.is_cancelled() => {}
+            result => log_bridge_task_join_result(result),
+        }
+    }
+}
+
 thread_local! {
     pub static CONN_SLOT: std::cell::RefCell<Option<Rc<std::cell::RefCell<Option<ConnectionSlot>>>>> =
         const { std::cell::RefCell::new(None) };
@@ -304,18 +322,27 @@ pub(super) fn take_connection_slot() -> Option<ConnectionSlot> {
     CONN_SLOT.with(|slot| slot.borrow().as_ref().and_then(|inner| inner.borrow_mut().take()))
 }
 
-pub(super) async fn shutdown_connection(app: &mut App) {
+pub(super) fn begin_shutdown_connection(app: &mut App) -> Option<ConnectionShutdown> {
     app.session_runtime.conn = None;
     let pending_slot = CONN_SLOT.with(|slot| slot.borrow_mut().take());
     if let Some(slot) = pending_slot {
         slot.borrow_mut().take();
     }
 
-    let Some(BridgeTask { shutdown_tx, join_handle }) = app.bridge_task.take() else {
+    let BridgeTask { shutdown_tx, join_handle } = app.bridge_task.take()?;
+    let _ = shutdown_tx.send(());
+    Some(ConnectionShutdown { join_handle })
+}
+
+pub(super) async fn shutdown_connection(app: &mut App) {
+    let Some(mut shutdown) = begin_shutdown_connection(app) else {
         return;
     };
-    let _ = shutdown_tx.send(());
-    if let Err(err) = join_handle.await {
+    shutdown.wait().await;
+}
+
+fn log_bridge_task_join_result(result: Result<(), tokio::task::JoinError>) {
+    if let Err(err) = result {
         tracing::error!(
             target: crate::logging::targets::BRIDGE_LIFECYCLE,
             event_name = "bridge_task_join_failed",

--- a/src/app/connect/tests.rs
+++ b/src/app/connect/tests.rs
@@ -87,3 +87,37 @@ async fn shutdown_connection_signals_and_awaits_the_owned_bridge_task() {
         })
         .await;
 }
+
+#[tokio::test(flavor = "current_thread")]
+async fn forced_connection_shutdown_aborts_the_owned_bridge_task() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            struct DropMarker(Rc<Cell<bool>>);
+
+            impl Drop for DropMarker {
+                fn drop(&mut self) {
+                    self.0.set(true);
+                }
+            }
+
+            let mut app = crate::app::App::test_default();
+            let dropped = Rc::new(Cell::new(false));
+            let dropped_for_task = Rc::clone(&dropped);
+            let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+            let join_handle = tokio::task::spawn_local(async move {
+                let _marker = DropMarker(dropped_for_task);
+                let _ = shutdown_rx.await;
+                std::future::pending::<()>().await;
+            });
+            tokio::task::yield_now().await;
+            app.bridge_task = Some(super::BridgeTask { shutdown_tx, join_handle });
+
+            let shutdown = super::begin_shutdown_connection(&mut app).expect("shutdown handle");
+            shutdown.force().await;
+
+            assert!(dropped.get());
+            assert!(app.bridge_task.is_none());
+            assert!(app.session_runtime.conn.is_none());
+        })
+        .await;
+}

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -79,6 +79,17 @@ impl TerminalEventOutcome {
 }
 
 pub fn handle_terminal_event(app: &mut App, event: Event) -> TerminalEventOutcome {
+    if app.shutdown_requested() {
+        if let Event::Key(key) = event
+            && should_dispatch_key_event(key)
+            && super::keys::is_ctrl_char_shortcut(key, 'c')
+        {
+            app.force_shutdown();
+            return TerminalEventOutcome::handled(true);
+        }
+        return TerminalEventOutcome::ignored();
+    }
+
     if matches!(app.terminal_lifecycle, super::TerminalLifecycleState::ReleasedToChild(_))
         && !matches!(&event, Event::Resize(_, _))
     {
@@ -197,6 +208,13 @@ fn log_resize_classification(app: &App, size_change: TerminalSizeChange, action:
 }
 
 fn dispatch_key_by_view(app: &mut App, key: crossterm::event::KeyEvent) -> TerminalEventOutcome {
+    if matches!(app.surface_mode, SurfaceMode::Fullscreen(_))
+        && super::keys::is_ctrl_char_shortcut(key, 'c')
+    {
+        super::view::dismiss_fullscreen_on_interrupt(app);
+        return TerminalEventOutcome::handled(true);
+    }
+
     match app.surface_mode {
         SurfaceMode::Chat => {
             app.paste.clear_active_session();

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -578,7 +578,7 @@ pub(super) fn handle_fatal_error_event(app: &mut App, error: AppError) {
     app.finalize_turn_runtime_artifacts(model::ToolCallStatus::Failed);
     app.turn.reset_for_new_session();
     app.exit_error = Some(error);
-    app.should_quit = true;
+    app.request_shutdown();
     app.status = AppStatus::Error;
     app.pending_submit = None;
 }

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -55,7 +55,6 @@ fn reset_session_identity_state(
     app.session_runtime.runtime_session_state = None;
     app.session_runtime.prompt_suggestion = None;
     app.session_runtime.last_rate_limit_update = None;
-    app.should_quit = false;
     app.files_accessed = 0;
     app.turn.clear_cancel_state();
     app.session_runtime.account_info = None;
@@ -287,5 +286,23 @@ mod tests {
         assert!(app.sdk_inventory.rewind_targets.is_empty());
         assert!(app.sdk_inventory.rewind_targets_session_id.is_none());
         assert!(!app.sdk_inventory.rewind_targets_in_flight);
+    }
+
+    #[test]
+    fn session_reset_does_not_cancel_requested_shutdown() {
+        let mut app = App::test_default();
+        app.request_shutdown();
+
+        reset_for_new_session(
+            &mut app,
+            model::SessionId::new("session-2"),
+            model::CurrentModel::new("test", "test", "test").authoritative(true),
+            None,
+            model::FastModeSnapshot::new(model::FastModeState::Off, None),
+            false,
+            ChatResetRenderMode::DeferTranscriptRender,
+        );
+
+        assert!(app.shutdown_requested());
     }
 }

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -1098,7 +1098,7 @@ fn test_app_defaults() {
     assert_eq!(app.terminal_lifecycle, TerminalLifecycleState::Running(SurfaceMode::Chat));
     assert!(!app.surface_dirty.fullscreen.redraw);
     assert!(!app.surface_dirty.terminal_mode);
-    assert!(!app.should_quit);
+    assert!(!app.shutdown_requested());
     assert!(app.session_runtime.session_id.is_none());
     assert_eq!(app.files_accessed, 0);
     assert!(app.turn.pending_interaction_ids.is_empty());
@@ -1778,7 +1778,7 @@ fn classified_turn_error_auth_required_sets_exit_error_and_quits() {
     );
 
     assert!(matches!(app.status, AppStatus::Error));
-    assert!(app.should_quit);
+    assert!(app.shutdown_requested());
     assert_eq!(app.exit_error, Some(crate::error::AppError::AuthRequired));
 }
 
@@ -1798,7 +1798,7 @@ fn classified_turn_error_model_unavailable_suggests_model_switch() {
     );
 
     assert!(matches!(app.status, AppStatus::Error));
-    assert!(!app.should_quit);
+    assert!(!app.shutdown_requested());
     assert_eq!(app.exit_error, None);
     let text = first_block_text(app.transcript.messages.last().expect("expected message"));
     assert!(text.contains("The selected model is unavailable"));
@@ -1821,7 +1821,7 @@ fn classified_turn_error_account_access_does_not_quit_for_login() {
     );
 
     assert!(matches!(app.status, AppStatus::Error));
-    assert!(!app.should_quit);
+    assert!(!app.shutdown_requested());
     assert_eq!(app.exit_error, None);
     let text = first_block_text(app.transcript.messages.last().expect("expected message"));
     assert!(text.contains("current account or organization"));
@@ -1844,7 +1844,7 @@ fn classified_turn_error_transient_service_suggests_retry() {
     );
 
     assert!(matches!(app.status, AppStatus::Error));
-    assert!(!app.should_quit);
+    assert!(!app.shutdown_requested());
     let text = first_block_text(app.transcript.messages.last().expect("expected message"));
     assert!(text.contains("temporarily overloaded or unavailable"));
     assert!(text.contains("retry"));
@@ -1948,7 +1948,7 @@ fn fatal_event_sets_exit_error_and_quits() {
     );
 
     assert!(matches!(app.status, AppStatus::Error));
-    assert!(app.should_quit);
+    assert!(app.shutdown_requested());
     assert_eq!(app.exit_error, Some(crate::error::AppError::ConnectionFailed));
 }
 
@@ -3315,7 +3315,39 @@ fn ctrl_c_quits() {
         Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
     );
 
-    assert!(app.should_quit);
+    assert!(app.shutdown_requested());
+}
+
+#[test]
+fn fullscreen_ctrl_c_returns_to_chat_without_stopping_active_turn() {
+    let mut app = make_test_app();
+    app.status = AppStatus::Running;
+    app.surface_mode = SurfaceMode::Fullscreen(FullscreenView::Config);
+    app.terminal_lifecycle =
+        TerminalLifecycleState::Running(SurfaceMode::Fullscreen(FullscreenView::Config));
+
+    handle_terminal_event(
+        &mut app,
+        Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+    );
+
+    assert_eq!(app.surface_mode, SurfaceMode::Chat);
+    assert_eq!(app.status, AppStatus::Running);
+    assert!(!app.shutdown_requested());
+    assert!(!app.turn.cancel_requested);
+}
+
+#[test]
+fn repeated_ctrl_c_escalates_requested_shutdown() {
+    let mut app = make_test_app();
+    app.request_shutdown();
+
+    handle_terminal_event(
+        &mut app,
+        Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+    );
+
+    assert!(app.shutdown_forced());
 }
 
 #[test]
@@ -3334,7 +3366,7 @@ fn ctrl_c_clears_local_draft_before_quitting() {
         Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
     );
 
-    assert!(!app.should_quit);
+    assert!(!app.shutdown_requested());
     assert!(app.input.is_empty());
     assert!(app.pending_submit.is_none());
     assert!(app.paste.pending_text.is_empty());
@@ -3345,7 +3377,7 @@ fn ctrl_c_clears_local_draft_before_quitting() {
         Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
     );
 
-    assert!(app.should_quit);
+    assert!(app.shutdown_requested());
 }
 
 #[test]
@@ -3357,7 +3389,7 @@ fn ctrl_q_quits() {
         Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL)),
     );
 
-    assert!(app.should_quit);
+    assert!(app.shutdown_requested());
 }
 
 #[test]
@@ -3390,7 +3422,7 @@ fn connecting_state_ctrl_q_quits() {
         Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL)),
     );
 
-    assert!(app.should_quit);
+    assert!(app.shutdown_requested());
 }
 
 #[test]
@@ -3425,7 +3457,7 @@ fn error_state_ctrl_q_quits() {
         Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL)),
     );
 
-    assert!(app.should_quit);
+    assert!(app.shutdown_requested());
 }
 
 #[test]
@@ -3438,7 +3470,7 @@ fn error_state_ctrl_c_quits() {
         Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
     );
 
-    assert!(app.should_quit);
+    assert!(app.shutdown_requested());
 }
 
 #[test]

--- a/src/app/events/turn.rs
+++ b/src/app/events/turn.rs
@@ -579,7 +579,7 @@ fn apply_turn_error_class_side_effects(
                 error_preview = %summary,
             );
             app.exit_error = Some(crate::error::AppError::AuthRequired);
-            app.should_quit = true;
+            app.request_shutdown();
         }
         TurnErrorClass::AccountAccess => {
             tracing::warn!(

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -247,7 +247,7 @@ fn execute_key_action(app: &mut App, action: KeyAction, key: KeyEvent) -> KeyOut
 fn execute_app_action(app: &mut App, action: AppAction) -> KeyOutcome {
     match action {
         AppAction::Quit => {
-            app.should_quit = true;
+            app.request_shutdown();
             KeyOutcome::Handled(true)
         }
         AppAction::ClearInputOrQuit => clear_input_or_quit(app).into(),
@@ -271,7 +271,7 @@ fn clear_input_or_quit(app: &mut App) -> bool {
         || app.paste.has_pending_text()
         || app.pending_submit.is_some();
     if !has_local_input {
-        app.should_quit = true;
+        app.request_shutdown();
         return true;
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -74,7 +74,7 @@ pub use state::{
     MessageBlock, MessageBlockId, MessageRole, MessageUsage, ModeInfo, ModeState, NoticeBlock,
     NoticeDedupKey, NoticeStage, PasteSessionState, PendingCommandAck, PostExitAction,
     RateLimitIncidentKey, RecentSessionInfo, SelectionPoint, SessionPickerState, SessionUsageState,
-    SessionUsageSummary, SubagentPermissionContext, SystemSeverity, TerminalSize,
+    SessionUsageSummary, ShutdownState, SubagentPermissionContext, SystemSeverity, TerminalSize,
     TerminalSizeChange, TextBlock, TextBlockSpacing, ToolCallInfo, ToolCallScope,
     TurnNoticeLocation, TurnNoticeRef, UpdatePromptAction, UpdatePromptState, UsageActivitySummary,
     UsageActivityWindow, UsageBehaviorAttribution, UsageNamedAttribution, UsageSnapshot,
@@ -137,8 +137,14 @@ pub async fn run_tui(app: &mut App) -> anyhow::Result<()> {
     let mut terminal_runtime = terminal_runtime::TerminalRuntime::bootstrap(app)?;
     let result = run_tui_loop(app, &mut terminal_runtime).await;
 
-    finish_run_tui(app, &mut terminal_runtime);
-    connect::shutdown_connection(app).await;
+    if result.is_err() {
+        prepare_app_shutdown(app);
+        restore_terminal_after_shutdown(app, &mut terminal_runtime);
+        connect::shutdown_connection(app).await;
+        return result;
+    }
+
+    restore_terminal_after_shutdown(app, &mut terminal_runtime);
 
     result
 }
@@ -181,7 +187,7 @@ async fn run_tui_loop(
                         error_message = %err,
                     );
                 }
-                app.should_quit = true;
+                app.request_shutdown();
             }
             _ = event_loop_interval.tick() => {}
         }
@@ -196,6 +202,10 @@ async fn run_tui_loop(
                     let outcome = events::handle_terminal_event(app, event);
                     handle_runtime_command(app, terminal_runtime, outcome.runtime_command())?;
                 }
+            }
+
+            if app.shutdown_requested() {
+                break;
             }
 
             if let Ok(event) = app.event_rx.try_recv() {
@@ -213,13 +223,16 @@ async fn run_tui_loop(
             }
         }
 
-        file_index::drain_events(app);
+        if !app.shutdown_requested() {
+            file_index::drain_events(app);
+        }
 
         let now = Instant::now();
         // Tick the burst detector: flush any held/buffered content that
         // has timed out. EmitChar re-inserts a single held character;
         // EmitPaste feeds the accumulated burst into the paste queue.
-        if app.surface_mode == SurfaceMode::Chat
+        if !app.shutdown_requested()
+            && app.surface_mode == SurfaceMode::Chat
             && let Some(action) = app.paste.burst.tick(now)
         {
             match action {
@@ -233,33 +246,42 @@ async fn run_tui_loop(
         }
 
         // Merge and process `Event::Paste` chunks as one paste action.
-        if app.surface_mode == SurfaceMode::Chat && app.paste.has_pending_text() {
+        if !app.shutdown_requested()
+            && app.surface_mode == SurfaceMode::Chat
+            && app.paste.has_pending_text()
+        {
             finalize_pending_paste_event(app);
         }
 
-        app.tick_git_context(now);
-        session_runtime::tick_context_usage_refresh(app, now);
+        if !app.shutdown_requested() {
+            app.tick_git_context(now);
+            session_runtime::tick_context_usage_refresh(app, now);
+        }
         // Deferred submit: if Enter was pressed and no paste payload arrived
         // in this drain cycle, restore the exact pre-submit snapshot and
         // submit that unchanged draft.
-        if app.surface_mode == SurfaceMode::Chat && app.pending_submit.is_some() {
+        if !app.shutdown_requested()
+            && app.surface_mode == SurfaceMode::Chat
+            && app.pending_submit.is_some()
+        {
             finalize_deferred_submit(app);
+        }
+
+        if app.shutdown_requested() {
+            prepare_app_shutdown(app);
         }
 
         terminal_runtime.sync_surface(app)?;
 
-        if app.should_quit {
-            break;
-        }
-
         // Phase 3: render once (only when something changed)
-        let is_animating = matches!(
-            app.status,
-            AppStatus::Connecting
-                | AppStatus::CommandPending
-                | AppStatus::Thinking
-                | AppStatus::Running
-        ) || app.turn.compaction.is_active();
+        let is_animating = !app.shutdown_requested()
+            && (matches!(
+                app.status,
+                AppStatus::Connecting
+                    | AppStatus::CommandPending
+                    | AppStatus::Thinking
+                    | AppStatus::Running
+            ) || app.turn.compaction.is_active());
         if is_animating {
             advance_spinner_frame(app, Instant::now());
             tab_title::update_tab_title(&app.status, app.spinner_frame, &app.cwd);
@@ -291,6 +313,11 @@ async fn run_tui_loop(
                 drop(draw_timer);
                 drop(timer);
             }
+        }
+
+        if app.shutdown_requested() {
+            shutdown_connection_with_interrupts(app, &mut events).await;
+            break;
         }
     }
 
@@ -375,7 +402,20 @@ fn handle_runtime_client_event(
     }
 }
 
-fn finish_run_tui(app: &mut App, terminal_runtime: &mut terminal_runtime::TerminalRuntime) {
+fn prepare_app_shutdown(app: &mut App) {
+    app.request_shutdown();
+    if matches!(app.surface_mode, SurfaceMode::Fullscreen(_)) {
+        view::set_chat_surface(app);
+    }
+    app.input.clear();
+    app.pending_images.clear();
+    app.paste.clear_all_sessions();
+    app.pending_submit = None;
+    app.mention = None;
+    app.slash = None;
+    app.subagent = None;
+    app.request_chat_visible_rebuild();
+
     // Dismiss all pending inline permissions (reject via last option)
     for tool_id in std::mem::take(&mut app.turn.pending_interaction_ids) {
         if let Some((mi, bi)) = app.lookup_tool_call(&tool_id)
@@ -407,10 +447,71 @@ fn finish_run_tui(app: &mut App, terminal_runtime: &mut terminal_runtime::Termin
     {
         let _ = conn.cancel(sid.to_string());
     }
+}
 
-    // Restore terminal
+fn restore_terminal_after_shutdown(
+    app: &mut App,
+    terminal_runtime: &mut terminal_runtime::TerminalRuntime,
+) {
     tab_title::restore_tab_title(&app.cwd);
     terminal_runtime.restore(app);
+}
+
+async fn shutdown_connection_with_interrupts(app: &mut App, events: &mut EventStream) {
+    let Some(mut shutdown) = connect::begin_shutdown_connection(app) else {
+        return;
+    };
+    if app.shutdown_forced() {
+        shutdown.force().await;
+        return;
+    }
+
+    let mut terminal_events_open = true;
+    let mut os_shutdown_open = true;
+    let mut os_shutdown = Box::pin(wait_for_shutdown_signal());
+    loop {
+        tokio::select! {
+            () = shutdown.wait() => return,
+            event = events.next(), if terminal_events_open => {
+                match event {
+                    Some(Ok(event)) => {
+                        let _ = events::handle_terminal_event(app, event);
+                    }
+                    Some(Err(err)) => {
+                        tracing::warn!(
+                            target: crate::logging::targets::APP_LIFECYCLE,
+                            event_name = "shutdown_terminal_listener_failed",
+                            message = "terminal event listener failed during shutdown",
+                            outcome = "degraded",
+                            error_message = %err,
+                        );
+                        terminal_events_open = false;
+                    }
+                    None => terminal_events_open = false,
+                }
+            }
+            signal = &mut os_shutdown, if os_shutdown_open => {
+                match signal {
+                    Ok(()) => app.force_shutdown(),
+                    Err(err) => {
+                        tracing::warn!(
+                            target: crate::logging::targets::APP_LIFECYCLE,
+                            event_name = "shutdown_force_listener_failed",
+                            message = "OS shutdown listener failed during cleanup",
+                            outcome = "degraded",
+                            error_message = %err,
+                        );
+                        os_shutdown_open = false;
+                    }
+                }
+            }
+        }
+
+        if app.shutdown_forced() {
+            shutdown.force().await;
+            return;
+        }
+    }
 }
 
 fn advance_spinner_frame(app: &mut App, now: Instant) {

--- a/src/app/session_picker.rs
+++ b/src/app/session_picker.rs
@@ -22,8 +22,8 @@ pub(crate) fn picker_turn_count(app: &App) -> usize {
 }
 
 pub fn handle_key(app: &mut App, key: KeyEvent) {
-    if is_ctrl(key, 'q') || is_ctrl(key, 'c') {
-        app.should_quit = true;
+    if is_ctrl(key, 'q') {
+        app.request_shutdown();
         return;
     }
 

--- a/src/app/state/app.rs
+++ b/src/app/state/app.rs
@@ -27,7 +27,7 @@ pub struct App {
     pub(crate) pending_session_resume: Option<PendingSessionResume>,
     /// Whether the synthetic session overview is eligible for chat transcript output.
     pub(crate) show_session_overview: bool,
-    pub should_quit: bool,
+    pub(crate) shutdown: ShutdownState,
     /// Optional fatal app error that should be surfaced at CLI boundary.
     pub exit_error: Option<crate::error::AppError>,
     pub(crate) cwd: String,
@@ -115,6 +115,26 @@ pub struct App {
 }
 
 impl App {
+    pub(crate) fn request_shutdown(&mut self) {
+        if matches!(self.shutdown, ShutdownState::Running) {
+            self.shutdown = ShutdownState::Requested;
+        }
+    }
+
+    pub(crate) fn force_shutdown(&mut self) {
+        self.shutdown = ShutdownState::Forced;
+    }
+
+    #[must_use]
+    pub fn shutdown_requested(&self) -> bool {
+        self.shutdown.is_requested()
+    }
+
+    #[must_use]
+    pub(crate) fn shutdown_forced(&self) -> bool {
+        self.shutdown.is_forced()
+    }
+
     pub(crate) fn set_pending_session_resume(
         &mut self,
         session_id: String,
@@ -195,7 +215,7 @@ impl App {
             pending_session_resume: None,
             show_session_overview: true,
             turn: TurnState::default(),
-            should_quit: false,
+            shutdown: ShutdownState::Running,
             exit_error: None,
             cwd: "/test".into(),
             cwd_raw: "/test".into(),

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -57,7 +57,7 @@ pub use types::{
     AppStatus, ExtraUsage, HistoryRetentionPolicy, HistoryRetentionStats, LoginHint, McpState,
     MessageUsage, ModeInfo, ModeState, PasteSessionState, PendingCommandAck, PostExitAction,
     RecentSessionInfo, RenderCacheBudget, SelectionPoint, SessionPickerState, SessionUsageState,
-    SessionUsageSummary, ToolCallScope, UpdatePromptAction, UpdatePromptState,
+    SessionUsageSummary, ShutdownState, ToolCallScope, UpdatePromptAction, UpdatePromptState,
     UsageActivitySummary, UsageActivityWindow, UsageBehaviorAttribution, UsageNamedAttribution,
     UsageSnapshot, UsageSourceKind, UsageSourceMode, UsageState, UsageWindow,
 };
@@ -79,7 +79,7 @@ mod prelude {
     pub(super) use super::types::{
         AppStatus, HistoryRetentionPolicy, HistoryRetentionStats, McpState, PasteSessionState,
         PendingCommandAck, RecentSessionInfo, RenderCacheBudget, SelectionPoint,
-        SessionPickerState, ToolCallScope, UpdatePromptState, UsageState,
+        SessionPickerState, ShutdownState, ToolCallScope, UpdatePromptState, UsageState,
     };
     pub(super) use crate::agent::events::ClientEvent;
     pub(super) use crate::agent::model;

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -298,6 +298,26 @@ pub enum AppStatus {
     Error,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ShutdownState {
+    #[default]
+    Running,
+    Requested,
+    Forced,
+}
+
+impl ShutdownState {
+    #[must_use]
+    pub const fn is_requested(self) -> bool {
+        !matches!(self, Self::Running)
+    }
+
+    #[must_use]
+    pub const fn is_forced(self) -> bool {
+        matches!(self, Self::Forced)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolCallScope {
     MainAgent,

--- a/src/app/terminal_runtime/chat_session.rs
+++ b/src/app/terminal_runtime/chat_session.rs
@@ -498,12 +498,13 @@ impl ChatTerminalSession {
         let footer_rows = Vec::from(footer.rows);
         let footer_row_count = u16::try_from(footer_rows.len()).unwrap_or(u16::MAX);
 
-        let editor = if matches!(
-            app.status,
-            crate::app::AppStatus::Connecting
-                | crate::app::AppStatus::CommandPending
-                | crate::app::AppStatus::Error
-        ) {
+        let editor = if app.shutdown_requested()
+            || matches!(
+                app.status,
+                crate::app::AppStatus::Connecting
+                    | crate::app::AppStatus::CommandPending
+                    | crate::app::AppStatus::Error
+            ) {
             ComposerEditor::Rows(blocked_input_lines(app))
         } else {
             let desired_height =

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5,6 +5,32 @@ use crate::agent::wire::BridgeCommand;
 use crate::app::{MessageBlock, MessageRole};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 
+#[test]
+fn shutdown_preparation_normalizes_ui_and_preserves_resume_identity() {
+    let mut app = App::test_default();
+    app.status = AppStatus::Running;
+    app.session_runtime.activate_session(model::SessionId::new("session-123"));
+    app.input.set_text("draft");
+    app.pending_submit = Some(app.input.snapshot());
+    app.pending_images.push(crate::app::clipboard_image::ImageAttachment {
+        data: "image".to_owned(),
+        mime_type: "image/png".to_owned(),
+    });
+    view::set_surface_mode(&mut app, SurfaceMode::Fullscreen(FullscreenView::Config));
+
+    prepare_app_shutdown(&mut app);
+
+    assert!(app.shutdown_requested());
+    assert_eq!(app.surface_mode, SurfaceMode::Chat);
+    assert!(app.input.is_empty());
+    assert!(app.pending_submit.is_none());
+    assert!(app.pending_images.is_empty());
+    assert_eq!(
+        app.session_runtime.resumable_session_id().map(ToString::to_string),
+        Some("session-123".to_owned())
+    );
+}
+
 #[tokio::test(start_paused = true)]
 async fn event_loop_interval_waits_between_idle_ticks() {
     let mut interval = event_loop_interval();

--- a/src/app/trust/mod.rs
+++ b/src/app/trust/mod.rs
@@ -59,8 +59,8 @@ pub fn initialize(app: &mut App) {
 }
 
 pub fn handle_key(app: &mut App, key: KeyEvent) {
-    if is_ctrl_shortcut(key, 'q') || is_ctrl_shortcut(key, 'c') {
-        app.should_quit = true;
+    if is_ctrl_shortcut(key, 'q') {
+        app.request_shutdown();
         return;
     }
 
@@ -99,7 +99,7 @@ pub fn accept(app: &mut App) -> Result<(), String> {
 }
 
 pub fn decline(app: &mut App) {
-    app.should_quit = true;
+    app.request_shutdown();
 }
 
 fn activate_selection(app: &mut App) {

--- a/src/app/trust/tests.rs
+++ b/src/app/trust/tests.rs
@@ -141,7 +141,7 @@ fn handle_key_declines_with_n() {
 
     handle_key(&mut app, KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
 
-    assert!(app.should_quit);
+    assert!(app.shutdown_requested());
 }
 
 #[test]
@@ -165,5 +165,5 @@ fn handle_key_enter_declines_when_no_is_selected() {
 
     handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 
-    assert!(app.should_quit);
+    assert!(app.shutdown_requested());
 }

--- a/src/app/update_prompt.rs
+++ b/src/app/update_prompt.rs
@@ -37,8 +37,8 @@ pub fn post_trust_surface(app: &App) -> SurfaceMode {
 }
 
 pub fn handle_key(app: &mut App, key: KeyEvent) {
-    if is_ctrl(key, 'q') || is_ctrl(key, 'c') {
-        app.should_quit = true;
+    if is_ctrl(key, 'q') {
+        app.request_shutdown();
         return;
     }
 
@@ -91,7 +91,7 @@ fn install(app: &mut App, method_override: Option<InstallMethod>) {
         latest_version: prompt.latest_version.clone(),
         method,
     });
-    app.should_quit = true;
+    app.request_shutdown();
 }
 
 fn skip_now(app: &mut App) {
@@ -210,7 +210,7 @@ mod tests {
 
         handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 
-        assert!(app.should_quit);
+        assert!(app.shutdown_requested());
         assert_eq!(
             app.post_exit_action,
             Some(PostExitAction::InstallUpdate {

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -56,6 +56,25 @@ pub fn set_chat_surface(app: &mut App) {
     set_surface_mode(app, SurfaceMode::Chat);
 }
 
+pub(crate) fn dismiss_fullscreen_on_interrupt(app: &mut App) {
+    let SurfaceMode::Fullscreen(view) = app.surface_mode else {
+        return;
+    };
+
+    match view {
+        FullscreenView::Config | FullscreenView::Trusted => {}
+        FullscreenView::SessionPicker => {
+            app.startup.resolve_session_picker();
+            app.session_picker.turn_session_id = None;
+        }
+        FullscreenView::Update => {
+            app.update_prompt = None;
+            app.startup.resolve_session_picker();
+        }
+    }
+    set_chat_surface(app);
+}
+
 fn clear_transient_view_state(app: &mut App) {
     app.paste.clear_all_sessions();
     app.pending_submit = None;

--- a/src/app/view/tests.rs
+++ b/src/app/view/tests.rs
@@ -136,6 +136,24 @@ fn surface_mode_reports_fullscreen_view_only_for_fullscreen_modes() {
 }
 
 #[test]
+fn interrupt_dismisses_every_fullscreen_surface_to_chat() {
+    for fullscreen in [
+        FullscreenView::Config,
+        FullscreenView::Trusted,
+        FullscreenView::SessionPicker,
+        FullscreenView::Update,
+    ] {
+        let mut app = App::test_default();
+        set_surface_mode(&mut app, SurfaceMode::Fullscreen(fullscreen));
+
+        dismiss_fullscreen_on_interrupt(&mut app);
+
+        assert_eq!(app.surface_mode, SurfaceMode::Chat);
+        assert!(!app.shutdown_requested());
+    }
+}
+
+#[test]
 fn set_surface_mode_updates_surface_and_lifecycle_while_running() {
     let mut app = App::test_default();
     app.chat_render.live_region.anchor_valid = true;

--- a/src/ui/input_rows.rs
+++ b/src/ui/input_rows.rs
@@ -54,6 +54,13 @@ pub(crate) fn build_composer_hint_rows(app: &App) -> Vec<Line<'static>> {
 }
 
 pub(crate) fn blocked_input_lines(app: &App) -> Vec<Line<'static>> {
+    if app.shutdown_requested() {
+        return vec![Line::from(Span::styled(
+            "Shutting down... Press Ctrl+C again to force exit.",
+            Style::default().fg(theme::DIM),
+        ))];
+    }
+
     match app.status {
         AppStatus::Connecting => {
             let spinner_ch = SPINNER_FRAMES[app.spinner_frame % SPINNER_FRAMES.len()];
@@ -189,5 +196,17 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert!(line_text(&rows[0]).contains("Input disabled due to error"));
         assert!(line_text(&rows[1]).contains("Press Ctrl+Q to quit and try again."));
+    }
+
+    #[test]
+    fn blocked_input_lines_prioritizes_shutdown_status() {
+        let mut app = App::test_default();
+        app.status = AppStatus::Running;
+        app.request_shutdown();
+
+        let rows = blocked_input_lines(&app);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(line_text(&rows[0]), "Shutting down... Press Ctrl+C again to force exit.");
     }
 }

--- a/tests/config_flow.rs
+++ b/tests/config_flow.rs
@@ -74,5 +74,5 @@ fn ctrl_q_still_quits_from_config() {
         Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL)),
     );
 
-    assert!(app.should_quit);
+    assert!(app.shutdown_requested());
 }


### PR DESCRIPTION
## Summary

- Make shutdown an explicit lifecycle that keeps the TUI valid while bridge and session cleanup completes.
- Close fullscreen views on `Ctrl+C` without cancelling an active turn, and allow a second `Ctrl+C` to force remaining cleanup to stop.
- Show one static shutdown message in the composer and print resumable-session guidance only after terminal restoration.

## Why

Repeated interrupts could previously quit from fullscreen views, leave stale TUI state visible during cleanup, or return to the shell without reliable resume guidance.

Closes #

## Validation

- Automated: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features --offline -- -D warnings`; `cargo test --offline` (1,774 library tests plus binary, integration, contract, and doc tests); `cargo check --offline`; `git diff --check`.
- Manual: Exercised graceful shutdown on Windows and confirmed terminal restoration and the post-exit resume command.
- Screenshot/video (if UI changed): Local screenshot available; not included in the commit.

## Notes

- Breaking changes: N/A
- Docs updated: Keyboard shortcuts and Unreleased changelog.
- Governance/release impact: N/A
