### PR TITLE
test(mention): fail loudly when background search never settles

### DIFF
--- a/src/app/mention.rs
+++ b/src/app/mention.rs
@@ -947,6 +947,11 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
+    /// Budget for the background walk and matcher to settle before a test reads
+    /// mention state. Sized for the slowest CI runner, not local hardware.
+    const SEARCH_SETTLE_TIMEOUT: Duration = Duration::from_secs(30);
+    const SEARCH_SETTLE_POLL_INTERVAL: Duration = Duration::from_millis(5);
+
     fn app_with_temp_files(files: &[&str]) -> (App, tempfile::TempDir) {
         let tmp = tempfile::tempdir().expect("tempdir");
         for file in files {
@@ -992,20 +997,32 @@ mod tests {
         file_index::restart(app);
     }
 
+    /// Drives the background file index until the mention search settles, and
+    /// fails loudly if it does not. Returning silently on timeout would let a
+    /// test assert against a half-scanned index and report a candidate
+    /// mismatch instead of the timeout that actually caused it.
     fn run_search(app: &mut App) {
-        for _ in 0..200 {
+        let deadline = Instant::now() + SEARCH_SETTLE_TIMEOUT;
+        loop {
             crate::app::file_index::drain_events(app);
-            std::thread::sleep(Duration::from_millis(5));
             let index_is_settled =
                 !matches!(app.file_index.status, file_index::FileIndexStatus::Scanning);
             let mention_is_settled = app.mention.as_ref().is_none_or(|mention| {
                 mention.pending_match_sequence.is_none()
                     && !matches!(mention.search_status, MentionSearchStatus::Searching)
             });
-            let is_settled = index_is_settled && mention_is_settled;
-            if is_settled {
+            if index_is_settled && mention_is_settled {
                 return;
             }
+            assert!(
+                Instant::now() < deadline,
+                "mention search did not settle within {SEARCH_SETTLE_TIMEOUT:?}: \
+                 index_status={:?}, search_status={:?}, pending_match_sequence={:?}",
+                app.file_index.status,
+                app.mention.as_ref().map(|mention| mention.search_status),
+                app.mention.as_ref().and_then(|mention| mention.pending_match_sequence),
+            );
+            std::thread::sleep(SEARCH_SETTLE_POLL_INTERVAL);
         }
     }
 


### PR DESCRIPTION
## Summary

<!-- What changed -->

`run_search`, the test helper that waits for the background file index in `src/app/mention.rs`, polled a fixed 200 × 5 ms (1 s) and then returned silently when the budget ran out. Callers then asserted against whatever half-scanned state existed.

- Replaced the fixed iteration count with a deadline, raising the budget to 30 s
- Turned an exhausted budget into an assertion failure that reports `index_status`, `search_status` and `pending_match_sequence`
- Drained events before sleeping, so an already-settled search returns without waiting out a poll interval

Test-only change; no production code is touched.

## Why

<!-- Why this change is needed -->

The Nightly run [34098364599](https://github.com/srothgan/claude-code-rust/actions/runs/34098364599) failed on both attempt 1 and attempt 2, only in `Test (macos-latest)`; Ubuntu, Windows and every build and smoke job passed.

- Attempt 1: `completed_search_includes_shallow_and_deep_matches` (`search_status != Ready`) and `query_change_refilters_from_cache_without_restarting_walk` (`left: 2, right: 1`)
- Attempt 2: only the latter, same assertion

`src/app/mention.rs` and `src/app/file_index.rs` were both last changed by dd12688 (2026-08-23), and the Aug 24 and Aug 31 nightlies passed on that same code, so this is not a regression. The shared cause is the silent timeout: on a loaded macOS runner the walk does not settle inside 1 s, and the tests then assert against a partial index. The current assertions cannot distinguish "the index never settled" from "the matcher settled and still returned the wrong candidates", which is why the failure reads as a confusing `2 vs 1` mismatch.

This does not by itself prove the extra candidate is only a test artifact. `apply_match_result` replaces `mention.candidates` wholesale and `for_each_candidate` skips entries whose `strip_prefix(root)` fails, so neither duplicate accumulation nor macOS `/var` → `/private/var` path pollution explains it; the remaining suspect is a stale nucleo snapshot around `rebuild_stream(false)` (`src/app/file_index.rs:510`). After this change, a recurrence reports which of the two it was.

Closes #

## Validation

- Automated: `cargo fmt --all -- --check` and `cargo test --lib app::mention::` pass locally on Windows. That is weak evidence — the failure is a macOS-only timing flake and did not reproduce locally before the change either. CI is the real check.
- Manual: N/A
- Screenshot/video (if UI changed): N/A

## Notes

- Breaking changes: N/A
- Docs updated: N/A
- Governance/release impact: N/A
- `cargo clippy --all-targets --all-features -- -D warnings` was not run locally; left to CI.
