### PR TITLE
fix(tui): align wrapped welcome overview fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixes
+
+- **Welcome overview wrapping** (#351, @srothgan): Align wrapped tips and metadata beneath their values and hide Ferris on narrow terminals.
 
 ## [0.14.5] - 2026-08-23 [Changes][v0.14.5]
 

--- a/src/ui/inline_chat_rows.rs
+++ b/src/ui/inline_chat_rows.rs
@@ -414,13 +414,13 @@ fn serialize_compact_welcome_entry(
     entry: &WelcomeBlock,
     width: u16,
 ) -> Vec<Line<'static>> {
-    let mut lines = vec![Line::from(Span::styled(
+    let heading = Line::from(Span::styled(
         "Overview",
         Style::default().fg(theme::RUST_ORANGE).add_modifier(Modifier::BOLD),
-    ))];
-    lines.extend(welcome::overview_lines(entry, Some(status_label(app))));
-
-    wrap_lines_to_physical_rows(&lines, width)
+    ));
+    let mut lines = wrap_lines_to_physical_rows(&[heading], width);
+    lines.extend(welcome::overview_lines(entry, Some(status_label(app)), width));
+    lines
 }
 
 fn status_label(app: &App) -> &'static str {
@@ -2182,6 +2182,23 @@ mod tests {
         let text = line_texts(&rows);
 
         assert_eq!(text.iter().filter(|line| line.as_str() == "Overview").count(), 1);
+    }
+
+    #[test]
+    fn live_welcome_tip_wraps_below_its_value() {
+        let mut message = ChatMessage::welcome("1.2.3", "Pro", "/workspace/demo", "session-123");
+        let Some(MessageBlock::Welcome(welcome)) = message.blocks.first_mut() else {
+            panic!("expected welcome block");
+        };
+        welcome.tip_seed = 7;
+        let mut app = App::test_default();
+        app.transcript.messages.push(message);
+
+        let text = line_texts(&serialize_live_rows(&mut app, 110));
+        let tip_row = text.iter().position(|line| line.contains("Tips: Start")).expect("tip row");
+
+        assert_eq!(text[tip_row].find("Tips:"), Some(20));
+        assert_eq!(text[tip_row + 1].find("noise"), Some(26));
     }
 
     #[test]

--- a/src/ui/two_column_list.rs
+++ b/src/ui/two_column_list.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 Simon Peter Rothgang
 
-use super::wrap::{
-    StyledChunk, blank_line, pad_line_to_width, wrap_styled_chunks, wrapped_line_count,
-};
+use super::wrap::{StyledChunk, join_column_lines, wrap_styled_chunks, wrapped_line_count};
 use ratatui::style::Style;
-use ratatui::text::{Line, Span};
+use ratatui::text::Line;
 
 #[derive(Clone, Debug)]
 pub(crate) struct TwoColumnItem {
@@ -83,34 +81,5 @@ pub(crate) fn render_lines(
     if lines.is_empty() {
         lines.push(Line::default());
     }
-    lines
-}
-
-#[must_use]
-pub(crate) fn join_column_lines(
-    mut left_lines: Vec<Line<'static>>,
-    mut right_lines: Vec<Line<'static>>,
-    left_width: usize,
-    gap: usize,
-) -> Vec<Line<'static>> {
-    let row_height = left_lines.len().max(right_lines.len()).max(1);
-    while left_lines.len() < row_height {
-        left_lines.push(blank_line(left_width, Style::default()));
-    }
-    while right_lines.len() < row_height {
-        right_lines.push(Line::default());
-    }
-
-    let mut lines = Vec::with_capacity(row_height);
-    for idx in 0..row_height {
-        let mut line =
-            pad_line_to_width(std::mem::take(&mut left_lines[idx]), left_width, Style::default());
-        if gap > 0 {
-            line.spans.push(Span::styled(" ".repeat(gap), Style::default()));
-        }
-        line.spans.extend(std::mem::take(&mut right_lines[idx].spans));
-        lines.push(line);
-    }
-
     lines
 }

--- a/src/ui/welcome.rs
+++ b/src/ui/welcome.rs
@@ -3,11 +3,19 @@
 
 use crate::app::WelcomeBlock;
 use crate::ui::theme;
+use crate::ui::wrap::{
+    StyledChunk, display_width, join_column_lines, wrap_styled_chunks,
+    wrap_styled_chunks_with_hanging_prefix,
+};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
 const FERRIS_ART: &[&str] =
     &[r"    _~^~^~_     ", r"\) /  o o  \ (/ ", r"  '_   -   _'   ", r"  / '-----' \   "];
+const FERRIS_LEFT_PADDING: &str = "  ";
+const FERRIS_TEXT_GAP: usize = 2;
+const MIN_INLINE_FIELD_VALUE_WIDTH: usize = 8;
+const WELCOME_FIELD_LABELS: &[&str] = &["Version", "Subscription", "Cwd", "Session ID", "Tips"];
 
 const WELCOME_TIPS: &[&str] = &[
     "Use /mode plan before larger changes, then switch back to code once the plan is clear",
@@ -37,8 +45,13 @@ const WELCOME_TIPS: &[&str] = &[
 pub(crate) fn overview_lines(
     block: &WelcomeBlock,
     loading_status: Option<&str>,
+    width: u16,
 ) -> Vec<Line<'static>> {
-    let pad = "  ";
+    let width = usize::from(width);
+    if width == 0 {
+        return vec![Line::default()];
+    }
+
     let loading = loading_status.unwrap_or("Loading");
     let subscription_missing = welcome_value_missing(&block.subscription);
     let session_missing = welcome_value_missing(&block.session_id);
@@ -50,41 +63,89 @@ pub(crate) fn overview_lines(
     } else {
         Style::default().fg(theme::RUST_ORANGE).add_modifier(Modifier::BOLD)
     };
-    let text_rows = vec![
-        welcome_field_line("Version", &block.version, Style::default().fg(theme::DIM)),
-        welcome_field_line("Subscription", &subscription_value, subscription_style),
-        welcome_field_line("Cwd", &block.cwd, Style::default().fg(theme::DIM)),
-        welcome_field_line("Session ID", &session_value, Style::default().fg(theme::DIM)),
-        Line::default(),
-        Line::from(Span::styled(
-            format!("Tips: {}", selected_tip(block)),
-            Style::default().fg(theme::DIM),
-        )),
-    ];
 
-    let art_width = FERRIS_ART.iter().map(|line| line.chars().count()).max().unwrap_or(0);
-    let row_count = FERRIS_ART.len().max(text_rows.len());
-    let mut lines = Vec::with_capacity(row_count + 1);
-    for idx in 0..row_count {
-        let art = FERRIS_ART.get(idx).copied().unwrap_or_default();
-        let mut spans = vec![Span::styled(
-            format!("{pad}{art:<art_width$}{pad}"),
-            Style::default().fg(theme::RUST_ORANGE),
-        )];
-        if let Some(text_row) = text_rows.get(idx) {
-            spans.extend(text_row.spans.clone());
-        }
-        lines.push(Line::from(spans));
-    }
+    let ferris_width = ferris_column_width();
+    let overview_offset = ferris_width.saturating_add(FERRIS_TEXT_GAP);
+    let overview_width = width.saturating_sub(overview_offset);
+    let side_by_side = overview_width >= minimum_overview_width();
+    let text_width = if side_by_side { overview_width } else { width };
+    let text_rows = overview_text_rows(
+        block,
+        &subscription_value,
+        subscription_style,
+        &session_value,
+        text_width,
+    );
+    let mut lines = if side_by_side {
+        join_column_lines(ferris_rows(), text_rows, ferris_width, FERRIS_TEXT_GAP)
+    } else {
+        text_rows
+    };
     lines.push(Line::default());
     lines
 }
 
-fn welcome_field_line(label: &str, value: &str, value_style: Style) -> Line<'static> {
-    Line::from(vec![
-        Span::styled(format!("{label}: "), Style::default().fg(theme::DIM)),
-        Span::styled(value.to_owned(), value_style),
-    ])
+fn overview_text_rows(
+    block: &WelcomeBlock,
+    subscription_value: &str,
+    subscription_style: Style,
+    session_value: &str,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let dim = Style::default().fg(theme::DIM);
+    let mut rows = Vec::new();
+    rows.extend(welcome_field_lines("Version", &block.version, dim, width));
+    rows.extend(welcome_field_lines("Subscription", subscription_value, subscription_style, width));
+    rows.extend(welcome_field_lines("Cwd", &block.cwd, dim, width));
+    rows.extend(welcome_field_lines("Session ID", session_value, dim, width));
+    rows.push(Line::default());
+    rows.extend(welcome_field_lines("Tips", selected_tip(block), dim, width));
+    rows
+}
+
+fn welcome_field_lines(
+    label: &str,
+    value: &str,
+    value_style: Style,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let prefix =
+        vec![StyledChunk { text: format!("{label}: "), style: Style::default().fg(theme::DIM) }];
+    let body = vec![StyledChunk { text: value.to_owned(), style: value_style }];
+    let prefix_width = prefix.iter().map(|chunk| display_width(&chunk.text)).sum::<usize>();
+    if width.saturating_sub(prefix_width) < MIN_INLINE_FIELD_VALUE_WIDTH {
+        let mut rows = wrap_styled_chunks(&prefix, width);
+        rows.extend(wrap_styled_chunks(&body, width));
+        return rows;
+    }
+
+    wrap_styled_chunks_with_hanging_prefix(&prefix, &body, width, Style::default())
+}
+
+fn ferris_column_width() -> usize {
+    display_width(FERRIS_LEFT_PADDING)
+        .saturating_add(FERRIS_ART.iter().map(|line| display_width(line)).max().unwrap_or(0))
+}
+
+fn ferris_rows() -> Vec<Line<'static>> {
+    FERRIS_ART
+        .iter()
+        .map(|art| {
+            Line::from(Span::styled(
+                format!("{FERRIS_LEFT_PADDING}{art}"),
+                Style::default().fg(theme::RUST_ORANGE),
+            ))
+        })
+        .collect()
+}
+
+fn minimum_overview_width() -> usize {
+    WELCOME_FIELD_LABELS
+        .iter()
+        .map(|label| display_width(&format!("{label}: ")))
+        .max()
+        .unwrap_or(0)
+        .saturating_add(MIN_INLINE_FIELD_VALUE_WIDTH)
 }
 
 fn welcome_value_missing(value: &str) -> bool {
@@ -103,16 +164,22 @@ pub(crate) fn selected_tip(block: &WelcomeBlock) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{WELCOME_TIPS, overview_lines};
+    use super::{Line, WELCOME_TIPS, overview_lines};
     use crate::app::{ChatMessage, MessageBlock};
+    use crate::ui::wrap::line_display_width;
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|span| span.content.as_ref()).collect()
+    }
 
     #[test]
     fn overview_lines_render_expected_fields() {
-        let message = ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-");
-        let MessageBlock::Welcome(block) = &message.blocks[0] else {
+        let mut message = ChatMessage::welcome(env!("CARGO_PKG_VERSION"), "-", "/cwd", "-");
+        let MessageBlock::Welcome(block) = &mut message.blocks[0] else {
             panic!("expected welcome block");
         };
-        let lines: Vec<String> = overview_lines(block, None)
+        block.tip_seed = 16;
+        let lines: Vec<String> = overview_lines(block, None, 120)
             .into_iter()
             .map(|line| line.spans.into_iter().map(|s| s.content).collect())
             .collect();
@@ -127,5 +194,59 @@ mod tests {
             WELCOME_TIPS.iter().any(|tip| lines.iter().any(|line| line.contains(tip))),
             "expected one welcome tip to be rendered"
         );
+    }
+
+    #[test]
+    fn wide_overview_wraps_tip_below_its_value() {
+        let mut message = ChatMessage::welcome("1.2.3", "Pro", "/workspace/demo", "session-123");
+        let MessageBlock::Welcome(block) = &mut message.blocks[0] else {
+            panic!("expected welcome block");
+        };
+        block.tip_seed = 7;
+
+        let lines = overview_lines(block, None, 110);
+        let text = lines.iter().map(line_text).collect::<Vec<_>>();
+        let tip_row = text.iter().position(|line| line.contains("Tips: Start")).expect("tip row");
+
+        assert_eq!(text[tip_row].find("Tips:"), Some(20));
+        assert_eq!(text[tip_row + 1].find("noise"), Some(26));
+        assert!(lines.iter().all(|line| line_display_width(line) <= 110));
+    }
+
+    #[test]
+    fn wide_overview_wraps_long_metadata_below_its_value() {
+        let mut message = ChatMessage::welcome(
+            "1.2.3",
+            "Pro",
+            "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda",
+            "session-123",
+        );
+        let MessageBlock::Welcome(block) = &mut message.blocks[0] else {
+            panic!("expected welcome block");
+        };
+
+        let text = overview_lines(block, None, 70).iter().map(line_text).collect::<Vec<_>>();
+        let cwd_row = text.iter().position(|line| line.contains("Cwd: alpha")).expect("cwd row");
+
+        assert_eq!(text[cwd_row].find("Cwd:"), Some(20));
+        assert_eq!(text[cwd_row + 1].find("iota"), Some(25));
+    }
+
+    #[test]
+    fn narrow_overview_hides_ferris_and_keeps_hanging_indent() {
+        let mut message = ChatMessage::welcome("1.2.3", "Pro", "/workspace/demo", "session-123");
+        let MessageBlock::Welcome(block) = &mut message.blocks[0] else {
+            panic!("expected welcome block");
+        };
+        block.tip_seed = 7;
+
+        let lines = overview_lines(block, None, 36);
+        let text = lines.iter().map(line_text).collect::<Vec<_>>();
+        let tip_row =
+            text.iter().position(|line| line.starts_with("Tips: Start")).expect("tip row");
+
+        assert!(!text.iter().any(|line| line.contains("_~^~^~_")));
+        assert_eq!(text[tip_row + 1].find(|ch: char| !ch.is_whitespace()), Some(6));
+        assert!(lines.iter().all(|line| line_display_width(line) <= 36));
     }
 }

--- a/src/ui/wrap.rs
+++ b/src/ui/wrap.rs
@@ -124,24 +124,7 @@ fn wrap_markdown_line_to_physical_rows(
         );
     }
 
-    let body_rows = wrap_styled_chunks(&body, width.saturating_sub(marker_width));
-    let mut rows = Vec::with_capacity(body_rows.len().max(1));
-    let mut body_rows = body_rows.into_iter();
-
-    let mut first_spans =
-        marker.into_iter().map(|chunk| Span::styled(chunk.text, chunk.style)).collect::<Vec<_>>();
-    if let Some(first_body) = body_rows.next() {
-        first_spans.extend(first_body.spans);
-    }
-    rows.push(Line::from(first_spans).style(line.style));
-
-    let continuation_prefix = " ".repeat(marker_width);
-    for body_row in body_rows {
-        let mut spans = vec![Span::styled(continuation_prefix.clone(), line.style)];
-        spans.extend(body_row.spans);
-        rows.push(Line::from(spans).style(line.style));
-    }
-    rows
+    wrap_styled_chunks_with_hanging_prefix(&marker, &body, width, line.style)
 }
 
 #[must_use]
@@ -197,6 +180,53 @@ pub(crate) fn wrap_styled_chunks(chunks: &[StyledChunk], width: usize) -> Vec<Li
         lines.push(Line::default());
     }
     lines
+}
+
+#[must_use]
+pub(crate) fn wrap_styled_chunks_with_hanging_prefix(
+    prefix: &[StyledChunk],
+    body: &[StyledChunk],
+    width: usize,
+    line_style: Style,
+) -> Vec<Line<'static>> {
+    if width == 0 {
+        return vec![Line::default()];
+    }
+
+    let prefix_width = prefix.iter().map(|chunk| display_width(&chunk.text)).sum::<usize>();
+    if prefix_width == 0 {
+        return wrap_styled_chunks(body, width)
+            .into_iter()
+            .map(|line| line.style(line_style))
+            .collect();
+    }
+    if prefix_width >= width {
+        let mut combined = Vec::with_capacity(prefix.len() + body.len());
+        combined.extend_from_slice(prefix);
+        combined.extend_from_slice(body);
+        return wrap_styled_chunks(&combined, width)
+            .into_iter()
+            .map(|line| line.style(line_style))
+            .collect();
+    }
+
+    let mut body_rows = wrap_styled_chunks(body, width - prefix_width).into_iter();
+    let mut first_spans = prefix
+        .iter()
+        .map(|chunk| Span::styled(chunk.text.clone(), chunk.style))
+        .collect::<Vec<_>>();
+    if let Some(first_body) = body_rows.next() {
+        first_spans.extend(first_body.spans);
+    }
+
+    let mut rows = vec![Line::from(first_spans).style(line_style)];
+    let continuation_prefix = " ".repeat(prefix_width);
+    rows.extend(body_rows.map(|body_row| {
+        let mut spans = vec![Span::styled(continuation_prefix.clone(), line_style)];
+        spans.extend(body_row.spans);
+        Line::from(spans).style(line_style)
+    }));
+    rows
 }
 
 fn split_line_chunks_at_byte(
@@ -291,6 +321,35 @@ pub(crate) fn pad_line_to_width(
 #[must_use]
 pub(crate) fn blank_line(width: usize, style: Style) -> Line<'static> {
     Line::from(Span::styled(" ".repeat(width), style))
+}
+
+#[must_use]
+pub(crate) fn join_column_lines(
+    mut left_lines: Vec<Line<'static>>,
+    mut right_lines: Vec<Line<'static>>,
+    left_width: usize,
+    gap: usize,
+) -> Vec<Line<'static>> {
+    let row_height = left_lines.len().max(right_lines.len()).max(1);
+    while left_lines.len() < row_height {
+        left_lines.push(blank_line(left_width, Style::default()));
+    }
+    while right_lines.len() < row_height {
+        right_lines.push(Line::default());
+    }
+
+    let mut lines = Vec::with_capacity(row_height);
+    for idx in 0..row_height {
+        let mut line =
+            pad_line_to_width(std::mem::take(&mut left_lines[idx]), left_width, Style::default());
+        if gap > 0 {
+            line.spans.push(Span::styled(" ".repeat(gap), Style::default()));
+        }
+        line.spans.extend(std::mem::take(&mut right_lines[idx].spans));
+        lines.push(line);
+    }
+
+    lines
 }
 
 fn tokenize_chunks(chunks: &[StyledChunk]) -> Vec<WrapToken> {
@@ -469,6 +528,36 @@ mod tests {
             32,
         );
         assert!(lines[0].spans[0].style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn hanging_prefix_wraps_continuations_below_the_body() {
+        let rows = wrap_styled_chunks_with_hanging_prefix(
+            &[StyledChunk { text: "Tips: ".to_owned(), style: Style::default() }],
+            &[StyledChunk { text: "alpha beta gamma delta".to_owned(), style: Style::default() }],
+            17,
+            Style::default(),
+        );
+
+        assert_eq!(
+            rows.into_iter().map(|line| line_text(&line)).collect::<Vec<_>>(),
+            vec!["Tips: alpha beta", "      gamma delta"]
+        );
+    }
+
+    #[test]
+    fn joined_columns_preserve_the_left_offset_on_continuation_rows() {
+        let rows = join_column_lines(
+            vec![Line::from("XX")],
+            vec![Line::from("one"), Line::from("two")],
+            2,
+            1,
+        );
+
+        assert_eq!(
+            rows.into_iter().map(|line| line_text(&line)).collect::<Vec<_>>(),
+            vec!["XX one", "   two"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Render welcome overview labels and values with hanging indentation so wrapped tips and metadata remain aligned beneath their values.
- Compose Ferris artwork and overview text as independent columns, hiding the decorative artwork when the terminal is too narrow for a usable value column.
- Share hanging-prefix wrapping and column-joining primitives across welcome rendering, Markdown lists, and existing two-column UI content.
- Add deterministic coverage for wide and narrow layouts, long metadata, wrapped tips, and the final inline transcript path.

## Why

The welcome overview previously concatenated its artwork padding and text into one logical line before applying generic paragraph wrapping. Ratatui restarted continuation rows at column zero, causing long tips, working directories, and session IDs to lose both the overview-column offset and their label/value alignment. Making the renderer width-aware preserves the intended structure across terminal sizes and keeps narrow layouts readable.

<!-- Closes #<issue-number> -->

## Validation

- Automated: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features --offline -- -D warnings`; `cargo test --offline --no-fail-fast` (all 1,823 tests passed); `cargo check --offline`; `git diff --check main...HEAD`.
- Manual: Not performed; the terminal layouts are covered by deterministic row-width and display-column assertions at wide and narrow viewport sizes.
- Screenshot/video (if UI changed): Original issue reproduction was provided; no post-change capture is included in this local draft.

## Notes

- Breaking changes: None.
- Docs updated: No; this changes internal terminal layout behavior without altering user-facing commands or configuration.
- Governance/release impact: None.
