### PR TITLE
chore(labels): restructure label taxonomy and wire advisory issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement
 title: "[Feature]: "
-labels: ["type: enhancement"]
+labels: ["type: feature", "status: triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,7 +61,7 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "type: dependencies"
-      - "javascript"
+      - "area: agent-sdk"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -84,7 +84,7 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "type: dependencies"
-      - "javascript"
+      - "area: agent-sdk"
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/.github/workflows/dependency-monitor.yml
+++ b/.github/workflows/dependency-monitor.yml
@@ -12,14 +12,119 @@ jobs:
   cargo-deny-advisories:
     name: Cargo Deny Advisories
     runs-on: ubuntu-latest
-    continue-on-error: true
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
-        with:
-          rust-version: "1.88.0"
-          command: check advisories
-          arguments: --all-features
+
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+
+      # The PR gate in pr.yml uses EmbarkStudios/cargo-deny-action, but that action
+      # runs in a container and only writes findings to the job log. This job needs
+      # the report as text so it can put it in the tracking issue, so it installs
+      # cargo-deny directly. Bump this pin by hand when cargo-deny releases.
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --version 0.20.2 --locked
+
+      - name: Check advisories
+        id: advisories
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          report="${RUNNER_TEMP}/cargo-deny-advisories.txt"
+          if cargo deny --all-features check advisories > "${report}" 2>&1; then
+            echo "clean=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "clean=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "report=${report}" >> "$GITHUB_OUTPUT"
+          cat "${report}"
+
+      - name: Sync advisory tracking issue
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          CLEAN: ${{ steps.advisories.outputs.clean }}
+          REPORT: ${{ steps.advisories.outputs.report }}
+        run: |
+          set -euo pipefail
+
+          # One tracking issue that gets refreshed, rather than one issue per
+          # advisory. The actions-rust-lang/audit setup this replaces opened a
+          # fresh issue per run and produced duplicates such as #41/#56.
+          issue_title="Security advisories in the dependency graph"
+
+          existing_issue="$(
+            gh issue list \
+              --repo "${REPO}" \
+              --state open \
+              --search "\"${issue_title}\" in:title" \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+
+          if [[ "${CLEAN}" == "true" ]]; then
+            if [[ -n "${existing_issue}" ]]; then
+              gh issue close "${existing_issue}" \
+                --repo "${REPO}" \
+                --reason completed \
+                --comment "\`cargo deny check advisories\` is clean again as of \`${GITHUB_WORKFLOW}\` run ${GITHUB_RUN_ID}."
+              echo "Closed issue #${existing_issue}."
+            else
+              echo "No advisories reported."
+            fi
+            exit 0
+          fi
+
+          issue_file="${RUNNER_TEMP}/advisory-issue.md"
+          cat > "${issue_file}" <<EOF
+          \`cargo deny check advisories\` reported findings against the policy in \`deny.toml\`.
+
+          Suggested next steps:
+
+          - Bump or replace the affected crates, or record a scoped exception in \`deny.toml\`.
+          - Yanked crates and unmaintained advisories are in scope because \`deny.toml\` sets \`yanked = "deny"\` and \`unmaintained = "workspace"\`.
+          - This issue closes itself once a later run reports no findings.
+
+          <details><summary>cargo-deny report</summary>
+
+          \`\`\`
+          EOF
+
+          # Issue bodies cap at 65536 characters and inclusion graphs get long.
+          head -c 50000 "${REPORT}" >> "${issue_file}"
+          if [[ "$(wc -c < "${REPORT}")" -gt 50000 ]]; then
+            echo "" >> "${issue_file}"
+            echo "... report truncated, see the workflow run for the full output." >> "${issue_file}"
+          fi
+
+          cat >> "${issue_file}" <<EOF
+          \`\`\`
+
+          </details>
+
+          This issue was opened or refreshed by \`${GITHUB_WORKFLOW}\`.
+          EOF
+
+          if [[ -n "${existing_issue}" ]]; then
+            gh issue edit "${existing_issue}" \
+              --repo "${REPO}" \
+              --add-label "type: security" \
+              --body-file "${issue_file}"
+            echo "Updated issue #${existing_issue}."
+          else
+            gh issue create \
+              --repo "${REPO}" \
+              --title "${issue_title}" \
+              --label "type: security" \
+              --body-file "${issue_file}"
+          fi
 
   agent-sdk-update-monitor:
     name: Check latest Agent SDK

--- a/.github/workflows/dependency-monitor.yml
+++ b/.github/workflows/dependency-monitor.yml
@@ -123,6 +123,8 @@ jobs:
             gh issue edit "${existing_issue}" \
               --repo "${REPO}" \
               --title "${issue_title}" \
+              --add-label "type: dependencies" \
+              --add-label "area: agent-sdk" \
               --body-file "${issue_file}"
             echo "Updated issue #${existing_issue}."
           else

--- a/.github/workflows/dependency-monitor.yml
+++ b/.github/workflows/dependency-monitor.yml
@@ -129,5 +129,7 @@ jobs:
             gh issue create \
               --repo "${REPO}" \
               --title "${issue_title}" \
+              --label "type: dependencies" \
+              --label "area: agent-sdk" \
               --body-file "${issue_file}"
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,25 @@ By participating, you agree to uphold this code.
 7. Push to your fork and open a Pull Request against `main`
 8. Fill out the PR summary, validation, and any relevant notes
 
+### Labels
+
+Labels use a `namespace: value` convention so they group visually and filter cleanly.
+Apply at most one `type:` label per issue or pull request.
+
+| Namespace | Values | Meaning |
+| --- | --- | --- |
+| `type:` | `bug`, `fix`, `feature`, `docs`, `refactor`, `security`, `dependencies`, `release` | What kind of work it is. Use `bug` for a reported defect and `fix` for the change that resolves one. |
+| `area:` | `tui`, `core`, `agent-sdk`, `install`, `ci` | Which part of the project it touches. |
+| `status:` | `triage`, `blocked`, `needs-info`, `discussion`, `wontfix` | Where it sits in the workflow. |
+
+`good first issue` and `help wanted` stay unprefixed because GitHub uses them to
+populate the repository contribution page.
+
+Issue templates apply `type:` and `status: triage` automatically, and Dependabot
+applies `type: dependencies` plus the matching `area:` label from
+`.github/dependabot.yml`. Renaming any of those labels requires updating that
+config in the same change.
+
 ## Development Setup
 
 ### Prerequisites

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,9 @@ By participating, you agree to uphold this code.
 ### Labels
 
 Labels use a `namespace: value` convention so they group visually and filter cleanly.
-Apply at most one `type:` label per issue or pull request.
+Apply one `type:` label per issue or pull request. The exception is a dependency
+update that also carries a security fix, which takes `type: dependencies` and
+`type: security` together.
 
 | Namespace | Values | Meaning |
 | --- | --- | --- |
@@ -60,10 +62,11 @@ Apply at most one `type:` label per issue or pull request.
 `good first issue` and `help wanted` stay unprefixed because GitHub uses them to
 populate the repository contribution page.
 
-Issue templates apply `type:` and `status: triage` automatically, and Dependabot
+Issue templates apply `type:` and `status: triage` automatically, Dependabot
 applies `type: dependencies` plus the matching `area:` label from
-`.github/dependabot.yml`. Renaming any of those labels requires updating that
-config in the same change.
+`.github/dependabot.yml`, and the weekly `Dependency Monitor` workflow applies
+`type: security` to the advisory issue it opens. Renaming any of those labels
+requires updating that config in the same change.
 
 ## Development Setup
 


### PR DESCRIPTION
## Summary

<!-- What changed -->

Reworks the repository labels into three consistent namespaces, aligns every `.github` file that depends on them, and restores the security-advisory notifications that were lost in #236.

Label changes applied via `gh label` (the repo now has 20 labels):

- **Added:** `type: fix`, `type: security`, `status: triage`, `status: needs-info`, `area: tui`, `area: core`, `area: agent-sdk`, `area: install`
- **Renamed:** `type: enhancement` → `type: feature`, `type: quality` → `type: refactor`, `type: documentation` → `type: docs`, `release` → `type: release`, `blocked` → `status: blocked`, `discussion` → `status: discussion`, `wontfix` → `status: wontfix`
- **Removed:** `dependencies` (duplicate of `type: dependencies`), `duplicate` (unused; GitHub has native duplicate marking), `javascript` (single-value outlier, replaced by `area:`)
- **Recoloured:** one colour family per namespace, resolving the `type: enhancement`/`area: ci` and `type: documentation`/`release` collisions

File changes in this PR:

- `feature_request.yml` now applies `type: feature` and `status: triage`
- `dependabot.yml` uses `area: agent-sdk` for both npm ecosystems instead of `javascript`
- `dependency-monitor.yml` labels the Agent SDK issue on both the create and the refresh path, and its advisory job now opens a labeled tracking issue
- `CONTRIBUTING.md` documents the namespaces and which labels automation depends on

## Why

<!-- Why this change is needed -->

The old set was issue-shaped and had no label for a fix. Every `fix(...)` PR was tagged `type: bug`, which reads as "this PR is a bug" rather than "this PR fixes one" — and #312 ended up carrying both `type: bug` and `type: enhancement` because neither fit. Splitting `type: bug` (a reported defect) from `type: fix` (the change that resolves it) removes that ambiguity, and the `type:` values now mirror the conventional-commit types `pr-title.yml` already enforces.

Auditing the label wiring surfaced three unrelated defects, all fixed here:

1. `bug_report.yml` has always applied `status: triage`, but that label did not exist, so GitHub silently dropped it on every bug report. The label now exists.
2. All 19 RUSTSEC and yanked-crate issues plus the 6 Agent SDK monitor issues were unlabeled. They have been back-labeled, and both monitor jobs now label the issues they open.
3. `type: enhancement` and `area: ci` shared a colour, as did `type: documentation` and `release`, which defeated the point of the prefixes.

### Advisory notifications

Tracing who opened the RUSTSEC issues turned up a regression. They came from `actions-rust-lang/audit` in `.github/workflows/audit.yml`, which #236 deleted on 2026-07-03 when advisory checking moved to `cargo-deny`. The replacement job runs `continue-on-error: true` and only writes to the job log, so nothing has surfaced an advisory since — the newest such issue is #218 from 2026-06-29.

This PR closes that gap on the `cargo-deny` side rather than restoring `cargo-audit`, because `deny.toml` is now the single source of advisory policy (`yanked = "deny"`, `unmaintained = "workspace"`); reintroducing `cargo-audit` would report findings that policy deliberately scopes out. `actions-rust-lang/audit` also cannot label the issues it creates, so it could not satisfy this requirement anyway.

The job now installs `cargo-deny` directly instead of using `EmbarkStudios/cargo-deny-action`, because that action runs in a container and its report only reaches the job log. The action is unchanged and still Dependabot-tracked through the two `pr.yml` gates, so nothing loses pin coverage; the version pin here is manual and flagged in a comment, matching the existing `cargo install mdbook --version 0.5.3 --locked` in `docs.yml`.

Behaviour is one tracking issue that gets refreshed and self-closes, not one issue per advisory per run. The old action produced duplicates for the same advisory — #41/#56, #42/#57, #131/#132, #4/#5 are all pairs.

Closes #

## Validation

- Automated: `js-yaml` parses `dependabot.yml`, `dependency-monitor.yml`, and both issue templates. Every `run:` block extracted from `dependency-monitor.yml` passes `bash -n`. Repo-wide grep confirms no reference to a removed or renamed label remains outside generated `docs/book/` output.
- Manual: exercised the new advisory step locally against a stubbed `gh` across all four paths — findings with no open issue (creates, labeled `type: security`), findings with an open issue (edits, re-applies the label), clean with an open issue (closes with a comment), clean with none (no-op) — and confirmed the generated markdown renders with literal backticks and intact code fences. Verified the truncation guard caps a 60 KB report at a 50.5 KB body, under the 65536 character limit. Read all 15 `.github` files end to end; `CODEOWNERS`, `config.yml`, `pull_request_template.md`, and the 8 workflows other than `dependency-monitor.yml` contain no label references and are intentionally untouched. Re-labeled the 27 PRs that carried `javascript` and the 2 that carried `dependencies` before deleting those labels, so no item lost its only classification.
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A — renames preserve existing attachments, and saved filters or bookmarks using the old names will need updating.
- Docs updated: yes, `CONTRIBUTING.md` gains a Labels section.
- Governance/release impact: N/A
- The advisory job no longer sets `continue-on-error: true`. Advisories themselves are handled by the issue, so a red job now means the workflow itself broke, which is worth seeing.
- `cargo install cargo-deny --locked` adds a few minutes to this weekly job. That seemed a fair trade for a report in the issue instead of a log link that expires with the run.
