### PR TITLE
chore(release): publish version 0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+<!-- ## [Unreleased] -->
+
+## [0.14.5] - 2026-08-23 [Changes][v0.14.5]
 
 ### Features
 
@@ -824,6 +826,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.14.5]: https://github.com/srothgan/claude-code-rust/compare/v0.14.4...v0.14.5
 [v0.14.4]: https://github.com/srothgan/claude-code-rust/compare/v0.14.3...v0.14.4
 [v0.14.3]: https://github.com/srothgan/claude-code-rust/compare/v0.14.2...v0.14.3
 [v0.14.2]: https://github.com/srothgan/claude-code-rust/compare/v0.14.1...v0.14.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rust",
-      "version": "0.14.4",
+      "version": "0.14.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.239"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Claude Code Rust - native Rust terminal interface for Claude Code",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary

- Bump Cargo and npm package metadata from 0.14.4 to 0.14.5.
- Publish the accumulated changelog entries under the dated 0.14.5 release and add its comparison link.

## Why

Prepare repository metadata and release notes for publishing version 0.14.5.

## Validation

- Automated: `cargo fmt --all -- --check`; `cargo check --offline`; `npm install --package-lock-only --ignore-scripts --offline`; Bun runtime manifest and third-party notice verification; `git diff --check`
- Manual: Confirmed Cargo and npm authorities agree on 0.14.5, the changelog release section is dated 2026-08-23, and no v0.14.5 tag or GitHub release exists.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: Changelog release section and comparison link
- Governance/release impact: Prepares the v0.14.5 release; the release workflow will publish only after merge to main.
