### PR TITLE
fix(tui): keep startup input responsive during indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
+- **Responsive startup and file indexing** (#352, @srothgan): Keep the composer editable while connecting, defer sends until the session is ready, and run one bounded post-connection file index.
 - **Welcome overview wrapping** (#351, @srothgan): Align wrapped tips and metadata beneath their values and hide Ferris on narrow terminals.
 
 ## [0.14.5] - 2026-08-23 [Changes][v0.14.5]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A native Rust terminal interface for Claude Code. Drop-in replacement for Anthro
 
 ## About
 
-Claude Code Rust replaces the stock Claude Code terminal interface with a native Rust binary built on [Ratatui](https://ratatui.rs/). It connects to the same Claude API through a local Agent SDK bridge. Core Claude Code functionality - tool calls, file editing, terminal commands, and permissions - works unchanged.
+Claude Code Rust replaces the stock Claude Code terminal interface with a native Rust binary built on [Ratatui](https://ratatui.rs/). It connects to the same Claude API through a local Agent SDK bridge. Core Claude Code functionality works unchanged, including tool calls, file editing, terminal commands, and permissions.
 
 ## Prerequisite
 
@@ -52,13 +52,13 @@ claude-rs
 Full documentation is available at [srothgan.github.io/claude-code-rust](https://srothgan.github.io/claude-code-rust/).
 
 > [!NOTE]
-> **Agent SDK billing unchanged.** Anthropic has paused the previously announced Agent SDK credit change. For now nothing changes: Claude Agent SDK usage — including `claude -p` and third-party apps like this one — still draws from your normal Claude subscription limits. See [Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan).
+> **Agent SDK billing unchanged.** Anthropic has paused the previously announced Agent SDK credit change. For now nothing changes: Claude Agent SDK usage (including `claude -p` and third-party apps like this one) still draws from your normal Claude subscription limits. See [Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan).
 
 ## Why
 
 The stock Claude Code TUI runs on Node.js with React Ink, which renders by redrawing full frames over raw ANSI escape codes. This causes real, widely-reported problems:
 
-- **Flickering**: The whole view is redrawn on every status update, causing constant flicker — bad enough to crash editors' integrated terminals during long sessions
+- **Flickering**: The whole view is redrawn on every status update, causing constant flicker (bad enough to crash editors' integrated terminals during long sessions)
 - **CPU**: Sustained high CPU even when idle, and runaway loops that spawn multiple background processes
 - **Memory**: 200-400MB baseline (and climbing with conversation length) vs ~20-50MB for a native binary
 - **Resize**: Window resizing leaves duplicated frames in scrollback, loses lines when shrinking, and can garble the display
@@ -66,7 +66,7 @@ The stock Claude Code TUI runs on Node.js with React Ink, which renders by redra
 - **Scrollback**: Hijacks the terminal's native scrollback, erasing history you can no longer scroll back to
 - **Paste**: Large pastes can flood stdout and freeze the terminal
 
-Claude Code Rust addresses these with a native terminal UI that uses diffed, direct terminal control via Crossterm and Ratatui -- no full-frame redraws and no React Ink rendering loop.
+Claude Code Rust addresses these with a native terminal UI that uses diffed, direct terminal control via Crossterm and Ratatui, with no full-frame redraws and no React Ink rendering loop.
 
 ## Documentation
 
@@ -96,9 +96,9 @@ This project is licensed under the [Apache License 2.0](LICENSE). Apache-2.0 was
 
 This project is not affiliated with, endorsed by, or supported by Anthropic.
 
-A quick note on where this project stands, since I know people worry about this kind of thing: claude-code-rust is a terminal UI that I wrote from scratch in Rust. It is not a fork, copy or port of the latest Claude Code source leak -- it talks to Anthropic's official [Agent SDK](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/agent-sdk) as a runtime dependency instead, the same way any other third-party tool would. No Anthropic source code was read or used as reference at any point during development.
+A quick note on where this project stands, since I know people worry about this kind of thing: claude-code-rust is a terminal UI that I wrote from scratch in Rust. It is not a fork, copy or port of the latest Claude Code source leak. It talks to Anthropic's official [Agent SDK](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/agent-sdk) as a runtime dependency instead, the same way any other third-party tool would. No Anthropic source code was read or used as reference at any point during development.
 
-The project authenticates through your existing Claude Code account via the Agent SDK, and the Agent SDK's terms allow building on top of it. Billing, credits, limits, and overage behavior are controlled by Anthropic, including any future changes Anthropic may make to how Agent SDK usage is metered. Other community projects do the same. As far as I can tell, using this project is fine -- but I am a single maintainer, not a lawyer. If anything changes on Anthropic's end, I will update this section and adjust the project accordingly.
+The project authenticates through your existing Claude Code account via the Agent SDK, and the Agent SDK's terms allow building on top of it. Billing, credits, limits, and overage behavior are controlled by Anthropic, including any future changes Anthropic may make to how Agent SDK usage is metered. Other community projects do the same. As far as I can tell, using this project is fine, but I am a single maintainer, not a lawyer. If anything changes on Anthropic's end, I will update this section and adjust the project accordingly.
 
 This project's source code is licensed under [Apache-2.0](LICENSE). The Agent SDK itself is proprietary and governed by [Anthropic's Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms).
 

--- a/src/app/connect/mod.rs
+++ b/src/app/connect/mod.rs
@@ -80,7 +80,7 @@ pub fn create_app(cli: &Cli) -> App {
     let cwd = resolve_startup_cwd(cli);
 
     let (event_tx, event_rx) = mpsc::channel(CLIENT_EVENT_QUEUE_CAPACITY);
-    let (file_index_event_tx, file_index_event_rx) = std::sync::mpsc::channel();
+    let (file_index_event_tx, file_index_event_rx) = super::file_index::event_channel();
     let perf_path = match crate::logging::resolve_perf_path(cli) {
         Ok(path) => path,
         Err(err) => {
@@ -243,7 +243,6 @@ pub fn create_app(cli: &Cli) -> App {
     app.rebuild_render_cache_accounting();
     trust::initialize(&mut app);
     app.sync_git_context();
-    super::file_index::restart(&mut app);
     app
 }
 

--- a/src/app/connect/tests.rs
+++ b/src/app/connect/tests.rs
@@ -22,7 +22,7 @@ fn map_session_update_preserves_config_option_update() {
 }
 
 #[test]
-fn create_app_prewarms_file_index_and_routes_untrusted_cwd_to_trust_surface() {
+fn create_app_defers_file_index_and_routes_untrusted_cwd_to_trust_surface() {
     let dir = tempfile::tempdir().expect("tempdir");
     let cli = Cli {
         command: None,
@@ -41,9 +41,9 @@ fn create_app_prewarms_file_index_and_routes_untrusted_cwd_to_trust_surface() {
 
     let app = super::create_app(&cli);
 
-    assert_eq!(app.file_index.root.as_deref(), Some(dir.path()));
-    assert!(app.file_index.scan.is_some());
-    assert!(app.file_index.watch.is_some());
+    assert!(app.file_index.root.is_none());
+    assert!(app.file_index.scan.is_none());
+    assert!(app.file_index.watch.is_none());
     assert_eq!(app.surface_mode, SurfaceMode::Fullscreen(FullscreenView::Trusted));
     assert_eq!(app.terminal_lifecycle, TerminalLifecycleState::Bootstrapping);
 }

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -254,10 +254,7 @@ fn dispatch_mouse_by_view(app: &mut App, mouse: crossterm::event::MouseEvent) {
 fn dispatch_paste_by_view(app: &mut App, text: &str) -> bool {
     match app.surface_mode {
         SurfaceMode::Chat => {
-            if !matches!(
-                app.status,
-                AppStatus::Connecting | AppStatus::CommandPending | AppStatus::Error
-            ) {
+            if app.composer_access().can_edit() {
                 reclaim_input_from_inline_prompt_if_needed(app);
                 app.queue_paste_text(text);
                 return true;

--- a/src/app/events/session.rs
+++ b/src/app/events/session.rs
@@ -6,7 +6,7 @@ use super::super::state::RecentSessionInfo;
 use super::super::view::{self, FullscreenView};
 use super::super::{App, AppStatus, LoginHint, SystemSeverity};
 use super::push_system_message_with_severity;
-use super::session_reset::{ChatResetRenderMode, load_resume_history, reset_for_new_session};
+use super::session_reset::{ChatResetKind, load_resume_history, reset_for_new_session};
 use crate::agent::client::AgentConnection;
 use crate::agent::events::ServiceStatusSeverity;
 use crate::agent::model;
@@ -63,8 +63,7 @@ pub(super) fn handle_connected_client_event(app: &mut App, event: ConnectedEvent
         current_model,
         mode,
         model::FastModeSnapshot::new(fast_mode_state, fast_mode_disabled_reason),
-        true,
-        ChatResetRenderMode::PreserveInlineViewport,
+        ChatResetKind::InitialConnection,
     );
     app.sdk_inventory.available_models = available_models;
     app.sync_welcome_snapshot();
@@ -193,7 +192,6 @@ pub(super) fn handle_connection_failed_event(app: &mut App, msg: &str) {
     crate::app::usage::reset_for_session_change(app);
     app.clear_pending_session_resume();
     app.finalize_turn_runtime_artifacts(model::ToolCallStatus::Failed);
-    app.input.clear();
     app.pending_submit = None;
     app.status = AppStatus::Error;
     app.turn.reset_for_new_session();
@@ -363,8 +361,7 @@ pub(super) fn handle_session_replaced_event(app: &mut App, event: SessionReplace
         current_model,
         mode,
         model::FastModeSnapshot::new(fast_mode_state, fast_mode_disabled_reason),
-        false,
-        ChatResetRenderMode::DeferTranscriptRender,
+        ChatResetKind::Replacement,
     );
     app.sync_welcome_snapshot();
     if !history_updates.is_empty() {
@@ -764,7 +761,7 @@ mod tests {
         let mut app = App::test_default();
         app.file_index.generation = 3;
         app.file_index.entries.insert("stale.rs".to_owned(), candidate("stale.rs"));
-        app.file_index.scan_finished = true;
+        app.file_index.status = crate::app::file_index::FileIndexStatus::Complete;
 
         handle_connected_client_event(
             &mut app,
@@ -788,7 +785,7 @@ mod tests {
         assert!(app.file_index.entries.is_empty());
         assert!(app.mention.is_none());
         wait_for(&mut app, Duration::from_secs(2), |app| {
-            app.file_index.scan_finished && app.file_index.entries.contains_key("new.rs")
+            app.file_index.status.is_finished() && app.file_index.entries.contains_key("new.rs")
         });
         assert_eq!(
             app.file_index.entries.keys().map(String::as_str).collect::<Vec<_>>(),
@@ -803,7 +800,7 @@ mod tests {
         let mut app = App::test_default();
         app.file_index.generation = 8;
         app.file_index.entries.insert("before.rs".to_owned(), candidate("before.rs"));
-        app.file_index.scan_finished = true;
+        app.file_index.status = crate::app::file_index::FileIndexStatus::Complete;
 
         handle_session_replaced_event(
             &mut app,
@@ -828,7 +825,7 @@ mod tests {
         assert!(app.file_index.entries.is_empty());
         assert!(app.mention.is_none());
         wait_for(&mut app, Duration::from_secs(2), |app| {
-            app.file_index.scan_finished && app.file_index.entries.contains_key("after.rs")
+            app.file_index.status.is_finished() && app.file_index.entries.contains_key("after.rs")
         });
         assert_eq!(
             app.file_index.entries.keys().map(String::as_str).collect::<Vec<_>>(),

--- a/src/app/events/session_reset.rs
+++ b/src/app/events/session_reset.rs
@@ -5,9 +5,23 @@ use super::super::{App, ChatMessage, MessageBlock, MessageRole, TextBlock};
 use crate::agent::model;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum ChatResetRenderMode {
-    PreserveInlineViewport,
-    DeferTranscriptRender,
+pub(super) enum ChatResetKind {
+    InitialConnection,
+    Replacement,
+}
+
+impl ChatResetKind {
+    const fn preserves_draft(self) -> bool {
+        matches!(self, Self::InitialConnection)
+    }
+
+    const fn preserves_welcome_tip(self) -> bool {
+        matches!(self, Self::InitialConnection)
+    }
+
+    const fn repaints_inline_viewport(self) -> bool {
+        matches!(self, Self::InitialConnection)
+    }
 }
 
 pub(super) fn reset_for_new_session(
@@ -16,15 +30,14 @@ pub(super) fn reset_for_new_session(
     current_model: model::CurrentModel,
     mode: Option<super::super::ModeState>,
     fast_mode: model::FastModeSnapshot,
-    preserve_current_welcome_tip: bool,
-    render_mode: ChatResetRenderMode,
+    reset_kind: ChatResetKind,
 ) {
     reset_session_identity_state(app, session_id, current_model, mode, fast_mode);
-    reset_messages_for_new_session(app, preserve_current_welcome_tip);
-    reset_input_state_for_new_session(app);
+    reset_messages_for_new_session(app, reset_kind.preserves_welcome_tip());
+    reset_input_state_for_new_session(app, reset_kind);
     reset_interaction_state_for_new_session(app);
     reset_render_state_for_new_session(app);
-    reset_cache_and_footer_state_for_new_session(app, render_mode);
+    reset_cache_and_footer_state_for_new_session(app, reset_kind);
     app.sync_git_context();
 }
 
@@ -73,11 +86,14 @@ fn reset_messages_for_new_session(app: &mut App, preserve_current_welcome_tip: b
     app.sync_welcome_snapshot();
 }
 
-fn reset_input_state_for_new_session(app: &mut App) {
-    app.input.clear();
+fn reset_input_state_for_new_session(app: &mut App, reset_kind: ChatResetKind) {
+    if !reset_kind.preserves_draft() {
+        app.input.clear();
+        app.pending_images.clear();
+        app.committed_mentions.clear();
+    }
     app.pending_submit = None;
     app.paste.clear_all_sessions();
-    app.pending_images.clear();
 }
 
 fn reset_interaction_state_for_new_session(app: &mut App) {
@@ -100,13 +116,12 @@ fn reset_render_state_for_new_session(app: &mut App) {
     app.subagent = None;
 }
 
-fn reset_cache_and_footer_state_for_new_session(app: &mut App, render_mode: ChatResetRenderMode) {
+fn reset_cache_and_footer_state_for_new_session(app: &mut App, reset_kind: ChatResetKind) {
     app.mcp = super::super::McpState::default();
     crate::app::usage::reset_for_session_change(app);
     crate::app::plugins::reset_for_session_change(app);
-    match render_mode {
-        ChatResetRenderMode::PreserveInlineViewport => app.request_chat_repaint(),
-        ChatResetRenderMode::DeferTranscriptRender => {}
+    if reset_kind.repaints_inline_viewport() {
+        app.request_chat_repaint();
     }
 }
 
@@ -177,7 +192,7 @@ pub(super) fn load_resume_history(app: &mut App, history_updates: &[model::Sessi
 
 #[cfg(test)]
 mod tests {
-    use super::{ChatResetRenderMode, reset_for_new_session};
+    use super::{ChatResetKind, reset_for_new_session};
     use crate::agent::model;
     use crate::app::{App, ChatMessage, ChatRebuildKind};
 
@@ -202,8 +217,7 @@ mod tests {
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
             model::FastModeSnapshot::new(model::FastModeState::Off, None),
-            false,
-            ChatResetRenderMode::DeferTranscriptRender,
+            ChatResetKind::Replacement,
         );
 
         assert_eq!(app.chat_render.terminal_width, 0);
@@ -226,12 +240,33 @@ mod tests {
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
             model::FastModeSnapshot::new(model::FastModeState::Off, None),
-            true,
-            ChatResetRenderMode::PreserveInlineViewport,
+            ChatResetKind::InitialConnection,
         );
 
         assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::None);
         assert!(app.surface_dirty.chat.repaint);
+    }
+
+    #[test]
+    fn startup_session_reset_preserves_connecting_draft_and_images() {
+        let mut app = App::test_default();
+        app.input.set_text("draft while connecting");
+        app.pending_images.push(crate::app::clipboard_image::ImageAttachment {
+            data: "image-data".to_owned(),
+            mime_type: "image/png".to_owned(),
+        });
+
+        reset_for_new_session(
+            &mut app,
+            model::SessionId::new("session-2"),
+            model::CurrentModel::new("test", "test", "test").authoritative(true),
+            None,
+            model::FastModeSnapshot::new(model::FastModeState::Off, None),
+            ChatResetKind::InitialConnection,
+        );
+
+        assert_eq!(app.input.text(), "draft while connecting");
+        assert_eq!(app.pending_images.len(), 1);
     }
 
     #[test]
@@ -252,8 +287,7 @@ mod tests {
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
             model::FastModeSnapshot::new(model::FastModeState::Off, None),
-            false,
-            ChatResetRenderMode::DeferTranscriptRender,
+            ChatResetKind::Replacement,
         );
 
         assert_eq!(app.surface_dirty.chat.rebuild, ChatRebuildKind::None);
@@ -279,8 +313,7 @@ mod tests {
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
             model::FastModeSnapshot::new(model::FastModeState::Off, None),
-            false,
-            ChatResetRenderMode::DeferTranscriptRender,
+            ChatResetKind::Replacement,
         );
 
         assert!(app.sdk_inventory.rewind_targets.is_empty());
@@ -299,8 +332,7 @@ mod tests {
             model::CurrentModel::new("test", "test", "test").authoritative(true),
             None,
             model::FastModeSnapshot::new(model::FastModeState::Off, None),
-            false,
-            ChatResetRenderMode::DeferTranscriptRender,
+            ChatResetKind::Replacement,
         );
 
         assert!(app.shutdown_requested());

--- a/src/app/events/tests.rs
+++ b/src/app/events/tests.rs
@@ -3285,24 +3285,21 @@ fn second_esc_after_permission_rejection_requests_turn_cancel() {
 }
 
 #[test]
-fn connecting_state_blocks_input_shortcuts_and_tab() {
+fn connecting_state_allows_drafting_but_blocks_submission() {
     let mut app = make_test_app();
     app.status = AppStatus::Connecting;
     app.input.set_text("seed");
-    app.pending_submit = None;
 
-    for key in [
-        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
-        KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
-        KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
-        KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE),
-        KeyEvent::new(KeyCode::Char('@'), KeyModifiers::NONE),
-        KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
-    ] {
-        handle_terminal_event(&mut app, Event::Key(key));
-    }
+    handle_terminal_event(
+        &mut app,
+        Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)),
+    );
+    handle_terminal_event(&mut app, Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)));
+    handle_terminal_event(&mut app, Event::Paste(" pasted".into()));
+    crate::app::input_submit::submit_input(&mut app);
 
-    assert_eq!(app.input.text(), "seed");
+    assert_eq!(app.input.text(), "seedx");
+    assert_eq!(app.paste.pending_text, " pasted");
     assert!(app.pending_submit.is_none());
 }
 

--- a/src/app/file_index.rs
+++ b/src/app/file_index.rs
@@ -8,11 +8,18 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, TryRecvError};
+use std::sync::mpsc::{
+    self, Receiver, RecvTimeoutError, Sender, SyncSender, TryRecvError, TrySendError,
+};
 use std::time::{Duration, Instant};
 
 const SCAN_BATCH_SIZE: usize = 256;
-const EVENT_DRAIN_BUDGET: usize = 64;
+const EVENT_QUEUE_CAPACITY: usize = 8;
+const MATCHER_INDEX_QUEUE_CAPACITY: usize = 512;
+const WATCH_EVENT_QUEUE_CAPACITY: usize = 256;
+const EVENT_DRAIN_COUNT_BUDGET: usize = 64;
+const EVENT_DRAIN_TIME_BUDGET: Duration = Duration::from_millis(2);
+pub(crate) const MAX_INDEX_ENTRIES: usize = 100_000;
 const WATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const WATCH_DEBOUNCE_INTERVAL: Duration = Duration::from_millis(50);
 const MAX_CANDIDATES: usize = 50;
@@ -29,6 +36,27 @@ pub struct FileCandidate {
     pub depth: usize,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum FileIndexStatus {
+    #[default]
+    NotStarted,
+    Scanning,
+    Complete,
+    Limited,
+}
+
+impl FileIndexStatus {
+    #[must_use]
+    pub const fn is_finished(self) -> bool {
+        matches!(self, Self::Complete | Self::Limited)
+    }
+
+    #[must_use]
+    pub const fn is_limited(self) -> bool {
+        matches!(self, Self::Limited)
+    }
+}
+
 #[derive(Default)]
 pub struct FileIndexState {
     pub root: Option<PathBuf>,
@@ -36,8 +64,7 @@ pub struct FileIndexState {
     pub generation: u64,
     pub index_version: u64,
     pub entries: BTreeMap<String, FileCandidate>,
-    pub scan_finished: bool,
-    pub rebuild_pending: bool,
+    pub status: FileIndexStatus,
     scan_overrides: ScanOverrides,
     pub scan: Option<FileIndexScanHandle>,
     pub watch: Option<FileIndexWatchHandle>,
@@ -53,7 +80,7 @@ pub struct FileIndexWatchHandle {
 }
 
 pub struct FileIndexMatcherHandle {
-    index_tx: Sender<FileIndexMatcherCommand>,
+    index_tx: SyncSender<FileIndexMatcherCommand>,
     query_tx: Sender<MentionMatchRequest>,
 }
 
@@ -89,12 +116,11 @@ pub enum FileIndexChange {
     Upsert(FileCandidate),
     RemoveExact { rel_path: String },
     RemovePrefix { rel_prefix: String },
-    ReplacePrefix { rel_prefix: String, entries: Vec<FileCandidate> },
 }
 
 pub enum FileIndexEvent {
     ScanBatch { generation: u64, entries: Vec<FileCandidate> },
-    ScanFinished { generation: u64 },
+    ScanFinished { generation: u64, limited: bool },
     FsBatch { generation: u64, changes: Vec<FileIndexChange> },
     RebuildRequested { generation: u64 },
     MatchResult(MentionMatchResult),
@@ -115,14 +141,31 @@ pub struct MentionMatchResult {
     pub sequence: u64,
     pub query: String,
     pub candidates: Vec<FileCandidate>,
-    pub scan_finished: bool,
+    pub status: FileIndexStatus,
 }
 
 enum FileIndexMatcherCommand {
-    Reset { generation: u64, index_version: u64, entries: Vec<FileCandidate>, scan_finished: bool },
-    ScanBatch { generation: u64, index_version: u64, entries: Vec<FileCandidate> },
-    ScanFinished { generation: u64, index_version: u64 },
-    FsBatch { generation: u64, index_version: u64, changes: Vec<FileIndexChange> },
+    Reset {
+        generation: u64,
+        index_version: u64,
+        entries: Vec<FileCandidate>,
+        status: FileIndexStatus,
+    },
+    ScanBatch {
+        generation: u64,
+        index_version: u64,
+        entries: Vec<FileCandidate>,
+    },
+    ScanFinished {
+        generation: u64,
+        index_version: u64,
+        status: FileIndexStatus,
+    },
+    FsBatch {
+        generation: u64,
+        index_version: u64,
+        changes: Vec<FileIndexChange>,
+    },
 }
 
 #[derive(Default)]
@@ -149,12 +192,16 @@ pub fn reset(app: &mut App) {
     app.file_index.root = None;
     app.file_index.respect_gitignore = app.config.respect_gitignore_effective();
     app.file_index.entries.clear();
-    app.file_index.scan_finished = false;
-    app.file_index.rebuild_pending = false;
+    app.file_index.status = FileIndexStatus::NotStarted;
     app.file_index.scan_overrides = ScanOverrides::default();
     app.file_index.scan = None;
     app.file_index.watch = None;
     app.file_index.matcher = None;
+}
+
+#[must_use]
+pub(crate) fn event_channel() -> (SyncSender<FileIndexEvent>, Receiver<FileIndexEvent>) {
+    mpsc::sync_channel(EVENT_QUEUE_CAPACITY)
 }
 
 pub fn restart(app: &mut App) {
@@ -180,8 +227,7 @@ pub fn restart(app: &mut App) {
     );
     app.file_index.root = Some(root.clone());
     app.file_index.respect_gitignore = respect_gitignore;
-    app.file_index.scan_finished = false;
-    app.file_index.rebuild_pending = false;
+    app.file_index.status = FileIndexStatus::Scanning;
     app.file_index.scan_overrides = ScanOverrides::default();
     app.file_index.matcher = Some(spawn_matcher(generation, app.file_index_event_tx.clone()));
     send_matcher_command(
@@ -190,7 +236,7 @@ pub fn restart(app: &mut App) {
             generation,
             index_version: app.file_index.index_version,
             entries: Vec::new(),
-            scan_finished: false,
+            status: FileIndexStatus::Scanning,
         },
     );
     app.file_index.scan = Some(spawn_scan(
@@ -201,37 +247,6 @@ pub fn restart(app: &mut App) {
     ));
     app.file_index.watch =
         Some(spawn_watch(&root, generation, respect_gitignore, app.file_index_event_tx.clone()));
-}
-
-pub fn ensure_started(app: &mut App) {
-    let respect_gitignore = app.config.respect_gitignore_effective();
-    let current_root = PathBuf::from(&app.cwd_raw);
-    let root_changed = app.file_index.root.as_ref() != Some(&current_root);
-    let respect_gitignore_changed = app.file_index.respect_gitignore != respect_gitignore;
-    let missing_root = app.file_index.root.is_none();
-    let scan_missing_while_unfinished =
-        !app.file_index.scan_finished && app.file_index.scan.is_none();
-    let needs_restart =
-        root_changed || respect_gitignore_changed || missing_root || scan_missing_while_unfinished;
-    if needs_restart {
-        tracing::debug!(
-            target: crate::logging::targets::APP_FILE_INDEX,
-            event_name = "file_index_ensure_restart",
-            message = "file index ensure_started requested restart",
-            root_changed,
-            respect_gitignore_changed,
-            missing_root,
-            scan_missing_while_unfinished,
-            current_root = %current_root.display(),
-            indexed_root = %app.file_index.root
-                .as_ref()
-                .map_or_else(|| "<none>".to_owned(), |root| root.display().to_string()),
-            generation = app.file_index.generation,
-            entries = app.file_index.entries.len(),
-            scan_finished = app.file_index.scan_finished,
-        );
-        restart(app);
-    }
 }
 
 pub fn request_match(app: &mut App, request: MentionMatchRequest) {
@@ -253,7 +268,9 @@ pub fn drain_events(app: &mut App) {
     let mut handled = 0;
     let mut stats = EventApplyStats::default();
     loop {
-        if handled >= EVENT_DRAIN_BUDGET {
+        if handled >= EVENT_DRAIN_COUNT_BUDGET
+            || (handled > 0 && started_at.elapsed() >= EVENT_DRAIN_TIME_BUDGET)
+        {
             break;
         }
         let event = match app.file_index_event_rx.try_recv() {
@@ -266,7 +283,7 @@ pub fn drain_events(app: &mut App) {
     if stats.index_changed {
         refresh_after_mutation(app, &stats);
     }
-    if stats.index_changed || stats.mention_changed {
+    if stats.mention_changed || (stats.index_changed && app.mention.is_some()) {
         app.request_chat_repaint();
     }
     if handled > 0 {
@@ -284,11 +301,12 @@ pub fn drain_events(app: &mut App) {
             rebuilds = stats.rebuilds,
             scan_finished_event = stats.scan_finished,
             match_results = stats.match_results,
-            budget_hit = handled >= EVENT_DRAIN_BUDGET,
+            count_budget_hit = handled >= EVENT_DRAIN_COUNT_BUDGET,
+            time_budget_hit = started_at.elapsed() >= EVENT_DRAIN_TIME_BUDGET,
             total_entries = app.file_index.entries.len(),
             index_version = app.file_index.index_version,
             generation = app.file_index.generation,
-            scan_finished = app.file_index.scan_finished,
+            index_status = ?app.file_index.status,
             mention_active = app.mention.is_some(),
         );
     }
@@ -363,21 +381,6 @@ impl MatcherEntries {
         before - self.entries.len()
     }
 
-    fn replace_prefix(
-        &mut self,
-        rel_prefix: &str,
-        entries: Vec<FileCandidate>,
-    ) -> (usize, MatcherUpsertStats) {
-        let removed = self.remove_prefix(rel_prefix);
-        let mut stats = MatcherUpsertStats::default();
-        for entry in entries {
-            let upsert_stats = self.upsert(entry);
-            stats.inserted += upsert_stats.inserted;
-            stats.replaced += upsert_stats.replaced;
-        }
-        (removed, stats)
-    }
-
     fn apply_change(&mut self, change: FileIndexChange) -> MatcherChangeStats {
         match change {
             FileIndexChange::Upsert(candidate) => {
@@ -396,10 +399,6 @@ impl MatcherEntries {
                 removed: self.remove_prefix(&rel_prefix),
                 ..MatcherChangeStats::default()
             },
-            FileIndexChange::ReplacePrefix { rel_prefix, entries } => {
-                let (removed, stats) = self.replace_prefix(&rel_prefix, entries);
-                MatcherChangeStats { inserted: stats.inserted, replaced: stats.replaced, removed }
-            }
         }
     }
 
@@ -592,73 +591,12 @@ impl MatcherChangeStats {
 fn apply_event(app: &mut App, event: FileIndexEvent) -> EventApplyStats {
     match event {
         FileIndexEvent::ScanBatch { generation, entries } => {
-            if generation != app.file_index.generation {
-                return EventApplyStats::default();
-            }
-            let scan_entries = entries.len();
-            let mut matcher_entries = Vec::with_capacity(entries.len());
-            for entry in entries {
-                if app.file_index.scan_overrides.blocks(&entry.rel_path) {
-                    continue;
-                }
-                matcher_entries.push(entry.clone());
-                app.file_index.entries.insert(entry.rel_path.clone(), entry);
-            }
-            if matcher_entries.is_empty() {
-                return EventApplyStats { scan_entries, ..EventApplyStats::default() };
-            }
-            let index_version = bump_index_version(app);
-            send_matcher_command(
-                app,
-                FileIndexMatcherCommand::ScanBatch {
-                    generation,
-                    index_version,
-                    entries: matcher_entries,
-                },
-            );
-            EventApplyStats { index_changed: true, scan_entries, ..EventApplyStats::default() }
+            apply_scan_batch(app, generation, entries)
         }
-        FileIndexEvent::ScanFinished { generation } => {
-            if generation != app.file_index.generation {
-                return EventApplyStats::default();
-            }
-            app.file_index.scan_finished = true;
-            app.file_index.scan_overrides = ScanOverrides::default();
-            app.file_index.scan = None;
-            let index_version = bump_index_version(app);
-            send_matcher_command(
-                app,
-                FileIndexMatcherCommand::ScanFinished { generation, index_version },
-            );
-            EventApplyStats {
-                index_changed: true,
-                scan_finished: true,
-                ..EventApplyStats::default()
-            }
+        FileIndexEvent::ScanFinished { generation, limited } => {
+            apply_scan_finished(app, generation, limited)
         }
-        FileIndexEvent::FsBatch { generation, changes } => {
-            if generation != app.file_index.generation {
-                return EventApplyStats::default();
-            }
-            let fs_changes = changes.len();
-            let matcher_changes = changes.clone();
-            for change in changes {
-                if !app.file_index.scan_finished {
-                    app.file_index.scan_overrides.record_change(&change);
-                }
-                apply_change(&mut app.file_index.entries, change);
-            }
-            let index_version = bump_index_version(app);
-            send_matcher_command(
-                app,
-                FileIndexMatcherCommand::FsBatch {
-                    generation,
-                    index_version,
-                    changes: matcher_changes,
-                },
-            );
-            EventApplyStats { index_changed: true, fs_changes, ..EventApplyStats::default() }
-        }
+        FileIndexEvent::FsBatch { generation, changes } => apply_fs_batch(app, generation, changes),
         FileIndexEvent::RebuildRequested { generation } => {
             if generation != app.file_index.generation {
                 return EventApplyStats::default();
@@ -671,6 +609,147 @@ fn apply_event(app: &mut App, event: FileIndexEvent) -> EventApplyStats {
             EventApplyStats { mention_changed, match_results: 1, ..EventApplyStats::default() }
         }
     }
+}
+
+fn apply_scan_batch(
+    app: &mut App,
+    generation: u64,
+    entries: Vec<FileCandidate>,
+) -> EventApplyStats {
+    if generation != app.file_index.generation || app.file_index.status.is_limited() {
+        return EventApplyStats::default();
+    }
+    let scan_entries = entries.len();
+    let mut matcher_entries = Vec::with_capacity(entries.len());
+    let mut limited = false;
+    for entry in entries {
+        if app.file_index.scan_overrides.blocks(&entry.rel_path) {
+            continue;
+        }
+        if !app.file_index.entries.contains_key(&entry.rel_path)
+            && app.file_index.entries.len() >= MAX_INDEX_ENTRIES
+        {
+            limited = true;
+            break;
+        }
+        matcher_entries.push(entry.clone());
+        app.file_index.entries.insert(entry.rel_path.clone(), entry);
+    }
+    if limited {
+        mark_index_limited(app);
+    }
+    if matcher_entries.is_empty() {
+        return EventApplyStats {
+            scan_entries,
+            scan_finished: limited,
+            ..EventApplyStats::default()
+        };
+    }
+    let index_version = bump_index_version(app);
+    send_matcher_command(
+        app,
+        FileIndexMatcherCommand::ScanBatch { generation, index_version, entries: matcher_entries },
+    );
+    if limited {
+        send_limited_status_to_matcher(app, generation, index_version);
+    }
+    EventApplyStats {
+        index_changed: true,
+        scan_entries,
+        scan_finished: limited,
+        ..EventApplyStats::default()
+    }
+}
+
+fn apply_scan_finished(app: &mut App, generation: u64, limited: bool) -> EventApplyStats {
+    if generation != app.file_index.generation {
+        return EventApplyStats::default();
+    }
+    let limited = limited || app.file_index.status.is_limited();
+    app.file_index.status =
+        if limited { FileIndexStatus::Limited } else { FileIndexStatus::Complete };
+    app.file_index.scan_overrides = ScanOverrides::default();
+    app.file_index.scan = None;
+    if limited {
+        app.file_index.watch = None;
+    }
+    let index_version = bump_index_version(app);
+    send_matcher_command(
+        app,
+        FileIndexMatcherCommand::ScanFinished {
+            generation,
+            index_version,
+            status: app.file_index.status,
+        },
+    );
+    EventApplyStats { index_changed: true, scan_finished: true, ..EventApplyStats::default() }
+}
+
+fn apply_fs_batch(
+    app: &mut App,
+    generation: u64,
+    changes: Vec<FileIndexChange>,
+) -> EventApplyStats {
+    if generation != app.file_index.generation || app.file_index.status.is_limited() {
+        return EventApplyStats::default();
+    }
+    let fs_changes = changes.len();
+    let mut matcher_changes = Vec::with_capacity(changes.len());
+    let mut limited = false;
+    for change in changes {
+        if !app.file_index.status.is_finished() {
+            app.file_index.scan_overrides.record_change(&change);
+        }
+        if apply_change(&mut app.file_index.entries, &change) {
+            matcher_changes.push(change);
+        } else {
+            limited = true;
+            break;
+        }
+    }
+    if matcher_changes.is_empty() && !limited {
+        return EventApplyStats { fs_changes, ..EventApplyStats::default() };
+    }
+    if limited {
+        mark_index_limited(app);
+    }
+    let index_version = bump_index_version(app);
+    if !matcher_changes.is_empty() {
+        send_matcher_command(
+            app,
+            FileIndexMatcherCommand::FsBatch {
+                generation,
+                index_version,
+                changes: matcher_changes,
+            },
+        );
+    }
+    if limited {
+        send_limited_status_to_matcher(app, generation, index_version);
+    }
+    EventApplyStats {
+        index_changed: true,
+        fs_changes,
+        scan_finished: limited,
+        ..EventApplyStats::default()
+    }
+}
+
+fn mark_index_limited(app: &mut App) {
+    app.file_index.status = FileIndexStatus::Limited;
+    app.file_index.scan = None;
+    app.file_index.watch = None;
+}
+
+fn send_limited_status_to_matcher(app: &mut App, generation: u64, index_version: u64) {
+    send_matcher_command(
+        app,
+        FileIndexMatcherCommand::ScanFinished {
+            generation,
+            index_version,
+            status: FileIndexStatus::Limited,
+        },
+    );
 }
 
 fn refresh_after_mutation(app: &mut App, stats: &EventApplyStats) {
@@ -688,24 +767,22 @@ fn bump_index_version(app: &mut App) -> u64 {
     app.file_index.index_version
 }
 
-fn apply_change(entries: &mut BTreeMap<String, FileCandidate>, change: FileIndexChange) {
+fn apply_change(entries: &mut BTreeMap<String, FileCandidate>, change: &FileIndexChange) -> bool {
     match change {
         FileIndexChange::Upsert(candidate) => {
-            entries.insert(candidate.rel_path.clone(), candidate);
+            if !entries.contains_key(&candidate.rel_path) && entries.len() >= MAX_INDEX_ENTRIES {
+                return false;
+            }
+            entries.insert(candidate.rel_path.clone(), candidate.clone());
         }
         FileIndexChange::RemoveExact { rel_path } => {
-            entries.remove(&rel_path);
+            entries.remove(rel_path);
         }
         FileIndexChange::RemovePrefix { rel_prefix } => {
-            entries.retain(|path, _| !path.starts_with(&rel_prefix));
-        }
-        FileIndexChange::ReplacePrefix { rel_prefix, entries: next_entries } => {
-            entries.retain(|path, _| !path.starts_with(&rel_prefix));
-            for entry in next_entries {
-                entries.insert(entry.rel_path.clone(), entry);
-            }
+            entries.retain(|path, _| !path.starts_with(rel_prefix));
         }
     }
+    true
 }
 
 fn ensure_matcher(app: &mut App) {
@@ -715,11 +792,11 @@ fn ensure_matcher(app: &mut App) {
     let generation = app.file_index.generation;
     let index_version = app.file_index.index_version;
     let entries = app.file_index.entries.values().cloned().collect();
-    let scan_finished = app.file_index.scan_finished;
+    let status = app.file_index.status;
     app.file_index.matcher = Some(spawn_matcher(generation, app.file_index_event_tx.clone()));
     send_matcher_command(
         app,
-        FileIndexMatcherCommand::Reset { generation, index_version, entries, scan_finished },
+        FileIndexMatcherCommand::Reset { generation, index_version, entries, status },
     );
 }
 
@@ -727,20 +804,24 @@ fn send_matcher_command(app: &mut App, command: FileIndexMatcherCommand) {
     let Some(matcher) = app.file_index.matcher.as_ref() else {
         return;
     };
-    if matcher.index_tx.send(command).is_err() {
-        app.file_index.matcher = None;
-        tracing::warn!(
-            target: crate::logging::targets::APP_FILE_INDEX,
-            event_name = "file_index_matcher_send_failed",
-            message = "file index matcher command channel is closed",
-            generation = app.file_index.generation,
-            index_version = app.file_index.index_version,
-        );
-    }
+    let error_kind = match matcher.index_tx.try_send(command) {
+        Ok(()) => return,
+        Err(TrySendError::Full(_)) => "full",
+        Err(TrySendError::Disconnected(_)) => "disconnected",
+    };
+    app.file_index.matcher = None;
+    tracing::warn!(
+        target: crate::logging::targets::APP_FILE_INDEX,
+        event_name = "file_index_matcher_send_failed",
+        message = "file index matcher command channel is unavailable; matcher will rebuild on demand",
+        error_kind,
+        generation = app.file_index.generation,
+        index_version = app.file_index.index_version,
+    );
 }
 
-fn spawn_matcher(generation: u64, event_tx: Sender<FileIndexEvent>) -> FileIndexMatcherHandle {
-    let (index_tx, index_rx) = mpsc::channel();
+fn spawn_matcher(generation: u64, event_tx: SyncSender<FileIndexEvent>) -> FileIndexMatcherHandle {
+    let (index_tx, index_rx) = mpsc::sync_channel(MATCHER_INDEX_QUEUE_CAPACITY);
     let (query_tx, query_rx) = mpsc::channel();
     std::thread::spawn(move || {
         FileIndexMatcherRuntime::new(generation, index_rx, query_rx, event_tx).run();
@@ -752,10 +833,10 @@ struct FileIndexMatcherRuntime {
     generation: u64,
     index_version: u64,
     matcher: MentionMatcher,
-    scan_finished: bool,
+    status: FileIndexStatus,
     index_rx: Receiver<FileIndexMatcherCommand>,
     query_rx: Receiver<MentionMatchRequest>,
-    event_tx: Sender<FileIndexEvent>,
+    event_tx: SyncSender<FileIndexEvent>,
 }
 
 struct CoalescedQuery {
@@ -768,13 +849,13 @@ impl FileIndexMatcherRuntime {
         generation: u64,
         index_rx: Receiver<FileIndexMatcherCommand>,
         query_rx: Receiver<MentionMatchRequest>,
-        event_tx: Sender<FileIndexEvent>,
+        event_tx: SyncSender<FileIndexEvent>,
     ) -> Self {
         Self {
             generation,
             index_version: 0,
             matcher: MentionMatcher::default(),
-            scan_finished: false,
+            status: FileIndexStatus::Scanning,
             index_rx,
             query_rx,
             event_tx,
@@ -856,19 +937,14 @@ impl FileIndexMatcherRuntime {
 
     fn apply_index_command(&mut self, command: FileIndexMatcherCommand) {
         match command {
-            FileIndexMatcherCommand::Reset {
-                generation,
-                index_version,
-                entries,
-                scan_finished,
-            } => {
-                self.reset(generation, index_version, entries, scan_finished);
+            FileIndexMatcherCommand::Reset { generation, index_version, entries, status } => {
+                self.reset(generation, index_version, entries, status);
             }
             FileIndexMatcherCommand::ScanBatch { generation, index_version, entries: batch } => {
                 self.apply_scan_batch(generation, index_version, batch);
             }
-            FileIndexMatcherCommand::ScanFinished { generation, index_version } => {
-                self.apply_scan_finished(generation, index_version);
+            FileIndexMatcherCommand::ScanFinished { generation, index_version, status } => {
+                self.apply_scan_finished(generation, index_version, status);
             }
             FileIndexMatcherCommand::FsBatch { generation, index_version, changes } => {
                 self.apply_fs_batch(generation, index_version, changes);
@@ -907,7 +983,12 @@ impl FileIndexMatcherRuntime {
         );
     }
 
-    fn apply_scan_finished(&mut self, generation: u64, index_version: u64) {
+    fn apply_scan_finished(
+        &mut self,
+        generation: u64,
+        index_version: u64,
+        status: FileIndexStatus,
+    ) {
         if generation != self.generation {
             self.log_ignored_index_command(
                 "file index matcher ignored stale scan finished",
@@ -919,7 +1000,7 @@ impl FileIndexMatcherRuntime {
             return;
         }
 
-        self.scan_finished = true;
+        self.status = status;
         self.index_version = index_version;
         tracing::debug!(
             target: crate::logging::targets::APP_FILE_INDEX,
@@ -929,6 +1010,7 @@ impl FileIndexMatcherRuntime {
             index_version = self.index_version,
             entries = self.matcher.len(),
             injected_items = self.matcher.injected_items(),
+            index_status = ?self.status,
         );
     }
 
@@ -994,14 +1076,14 @@ impl FileIndexMatcherRuntime {
         generation: u64,
         index_version: u64,
         entries: Vec<FileCandidate>,
-        scan_finished: bool,
+        status: FileIndexStatus,
     ) {
         let entries_before = self.matcher.len();
         let incoming_entries = entries.len();
         self.generation = generation;
         self.index_version = index_version;
         let upserts = self.matcher.reset(entries);
-        self.scan_finished = scan_finished;
+        self.status = status;
         tracing::debug!(
             target: crate::logging::targets::APP_FILE_INDEX,
             event_name = "file_index_matcher_reset",
@@ -1014,7 +1096,7 @@ impl FileIndexMatcherRuntime {
             injected_items = self.matcher.injected_items(),
             inserted = upserts.inserted,
             replaced = upserts.replaced,
-            scan_finished = self.scan_finished,
+            index_status = ?self.status,
         );
     }
 
@@ -1070,7 +1152,7 @@ impl FileIndexMatcherRuntime {
             query_chars = request.query.chars().count(),
             query_bytes = request.query.len(),
             result_count = candidates.len(),
-            scan_finished = self.scan_finished,
+            index_status = ?self.status,
             match_strategy = "nucleo",
             nucleo_ticks = tick_count,
             nucleo_running = status.running,
@@ -1083,7 +1165,7 @@ impl FileIndexMatcherRuntime {
             sequence: request.sequence,
             query: request.query,
             candidates,
-            scan_finished: self.scan_finished,
+            status: self.status,
         };
         self.event_tx.send(FileIndexEvent::MatchResult(result)).is_ok()
     }
@@ -1093,7 +1175,7 @@ fn spawn_scan(
     root: PathBuf,
     generation: u64,
     respect_gitignore: bool,
-    event_tx: Sender<FileIndexEvent>,
+    event_tx: SyncSender<FileIndexEvent>,
 ) -> FileIndexScanHandle {
     let cancel = Arc::new(AtomicBool::new(false));
     let cancel_clone = Arc::clone(&cancel);
@@ -1108,22 +1190,31 @@ fn run_scan(
     generation: u64,
     respect_gitignore: bool,
     cancel: &Arc<AtomicBool>,
-    event_tx: &Sender<FileIndexEvent>,
+    event_tx: &SyncSender<FileIndexEvent>,
+) {
+    run_scan_with_limit(root, generation, respect_gitignore, cancel, event_tx, MAX_INDEX_ENTRIES);
+}
+
+fn run_scan_with_limit(
+    root: &Path,
+    generation: u64,
+    respect_gitignore: bool,
+    cancel: &Arc<AtomicBool>,
+    event_tx: &SyncSender<FileIndexEvent>,
+    max_entries: usize,
 ) {
     let started_at = Instant::now();
-    tracing::info!(
-        target: crate::logging::targets::APP_FILE_INDEX,
-        event_name = "file_index_scan_started",
-        message = "file index scan started",
-        generation,
-        root = %root.display(),
-        respect_gitignore,
-        batch_size = SCAN_BATCH_SIZE,
-    );
+    log_scan_started(root, generation, respect_gitignore, max_entries);
     let mut batch = Vec::with_capacity(SCAN_BATCH_SIZE);
     let mut candidates_seen = 0usize;
     let mut batches_sent = 0usize;
+    let mut limited = false;
+    let mut receiver_dropped = false;
     let mut emit_candidate = |candidate: FileCandidate| {
+        if candidates_seen >= max_entries {
+            limited = true;
+            return false;
+        }
         candidates_seen += 1;
         batch.push(candidate);
         if batch.len() < SCAN_BATCH_SIZE {
@@ -1141,30 +1232,15 @@ fn run_scan(
                 duration_ms = elapsed_ms(started_at),
             );
         }
-        event_tx
+        let sent = event_tx
             .send(FileIndexEvent::ScanBatch { generation, entries: std::mem::take(&mut batch) })
-            .is_ok()
+            .is_ok();
+        receiver_dropped = !sent;
+        sent
     };
-    if !for_each_candidate(
-        root,
-        root,
-        respect_gitignore,
-        Some(1),
-        Some(cancel),
-        &mut emit_candidate,
-    ) {
-        tracing::info!(
-            target: crate::logging::targets::APP_FILE_INDEX,
-            event_name = "file_index_scan_cancelled",
-            message = "file index shallow scan cancelled before completion",
-            generation,
-            candidates_seen,
-            batches_sent,
-            duration_ms = elapsed_ms(started_at),
-        );
-        return;
-    }
-    if !for_each_candidate(root, root, respect_gitignore, None, Some(cancel), &mut emit_candidate) {
+    let scan_complete =
+        for_each_candidate(root, root, respect_gitignore, Some(cancel), &mut emit_candidate);
+    if !scan_complete && !limited {
         tracing::info!(
             target: crate::logging::targets::APP_FILE_INDEX,
             event_name = "file_index_scan_cancelled",
@@ -1174,6 +1250,9 @@ fn run_scan(
             batches_sent,
             duration_ms = elapsed_ms(started_at),
         );
+        return;
+    }
+    if receiver_dropped || cancel.load(AtomicOrdering::Relaxed) {
         return;
     }
     let final_batch_len = batch.len();
@@ -1193,7 +1272,7 @@ fn run_scan(
             return;
         }
     }
-    let _ = event_tx.send(FileIndexEvent::ScanFinished { generation });
+    let _ = event_tx.send(FileIndexEvent::ScanFinished { generation, limited });
     tracing::info!(
         target: crate::logging::targets::APP_FILE_INDEX,
         event_name = "file_index_scan_finished",
@@ -1202,7 +1281,22 @@ fn run_scan(
         candidates_seen,
         batches_sent,
         final_batch_len,
+        limited,
+        max_entries,
         duration_ms = elapsed_ms(started_at),
+    );
+}
+
+fn log_scan_started(root: &Path, generation: u64, respect_gitignore: bool, max_entries: usize) {
+    tracing::info!(
+        target: crate::logging::targets::APP_FILE_INDEX,
+        event_name = "file_index_scan_started",
+        message = "file index scan started",
+        generation,
+        root = %root.display(),
+        respect_gitignore,
+        batch_size = SCAN_BATCH_SIZE,
+        max_entries,
     );
 }
 
@@ -1210,82 +1304,145 @@ fn spawn_watch(
     root: &Path,
     generation: u64,
     respect_gitignore: bool,
-    event_tx: Sender<FileIndexEvent>,
+    event_tx: SyncSender<FileIndexEvent>,
 ) -> FileIndexWatchHandle {
     let cancel = Arc::new(AtomicBool::new(false));
     let cancel_clone = Arc::clone(&cancel);
     let root_for_thread = root.to_path_buf();
     std::thread::spawn(move || {
-        tracing::info!(
-            target: crate::logging::targets::APP_FILE_INDEX,
-            event_name = "file_index_watch_started",
-            message = "file index watcher thread started",
-            generation,
-            root = %root_for_thread.display(),
-            respect_gitignore,
-            debounce_ms = WATCH_DEBOUNCE_INTERVAL.as_millis(),
-        );
-        let (watch_tx, watch_rx) = mpsc::channel();
-        let mut watcher = match notify::recommended_watcher(move |result| {
-            let _ = watch_tx.send(result);
-        }) {
-            Ok(watcher) => watcher,
-            Err(err) => {
-                tracing::warn!(
-                    target: crate::logging::targets::APP_FILE_INDEX,
-                    event_name = "file_index_watch_setup_failed",
-                    message = "file index watcher setup failed",
-                    generation,
-                    root = %root_for_thread.display(),
-                    error_message = %err,
-                );
-                return;
-            }
-        };
-        if let Err(err) =
-            notify::Watcher::watch(&mut watcher, &root_for_thread, notify::RecursiveMode::Recursive)
-        {
+        run_watch(&root_for_thread, generation, respect_gitignore, &cancel_clone, &event_tx);
+    });
+    FileIndexWatchHandle { cancel }
+}
+
+fn run_watch(
+    root: &Path,
+    generation: u64,
+    respect_gitignore: bool,
+    cancel: &AtomicBool,
+    event_tx: &SyncSender<FileIndexEvent>,
+) {
+    tracing::info!(
+        target: crate::logging::targets::APP_FILE_INDEX,
+        event_name = "file_index_watch_started",
+        message = "file index watcher thread started",
+        generation,
+        root = %root.display(),
+        respect_gitignore,
+        debounce_ms = WATCH_DEBOUNCE_INTERVAL.as_millis(),
+    );
+    let watch_overflowed = Arc::new(AtomicBool::new(false));
+    let watch_overflowed_for_callback = Arc::clone(&watch_overflowed);
+    let (watch_tx, watch_rx) = mpsc::sync_channel(WATCH_EVENT_QUEUE_CAPACITY);
+    let mut watcher = match notify::recommended_watcher(move |result| {
+        if matches!(watch_tx.try_send(result), Err(TrySendError::Full(_))) {
+            watch_overflowed_for_callback.store(true, AtomicOrdering::Relaxed);
+        }
+    }) {
+        Ok(watcher) => watcher,
+        Err(err) => {
             tracing::warn!(
                 target: crate::logging::targets::APP_FILE_INDEX,
-                event_name = "file_index_watch_start_failed",
-                message = "file index watcher start failed",
+                event_name = "file_index_watch_setup_failed",
+                message = "file index watcher setup failed",
                 generation,
-                root = %root_for_thread.display(),
+                root = %root.display(),
                 error_message = %err,
             );
             return;
         }
-
-        let mut pending = Vec::new();
-        while !cancel_clone.load(AtomicOrdering::Relaxed) {
-            let timeout =
-                if pending.is_empty() { WATCH_POLL_INTERVAL } else { WATCH_DEBOUNCE_INTERVAL };
-            match watch_rx.recv_timeout(timeout) {
-                Ok(event) => pending.push(event),
-                Err(RecvTimeoutError::Timeout) if pending.is_empty() => {}
-                Err(RecvTimeoutError::Timeout) => {
-                    if let Some(next_event) = normalize_watch_events(
-                        &root_for_thread,
-                        generation,
-                        respect_gitignore,
-                        pending.drain(..),
-                    ) {
-                        let _ = event_tx.send(next_event);
-                    }
-                }
-                Err(RecvTimeoutError::Disconnected) => break,
-            }
-        }
-        if let Some(next_event) = normalize_watch_events(
-            &root_for_thread,
+    };
+    if let Err(err) = notify::Watcher::watch(&mut watcher, root, notify::RecursiveMode::Recursive) {
+        tracing::warn!(
+            target: crate::logging::targets::APP_FILE_INDEX,
+            event_name = "file_index_watch_start_failed",
+            message = "file index watcher start failed",
             generation,
-            respect_gitignore,
-            pending.drain(..),
-        ) {
-            let _ = event_tx.send(next_event);
+            root = %root.display(),
+            error_message = %err,
+        );
+        return;
+    }
+    run_watch_loop(
+        root,
+        generation,
+        respect_gitignore,
+        cancel,
+        &watch_overflowed,
+        &watch_rx,
+        event_tx,
+    );
+}
+
+fn run_watch_loop(
+    root: &Path,
+    generation: u64,
+    respect_gitignore: bool,
+    cancel: &AtomicBool,
+    watch_overflowed: &AtomicBool,
+    watch_rx: &Receiver<notify::Result<notify::Event>>,
+    event_tx: &SyncSender<FileIndexEvent>,
+) {
+    let mut pending = Vec::new();
+    while !cancel.load(AtomicOrdering::Relaxed) {
+        if watch_overflowed.swap(false, AtomicOrdering::Relaxed) {
+            tracing::warn!(
+                target: crate::logging::targets::APP_FILE_INDEX,
+                event_name = "file_index_watch_overflowed",
+                message = "file index watcher exceeded its event buffer; requesting a bounded rebuild",
+                generation,
+                root = %root.display(),
+                queue_capacity = WATCH_EVENT_QUEUE_CAPACITY,
+            );
+            let _ = event_tx.send(FileIndexEvent::RebuildRequested { generation });
+            return;
         }
-    });
-    FileIndexWatchHandle { cancel }
+        let timeout =
+            if pending.is_empty() { WATCH_POLL_INTERVAL } else { WATCH_DEBOUNCE_INTERVAL };
+        match watch_rx.recv_timeout(timeout) {
+            Ok(event) => {
+                pending.push(event);
+                if pending.len() >= WATCH_EVENT_QUEUE_CAPACITY {
+                    tracing::warn!(
+                        target: crate::logging::targets::APP_FILE_INDEX,
+                        event_name = "file_index_watch_batch_limit_reached",
+                        message = "file index watcher exceeded its debounce batch; requesting a bounded rebuild",
+                        generation,
+                        root = %root.display(),
+                        batch_limit = WATCH_EVENT_QUEUE_CAPACITY,
+                    );
+                    let _ = event_tx.send(FileIndexEvent::RebuildRequested { generation });
+                    return;
+                }
+            }
+            Err(RecvTimeoutError::Timeout) if pending.is_empty() => {}
+            Err(RecvTimeoutError::Timeout) => {
+                if !send_watch_events(
+                    root,
+                    generation,
+                    respect_gitignore,
+                    pending.drain(..),
+                    event_tx,
+                ) {
+                    return;
+                }
+            }
+            Err(RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    let _ = send_watch_events(root, generation, respect_gitignore, pending, event_tx);
+}
+
+fn send_watch_events(
+    root: &Path,
+    generation: u64,
+    respect_gitignore: bool,
+    events: impl IntoIterator<Item = notify::Result<notify::Event>>,
+    event_tx: &SyncSender<FileIndexEvent>,
+) -> bool {
+    normalize_watch_events(root, generation, respect_gitignore, events)
+        .into_iter()
+        .all(|event| event_tx.send(event).is_ok())
 }
 
 fn normalize_watch_events(
@@ -1293,7 +1450,7 @@ fn normalize_watch_events(
     generation: u64,
     respect_gitignore: bool,
     events: impl IntoIterator<Item = notify::Result<notify::Event>>,
-) -> Option<FileIndexEvent> {
+) -> Vec<FileIndexEvent> {
     use notify::event::{CreateKind, EventKind, ModifyKind, RemoveKind, RenameMode};
 
     let mut rebuild = false;
@@ -1359,17 +1516,20 @@ fn normalize_watch_events(
             rename_paths = rename_paths.len(),
             remove_paths = remove_paths.len(),
         );
-        return Some(FileIndexEvent::RebuildRequested { generation });
+        return vec![FileIndexEvent::RebuildRequested { generation }];
     }
 
-    let mut changes = Vec::new();
-    changes.extend(collect_rename_changes(root, respect_gitignore, &rename_paths));
-    changes.extend(collect_create_or_modify_changes(
-        root,
-        respect_gitignore,
-        &create_or_modify_paths,
-    ));
+    let Some(mut changes) = collect_rename_changes(root, respect_gitignore, &rename_paths) else {
+        return vec![FileIndexEvent::RebuildRequested { generation }];
+    };
+    let Some(create_or_modify_changes) =
+        collect_create_or_modify_changes(root, respect_gitignore, &create_or_modify_paths)
+    else {
+        return vec![FileIndexEvent::RebuildRequested { generation }];
+    };
+    changes.extend(create_or_modify_changes);
     changes.extend(collect_remove_changes(root, &remove_paths));
+    let events = chunk_fs_changes(generation, changes);
     if raw_events > 0 {
         tracing::debug!(
             target: crate::logging::targets::APP_FILE_INDEX,
@@ -1380,11 +1540,23 @@ fn normalize_watch_events(
             create_or_modify_paths = create_or_modify_paths.len(),
             rename_paths = rename_paths.len(),
             remove_paths = remove_paths.len(),
-            changes = changes.len(),
+            fs_batches = events.len(),
         );
     }
 
-    (!changes.is_empty()).then_some(FileIndexEvent::FsBatch { generation, changes })
+    events
+}
+
+fn chunk_fs_changes(generation: u64, changes: Vec<FileIndexChange>) -> Vec<FileIndexEvent> {
+    let mut changes = changes.into_iter();
+    let mut events = Vec::new();
+    loop {
+        let batch = changes.by_ref().take(SCAN_BATCH_SIZE).collect::<Vec<_>>();
+        if batch.is_empty() {
+            return events;
+        }
+        events.push(FileIndexEvent::FsBatch { generation, changes: batch });
+    }
 }
 
 fn extend_unique_paths(paths: &mut Vec<PathBuf>, next_paths: impl IntoIterator<Item = PathBuf>) {
@@ -1419,13 +1591,11 @@ fn collect_create_or_modify_changes(
     root: &Path,
     respect_gitignore: bool,
     paths: &[PathBuf],
-) -> Vec<FileIndexChange> {
+) -> Option<Vec<FileIndexChange>> {
     let mut changes = Vec::new();
     for path in paths {
         if path.is_dir() {
-            if let Some(change) = replace_subtree_change(root, path, respect_gitignore) {
-                changes.push(change);
-            }
+            return None;
         } else if path.is_file() {
             let mut entries = scan_subtree(root, path, respect_gitignore);
             if let Some(candidate) = entries.pop() {
@@ -1435,7 +1605,7 @@ fn collect_create_or_modify_changes(
             }
         }
     }
-    changes
+    Some(changes)
 }
 
 fn collect_remove_changes(root: &Path, paths: &[PathBuf]) -> Vec<FileIndexChange> {
@@ -1454,60 +1624,35 @@ fn collect_rename_changes(
     root: &Path,
     respect_gitignore: bool,
     paths: &[PathBuf],
-) -> Vec<FileIndexChange> {
-    if paths.len() < 2 {
+) -> Option<Vec<FileIndexChange>> {
+    if paths.is_empty() {
+        return Some(Vec::new());
+    }
+    if paths.len() == 1 {
         // macOS FSEvents emits two separate RenameMode::Any events (one per
         // path) instead of a single paired event. If the path no longer exists
         // it is the "from" side of the rename and should be treated as a remove.
         if paths.first().is_some_and(|p| !p.exists()) {
-            return collect_remove_changes(root, paths);
+            return Some(collect_remove_changes(root, paths));
         }
-        return collect_parent_rescan_changes(root, respect_gitignore, paths);
+        return collect_create_or_modify_changes(root, respect_gitignore, paths);
     }
-    collect_parent_rescan_changes(root, respect_gitignore, paths)
+    if paths.len() != 2 {
+        return None;
+    }
+    let mut changes = collect_remove_changes(root, &paths[..1]);
+    changes.extend(collect_create_or_modify_changes(root, respect_gitignore, &paths[1..])?);
+    Some(changes)
 }
 
 fn scan_subtree(root: &Path, path: &Path, respect_gitignore: bool) -> Vec<FileCandidate> {
     collect_candidates(root, path, respect_gitignore, None)
 }
 
-fn collect_parent_rescan_changes(
-    root: &Path,
-    respect_gitignore: bool,
-    paths: &[PathBuf],
-) -> Vec<FileIndexChange> {
-    let mut changes = Vec::new();
-    let mut seen_prefixes = BTreeSet::new();
-    for path in paths {
-        let Some(parent) = path.parent() else { continue };
-        let Some(change) = replace_subtree_change(root, parent, respect_gitignore) else {
-            continue;
-        };
-        let FileIndexChange::ReplacePrefix { rel_prefix, .. } = &change else {
-            continue;
-        };
-        if seen_prefixes.insert(rel_prefix.clone()) {
-            changes.push(change);
-        }
-    }
-    changes
-}
-
-fn replace_subtree_change(
-    root: &Path,
-    path: &Path,
-    respect_gitignore: bool,
-) -> Option<FileIndexChange> {
-    let rel_prefix = if path == root { String::new() } else { normalized_prefix(root, path)? };
-    let entries = scan_subtree(root, path, respect_gitignore);
-    Some(FileIndexChange::ReplacePrefix { rel_prefix, entries })
-}
-
 fn for_each_candidate(
     root: &Path,
     walk_root: &Path,
     respect_gitignore: bool,
-    max_depth: Option<usize>,
     cancel: Option<&Arc<AtomicBool>>,
     emit: &mut impl FnMut(FileCandidate) -> bool,
 ) -> bool {
@@ -1518,7 +1663,6 @@ fn for_each_candidate(
         .git_global(respect_gitignore)
         .git_exclude(respect_gitignore)
         .sort_by_file_path(std::cmp::Ord::cmp);
-    builder.max_depth(max_depth);
 
     for result in builder.build() {
         if cancel.is_some_and(|flag| flag.load(AtomicOrdering::Relaxed)) {
@@ -1541,11 +1685,10 @@ fn collect_candidates(
     cancel: Option<&Arc<AtomicBool>>,
 ) -> Vec<FileCandidate> {
     let mut candidates = Vec::new();
-    let _ =
-        for_each_candidate(root, walk_root, respect_gitignore, None, cancel, &mut |candidate| {
-            candidates.push(candidate);
-            true
-        });
+    let _ = for_each_candidate(root, walk_root, respect_gitignore, cancel, &mut |candidate| {
+        candidates.push(candidate);
+        true
+    });
     candidates
 }
 
@@ -1578,10 +1721,6 @@ fn normalize_relative_path(root: &Path, path: &Path) -> Option<String> {
     (!rel_str.is_empty()).then_some(rel_str)
 }
 
-fn normalized_prefix(root: &Path, path: &Path) -> Option<String> {
-    normalize_relative_path(root, path).map(ensure_dir_suffix)
-}
-
 fn ensure_dir_suffix(mut rel_path: String) -> String {
     if !rel_path.ends_with('/') {
         rel_path.push('/');
@@ -1603,8 +1742,7 @@ impl ScanOverrides {
             FileIndexChange::RemoveExact { rel_path } => {
                 self.exact_paths.insert(rel_path.clone());
             }
-            FileIndexChange::RemovePrefix { rel_prefix }
-            | FileIndexChange::ReplacePrefix { rel_prefix, .. } => {
+            FileIndexChange::RemovePrefix { rel_prefix } => {
                 self.blocked_prefixes.push(rel_prefix.clone());
             }
         }
@@ -1662,14 +1800,42 @@ mod tests {
     }
 
     #[test]
+    fn candidate_walk_respects_root_and_nested_gitignore_files() {
+        let (app, _tmp) = app_with_temp_files(&[
+            ".git/marker",
+            ".gitignore",
+            "ignored.rs",
+            "visible.rs",
+            "src/.gitignore",
+            "src/hidden.rs",
+            "src/visible.rs",
+        ]);
+        let root = PathBuf::from(app.cwd_raw);
+        std::fs::write(root.join(".gitignore"), "ignored.rs\n").expect("write root gitignore");
+        std::fs::write(root.join("src/.gitignore"), "hidden.rs\n").expect("write nested gitignore");
+        let mut paths = Vec::new();
+
+        assert!(for_each_candidate(&root, &root, true, None, &mut |candidate| {
+            paths.push(candidate.rel_path);
+            true
+        },));
+
+        assert!(paths.iter().any(|path| path == "visible.rs"));
+        assert!(paths.iter().any(|path| path == "src/visible.rs"));
+        assert!(!paths.iter().any(|path| path == "ignored.rs"), "paths: {paths:?}");
+        assert!(!paths.iter().any(|path| path == "src/hidden.rs"), "paths: {paths:?}");
+    }
+
+    #[test]
     fn reopening_mention_reuses_existing_generation() {
         let (mut app, _tmp) = app_with_temp_files(&["src/main.rs"]);
+        restart(&mut app);
         app.input.set_text("@rs");
         let _ = app.input.set_cursor(0, 3);
 
         mention::activate(&mut app);
         wait_for(&mut app, Duration::from_secs(2), |app| {
-            app.file_index.scan_finished && !app.file_index.entries.is_empty()
+            app.file_index.status.is_finished() && !app.file_index.entries.is_empty()
         });
         let generation = app.file_index.generation;
 
@@ -1707,7 +1873,7 @@ mod tests {
     fn live_remove_blocks_late_scan_entry_from_same_generation() {
         let mut app = App::test_default();
         app.file_index.generation = 7;
-        app.file_index.scan_finished = false;
+        app.file_index.status = FileIndexStatus::Scanning;
 
         app.file_index_event_tx
             .send(FileIndexEvent::FsBatch {
@@ -1747,26 +1913,6 @@ mod tests {
             entries.iter().map(|candidate| candidate.rel_path.as_str()).collect::<Vec<_>>();
         assert_eq!(remaining, vec!["a.rs"]);
         assert_eq!(entries.len(), 1);
-    }
-
-    #[test]
-    fn matcher_entries_replace_prefix_keeps_lookup_consistent() {
-        let mut entries = MatcherEntries::default();
-        entries.upsert(candidate("src/a.rs"));
-        entries.upsert(candidate("src/nested/b.rs"));
-        entries.upsert(candidate("tests/c.rs"));
-
-        let (removed, stats) =
-            entries.replace_prefix("src/", vec![candidate("src/new.rs"), candidate("src/lib.rs")]);
-
-        assert_eq!(removed, 2);
-        assert_eq!(stats.inserted, 2);
-        assert_eq!(stats.replaced, 0);
-        assert!(!entries.remove_exact("src/a.rs"));
-        assert!(entries.remove_exact("src/new.rs"));
-        assert!(entries.remove_exact("src/lib.rs"));
-        assert!(entries.remove_exact("tests/c.rs"));
-        assert_eq!(entries.len(), 0);
     }
 
     fn mention_matcher_paths(matcher: &mut MentionMatcher, query: &str) -> Vec<String> {
@@ -1867,9 +2013,9 @@ mod tests {
     fn matcher_runtime_prioritizes_query_over_pending_scan_batches() {
         let (index_tx, index_rx) = mpsc::channel();
         let (query_tx, query_rx) = mpsc::channel();
-        let (event_tx, event_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::sync_channel(EVENT_QUEUE_CAPACITY);
         let mut runtime = FileIndexMatcherRuntime::new(1, index_rx, query_rx, event_tx);
-        runtime.reset(1, 1, vec![candidate("target.rs")], false);
+        runtime.reset(1, 1, vec![candidate("target.rs")], FileIndexStatus::Scanning);
         for idx in 0..32 {
             index_tx
                 .send(FileIndexMatcherCommand::ScanBatch {
@@ -1907,7 +2053,7 @@ mod tests {
             std::fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
             std::fs::write(path, "").expect("write file");
         }
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::sync_channel(EVENT_QUEUE_CAPACITY);
         let _scan = spawn_scan(tmp.path().to_path_buf(), 1, true, tx);
 
         let first = rx.recv_timeout(Duration::from_secs(2)).expect("first scan event");
@@ -1915,7 +2061,72 @@ mod tests {
     }
 
     #[test]
-    fn spawn_scan_emits_root_children_before_deep_subtrees() {
+    fn file_index_event_channel_applies_bounded_backpressure() {
+        let (tx, _rx) = event_channel();
+        for generation in 0..EVENT_QUEUE_CAPACITY {
+            tx.try_send(FileIndexEvent::ScanFinished {
+                generation: generation as u64,
+                limited: false,
+            })
+            .expect("event should fit within configured capacity");
+        }
+
+        assert!(matches!(
+            tx.try_send(FileIndexEvent::ScanFinished { generation: 99, limited: false }),
+            Err(mpsc::TrySendError::Full(_))
+        ));
+    }
+
+    #[test]
+    fn scan_stops_at_the_entry_limit_and_reports_partial_state() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        for idx in 0..5 {
+            std::fs::write(tmp.path().join(format!("file-{idx}.rs")), "").expect("write file");
+        }
+        let (tx, rx) = mpsc::sync_channel(EVENT_QUEUE_CAPACITY);
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        run_scan_with_limit(tmp.path(), 7, true, &cancel, &tx, 3);
+
+        let mut entries = Vec::new();
+        let mut limited = false;
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                FileIndexEvent::ScanBatch { entries: batch, .. } => entries.extend(batch),
+                FileIndexEvent::ScanFinished { limited: event_limited, .. } => {
+                    limited = event_limited;
+                }
+                FileIndexEvent::FsBatch { .. }
+                | FileIndexEvent::RebuildRequested { .. }
+                | FileIndexEvent::MatchResult(_) => {}
+            }
+        }
+
+        assert_eq!(entries.len(), 3);
+        assert!(limited);
+    }
+
+    #[test]
+    fn background_index_updates_do_not_repaint_without_an_active_mention() {
+        let mut app = App::test_default();
+        app.file_index.generation = 4;
+        app.file_index.status = FileIndexStatus::Scanning;
+        app.surface_dirty.chat.repaint = false;
+        app.file_index_event_tx
+            .send(FileIndexEvent::ScanBatch {
+                generation: 4,
+                entries: vec![candidate("src/main.rs")],
+            })
+            .expect("send scan batch");
+
+        drain_events(&mut app);
+
+        assert!(app.file_index.entries.contains_key("src/main.rs"));
+        assert!(!app.surface_dirty.chat.repaint);
+    }
+
+    #[test]
+    fn spawn_scan_indexes_each_candidate_once_in_a_single_walk() {
         let tmp = tempfile::tempdir().expect("tempdir");
         std::fs::create_dir_all(tmp.path().join("aaa_huge")).expect("create huge sibling");
         std::fs::create_dir_all(tmp.path().join("web_dev_work")).expect("create target sibling");
@@ -1923,22 +2134,35 @@ mod tests {
             let path = tmp.path().join("aaa_huge").join(format!("file-{idx}.rs"));
             std::fs::write(path, "").expect("write file");
         }
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::sync_channel(EVENT_QUEUE_CAPACITY);
         let _scan = spawn_scan(tmp.path().to_path_buf(), 1, true, tx);
+        let mut paths = Vec::new();
 
-        let first = rx.recv_timeout(Duration::from_secs(2)).expect("first scan event");
-        let FileIndexEvent::ScanBatch { entries, .. } = first else {
-            panic!("expected first scan batch");
-        };
+        loop {
+            match rx.recv_timeout(Duration::from_secs(2)).expect("scan event") {
+                FileIndexEvent::ScanBatch { entries, .. } => {
+                    paths.extend(entries.into_iter().map(|candidate| candidate.rel_path));
+                }
+                FileIndexEvent::ScanFinished { limited, .. } => {
+                    assert!(!limited);
+                    break;
+                }
+                FileIndexEvent::FsBatch { .. }
+                | FileIndexEvent::RebuildRequested { .. }
+                | FileIndexEvent::MatchResult(_) => panic!("unexpected scan event"),
+            }
+        }
 
-        assert!(entries.iter().any(|candidate| candidate.rel_path == "web_dev_work/"));
+        let unique = paths.iter().collect::<BTreeSet<_>>();
+        assert_eq!(unique.len(), paths.len());
+        assert!(paths.iter().any(|path| path == "web_dev_work/"));
     }
 
     #[test]
     fn fs_batch_create_updates_matcher_candidates_without_real_watcher() {
         let mut app = App::test_default();
         app.file_index.generation = 5;
-        app.file_index.scan_finished = true;
+        app.file_index.status = FileIndexStatus::Complete;
         app.file_index.entries.insert("existing.rs".to_owned(), candidate("existing.rs"));
         app.mention = Some(mention::MentionState::new(0, 0, "new".to_owned(), Vec::new()));
 
@@ -1973,7 +2197,7 @@ mod tests {
         let (mut app, tmp) = app_with_temp_files(&["before.rs", "keep.rs"]);
         let root = tmp.path().canonicalize().expect("canonicalize tempdir");
         app.file_index.generation = 9;
-        app.file_index.scan_finished = true;
+        app.file_index.status = FileIndexStatus::Complete;
         app.file_index.root = Some(root.clone());
         app.file_index.entries.insert("before.rs".to_owned(), candidate("before.rs"));
         app.file_index.entries.insert("keep.rs".to_owned(), candidate("keep.rs"));
@@ -1982,7 +2206,8 @@ mod tests {
         std::fs::rename(root.join("before.rs"), root.join("after.rs"))
             .expect("rename watched file");
         let changes =
-            collect_rename_changes(&root, true, &[root.join("before.rs"), root.join("after.rs")]);
+            collect_rename_changes(&root, true, &[root.join("before.rs"), root.join("after.rs")])
+                .expect("file rename should not require rebuild");
         app.file_index_event_tx
             .send(FileIndexEvent::FsBatch { generation: 9, changes })
             .expect("send rename fs batch");
@@ -2020,7 +2245,9 @@ mod tests {
             Ok(Event::new(EventKind::Create(CreateKind::File)).add_path(root.join("b.rs"))),
         ];
 
-        let event = normalize_watch_events(&root, 3, true, events).expect("watch event");
+        let mut normalized = normalize_watch_events(&root, 3, true, events);
+        assert_eq!(normalized.len(), 1);
+        let event = normalized.pop().expect("watch event");
 
         let FileIndexEvent::FsBatch { generation, changes } = event else {
             panic!("expected fs batch");
@@ -2036,6 +2263,20 @@ mod tests {
     }
 
     #[test]
+    fn watcher_changes_are_split_into_bounded_batches() {
+        let changes = (0..=SCAN_BATCH_SIZE)
+            .map(|idx| FileIndexChange::Upsert(candidate(&format!("file-{idx}.rs"))))
+            .collect();
+
+        let events = chunk_fs_changes(3, changes);
+
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|event| {
+            matches!(event, FileIndexEvent::FsBatch { changes, .. } if changes.len() <= SCAN_BATCH_SIZE)
+        }));
+    }
+
+    #[test]
     fn batched_watch_events_prefer_rebuild_for_ignore_semantics_change() {
         use notify::Event;
         use notify::event::{CreateKind, EventKind};
@@ -2047,28 +2288,29 @@ mod tests {
             Ok(Event::new(EventKind::Create(CreateKind::File)).add_path(root.join(".gitignore"))),
         ];
 
-        let event = normalize_watch_events(&root, 5, true, events).expect("watch event");
+        let mut normalized = normalize_watch_events(&root, 5, true, events);
+        assert_eq!(normalized.len(), 1);
+        let event = normalized.pop().expect("watch event");
 
         assert!(matches!(event, FileIndexEvent::RebuildRequested { generation: 5 }));
     }
 
     #[test]
-    fn root_file_rename_rescans_root_subtree() {
+    fn root_file_rename_emits_bounded_remove_and_upsert_changes() {
         let (_app, tmp) = app_with_temp_files(&["before.rs", "keep.rs"]);
         let root = tmp.path().canonicalize().expect("canonicalize tempdir");
         std::fs::rename(root.join("before.rs"), root.join("after.rs"))
             .expect("rename watched file");
 
         let changes =
-            collect_rename_changes(&root, true, &[root.join("before.rs"), root.join("after.rs")]);
+            collect_rename_changes(&root, true, &[root.join("before.rs"), root.join("after.rs")])
+                .expect("file rename should not require rebuild");
 
-        assert_eq!(changes.len(), 1);
-        let FileIndexChange::ReplacePrefix { rel_prefix, entries } = &changes[0] else {
-            panic!("expected replace prefix");
-        };
-        assert_eq!(rel_prefix, "");
-        assert!(entries.iter().any(|candidate| candidate.rel_path == "after.rs"));
-        assert!(entries.iter().any(|candidate| candidate.rel_path == "keep.rs"));
-        assert!(!entries.iter().any(|candidate| candidate.rel_path == "before.rs"));
+        assert!(changes.iter().any(|change| {
+            matches!(change, FileIndexChange::RemoveExact { rel_path } if rel_path == "before.rs")
+        }));
+        assert!(changes.iter().any(|change| {
+            matches!(change, FileIndexChange::Upsert(candidate) if candidate.rel_path == "after.rs")
+        }));
     }
 }

--- a/src/app/input_submit.rs
+++ b/src/app/input_submit.rs
@@ -6,7 +6,7 @@ use crate::agent::model;
 use crate::app::slash;
 
 pub(super) fn submit_input(app: &mut App) {
-    if matches!(app.status, AppStatus::Connecting | AppStatus::CommandPending | AppStatus::Error) {
+    if !app.composer_access().can_submit() {
         return;
     }
 
@@ -134,6 +134,17 @@ mod tests {
         app.session_runtime.conn = Some(std::rc::Rc::new(connection));
         app.session_runtime.session_id = Some(model::SessionId::new("session-1"));
         (app, rx)
+    }
+
+    #[test]
+    fn connecting_submission_preserves_the_draft() {
+        let mut app = App::test_default();
+        app.status = AppStatus::Connecting;
+        app.input.set_text("draft while connecting");
+
+        submit_input(&mut app);
+
+        assert_eq!(app.input.text(), "draft while connecting");
     }
 
     #[test]

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -90,7 +90,7 @@ pub(super) fn is_ctrl_char_shortcut(key: KeyEvent, expected: char) -> bool {
 }
 
 pub(super) fn dispatch_key_by_focus(app: &mut App, key: KeyEvent) -> KeyOutcome {
-    if matches!(app.status, AppStatus::Connecting | AppStatus::CommandPending | AppStatus::Error) {
+    if !app.composer_access().can_edit() {
         return handle_keymap_context(app, KeyContext::ChatBlocked, key);
     }
 
@@ -475,6 +475,10 @@ fn handle_turn_control(app: &mut App) -> bool {
 }
 
 fn handle_submit(app: &mut App) -> bool {
+    if !app.composer_access().can_submit() {
+        app.pending_submit = None;
+        return true;
+    }
     let now = Instant::now();
 
     // During an active burst or the post-burst suppression window, Enter

--- a/src/app/mention.rs
+++ b/src/app/mention.rs
@@ -39,9 +39,11 @@ pub struct CommittedMentionSpan {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MentionSearchStatus {
     Hint,
+    WaitingForIndex,
     Searching,
     Ready,
     NoMatches,
+    Limited,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -109,8 +111,15 @@ impl MentionState {
 
         match self.search_status {
             MentionSearchStatus::Hint => Some("Type a file or folder name after @".to_owned()),
+            MentionSearchStatus::WaitingForIndex => {
+                Some("File search will start when the session is ready".to_owned())
+            }
             MentionSearchStatus::Searching => Some("Searching files...".to_owned()),
             MentionSearchStatus::NoMatches => Some("No matching files or folders".to_owned()),
+            MentionSearchStatus::Limited => Some(format!(
+                "No match in the first {} indexed files or folders",
+                file_index::MAX_INDEX_ENTRIES
+            )),
             MentionSearchStatus::Ready => None,
         }
     }
@@ -331,15 +340,17 @@ pub fn apply_match_result(app: &mut App, result: file_index::MentionMatchResult)
     mention.pending_match_sequence = None;
     let needs_follow_up = mention.refresh_after_pending_match
         || result.index_version < app.file_index.index_version
-        || result.scan_finished != app.file_index.scan_finished;
+        || result.status != app.file_index.status;
     mention.refresh_after_pending_match = false;
     mention.search_status = if mention.candidates.is_empty() {
-        if result.scan_finished {
+        if result.status.is_limited() {
+            MentionSearchStatus::Limited
+        } else if result.status.is_finished() {
             MentionSearchStatus::NoMatches
         } else {
             MentionSearchStatus::Searching
         }
-    } else if result.scan_finished {
+    } else if result.status.is_finished() {
         MentionSearchStatus::Ready
     } else {
         MentionSearchStatus::Searching
@@ -359,8 +370,8 @@ pub fn apply_match_result(app: &mut App, result: file_index::MentionMatchResult)
         sequence = result.sequence,
         query_chars = result.query.chars().count(),
         result_count,
-        result_scan_finished = result.scan_finished,
-        current_scan_finished = app.file_index.scan_finished,
+        result_index_status = ?result.status,
+        current_index_status = ?app.file_index.status,
         follow_up_requested = needs_follow_up,
     );
     true
@@ -377,7 +388,11 @@ fn refresh_query_state(app: &mut App) {
         return;
     }
 
-    file_index::ensure_started(app);
+    if app.file_index.root.is_none() {
+        mention.search_status = MentionSearchStatus::WaitingForIndex;
+        sync_focus(app);
+        return;
+    }
     request_match_for_active_mention(app, MatchRequestMode::UserQuery);
 }
 
@@ -967,19 +982,27 @@ mod tests {
     fn index_paths(app: &mut App, paths: &[&str]) {
         app.file_index.root = Some(PathBuf::from(&app.cwd_raw));
         app.file_index.respect_gitignore = app.config.respect_gitignore_effective();
-        app.file_index.scan_finished = true;
+        app.file_index.status = file_index::FileIndexStatus::Complete;
         for path in paths {
             app.file_index.entries.insert((*path).to_owned(), candidate(path));
         }
+    }
+
+    fn start_session_index(app: &mut App) {
+        file_index::restart(app);
     }
 
     fn run_search(app: &mut App) {
         for _ in 0..200 {
             crate::app::file_index::drain_events(app);
             std::thread::sleep(Duration::from_millis(5));
-            let is_settled = app.mention.as_ref().is_none_or(|mention| {
-                !matches!(mention.search_status, MentionSearchStatus::Searching)
+            let index_is_settled =
+                !matches!(app.file_index.status, file_index::FileIndexStatus::Scanning);
+            let mention_is_settled = app.mention.as_ref().is_none_or(|mention| {
+                mention.pending_match_sequence.is_none()
+                    && !matches!(mention.search_status, MentionSearchStatus::Searching)
             });
+            let is_settled = index_is_settled && mention_is_settled;
             if is_settled {
                 return;
             }
@@ -989,6 +1012,7 @@ mod tests {
     #[test]
     fn sync_with_cursor_activates_inside_existing_mention() {
         let (mut app, _tmp) = app_with_temp_files(&["src/main.rs", "tests/integration.rs"]);
+        start_session_index(&mut app);
         app.input.set_text("open @src/main.rs now");
         let _ = app.input.set_cursor(0, "open @src".chars().count());
 
@@ -1155,6 +1179,7 @@ mod tests {
     #[test]
     fn confirm_selection_replaces_full_existing_token_without_double_space() {
         let (mut app, _tmp) = app_with_temp_files(&["src/lib.rs"]);
+        start_session_index(&mut app);
         app.input.set_text("open @src/lib.txt now");
         let _ = app.input.set_cursor(0, "open @src/lib".chars().count());
 
@@ -1169,6 +1194,7 @@ mod tests {
     #[test]
     fn confirm_selection_at_end_keeps_trailing_space() {
         let (mut app, _tmp) = app_with_temp_files(&["src/main.rs"]);
+        start_session_index(&mut app);
         app.input.set_text("@src/mai");
         let _ = app.input.set_cursor(0, app.input.lines()[0].chars().count());
 
@@ -1182,6 +1208,7 @@ mod tests {
     #[test]
     fn confirming_spaced_candidate_at_end_inserts_trailing_space() {
         let (mut app, _tmp) = app_with_temp_files(&["path with spaces.md"]);
+        start_session_index(&mut app);
         app.input.set_text("@path");
         let _ = app.input.set_cursor(0, "@path".chars().count());
 
@@ -1227,6 +1254,22 @@ mod tests {
             mention.placeholder_message().as_deref(),
             Some("Type a file or folder name after @")
         );
+    }
+
+    #[test]
+    fn activate_waits_for_the_session_index_without_starting_a_scan() {
+        let (mut app, _tmp) = app_with_temp_files(&["src/main.rs"]);
+        app.input.set_text("@main");
+        let _ = app.input.set_cursor(0, app.input.lines()[0].chars().count());
+
+        activate(&mut app);
+
+        assert!(app.file_index.root.is_none());
+        assert!(app.file_index.scan.is_none());
+        assert!(matches!(app.file_index.status, file_index::FileIndexStatus::NotStarted));
+        assert!(app.mention.as_ref().is_some_and(|mention| {
+            matches!(mention.search_status, MentionSearchStatus::WaitingForIndex)
+        }));
     }
 
     #[test]
@@ -1375,6 +1418,7 @@ mod tests {
         let (mut app, tmp) = app_with_temp_files(&["visible.rs", "ignored.rs"]);
         std::fs::create_dir_all(tmp.path().join(".git")).expect("create .git");
         std::fs::write(tmp.path().join(".gitignore"), "ignored.rs\n").expect("write .gitignore");
+        start_session_index(&mut app);
         app.input.set_text("@rs");
         let _ = app.input.set_cursor(0, 3);
 
@@ -1395,6 +1439,7 @@ mod tests {
             &mut app.config.committed_preferences_document,
             false,
         );
+        start_session_index(&mut app);
         app.input.set_text("@rs");
         let _ = app.input.set_cursor(0, 3);
 
@@ -1414,6 +1459,7 @@ mod tests {
         std::fs::create_dir_all(root.join(".git")).expect("create .git");
         std::fs::write(root.join("src").join(".gitignore"), "hidden.rs\n")
             .expect("write .gitignore");
+        start_session_index(&mut app);
         app.input.set_text("@rs");
         let _ = app.input.set_cursor(0, 3);
 
@@ -1428,6 +1474,7 @@ mod tests {
     #[test]
     fn update_query_loads_candidates_once_threshold_is_reached() {
         let (mut app, _tmp) = app_with_temp_files(&["src/main.rs"]);
+        start_session_index(&mut app);
         app.input.set_text("@s");
         let _ = app.input.set_cursor(0, 2);
 
@@ -1445,9 +1492,10 @@ mod tests {
     }
 
     #[test]
-    fn progressive_search_publishes_shallow_matches_before_deeper_levels() {
+    fn completed_search_includes_shallow_and_deep_matches() {
         let (mut app, _tmp) =
             app_with_temp_files(&["root.rs", "src/nested/deep.rs", "src/other.txt"]);
+        start_session_index(&mut app);
         app.input.set_text("@rs");
         let _ = app.input.set_cursor(0, 3);
 
@@ -1466,6 +1514,7 @@ mod tests {
     fn query_change_refilters_from_cache_without_restarting_walk() {
         let (mut app, _tmp) =
             app_with_temp_files(&["root.rs", "src/nested/needle.rs", "src/nested/other.rs"]);
+        start_session_index(&mut app);
         app.input.set_text("@rs");
         let _ = app.input.set_cursor(0, 3);
 
@@ -1491,7 +1540,7 @@ mod tests {
     fn scan_refresh_does_not_starve_pending_query_result() {
         let mut app = App::test_default();
         app.file_index.index_version = 5;
-        app.file_index.scan_finished = false;
+        app.file_index.status = file_index::FileIndexStatus::Scanning;
         let mut state = MentionState::new(0, 0, "web".to_owned(), Vec::new());
         state.next_match_sequence = 1;
         state.pending_match_sequence = Some(1);
@@ -1517,7 +1566,7 @@ mod tests {
                     basename_lower: "web_dev_work".to_owned(),
                     depth: 0,
                 }],
-                scan_finished: false,
+                status: file_index::FileIndexStatus::Scanning,
             },
         );
 
@@ -1533,7 +1582,7 @@ mod tests {
         let mut app = App::test_default();
         app.file_index.root = Some(std::path::PathBuf::from(&app.cwd_raw));
         app.file_index.respect_gitignore = app.config.respect_gitignore_effective();
-        app.file_index.scan_finished = true;
+        app.file_index.status = file_index::FileIndexStatus::Complete;
         app.file_index.entries.insert(
             "docs/guide-rs.txt".to_owned(),
             file_index::FileCandidate {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -65,6 +65,7 @@ pub use lifecycle::{
 };
 pub use service_status_check::start_service_status_check;
 pub use settings::{AppSettings, UpdatePrompt};
+pub(crate) use state::ComposerBlockReason;
 pub(crate) use state::MarkdownRenderKey;
 pub use state::{
     ActiveCompaction, App, AppStatus, AutocompleteKind, BlockCache, CacheMetrics, ChatMessage,

--- a/src/app/state/app.rs
+++ b/src/app/state/app.rs
@@ -38,7 +38,7 @@ pub struct App {
     pub turn: TurnState,
     pub(crate) event_tx: mpsc::Sender<ClientEvent>,
     pub(crate) event_rx: mpsc::Receiver<ClientEvent>,
-    pub(crate) file_index_event_tx: std_mpsc::Sender<file_index::FileIndexEvent>,
+    pub(crate) file_index_event_tx: std_mpsc::SyncSender<file_index::FileIndexEvent>,
     pub(crate) file_index_event_rx: std_mpsc::Receiver<file_index::FileIndexEvent>,
     pub spinner_frame: usize,
     pub(crate) spinner_last_advance_at: Option<Instant>,
@@ -115,6 +115,21 @@ pub struct App {
 }
 
 impl App {
+    #[must_use]
+    pub(crate) fn composer_access(&self) -> ComposerAccess {
+        if self.shutdown_requested() {
+            return ComposerAccess::Blocked(ComposerBlockReason::Shutdown);
+        }
+        match self.status {
+            AppStatus::Connecting => ComposerAccess::DraftOnly,
+            AppStatus::CommandPending => {
+                ComposerAccess::Blocked(ComposerBlockReason::CommandPending)
+            }
+            AppStatus::Error => ComposerAccess::Blocked(ComposerBlockReason::Error),
+            AppStatus::Ready | AppStatus::Thinking | AppStatus::Running => ComposerAccess::Active,
+        }
+    }
+
     pub(crate) fn request_shutdown(&mut self) {
         if matches!(self.shutdown, ShutdownState::Running) {
             self.shutdown = ShutdownState::Requested;
@@ -197,7 +212,7 @@ impl App {
     #[allow(clippy::too_many_lines)]
     pub fn test_default() -> Self {
         let (tx, rx) = mpsc::channel(crate::app::connect::CLIENT_EVENT_QUEUE_CAPACITY);
-        let (file_index_tx, file_index_rx) = std_mpsc::channel();
+        let (file_index_tx, file_index_rx) = file_index::event_channel();
         Self {
             surface_mode: SurfaceMode::Chat,
             terminal_lifecycle: TerminalLifecycleState::Running(SurfaceMode::Chat),

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -53,6 +53,7 @@ pub use tool_call_info::{
 pub use transcript::Transcript;
 pub use turn::{ActiveCompaction, CompactionState, TurnState};
 pub use turn_notices::{NoticeStage, TurnNoticeLocation, TurnNoticeRef};
+pub(crate) use types::ComposerBlockReason;
 pub use types::{
     AppStatus, ExtraUsage, HistoryRetentionPolicy, HistoryRetentionStats, LoginHint, McpState,
     MessageUsage, ModeInfo, ModeState, PasteSessionState, PendingCommandAck, PostExitAction,
@@ -77,9 +78,10 @@ mod prelude {
     pub(super) use super::turn::TurnState;
     pub(super) use super::turn_notices::TurnNoticeRef;
     pub(super) use super::types::{
-        AppStatus, HistoryRetentionPolicy, HistoryRetentionStats, McpState, PasteSessionState,
-        PendingCommandAck, RecentSessionInfo, RenderCacheBudget, SelectionPoint,
-        SessionPickerState, ShutdownState, ToolCallScope, UpdatePromptState, UsageState,
+        AppStatus, ComposerAccess, ComposerBlockReason, HistoryRetentionPolicy,
+        HistoryRetentionStats, McpState, PasteSessionState, PendingCommandAck, RecentSessionInfo,
+        RenderCacheBudget, SelectionPoint, SessionPickerState, ShutdownState, ToolCallScope,
+        UpdatePromptState, UsageState,
     };
     pub(super) use crate::agent::events::ClientEvent;
     pub(super) use crate::agent::model;

--- a/src/app/state/tests.rs
+++ b/src/app/state/tests.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use super::types::{ComposerAccess, ComposerBlockReason};
 use super::*;
 use crate::agent::model;
 use crate::app::focus::{FocusOwner, FocusTarget};
@@ -7,6 +8,26 @@ use pretty_assertions::assert_eq;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use std::time::Instant;
+
+#[test]
+fn composer_access_is_the_authoritative_status_policy() {
+    let mut app = App::test_default();
+    for (status, expected) in [
+        (AppStatus::Connecting, ComposerAccess::DraftOnly),
+        (AppStatus::CommandPending, ComposerAccess::Blocked(ComposerBlockReason::CommandPending)),
+        (AppStatus::Ready, ComposerAccess::Active),
+        (AppStatus::Thinking, ComposerAccess::Active),
+        (AppStatus::Running, ComposerAccess::Active),
+        (AppStatus::Error, ComposerAccess::Blocked(ComposerBlockReason::Error)),
+    ] {
+        app.status = status;
+        assert_eq!(app.composer_access(), expected);
+    }
+
+    app.status = AppStatus::Ready;
+    app.request_shutdown();
+    assert_eq!(app.composer_access(), ComposerAccess::Blocked(ComposerBlockReason::Shutdown));
+}
 
 // BlockCache
 

--- a/src/app/state/types.rs
+++ b/src/app/state/types.rs
@@ -285,7 +285,8 @@ pub struct CacheBudgetEnforceStats {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum AppStatus {
-    /// Waiting for bridge adapter connection (TUI shown, input disabled).
+    /// Waiting for bridge adapter connection. Draft editing remains available,
+    /// but submission is disabled until a session is established.
     Connecting,
     /// A slash command is in flight (input disabled, spinner shown).
     CommandPending,
@@ -293,6 +294,40 @@ pub enum AppStatus {
     Thinking,
     Running,
     Error,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ComposerBlockReason {
+    CommandPending,
+    Error,
+    Shutdown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ComposerAccess {
+    Active,
+    DraftOnly,
+    Blocked(ComposerBlockReason),
+}
+
+impl ComposerAccess {
+    #[must_use]
+    pub const fn can_edit(self) -> bool {
+        matches!(self, Self::Active | Self::DraftOnly)
+    }
+
+    #[must_use]
+    pub const fn can_submit(self) -> bool {
+        matches!(self, Self::Active)
+    }
+
+    #[must_use]
+    pub const fn blocked_reason(self) -> Option<ComposerBlockReason> {
+        match self {
+            Self::Blocked(reason) => Some(reason),
+            Self::Active | Self::DraftOnly => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/app/terminal_runtime/chat_session.rs
+++ b/src/app/terminal_runtime/chat_session.rs
@@ -498,14 +498,8 @@ impl ChatTerminalSession {
         let footer_rows = Vec::from(footer.rows);
         let footer_row_count = u16::try_from(footer_rows.len()).unwrap_or(u16::MAX);
 
-        let editor = if app.shutdown_requested()
-            || matches!(
-                app.status,
-                crate::app::AppStatus::Connecting
-                    | crate::app::AppStatus::CommandPending
-                    | crate::app::AppStatus::Error
-            ) {
-            ComposerEditor::Rows(blocked_input_lines(app))
+        let editor = if let Some(reason) = app.composer_access().blocked_reason() {
+            ComposerEditor::Rows(blocked_input_lines(app, reason))
         } else {
             let desired_height =
                 input::visual_line_count(app, width).saturating_sub(hint_row_count).max(1);

--- a/src/ui/input_rows.rs
+++ b/src/ui/input_rows.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 Simon Peter Rothgang
 
-use crate::app::{App, AppStatus, FocusOwner};
+use crate::app::{App, ComposerBlockReason, FocusOwner};
 use crate::ui::{autocomplete, theme};
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
@@ -53,23 +53,9 @@ pub(crate) fn build_composer_hint_rows(app: &App) -> Vec<Line<'static>> {
     rows
 }
 
-pub(crate) fn blocked_input_lines(app: &App) -> Vec<Line<'static>> {
-    if app.shutdown_requested() {
-        return vec![Line::from(Span::styled(
-            "Shutting down... Press Ctrl+C again to force exit.",
-            Style::default().fg(theme::DIM),
-        ))];
-    }
-
-    match app.status {
-        AppStatus::Connecting => {
-            let spinner_ch = SPINNER_FRAMES[app.spinner_frame % SPINNER_FRAMES.len()];
-            vec![Line::from(vec![
-                Span::styled(format!("{spinner_ch} "), Style::default().fg(theme::DIM)),
-                Span::styled("Connecting to Claude Code...", Style::default().fg(theme::DIM)),
-            ])]
-        }
-        AppStatus::CommandPending => {
+pub(crate) fn blocked_input_lines(app: &App, reason: ComposerBlockReason) -> Vec<Line<'static>> {
+    match reason {
+        ComposerBlockReason::CommandPending => {
             let spinner_ch = SPINNER_FRAMES[app.spinner_frame % SPINNER_FRAMES.len()];
             let label =
                 app.turn.pending_command_label.as_deref().unwrap_or("Processing command...");
@@ -78,7 +64,7 @@ pub(crate) fn blocked_input_lines(app: &App) -> Vec<Line<'static>> {
                 Span::styled(label.to_owned(), Style::default().fg(theme::DIM)),
             ])]
         }
-        AppStatus::Error => vec![
+        ComposerBlockReason::Error => vec![
             Line::from(Span::styled(
                 "Input disabled due to error",
                 Style::default().fg(theme::STATUS_ERROR),
@@ -88,14 +74,17 @@ pub(crate) fn blocked_input_lines(app: &App) -> Vec<Line<'static>> {
                 Style::default().fg(theme::DIM),
             )),
         ],
-        AppStatus::Ready | AppStatus::Thinking | AppStatus::Running => Vec::new(),
+        ComposerBlockReason::Shutdown => vec![Line::from(Span::styled(
+            "Shutting down... Press Ctrl+C again to force exit.",
+            Style::default().fg(theme::DIM),
+        ))],
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{blocked_input_lines, build_composer_hint_rows};
-    use crate::app::{App, AppStatus, FocusTarget, LoginHint};
+    use crate::app::{App, AppStatus, ComposerBlockReason, FocusTarget, LoginHint};
 
     fn line_text(line: &ratatui::text::Line<'_>) -> String {
         line.spans.iter().map(|span| span.content.as_ref()).collect()
@@ -163,24 +152,12 @@ mod tests {
     }
 
     #[test]
-    fn blocked_input_lines_shows_connecting_status() {
-        let mut app = App::test_default();
-        app.status = AppStatus::Connecting;
-        app.spinner_frame = 3;
-
-        let rows = blocked_input_lines(&app);
-
-        assert_eq!(rows.len(), 1);
-        assert!(line_text(&rows[0]).contains("Connecting to Claude Code..."));
-    }
-
-    #[test]
     fn blocked_input_lines_shows_pending_command_label() {
         let mut app = App::test_default();
         app.status = AppStatus::CommandPending;
         app.turn.pending_command_label = Some("Switching model...".to_owned());
 
-        let rows = blocked_input_lines(&app);
+        let rows = blocked_input_lines(&app, ComposerBlockReason::CommandPending);
 
         assert_eq!(rows.len(), 1);
         assert!(line_text(&rows[0]).contains("Switching model..."));
@@ -191,7 +168,7 @@ mod tests {
         let mut app = App::test_default();
         app.status = AppStatus::Error;
 
-        let rows = blocked_input_lines(&app);
+        let rows = blocked_input_lines(&app, ComposerBlockReason::Error);
 
         assert_eq!(rows.len(), 2);
         assert!(line_text(&rows[0]).contains("Input disabled due to error"));
@@ -204,7 +181,7 @@ mod tests {
         app.status = AppStatus::Running;
         app.request_shutdown();
 
-        let rows = blocked_input_lines(&app);
+        let rows = blocked_input_lines(&app, ComposerBlockReason::Shutdown);
 
         assert_eq!(rows.len(), 1);
         assert_eq!(line_text(&rows[0]), "Shutting down... Press Ctrl+C again to force exit.");


### PR DESCRIPTION
## Summary

- Allow users to type and paste into the composer while the Agent SDK connection is being established, while continuing to block submission until the session is ready.
- Centralize composer editing and submission availability so connection, pending-command, error, and shutdown behavior use one policy across input handling and rendering.
- Start file indexing only after session establishment and replace the previous staged and repeated scans with one `.gitignore`-aware filesystem traversal.
- Bound index size, scan and watcher batches, background queues, and per-tick UI work, with an explicit limited-index state when the entry cap is reached.

## Why

Starting the TUI from a large repository or broad directory such as the desktop could make typing feel delayed. File indexing began before the SDK session was established, could be started again by later lifecycle paths, traversed parts of the tree more than once, and passed work through unbounded queues. At the same time, the connecting state replaced the composer with a placeholder, preventing users from drafting while startup completed.

This change separates connection readiness from composer editing and gives indexing a single bounded lifecycle after session establishment. It protects the UI event loop from indexing bursts while retaining file mention indexing and `.gitignore` behavior.

<!-- Closes None -->

## Validation

- Automated: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo check --offline`; `cargo test` (1,830 tests passed).
- Manual: User-verified startup responsiveness in the previously affected large-directory scenario and confirmed that startup now feels fast.
- Screenshot/video (if UI changed): N/A; this changes composer availability and removes the temporary connecting placeholder without introducing a new visual surface.

## Notes

- Breaking changes: N/A
- Docs updated: N/A; unrelated README edits are intentionally outside this change.
- Governance/release impact: N/A
- The index is capped at 100,000 entries. When the cap is reached, file mention search reports that it is using a limited index instead of continuing unbounded work.
