### PR TITLE
chore(release): publish version 0.14.4

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: PR
+name: CI
 
 on:
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+<!-- ## [Unreleased] -->
+
+## [0.14.4] - 2026-08-13 [Changes][v0.14.4]
 
 ### Features
 
@@ -814,6 +816,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.14.4]: https://github.com/srothgan/claude-code-rust/compare/v0.14.3...v0.14.4
 [v0.14.3]: https://github.com/srothgan/claude-code-rust/compare/v0.14.2...v0.14.3
 [v0.14.2]: https://github.com/srothgan/claude-code-rust/compare/v0.14.1...v0.14.2
 [v0.14.1]: https://github.com/srothgan/claude-code-rust/compare/v0.14.0...v0.14.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 A native Rust terminal interface for Claude Code. Drop-in replacement for Anthropic's stock Node.js/React Ink TUI, built for performance and a better user experience.
 
-[![npm version](https://img.shields.io/npm/v/claude-code-rust)](https://www.npmjs.com/package/claude-code-rust)
-[![npm downloads](https://img.shields.io/npm/dm/claude-code-rust)](https://www.npmjs.com/package/claude-code-rust)
+[![Version](https://img.shields.io/github/v/release/srothgan/claude-code-rust?label=version)](https://github.com/srothgan/claude-code-rust/releases/latest)
 [![CI](https://github.com/srothgan/claude-code-rust/actions/workflows/pr.yml/badge.svg)](https://github.com/srothgan/claude-code-rust/actions/workflows/pr.yml)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://srothgan.github.io/claude-code-rust/)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://www.apache.org/licenses/LICENSE-2.0)
 
 <p align="center">
   <img src="assets/banner.png" alt="Claude Code Rust running a Read tool call with syntax-highlighted output" width="900">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rust",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.227"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Claude Code Rust - native Rust terminal interface for Claude Code",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary

- Bump the Cargo and npm package metadata from 0.14.3 to 0.14.4.
- Publish the accumulated changelog entries under the dated 0.14.4 release and add its comparison link.
- Refresh the README badge row around the GitHub release, CI, documentation, and license sources, and label the primary workflow as CI.

## Why

Prepare the repository metadata and release notes for publishing version 0.14.4 while making the project status badges reflect their current sources more directly.

## Validation

- Automated: `cargo fmt --all -- --check`; `git diff --check`
- Manual: Confirmed the Cargo and npm manifest/lockfile versions are consistently set to 0.14.4 and verified the README CI badge targets the existing `pr.yml` workflow.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: README badges and CHANGELOG release entry
- Governance/release impact: Prepares the v0.14.4 release; the Version badge will update when the GitHub release is published.
