### PR TITLE
chore(release): publish version 0.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+<!-- ## [Unreleased] -->
+
+## [0.14.6] - 2026-09-02 [Changes][v0.14.6]
 
 ### Features
 
@@ -835,6 +837,7 @@ Performance optimization was a major release theme across recent commits:
   - `PromptResponse.usage` is `None`
 - Session resume (`--resume`) is blocked on an upstream adapter release that contains a Windows path encoding fix
 
+[v0.14.6]: https://github.com/srothgan/claude-code-rust/compare/v0.14.5...v0.14.6
 [v0.14.5]: https://github.com/srothgan/claude-code-rust/compare/v0.14.4...v0.14.5
 [v0.14.4]: https://github.com/srothgan/claude-code-rust/compare/v0.14.3...v0.14.4
 [v0.14.3]: https://github.com/srothgan/claude-code-rust/compare/v0.14.2...v0.14.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-code-rust"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-rust"
-version = "0.14.5"
+version = "0.14.6"
 edition = "2024"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-rust",
-      "version": "0.14.5",
+      "version": "0.14.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.258"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-rust",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "Claude Code Rust - native Rust terminal interface for Claude Code",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary

- Bump the Cargo and npm package versions to `0.14.6`.
- Publish the accumulated changelog entries as the `2026-09-02` release and add its comparison link.

## Why

Prepare the merged changes on `main` for the `0.14.6` release.

Closes #

## Validation

- Automated: `cargo fmt --all -- --check`, `cargo check --offline`, Cargo/npm version checks, and `git diff --check`.
- Manual: N/A
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: `CHANGELOG.md`
- Governance/release impact: Publishes version `0.14.6` from the protected release workflow.
